### PR TITLE
Automated STIG Control File Creation

### DIFF
--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -1,2033 +1,2056 @@
 policy: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
-source: https://public.cyber.mil/stigs/downloads/
 title: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
 id: stig_rhel8
-version: V1R3
+source: https://public.cyber.mil/stigs/downloads/
 levels:
-  - id: high
-  - id: medium
-  - id: low
-
+    -   id: high
+    -   id: medium
+    -   id: low
 controls:
     -   id: RHEL-08-010000
         levels:
             - high
+        title: RHEL 8 must be a vendor-supported release.
         rules:
             - installed_OS_is_vendor_supported
-        title: RHEL 8 must be a vendor-supported release.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010010
         levels:
             - medium
-        rules:
-            - security_patches_up_to_date
         title: RHEL 8 vendor packaged system security patches and updates must be installed
             and up to date.
-        automated: 'yes'
+        rules:
+            - security_patches_up_to_date
+        status: automated
     -   id: RHEL-08-010020
         levels:
             - high
-        rules:
-            - enable_fips_mode
-            - sysctl_crypto_fips_enabled
         title: 'RHEL 8 must implement NIST FIPS-validated cryptography for the following:
     to provision digital signatures, to generate cryptographic hashes, and to protect
     data requiring data-at-rest protections in accordance with applicable federal
     laws, Executive Orders, directives, policies, regulations, and standards.'
-        automated: 'yes'
+        rules:
+            - enable_fips_mode
+            - sysctl_crypto_fips_enabled
+        status: automated
     -   id: RHEL-08-010030
         levels:
             - medium
-        rules:
-            - encrypt_partitions
         title: All RHEL 8 local disk partitions must implement cryptographic mechanisms
             to prevent unauthorized disclosure or modification of all information that requires
             at rest protection.
-        automated: 'yes'
+        rules:
+            - encrypt_partitions
+        status: automated
     -   id: RHEL-08-010040
         levels:
             - medium
-        rules:
-            - sshd_enable_warning_banner
         title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
             before granting local or remote access to the system via a ssh logon.
-        automated: 'yes'
+        rules:
+            - sshd_enable_warning_banner
+        status: automated
     -   id: RHEL-08-010050
         levels:
             - medium
-        rules:
-            - dconf_gnome_banner_enabled
-            - dconf_gnome_login_banner_text
         title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
             before granting local or remote access to the system via a graphical user logon.
-        automated: 'yes'
+        rules:
+            - dconf_gnome_login_banner_text
+        status: automated
     -   id: RHEL-08-010060
         levels:
             - medium
-        rules:
-            - banner_etc_issue
         title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
             before granting local or remote access to the system via a command line user logon.
-        automated: 'yes'
+        rules:
+            - banner_etc_issue
+        status: automated
     -   id: RHEL-08-010070
         levels:
             - medium
+        title: All RHEL 8 remote access methods must be monitored.
         rules:
             - rsyslog_remote_access_monitoring
-        title: All RHEL 8 remote access methods must be monitored.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010090
         levels:
             - medium
         title: RHEL 8, for PKI-based authentication, must validate certificates by constructing
             a certification path (which includes status information) to an accepted trust
             anchor.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010100
         levels:
             - medium
         title: RHEL 8, for certificate-based authentication, must enforce authorized access
             to the corresponding private key.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010110
         levels:
             - medium
-        rules:
-            - set_password_hashing_algorithm_logindefs
         title: RHEL 8 must encrypt all stored passwords with a FIPS 140-2 approved cryptographic
             hashing algorithm.
-        automated: 'yes'
+        rules:
+            - set_password_hashing_algorithm_logindefs
+        status: automated
     -   id: RHEL-08-010120
         levels:
             - medium
-        rules:
-            - accounts_password_all_shadowed_sha512
         title: RHEL 8 must employ FIPS 140-2 approved cryptographic hashing algorithms for
             all stored passwords.
-        automated: 'yes'
+        rules:
+            - accounts_password_all_shadowed_sha512
+        status: automated
     -   id: RHEL-08-010130
         levels:
             - medium
-        rules:
-            - accounts_password_pam_unix_rounds_password_auth
-            - accounts_password_pam_unix_rounds_system_auth
         title: The RHEL 8 password-auth file must be configured to use a sufficient number
             of hashing rounds.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_unix_rounds_password_auth
+        status: automated
     -   id: RHEL-08-010140
         levels:
             - high
-        rules:
-            - grub2_uefi_admin_username
-            - grub2_uefi_password
         title: RHEL 8 operating systems booted with United Extensible Firmware Interface
             (UEFI) must require authentication upon booting into single-user mode and maintenance.
-        automated: 'yes'
+        rules:
+            - grub2_uefi_password
+        status: automated
     -   id: RHEL-08-010150
         levels:
             - high
-        rules:
-            - grub2_admin_username
-            - grub2_password
         title: RHEL 8 operating systems booted with a BIOS must require authentication upon
             booting into single-user and maintenance modes.
-        automated: 'yes'
+        rules:
+            - grub2_password
+        status: automated
     -   id: RHEL-08-010151
         levels:
             - medium
-        rules:
-            - require_emergency_target_auth
-            - require_singleuser_auth
         title: RHEL 8 operating systems must require authentication upon booting into rescue
             mode.
-        automated: 'yes'
+        rules:
+            - require_singleuser_auth
+        status: automated
     -   id: RHEL-08-010160
         levels:
             - medium
-        rules:
-            - set_password_hashing_algorithm_systemauth
         title: The RHEL 8 pam_unix.so module must be configured in the password-auth file
             to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
-        automated: 'yes'
+        rules:
+            - set_password_hashing_algorithm_systemauth
+        status: automated
     -   id: RHEL-08-010161
         levels:
             - medium
+        title: RHEL 8 must prevent system daemons from using Kerberos for authentication.
         rules:
             - kerberos_disable_no_keytab
-        title: RHEL 8 must prevent system daemons from using Kerberos for authentication.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010162
         levels:
             - medium
+        title: The krb5-workstation package must not be installed on RHEL 8.
         rules:
             - package_krb5-workstation_removed
-        title: The krb5-workstation package must not be installed on RHEL 8.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010170
         levels:
             - medium
-        rules:
-            - selinux_state
         title: RHEL 8 must use a Linux Security Module configured to enforce limits on system
             services.
-        automated: 'yes'
+        rules:
+            - selinux_state
+        status: automated
     -   id: RHEL-08-010171
         levels:
             - low
+        title: RHEL 8 must have policycoreutils package installed.
         rules:
             - package_policycoreutils_installed
-        title: RHEL 8 must have policycoreutils package installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010180
         levels:
             - medium
         title: All RHEL 8 public directories must be owned by root or a system account to
             prevent unauthorized and unintended information transferred via shared system
             resources.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010190
         levels:
             - medium
-        rules:
-            - dir_perms_world_writable_sticky_bits
         title: A sticky bit must be set on all RHEL 8 public directories to prevent unauthorized
             and unintended information transferred via shared system resources.
-        automated: 'yes'
+        rules:
+            - dir_perms_world_writable_sticky_bits
+        status: automated
     -   id: RHEL-08-010200
         levels:
             - medium
-        rules:
-            - sshd_set_idle_timeout
-            - sshd_set_keepalive_0
         title: RHEL 8 must be configured so that all network connections associated with
             SSH traffic are terminated at the end of the session or after 10 minutes of inactivity,
             except to fulfill documented and validated mission requirements.
-        automated: 'yes'
+        rules:
+            - sshd_set_keepalive_0
+        status: automated
     -   id: RHEL-08-010210
         levels:
             - medium
+        title: The RHEL 8 /var/log/messages file must have mode 0640 or less permissive.
         rules:
             - file_permissions_var_log_messages
-        title: The RHEL 8 /var/log/messages file must have mode 0640 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010220
         levels:
             - medium
+        title: The RHEL 8 /var/log/messages file must be owned by root.
         rules:
             - file_owner_var_log_messages
-        title: The RHEL 8 /var/log/messages file must be owned by root.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010230
         levels:
             - medium
+        title: The RHEL 8 /var/log/messages file must be group-owned by root.
         rules:
             - file_groupowner_var_log_messages
-        title: The RHEL 8 /var/log/messages file must be group-owned by root.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010240
         levels:
             - medium
+        title: The RHEL 8 /var/log directory must have mode 0755 or less permissive.
         rules:
             - file_permissions_var_log
-        title: The RHEL 8 /var/log directory must have mode 0755 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010250
         levels:
             - medium
+        title: The RHEL 8 /var/log directory must be owned by root.
         rules:
             - file_owner_var_log
-        title: The RHEL 8 /var/log directory must be owned by root.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010260
         levels:
             - medium
+        title: The RHEL 8 /var/log directory must be group-owned by root.
         rules:
             - file_groupowner_var_log
-        title: The RHEL 8 /var/log directory must be group-owned by root.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010290
         levels:
             - medium
-        rules:
-            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-            - harden_sshd_macs_openssh_conf_crypto_policy
-            - harden_sshd_macs_opensshserver_conf_crypto_policy
         title: The RHEL 8 SSH server must be configured to use only Message Authentication
             Codes (MACs) employing FIPS 140-2 validated cryptographic hash algorithms.
-        automated: 'yes'
+        rules:
+            - harden_sshd_macs_opensshserver_conf_crypto_policy
+        status: automated
     -   id: RHEL-08-010291
         levels:
             - medium
-        rules:
-            - harden_sshd_ciphers_openssh_conf_crypto_policy
         title: The RHEL 8 operating system must implement DoD-approved encryption to protect
             the confidentiality of SSH server connections.
-        automated: 'yes'
+        rules:
+            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+        status: automated
     -   id: RHEL-08-010292
         levels:
             - low
+        title: RHEL 8 must ensure the SSH server uses strong entropy.
         rules:
             - sshd_use_strong_rng
-        title: RHEL 8 must ensure the SSH server uses strong entropy.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010293
         levels:
             - medium
-        rules:
-            - configure_openssl_crypto_policy
         title: The RHEL 8 operating system must implement DoD-approved encryption in the
             OpenSSL package.
-        automated: 'yes'
+        rules:
+            - configure_openssl_crypto_policy
+        status: automated
     -   id: RHEL-08-010294
         levels:
             - medium
-        rules:
-            - configure_openssl_tls_crypto_policy
         title: The RHEL 8 operating system must implement DoD-approved TLS encryption in
             the OpenSSL package.
-        automated: 'yes'
+        rules:
+            - configure_openssl_tls_crypto_policy
+        status: automated
     -   id: RHEL-08-010295
         levels:
             - medium
-        rules:
-            - configure_gnutls_tls_crypto_policy
         title: The RHEL 8 operating system must implement DoD-approved TLS encryption in
             the GnuTLS package.
-        automated: 'yes'
+        rules:
+            - configure_gnutls_tls_crypto_policy
+        status: automated
     -   id: RHEL-08-010300
         levels:
             - medium
+        title: RHEL 8 system commands must have mode 0755 or less permissive.
         rules:
             - file_permissions_binary_dirs
-        title: RHEL 8 system commands must have mode 0755 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010310
         levels:
             - medium
+        title: RHEL 8 system commands must be owned by root.
         rules:
             - file_ownership_binary_dirs
-        title: RHEL 8 system commands must be owned by root.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010320
         levels:
             - medium
+        title: RHEL 8 system commands must be group-owned by root or a system account.
         rules:
             - file_groupownership_system_commands_dirs
-        title: RHEL 8 system commands must be group-owned by root or a system account.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010330
         levels:
             - medium
+        title: RHEL 8 library files must have mode 0755 or less permissive.
         rules:
             - file_permissions_library_dirs
-        title: RHEL 8 library files must have mode 0755 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010340
         levels:
             - medium
+        title: RHEL 8 library files must be owned by root.
         rules:
             - file_ownership_library_dirs
-        title: RHEL 8 library files must be owned by root.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010350
         levels:
             - medium
+        title: RHEL 8 library files must be group-owned by root or a system account.
         rules:
             - dir_group_ownership_library_dirs
             - root_permissions_syslibrary_files
-        title: RHEL 8 library files must be group-owned by root or a system account.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010360
         levels:
             - medium
-        rules:
-            - aide_scan_notification
-            - package_aide_installed
         title: The RHEL 8 file integrity tool must notify the system administrator when
             changes to the baseline configuration or anomalies in the operation of any security
             functions are discovered within an organizationally defined frequency.
-        automated: 'yes'
+        rules:
+            - aide_scan_notification
+            - package_aide_installed
+        status: automated
     -   id: RHEL-08-010370
         levels:
             - high
-        rules:
-            - ensure_gpgcheck_globally_activated
         title: RHEL 8 must prevent the installation of software, patches, service packs,
             device drivers, or operating system components from a repository without verification
             they have been digitally signed using a certificate that is issued by a Certificate
             Authority (CA) that is recognized and approved by the organization.
-        automated: 'yes'
+        rules:
+            - ensure_gpgcheck_globally_activated
+        status: automated
     -   id: RHEL-08-010371
         levels:
             - high
-        rules:
-            - ensure_gpgcheck_local_packages
         title: RHEL 8 must prevent the installation of software, patches, service packs,
             device drivers, or operating system components of local packages without verification
             they have been digitally signed using a certificate that is issued by a Certificate
             Authority (CA) that is recognized and approved by the organization.
-        automated: 'yes'
+        rules:
+            - ensure_gpgcheck_local_packages
+        status: automated
     -   id: RHEL-08-010372
         levels:
             - medium
+        title: RHEL 8 must prevent the loading of a new kernel for later execution.
         rules:
             - sysctl_kernel_kexec_load_disabled
-        title: RHEL 8 must prevent the loading of a new kernel for later execution.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010373
         levels:
             - medium
-        rules:
-            - sysctl_fs_protected_symlinks
         title: RHEL 8 must enable kernel parameters to enforce discretionary access control
             on symlinks.
-        automated: 'yes'
+        rules:
+            - sysctl_fs_protected_symlinks
+        status: automated
     -   id: RHEL-08-010374
         levels:
             - medium
-        rules:
-            - sysctl_fs_protected_hardlinks
         title: RHEL 8 must enable kernel parameters to enforce discretionary access control
             on hardlinks.
-        automated: 'yes'
+        rules:
+            - sysctl_fs_protected_hardlinks
+        status: automated
     -   id: RHEL-08-010375
         levels:
             - low
+        title: RHEL 8 must restrict access to the kernel message buffer.
         rules:
             - sysctl_kernel_dmesg_restrict
-        title: RHEL 8 must restrict access to the kernel message buffer.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010376
         levels:
             - low
+        title: RHEL 8 must prevent kernel profiling by unprivileged users.
         rules:
             - sysctl_kernel_perf_event_paranoid
-        title: RHEL 8 must prevent kernel profiling by unprivileged users.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010380
         levels:
             - medium
+        title: RHEL 8 must require users to provide a password for privilege escalation.
         rules:
             - sudo_remove_nopasswd
-        title: RHEL 8 must require users to provide a password for privilege escalation.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010381
         levels:
             - medium
+        title: RHEL 8 must require users to reauthenticate for privilege escalation.
         rules:
             - sudo_remove_no_authenticate
-        title: RHEL 8 must require users to reauthenticate for privilege escalation.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010390
         levels:
             - medium
+        title: RHEL 8 must have the packages required for multifactor authentication installed.
         rules:
             - install_smartcard_packages
-        title: RHEL 8 must have the packages required for multifactor authentication installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010400
         levels:
             - medium
         title: RHEL 8 must implement certificate status checking for multifactor authentication.
-        automated: 'no'
-
+        rules:
+            - sssd_certificate_verification
+        status: automated
     -   id: RHEL-08-010410
         levels:
             - medium
+        title: RHEL 8 must accept Personal Identity Verification (PIV) credentials.
         rules:
             - package_opensc_installed
-        title: RHEL 8 must accept Personal Identity Verification (PIV) credentials.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010420
         levels:
             - medium
         title: RHEL 8 must implement non-executable data to protect its memory from unauthorized
             code execution.
-        automated: 'no'
-
+        rules:
+            - bios_enable_execution_restrictions
+        status: automated
     -   id: RHEL-08-010421
         levels:
             - medium
+        title: RHEL 8 must clear the page allocator to prevent use-after-free attacks.
         rules:
             - grub2_page_poison_argument
-        title: RHEL 8 must clear the page allocator to prevent use-after-free attacks.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010422
         levels:
             - medium
+        title: RHEL 8 must disable virtual syscalls.
         rules:
             - grub2_vsyscall_argument
-        title: RHEL 8 must disable virtual syscalls.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010423
         levels:
             - medium
+        title: RHEL 8 must clear SLUB/SLAB objects to prevent use-after-free attacks.
         rules:
             - grub2_slub_debug_argument
-        title: RHEL 8 must clear SLUB/SLAB objects to prevent use-after-free attacks.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010430
         levels:
             - medium
-        rules:
-            - sysctl_kernel_randomize_va_space
         title: RHEL 8 must implement address space layout randomization (ASLR) to protect
             its memory from unauthorized code execution.
-        automated: 'yes'
+        rules:
+            - sysctl_kernel_randomize_va_space
+        status: automated
     -   id: RHEL-08-010440
         levels:
             - low
-        rules:
-            - clean_components_post_updating
         title: YUM must remove all software components after updated versions have been
             installed on RHEL 8.
-        automated: 'yes'
+        rules:
+            - clean_components_post_updating
+        status: automated
     -   id: RHEL-08-010450
         levels:
             - medium
+        title: RHEL 8 must enable the SELinux targeted policy.
         rules:
             - selinux_policytype
-        title: RHEL 8 must enable the SELinux targeted policy.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010460
         levels:
             - high
+        title: There must be no shosts.equiv files on the RHEL 8 operating system.
         rules:
             - no_host_based_files
-        title: There must be no shosts.equiv files on the RHEL 8 operating system.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010470
         levels:
             - high
+        title: There must be no .shosts files on the RHEL 8 operating system.
         rules:
             - no_user_host_based_files
-        title: There must be no .shosts files on the RHEL 8 operating system.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010471
         levels:
             - low
-        rules:
-            - service_rngd_enabled
-            - package_rng-tools_installed
         title: RHEL 8 must enable the hardware random number generator entropy gatherer
             service.
-        automated: 'yes'
+        rules:
+            - service_rngd_enabled
+        status: automated
     -   id: RHEL-08-010480
         levels:
             - medium
+        title: The RHEL 8 SSH public host key files must have mode 0644 or less permissive.
         rules:
             - file_permissions_sshd_pub_key
-        title: The RHEL 8 SSH public host key files must have mode 0644 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010490
         levels:
             - medium
+        title: The RHEL 8 SSH private host key files must have mode 0600 or less permissive.
         rules:
             - file_permissions_sshd_private_key
-        title: The RHEL 8 SSH private host key files must have mode 0600 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010500
         levels:
             - medium
-        rules:
-            - sshd_enable_strictmodes
         title: The RHEL 8 SSH daemon must perform strict mode checking of home directory
             configuration files.
-        automated: 'yes'
+        rules:
+            - sshd_enable_strictmodes
+        status: automated
     -   id: RHEL-08-010510
         levels:
             - medium
-        rules:
-            - sshd_disable_compression
         title: The RHEL 8 SSH daemon must not allow compression or must only allow compression
             after successful authentication.
-        automated: 'yes'
+        rules:
+            - sshd_disable_compression
+        status: automated
     -   id: RHEL-08-010520
         levels:
             - medium
-        rules:
-            - sshd_disable_user_known_hosts
         title: "The RHEL 8 SSH daemon must not allow authentication using known host\u2019\
     s authentication."
-        automated: 'yes'
+        rules:
+            - sshd_disable_user_known_hosts
+        status: automated
     -   id: RHEL-08-010521
         levels:
             - medium
-        rules:
-            - sshd_disable_gssapi_auth
-            - sshd_disable_kerb_auth
         title: The RHEL 8 SSH daemon must not allow Kerberos authentication, except to fulfill
             documented and validated mission requirements.
-        automated: 'yes'
+        rules:
+            - sshd_disable_kerb_auth
+        status: automated
     -   id: RHEL-08-010540
         levels:
             - low
+        title: RHEL 8 must use a separate file system for /var.
         rules:
             - partition_for_var
-        title: RHEL 8 must use a separate file system for /var.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010541
         levels:
             - low
+        title: RHEL 8 must use a separate file system for /var/log.
         rules:
             - partition_for_var_log
-        title: RHEL 8 must use a separate file system for /var/log.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010542
         levels:
             - low
+        title: RHEL 8 must use a separate file system for the system audit data path.
         rules:
             - partition_for_var_log_audit
-        title: RHEL 8 must use a separate file system for the system audit data path.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010543
         levels:
             - medium
+        title: A separate RHEL 8 filesystem must be used for the /tmp directory.
         rules:
             - partition_for_tmp
-        title: A separate RHEL 8 filesystem must be used for the /tmp directory.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010550
         levels:
             - medium
-        rules:
-            - sshd_disable_root_login
         title: RHEL 8 must not permit direct logons to the root account using remote access
             via SSH.
-        automated: 'yes'
+        rules:
+            - sshd_disable_root_login
+        status: automated
     -   id: RHEL-08-010560
         levels:
             - medium
-        rules:
-            - service_auditd_enabled
         title: The auditd service must be running in RHEL 8.
-        automated: 'yes'
+        status: pending
     -   id: RHEL-08-010561
         levels:
             - medium
+        title: The rsyslog service must be running in RHEL 8.
         rules:
             - service_rsyslog_enabled
-        title: The rsyslog service must be running in RHEL 8.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010570
         levels:
             - medium
-        rules:
-            - mount_option_home_nosuid
         title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
             on file systems that contain user home directories.
-        automated: 'yes'
+        rules:
+            - mount_option_home_nosuid
+        status: automated
     -   id: RHEL-08-010571
         levels:
             - medium
-        rules:
-            - mount_option_boot_nosuid
         title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
             on the /boot directory.
-        automated: 'yes'
+        rules:
+            - mount_option_boot_nosuid
+        status: automated
     -   id: RHEL-08-010580
         levels:
             - medium
+        title: RHEL 8 must prevent special devices on non-root local partitions.
         rules:
             - mount_option_nodev_nonroot_local_partitions
-        title: RHEL 8 must prevent special devices on non-root local partitions.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010590
         levels:
             - medium
-        rules:
-            - mount_option_home_noexec
         title: RHEL 8 must prevent code from being executed on file systems that contain
             user home directories.
-        automated: 'yes'
+        rules:
+            - mount_option_home_noexec
+        status: automated
     -   id: RHEL-08-010600
         levels:
             - medium
-        rules:
-            - mount_option_nodev_removable_partitions
         title: RHEL 8 must prevent special devices on file systems that are used with removable
             media.
-        automated: 'yes'
+        rules:
+            - mount_option_nodev_removable_partitions
+        status: automated
     -   id: RHEL-08-010610
         levels:
             - medium
-        rules:
-            - mount_option_noexec_removable_partitions
         title: RHEL 8 must prevent code from being executed on file systems that are used
             with removable media.
-        automated: 'yes'
+        rules:
+            - mount_option_noexec_removable_partitions
+        status: automated
     -   id: RHEL-08-010620
         levels:
             - medium
-        rules:
-            - mount_option_nosuid_removable_partitions
         title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
             on file systems that are used with removable media.
-        automated: 'yes'
+        rules:
+            - mount_option_nosuid_removable_partitions
+        status: automated
     -   id: RHEL-08-010630
         levels:
             - medium
-        rules:
-            - mount_option_noexec_remote_filesystems
         title: RHEL 8 must prevent code from being executed on file systems that are imported
             via Network File System (NFS).
-        automated: 'yes'
+        rules:
+            - mount_option_noexec_remote_filesystems
+        status: automated
     -   id: RHEL-08-010640
         levels:
             - medium
-        rules:
-            - mount_option_nodev_remote_filesystems
         title: RHEL 8 must prevent special devices on file systems that are imported via
             Network File System (NFS).
-        automated: 'yes'
+        rules:
+            - mount_option_nodev_remote_filesystems
+        status: automated
     -   id: RHEL-08-010650
         levels:
             - medium
-        rules:
-            - mount_option_nosuid_remote_filesystems
         title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
             on file systems that are imported via Network File System (NFS).
-        automated: 'yes'
+        rules:
+            - mount_option_nosuid_remote_filesystems
+        status: automated
     -   id: RHEL-08-010660
         levels:
             - medium
+        title: Local RHEL 8 initialization files must not execute world-writable programs.
         rules:
             - accounts_user_dot_no_world_writable_programs
-        title: Local RHEL 8 initialization files must not execute world-writable programs.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010670
         levels:
             - medium
+        title: RHEL 8 must disable kernel dumps unless needed.
         rules:
             - service_kdump_disabled
-        title: RHEL 8 must disable kernel dumps unless needed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010671
         levels:
             - medium
+        title: RHEL 8 must disable the kernel.core_pattern.
         rules:
             - sysctl_kernel_core_pattern
-        title: RHEL 8 must disable the kernel.core_pattern.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010672
         levels:
             - medium
+        title: RHEL 8 must disable acquiring, saving, and processing core dumps.
         rules:
             - service_systemd-coredump_disabled
-        title: RHEL 8 must disable acquiring, saving, and processing core dumps.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010673
         levels:
             - medium
+        title: RHEL 8 must disable core dumps for all users.
         rules:
             - disable_users_coredumps
-        title: RHEL 8 must disable core dumps for all users.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010674
         levels:
             - medium
+        title: RHEL 8 must disable storing core dumps.
         rules:
             - coredump_disable_storage
-        title: RHEL 8 must disable storing core dumps.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010675
         levels:
             - medium
+        title: RHEL 8 must disable core dump backtraces.
         rules:
             - coredump_disable_backtraces
-        title: RHEL 8 must disable core dump backtraces.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010680
         levels:
             - medium
-        rules:
-            - network_configure_name_resolution
         title: For RHEL 8 systems using Domain Name Servers (DNS) resolution, at least two
             name servers must be configured.
-        automated: 'yes'
+        rules:
+            - network_configure_name_resolution
+        status: automated
     -   id: RHEL-08-010690
         levels:
             - medium
-        rules:
-            - accounts_user_home_paths_only
         title: Executable search paths within the initialization files of all local interactive
             RHEL 8 users must only contain paths that resolve to the system default or the
             users home directory.
-        automated: 'yes'
+        rules:
+            - accounts_user_home_paths_only
+        status: automated
     -   id: RHEL-08-010700
         levels:
             - medium
-        rules:
-            - dir_perms_world_writable_root_owned
         title: All RHEL 8 world-writable directories must be owned by root, sys, bin, or
             an application user.
-        automated: 'yes'
+        rules:
+            - dir_perms_world_writable_root_owned
+        status: automated
     -   id: RHEL-08-010710
         levels:
             - medium
         title: All RHEL 8 world-writable directories must be group-owned by root, sys, bin,
             or an application group.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010720
         levels:
             - medium
-        rules:
-            - accounts_user_interactive_home_directory_defined
         title: All RHEL 8 local interactive users must have a home directory assigned in
             the /etc/passwd file.
-        automated: 'yes'
+        rules:
+            - accounts_user_interactive_home_directory_defined
+        status: automated
     -   id: RHEL-08-010730
         levels:
             - medium
-        rules:
-            - file_permissions_home_directories
         title: All RHEL 8 local interactive user home directories must have mode 0750 or
             less permissive.
-        automated: 'yes'
+        rules:
+            - file_permissions_home_directories
+        status: automated
     -   id: RHEL-08-010740
         levels:
             - medium
-        rules:
-            - file_groupownership_home_directories
         title: "All RHEL 8 local interactive user home directories must be group-owned by\
     \ the home directory owner\u2019s primary group."
-        automated: 'yes'
+        rules:
+            - file_groupownership_home_directories
+        status: automated
     -   id: RHEL-08-010750
         levels:
             - medium
-        rules:
-            - accounts_user_interactive_home_directory_exists
         title: All RHEL 8 local interactive user home directories defined in the /etc/passwd
             file must exist.
-        automated: 'yes'
+        rules:
+            - accounts_user_interactive_home_directory_exists
+        status: automated
     -   id: RHEL-08-010760
         levels:
             - medium
-        rules:
-            - accounts_have_homedir_login_defs
         title: All RHEL 8 local interactive user accounts must be assigned a home directory
             upon creation.
-        automated: 'yes'
+        rules:
+            - accounts_have_homedir_login_defs
+        status: automated
     -   id: RHEL-08-010770
         levels:
             - medium
+        title: All RHEL 8 local initialization files must have mode 0740 or less permissive.
         rules:
             - file_permission_user_init_files
-        title: All RHEL 8 local initialization files must have mode 0740 or less permissive.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010780
         levels:
             - medium
+        title: All RHEL 8 local files and directories must have a valid owner.
         rules:
             - no_files_unowned_by_user
-        title: All RHEL 8 local files and directories must have a valid owner.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010790
         levels:
             - medium
+        title: All RHEL 8 local files and directories must have a valid group owner.
         rules:
             - file_permissions_ungroupowned
-        title: All RHEL 8 local files and directories must have a valid group owner.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010800
         levels:
             - medium
-        rules:
-            - partition_for_home
         title: A separate RHEL 8 filesystem must be used for user home directories (such
             as /home or an equivalent).
-        automated: 'yes'
+        rules:
+            - partition_for_home
+        status: automated
     -   id: RHEL-08-010820
         levels:
             - high
-        rules:
-            - gnome_gdm_disable_automatic_login
         title: Unattended or automatic logon via the RHEL 8 graphical user interface must
             not be allowed.
-        automated: 'yes'
+        rules:
+            - gnome_gdm_disable_automatic_login
+        status: automated
     -   id: RHEL-08-010830
         levels:
             - medium
+        title: RHEL 8 must not allow users to override SSH environment variables.
         rules:
             - sshd_do_not_permit_user_env
-        title: RHEL 8 must not allow users to override SSH environment variables.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020000
         levels:
             - medium
-        rules:
-            - account_temp_expire_date
         title: RHEL 8 temporary user accounts must be provisioned with an expiration time
             of 72 hours or less.
-        automated: 'yes'
+        rules:
+            - account_temp_expire_date
+        status: automated
     -   id: RHEL-08-020010
         levels:
             - medium
-        rules:
-            - accounts_passwords_pam_faillock_deny
         title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
             occur.
-        automated: 'yes'
+        rules:
+            - accounts_passwords_pam_faillock_deny
+        status: automated
     -   id: RHEL-08-020011
         levels:
             - medium
         title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
             occur.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020012
         levels:
             - medium
-        rules:
-            - accounts_passwords_pam_faillock_interval
         title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
             occur during a 15-minute time period.
-        automated: 'yes'
+        rules:
+            - accounts_passwords_pam_faillock_interval
+        status: automated
     -   id: RHEL-08-020013
         levels:
             - medium
         title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
             occur during a 15-minute time period.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020014
         levels:
             - medium
-        rules:
-            - accounts_passwords_pam_faillock_unlock_time
         title: RHEL 8 must automatically lock an account until the locked account is released
             by an administrator when three unsuccessful logon attempts occur during a 15-minute
             time period.
-        automated: 'yes'
+        rules:
+            - accounts_passwords_pam_faillock_unlock_time
+        status: automated
     -   id: RHEL-08-020015
         levels:
             - medium
         title: RHEL 8 must automatically lock an account until the locked account is released
             by an administrator when three unsuccessful logon attempts occur during a 15-minute
             time period.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020016
         levels:
             - medium
         title: RHEL 8 must ensure account lockouts persist.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020017
         levels:
             - medium
         title: RHEL 8 must ensure account lockouts persist.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020018
         levels:
             - medium
         title: RHEL 8 must prevent system messages from being presented when three unsuccessful
             logon attempts occur.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020019
         levels:
             - medium
         title: RHEL 8 must prevent system messages from being presented when three unsuccessful
             logon attempts occur.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020020
         levels:
             - medium
         title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020021
         levels:
             - medium
         title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020022
         levels:
             - medium
-        rules:
-            - accounts_passwords_pam_faillock_deny_root
         title: RHEL 8 must include root when automatically locking an account until the
             locked account is released by an administrator when three unsuccessful logon attempts
             occur during a 15-minute time period.
-        automated: 'yes'
+        rules:
+            - accounts_passwords_pam_faillock_deny_root
+        status: automated
     -   id: RHEL-08-020023
         levels:
             - medium
         title: RHEL 8 must include root when automatically locking an account until the
             locked account is released by an administrator when three unsuccessful logon attempts
             occur during a 15-minute time period.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020024
         levels:
             - low
-        rules:
-            - accounts_max_concurrent_login_sessions
         title: RHEL 8 must limit the number of concurrent sessions to ten for all accounts
             and/or account types.
-        automated: 'yes'
+        rules:
+            - accounts_max_concurrent_login_sessions
+        status: automated
     -   id: RHEL-08-020030
         levels:
             - medium
-        rules:
-            - dconf_gnome_screensaver_lock_enabled
         title: RHEL 8 must enable a user session lock until that user re-establishes access
             using established identification and authentication procedures for graphical user
             sessions.
-        automated: 'yes'
+        rules:
+            - dconf_gnome_screensaver_lock_enabled
+        status: automated
     -   id: RHEL-08-020040
         levels:
             - medium
-        rules:
-            - configure_tmux_lock_command
-            - package_tmux_installed
         title: RHEL 8 must enable a user session lock until that user re-establishes access
             using established identification and authentication procedures for command line
             sessions.
-        automated: 'yes'
+        rules:
+            - configure_tmux_lock_command
+        status: automated
     -   id: RHEL-08-020041
         levels:
             - medium
+        title: RHEL 8 must ensure session control is automatically started at shell initialization.
         rules:
             - configure_bashrc_exec_tmux
-        title: RHEL 8 must ensure session control is automatically started at shell initialization.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020042
         levels:
             - low
+        title: RHEL 8 must prevent users from disabling session control mechanisms.
         rules:
             - no_tmux_in_shells
-        title: RHEL 8 must prevent users from disabling session control mechanisms.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020050
         levels:
             - medium
-        rules:
-            - dconf_gnome_lock_screen_on_smartcard_removal
         title: RHEL 8 must be able to initiate directly a session lock for all connection
             types using smartcard when the smartcard is removed.
-        automated: 'yes'
+        rules:
+            - dconf_gnome_lock_screen_on_smartcard_removal
+        status: automated
     -   id: RHEL-08-020060
         levels:
             - medium
-        rules:
-            - dconf_gnome_screensaver_idle_delay
         title: RHEL 8 must automatically lock graphical user sessions after 15 minutes of
             inactivity.
-        automated: 'yes'
+        rules:
+            - dconf_gnome_screensaver_idle_delay
+        status: automated
     -   id: RHEL-08-020070
         levels:
             - medium
-        rules:
-            - configure_tmux_lock_after_time
         title: RHEL 8 must automatically lock command line user sessions after 15 minutes
             of inactivity.
-        automated: 'yes'
+        rules:
+            - configure_tmux_lock_after_time
+        status: automated
     -   id: RHEL-08-020080
         levels:
             - medium
         title: RHEL 8 must prevent a user from overriding the session lock-delay setting
             for the graphical user interface.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020090
         levels:
             - medium
-        rules:
-            - sssd_enable_certmap
         title: RHEL 8 must map the authenticated identity to the user or group account for
             PKI-based authentication.
-        automated: 'yes'
+        rules:
+            - sssd_enable_certmap
+        status: automated
     -   id: RHEL-08-020100
         levels:
             - medium
+        title: RHEL 8 must ensure a password complexity module is enabled.
         rules:
             - accounts_password_pam_retry
-        title: RHEL 8 must ensure a password complexity module is enabled.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020110
         levels:
             - medium
-        rules:
-            - accounts_password_pam_ucredit
         title: RHEL 8 must enforce password complexity by requiring that at least one uppercase
             character be used.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_ucredit
+        status: automated
     -   id: RHEL-08-020120
         levels:
             - medium
-        rules:
-            - accounts_password_pam_lcredit
         title: RHEL 8 must enforce password complexity by requiring that at least one lower-case
             character be used.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_lcredit
+        status: automated
     -   id: RHEL-08-020130
         levels:
             - medium
-        rules:
-            - accounts_password_pam_dcredit
         title: RHEL 8 must enforce password complexity by requiring that at least one numeric
             character be used.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_dcredit
+        status: automated
     -   id: RHEL-08-020140
         levels:
             - medium
-        rules:
-            - accounts_password_pam_maxclassrepeat
         title: RHEL 8 must require the maximum number of repeating characters of the same
             character class be limited to four when passwords are changed.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_maxclassrepeat
+        status: automated
     -   id: RHEL-08-020150
         levels:
             - medium
-        rules:
-            - accounts_password_pam_maxrepeat
         title: RHEL 8 must require the maximum number of repeating characters be limited
             to three when passwords are changed.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_maxrepeat
+        status: automated
     -   id: RHEL-08-020160
         levels:
             - medium
-        rules:
-            - accounts_password_pam_minclass
         title: RHEL 8 must require the change of at least four character classes when passwords
             are changed.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_minclass
+        status: automated
     -   id: RHEL-08-020170
         levels:
             - medium
-        rules:
-            - accounts_password_pam_difok
         title: RHEL 8 must require the change of at least 8 characters when passwords are
             changed.
-        automated: 'yes'
+        rules:
+            - accounts_password_pam_difok
+        status: automated
     -   id: RHEL-08-020180
         levels:
             - medium
-        rules:
-            - accounts_password_set_min_life_existing
         title: RHEL 8 passwords must have a 24 hours/1 day minimum password lifetime restriction
             in /etc/shadow.
-        automated: 'yes'
+        rules:
+            - accounts_password_set_min_life_existing
+        status: automated
     -   id: RHEL-08-020190
         levels:
             - medium
-        rules:
-            - accounts_minimum_age_login_defs
         title: RHEL 8 passwords for new users or password changes must have a 24 hours/1
             day minimum password lifetime restriction in /etc/logins.def.
-        automated: 'yes'
+        rules:
+            - accounts_minimum_age_login_defs
+        status: automated
     -   id: RHEL-08-020200
         levels:
             - medium
-        rules:
-            - accounts_maximum_age_login_defs
         title: RHEL 8 user account passwords must have a 60-day maximum password lifetime
             restriction.
-        automated: 'yes'
+        rules:
+            - accounts_maximum_age_login_defs
+        status: automated
     -   id: RHEL-08-020210
         levels:
             - medium
-        rules:
-            - accounts_password_set_max_life_existing
         title: RHEL 8 user account passwords must be configured so that existing passwords
             are restricted to a 60-day maximum lifetime.
-        automated: 'yes'
+        rules:
+            - accounts_password_set_max_life_existing
+        status: automated
     -   id: RHEL-08-020220
         levels:
             - medium
+        title: RHEL 8 passwords must be prohibited from reuse for a minimum of five generations.
         rules:
             - accounts_password_pam_pwhistory_remember_password_auth
             - accounts_password_pam_pwhistory_remember_system_auth
-            - accounts_password_pam_unix_remember
-        title: RHEL 8 passwords must be prohibited from reuse for a minimum of five generations.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020230
         levels:
             - medium
+        title: RHEL 8 passwords must have a minimum of 15 characters.
         rules:
             - accounts_password_pam_minlen
-        title: RHEL 8 passwords must have a minimum of 15 characters.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020231
         levels:
             - medium
+        title: RHEL 8 passwords for new users must have a minimum of 15 characters.
         rules:
             - accounts_password_minlen_login_defs
-        title: RHEL 8 passwords for new users must have a minimum of 15 characters.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020240
         levels:
             - medium
         title: RHEL 8 duplicate User IDs (UIDs) must not exist for interactive users.
-        automated: 'no'
-
+        rules:
+            - account_unique_id
+        status: automated
     -   id: RHEL-08-020250
         levels:
             - medium
-        rules:
-            - sssd_enable_smartcards
         title: RHEL 8 must implement smart card logon for multifactor authentication for
             access to interactive accounts.
-        automated: 'yes'
+        rules:
+            - sssd_enable_smartcards
+        status: automated
     -   id: RHEL-08-020260
         levels:
             - medium
-        rules:
-            - account_disable_post_pw_expiration
         title: RHEL 8 account identifiers (individuals, groups, roles, and devices) must
             be disabled after 35 days of inactivity.
-        automated: 'yes'
+        rules:
+            - account_disable_post_pw_expiration
+        status: automated
     -   id: RHEL-08-020270
         levels:
             - medium
-        rules:
-            - account_emergency_expire_date
         title: RHEL 8 emergency accounts must be automatically removed or disabled after
             the crisis is resolved or within 72 hours.
-        automated: 'yes'
+        rules:
+            - account_emergency_expire_date
+        status: automated
     -   id: RHEL-08-020280
         levels:
             - medium
+        title: All RHEL 8 passwords must contain at least one special character.
         rules:
             - accounts_password_pam_ocredit
-        title: All RHEL 8 passwords must contain at least one special character.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020290
         levels:
             - medium
+        title: RHEL 8 must prohibit the use of cached authentications after one day.
         rules:
             - sssd_offline_cred_expiration
-        title: RHEL 8 must prohibit the use of cached authentications after one day.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020300
         levels:
             - medium
+        title: RHEL 8 must prevent the use of dictionary words for passwords.
         rules:
             - accounts_password_pam_dictcheck
-        title: RHEL 8 must prevent the use of dictionary words for passwords.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020310
         levels:
             - medium
-        rules:
-            - accounts_logon_fail_delay
         title: RHEL 8 must enforce a delay of at least four seconds between logon prompts
             following a failed logon attempt.
-        automated: 'yes'
+        rules:
+            - accounts_logon_fail_delay
+        status: automated
     -   id: RHEL-08-020320
         levels:
             - medium
+        title: RHEL 8 must not have unnecessary accounts.
         rules:
             - accounts_authorized_local_users
-        title: RHEL 8 must not have unnecessary accounts.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020330
         levels:
             - high
+        title: RHEL 8 must not allow accounts configured with blank or null passwords.
         rules:
             - sshd_disable_empty_passwords
-            - no_empty_passwords
-        title: RHEL 8 must not allow accounts configured with blank or null passwords.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020340
         levels:
             - low
-        rules:
-            - display_login_attempts
         title: RHEL 8 must display the date and time of the last successful account logon
             upon logon.
-        automated: 'yes'
+        rules:
+            - display_login_attempts
+        status: automated
     -   id: RHEL-08-020350
         levels:
             - medium
-        rules:
-            - sshd_print_last_log
         title: RHEL 8 must display the date and time of the last successful account logon
             upon an SSH logon.
-        automated: 'yes'
+        rules:
+            - sshd_print_last_log
+        status: automated
     -   id: RHEL-08-020351
         levels:
             - medium
-        rules:
-            - accounts_umask_etc_login_defs
         title: RHEL 8 must define default permissions for all authenticated users in such
             a way that the user can only read and modify their own files.
-        automated: 'yes'
+        rules:
+            - accounts_umask_etc_login_defs
+        status: automated
     -   id: RHEL-08-020352
         levels:
             - medium
+        title: RHEL 8 must set the umask value to 077 for all local interactive user accounts.
         rules:
             - accounts_umask_interactive_users
-        title: RHEL 8 must set the umask value to 077 for all local interactive user accounts.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-020353
         levels:
             - medium
+        title: RHEL 8 must define default permissions for logon and non-logon shells.
         rules:
             - accounts_umask_etc_bashrc
-        title: RHEL 8 must define default permissions for logon and non-logon shells.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030000
         levels:
             - medium
-        rules:
-            - audit_rules_suid_privilege_function
         title: The RHEL 8 audit system must be configured to audit the execution of privileged
             functions and prevent all software from executing at higher privilege levels than
             users executing the software.
-        automated: 'yes'
+        rules:
+            - audit_rules_suid_privilege_function
+        status: automated
     -   id: RHEL-08-030010
         levels:
             - medium
+        title: Cron logging must be implemented in RHEL 8.
         rules:
             - rsyslog_cron_logging
-        title: Cron logging must be implemented in RHEL 8.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030020
         levels:
             - medium
-        rules:
-            - auditd_data_retention_action_mail_acct
         title: The RHEL 8 System Administrator (SA) and Information System Security Officer
             (ISSO) (at a minimum) must be alerted of an audit processing failure event.
-        automated: 'yes'
+        rules:
+            - auditd_data_retention_action_mail_acct
+        status: automated
     -   id: RHEL-08-030030
         levels:
             - medium
-        rules:
-            - postfix_client_configure_mail_alias
         title: The RHEL 8 Information System Security Officer (ISSO) and System Administrator
             (SA) (at a minimum) must have mail aliases to be notified of an audit processing
             failure.
-        automated: 'yes'
+        rules:
+            - postfix_client_configure_mail_alias
+        status: automated
     -   id: RHEL-08-030040
         levels:
             - medium
-        rules:
-            - auditd_data_disk_error_action
         title: The RHEL 8 System must take appropriate action when an audit processing failure
             occurs.
-        automated: 'yes'
+        rules:
+            - auditd_data_disk_error_action
+        status: automated
     -   id: RHEL-08-030050
         levels:
             - medium
-        rules:
-            - auditd_data_retention_max_log_file_action
         title: The RHEL 8 System Administrator (SA) and Information System Security Officer
             (ISSO) (at a minimum) must be alerted when the audit storage volume is full.
-        automated: 'yes'
+        rules:
+            - auditd_data_retention_max_log_file_action
+        status: automated
     -   id: RHEL-08-030060
         levels:
             - medium
-        rules:
-            - auditd_data_disk_full_action
         title: The RHEL 8 audit system must take appropriate action when the audit storage
             volume is full.
-        automated: 'yes'
+        rules:
+            - auditd_data_disk_full_action
+        status: automated
     -   id: RHEL-08-030061
         levels:
             - medium
+        title: The RHEL 8 audit system must audit local events.
         rules:
             - auditd_local_events
-        title: The RHEL 8 audit system must audit local events.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030062
         levels:
             - medium
-        rules:
-            - auditd_name_format
         title: RHEL 8 must label all off-loaded audit logs before sending them to the central
             log server.
-        automated: 'yes'
+        rules:
+            - auditd_name_format
+        status: automated
     -   id: RHEL-08-030063
         levels:
             - low
+        title: RHEL 8 must resolve audit information before writing to disk.
         rules:
             - auditd_log_format
-        title: RHEL 8 must resolve audit information before writing to disk.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030070
         levels:
             - medium
-        rules:
-            - file_permissions_var_log_audit
         title: RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent
             unauthorized read access.
-        automated: 'yes'
+        rules:
+            - file_permissions_var_log_audit
+        status: automated
     -   id: RHEL-08-030080
         levels:
             - medium
-        rules:
-            - file_ownership_var_log_audit
-            - file_ownership_var_log_audit_stig
         title: RHEL 8 audit logs must be owned by root to prevent unauthorized read access.
-        automated: 'yes'
+        rules:
+            - file_ownership_var_log_audit_stig
+        status: automated
     -   id: RHEL-08-030090
         levels:
             - medium
-        rules:
-            - file_group_ownership_var_log_audit
         title: RHEL 8 audit logs must be group-owned by root to prevent unauthorized read
             access.
-        automated: 'yes'
+        rules:
+            - file_group_ownership_var_log_audit
+        status: automated
     -   id: RHEL-08-030100
         levels:
             - medium
-        rules:
-            - directory_ownership_var_log_audit
         title: RHEL 8 audit log directory must be owned by root to prevent unauthorized
             read access.
-        automated: 'yes'
+        rules:
+            - directory_ownership_var_log_audit
+        status: automated
     -   id: RHEL-08-030110
         levels:
             - medium
-        rules:
-            - directory_group_ownership_var_log_audit
         title: RHEL 8 audit log directory must be group-owned by root to prevent unauthorized
             read access.
-        automated: 'yes'
+        rules:
+            - directory_group_ownership_var_log_audit
+        status: automated
     -   id: RHEL-08-030120
         levels:
             - medium
-        rules:
-            - directory_permissions_var_log_audit
         title: RHEL 8 audit log directory must have a mode of 0700 or less permissive to
             prevent unauthorized read access.
-        automated: 'yes'
+        rules:
+            - directory_permissions_var_log_audit
+        status: automated
     -   id: RHEL-08-030121
         levels:
             - medium
+        title: RHEL 8 audit system must protect auditing rules from unauthorized change.
         rules:
             - audit_rules_immutable
-        title: RHEL 8 audit system must protect auditing rules from unauthorized change.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030122
         levels:
             - medium
+        title: RHEL 8 audit system must protect logon UIDs from unauthorized change.
         rules:
             - audit_immutable_login_uids
-        title: RHEL 8 audit system must protect logon UIDs from unauthorized change.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030130
         levels:
             - medium
-        rules:
-            - audit_rules_usergroup_modification_shadow
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/shadow.
-        automated: 'yes'
+        rules:
+            - audit_rules_usergroup_modification_shadow
+        status: automated
     -   id: RHEL-08-030140
         levels:
             - medium
-        rules:
-            - audit_rules_usergroup_modification_opasswd
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/security/opasswd.
-        automated: 'yes'
+        rules:
+            - audit_rules_usergroup_modification_opasswd
+        status: automated
     -   id: RHEL-08-030150
         levels:
             - medium
-        rules:
-            - audit_rules_usergroup_modification_passwd
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/passwd.
-        automated: 'yes'
+        rules:
+            - audit_rules_usergroup_modification_passwd
+        status: automated
     -   id: RHEL-08-030160
         levels:
             - medium
-        rules:
-            - audit_rules_usergroup_modification_gshadow
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/gshadow.
-        automated: 'yes'
+        rules:
+            - audit_rules_usergroup_modification_gshadow
+        status: automated
     -   id: RHEL-08-030170
         levels:
             - medium
-        rules:
-            - audit_rules_usergroup_modification_group
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/group.
-        automated: 'yes'
+        rules:
+            - audit_rules_usergroup_modification_group
+        status: automated
     -   id: RHEL-08-030171
         levels:
             - medium
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/sudoers.
-        automated: 'no'
-
+        rules:
+            - audit_rules_sudoers
+        status: automated
     -   id: RHEL-08-030172
         levels:
             - medium
-        rules:
-            - audit_rules_sysadmin_actions
         title: RHEL 8 must generate audit records for all account creations, modifications,
             disabling, and termination events that affect /etc/sudoers.d/.
-        automated: 'yes'
+        rules:
+            - audit_rules_sudoers_d
+        status: automated
     -   id: RHEL-08-030180
         levels:
             - medium
+        title: The RHEL 8 audit package must be installed.
         rules:
             - package_audit_installed
-        title: The RHEL 8 audit package must be installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030190
         levels:
             - medium
         title: Successful/unsuccessful uses of the su command in RHEL 8 must generate an
             audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_su
+        status: automated
     -   id: RHEL-08-030200
         levels:
             - medium
         title: The RHEL 8 audit system must be configured to audit any usage of the lremovexattr
             system call.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_lremovexattr
+        status: automated
     -   id: RHEL-08-030210
         levels:
             - medium
         title: The RHEL 8 audit system must be configured to audit any usage of the removexattr
             system call.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_removexattr
+        status: automated
     -   id: RHEL-08-030220
         levels:
             - medium
         title: The RHEL 8 audit system must be configured to audit any usage of the lsetxattr
             system call.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_lsetxattr
+        status: automated
     -   id: RHEL-08-030230
         levels:
             - medium
         title: The RHEL 8 audit system must be configured to audit any usage of the fsetxattr
             system call.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_fsetxattr
+        status: automated
     -   id: RHEL-08-030240
         levels:
             - medium
         title: The RHEL 8 audit system must be configured to audit any usage of the fremovexattr
             system call.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_fremovexattr
+        status: automated
     -   id: RHEL-08-030250
         levels:
             - medium
         title: Successful/unsuccessful uses of the chage command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_chage
+        status: automated
     -   id: RHEL-08-030260
         levels:
             - medium
         title: Successful/unsuccessful uses of the chcon command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_execution_chcon
+        status: automated
     -   id: RHEL-08-030270
         levels:
             - medium
         title: The RHEL 8 audit system must be configured to audit any usage of the setxattr
             system call.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_setxattr
+        status: automated
     -   id: RHEL-08-030280
         levels:
             - medium
         title: Successful/unsuccessful uses of the ssh-agent in RHEL 8 must generate an
             audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_ssh_agent
+        status: automated
     -   id: RHEL-08-030290
         levels:
             - medium
         title: Successful/unsuccessful uses of the passwd command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_passwd
+        status: automated
     -   id: RHEL-08-030300
         levels:
             - medium
         title: Successful/unsuccessful uses of the mount command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_mount
+        status: automated
     -   id: RHEL-08-030301
         levels:
             - medium
         title: Successful/unsuccessful uses of the umount command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_umount
+        status: automated
     -   id: RHEL-08-030302
         levels:
             - medium
         title: Successful/unsuccessful uses of the mount syscall in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_media_export
+        status: automated
     -   id: RHEL-08-030310
         levels:
             - medium
         title: Successful/unsuccessful uses of the unix_update in RHEL 8 must generate an
             audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_unix_update
+        status: automated
     -   id: RHEL-08-030311
         levels:
             - medium
         title: Successful/unsuccessful uses of postdrop in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_postdrop
+        status: automated
     -   id: RHEL-08-030312
         levels:
             - medium
         title: Successful/unsuccessful uses of postqueue in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_postqueue
+        status: automated
     -   id: RHEL-08-030313
         levels:
             - medium
         title: Successful/unsuccessful uses of semanage in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_execution_semanage
+        status: automated
     -   id: RHEL-08-030314
         levels:
             - medium
         title: Successful/unsuccessful uses of setfiles in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_execution_setfiles
+        status: automated
     -   id: RHEL-08-030315
         levels:
             - medium
         title: Successful/unsuccessful uses of userhelper in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_userhelper
+        status: automated
     -   id: RHEL-08-030316
         levels:
             - medium
         title: Successful/unsuccessful uses of setsebool in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_execution_setsebool
+        status: automated
     -   id: RHEL-08-030317
         levels:
             - medium
         title: Successful/unsuccessful uses of unix_chkpwd in RHEL 8 must generate an audit
             record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_unix_chkpwd
+        status: automated
     -   id: RHEL-08-030320
         levels:
             - medium
         title: Successful/unsuccessful uses of the ssh-keysign in RHEL 8 must generate an
             audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_ssh_keysign
+        status: automated
     -   id: RHEL-08-030330
         levels:
             - medium
         title: Successful/unsuccessful uses of the setfacl command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_execution_setfacl
+        status: automated
     -   id: RHEL-08-030340
         levels:
             - medium
         title: Successful/unsuccessful uses of the pam_timestamp_check command in RHEL 8
             must generate an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_pam_timestamp_check
+        status: automated
     -   id: RHEL-08-030350
         levels:
             - medium
         title: Successful/unsuccessful uses of the newgrp command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_newgrp
+        status: automated
     -   id: RHEL-08-030360
         levels:
             - medium
         title: Successful/unsuccessful uses of the init_module command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_kernel_module_loading_init
+        status: automated
     -   id: RHEL-08-030361
         levels:
             - medium
         title: Successful/unsuccessful uses of the rename command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_file_deletion_events_rename
+        status: automated
     -   id: RHEL-08-030362
         levels:
             - medium
         title: Successful/unsuccessful uses of the renameat command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_file_deletion_events_renameat
+        status: automated
     -   id: RHEL-08-030363
         levels:
             - medium
         title: Successful/unsuccessful uses of the rmdir command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_file_deletion_events_rmdir
+        status: automated
     -   id: RHEL-08-030364
         levels:
             - medium
         title: Successful/unsuccessful uses of the unlink command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_file_deletion_events_unlink
+        status: automated
     -   id: RHEL-08-030365
         levels:
             - medium
         title: Successful/unsuccessful uses of the unlinkat command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_file_deletion_events_unlinkat
+        status: automated
     -   id: RHEL-08-030370
         levels:
             - medium
         title: Successful/unsuccessful uses of the gpasswd command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_gpasswd
+        status: automated
     -   id: RHEL-08-030380
         levels:
             - medium
         title: Successful/unsuccessful uses of the finit_module command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_kernel_module_loading_finit
+        status: automated
     -   id: RHEL-08-030390
         levels:
             - medium
         title: Successful/unsuccessful uses of the delete_module command in RHEL 8 must
             generate an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_kernel_module_loading_delete
+        status: automated
     -   id: RHEL-08-030400
         levels:
             - medium
         title: Successful/unsuccessful uses of the crontab command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_crontab
+        status: automated
     -   id: RHEL-08-030410
         levels:
             - medium
         title: Successful/unsuccessful uses of the chsh command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_chsh
+        status: automated
     -   id: RHEL-08-030420
         levels:
             - medium
         title: Successful/unsuccessful uses of the truncate command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_unsuccessful_file_modification_truncate
+        status: automated
     -   id: RHEL-08-030430
         levels:
             - medium
         title: Successful/unsuccessful uses of the openat system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_unsuccessful_file_modification_openat
+        status: automated
     -   id: RHEL-08-030440
         levels:
             - medium
         title: Successful/unsuccessful uses of the open system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_unsuccessful_file_modification_open
+        status: automated
     -   id: RHEL-08-030450
         levels:
             - medium
         title: Successful/unsuccessful uses of the open_by_handle_at system call in RHEL
             8 must generate an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_unsuccessful_file_modification_open_by_handle_at
+        status: automated
     -   id: RHEL-08-030460
         levels:
             - medium
         title: Successful/unsuccessful uses of the ftruncate command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_unsuccessful_file_modification_ftruncate
+        status: automated
     -   id: RHEL-08-030470
         levels:
             - medium
         title: Successful/unsuccessful uses of the creat system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_unsuccessful_file_modification_creat
+        status: automated
     -   id: RHEL-08-030480
         levels:
             - medium
         title: Successful/unsuccessful uses of the chown command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_chown
+        status: automated
     -   id: RHEL-08-030490
         levels:
             - medium
         title: Successful/unsuccessful uses of the chmod command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_chmod
+        status: automated
     -   id: RHEL-08-030500
         levels:
             - medium
         title: Successful/unsuccessful uses of the lchown system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_lchown
+        status: automated
     -   id: RHEL-08-030510
         levels:
             - medium
         title: Successful/unsuccessful uses of the fchownat system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_fchownat
+        status: automated
     -   id: RHEL-08-030520
         levels:
             - medium
         title: Successful/unsuccessful uses of the fchown system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_fchown
+        status: automated
     -   id: RHEL-08-030530
         levels:
             - medium
         title: Successful/unsuccessful uses of the fchmodat system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_fchmodat
+        status: automated
     -   id: RHEL-08-030540
         levels:
             - medium
         title: Successful/unsuccessful uses of the fchmod system call in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_dac_modification_fchmod
+        status: automated
     -   id: RHEL-08-030550
         levels:
             - medium
         title: Successful/unsuccessful uses of the sudo command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_sudo
+        status: automated
     -   id: RHEL-08-030560
         levels:
             - medium
         title: Successful/unsuccessful uses of the usermod command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_usermod
+        status: automated
     -   id: RHEL-08-030570
         levels:
             - medium
         title: Successful/unsuccessful uses of the chacl command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_execution_chacl
+        status: automated
     -   id: RHEL-08-030580
         levels:
             - medium
         title: Successful/unsuccessful uses of the kmod command in RHEL 8 must generate
             an audit record.
-        automated: 'no'
-
+        rules:
+            - audit_rules_privileged_commands_kmod
+        status: automated
     -   id: RHEL-08-030590
         levels:
             - medium
         title: Successful/unsuccessful modifications to the faillock log file in RHEL 8
             must generate an audit record.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-030600
         levels:
             - medium
-        rules:
-            - audit_rules_login_events_lastlog
         title: Successful/unsuccessful modifications to the lastlog file in RHEL 8 must
             generate an audit record.
-        automated: 'yes'
+        rules:
+            - audit_rules_login_events_lastlog
+        status: automated
     -   id: RHEL-08-030601
         levels:
             - low
+        title: RHEL 8 must enable auditing of processes that start prior to the audit daemon.
         rules:
             - grub2_audit_argument
-        title: RHEL 8 must enable auditing of processes that start prior to the audit daemon.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030602
         levels:
             - low
-        rules:
-            - grub2_audit_backlog_limit_argument
         title: RHEL 8 must allocate an audit_backlog_limit of sufficient size to capture
             processes that start prior to the audit daemon.
-        automated: 'yes'
+        rules:
+            - grub2_audit_backlog_limit_argument
+        status: automated
     -   id: RHEL-08-030603
         levels:
             - low
+        title: RHEL 8 must enable Linux audit logging for the USBGuard daemon.
         rules:
             - configure_usbguard_auditbackend
-        title: RHEL 8 must enable Linux audit logging for the USBGuard daemon.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030610
         levels:
             - medium
-        rules:
-            - file_permissions_etc_audit_auditd
-            - file_permissions_etc_audit_rulesd
         title: RHEL 8 must allow only the Information System Security Manager (ISSM) (or
             individuals or roles appointed by the ISSM) to select which auditable events are
             to be audited.
-        automated: 'yes'
+        rules:
+            - file_permissions_etc_audit_auditd
+            - file_permissions_etc_audit_rulesd
+        status: automated
     -   id: RHEL-08-030620
         levels:
             - medium
         title: RHEL 8 audit tools must have a mode of 0755 or less permissive.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-030630
         levels:
             - medium
         title: RHEL 8 audit tools must be owned by root.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-030640
         levels:
             - medium
         title: RHEL 8 audit tools must be group-owned by root.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-030650
         levels:
             - medium
         title: RHEL 8 must use cryptographic mechanisms to protect the integrity of audit
             tools.
-        automated: 'no'
-
+        rules:
+            - aide_check_audit_tools
+        status: automated
     -   id: RHEL-08-030660
         levels:
             - medium
-        rules:
-            - auditd_audispd_configure_sufficiently_large_partition
         title: RHEL 8 must allocate audit record storage capacity to store at least one
             week of audit records, when audit records are not immediately sent to a central
             audit record storage facility.
-        automated: 'yes'
+        rules:
+            - auditd_audispd_configure_sufficiently_large_partition
+        status: automated
     -   id: RHEL-08-030670
         levels:
             - medium
+        title: RHEL 8 must have the packages required for offloading audit logs installed.
         rules:
             - package_rsyslog_installed
-        title: RHEL 8 must have the packages required for offloading audit logs installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030680
         levels:
             - medium
-        rules:
-            - package_rsyslog-gnutls_installed
         title: RHEL 8 must have the packages required for encrypting offloaded audit logs
             installed.
-        automated: 'yes'
+        rules:
+            - package_rsyslog-gnutls_installed
+        status: automated
     -   id: RHEL-08-030690
         levels:
             - medium
-        rules:
-            - rsyslog_remote_loghost
         title: The RHEL 8 audit records must be off-loaded onto a different system or storage
             media from the system being audited.
-        automated: 'yes'
+        rules:
+            - rsyslog_remote_loghost
+        status: automated
     -   id: RHEL-08-030700
         levels:
             - medium
+        title: RHEL 8 must take appropriate action when the internal event queue is full.
         rules:
             - auditd_overflow_action
-        title: RHEL 8 must take appropriate action when the internal event queue is full.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030710
         levels:
             - medium
+        title: RHEL 8 must encrypt the transfer of audit records off-loaded onto a different
+            system or media from the system being audited.
         rules:
             - rsyslog_encrypt_offload_actionsendstreamdrivermode
             - rsyslog_encrypt_offload_defaultnetstreamdriver
-        title: RHEL 8 must encrypt the transfer of audit records off-loaded onto a different
-            system or media from the system being audited.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030720
         levels:
             - medium
         title: RHEL 8 must authenticate the remote logging server for off-loading audit
             logs.
-        automated: 'no'
-
+        rules:
+            - rsyslog_encrypt_offload_actionsendstreamdriverauthmode
+        status: automated
     -   id: RHEL-08-030730
         levels:
             - medium
-        rules:
-            - auditd_data_retention_space_left
-            - auditd_data_retention_space_left_action
         title: RHEL 8 must take action when allocated audit record storage volume reaches
             75 percent of the repository maximum audit record storage capacity.
-        automated: 'yes'
+        rules:
+            - auditd_data_retention_space_left_percentage
+        status: automated
     -   id: RHEL-08-030740
         levels:
             - medium
-        rules:
-            - chronyd_or_ntpd_set_maxpoll
         title: RHEL 8 must securely compare internal information system clocks at least
             every 24 hours with a server synchronized to an authoritative time source, such
             as the United States Naval Observatory (USNO) time servers, or a time server designated
             for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning
             System (GPS).
-        automated: 'yes'
+        rules:
+            - chronyd_or_ntpd_set_maxpoll
+        status: automated
     -   id: RHEL-08-030741
         levels:
             - low
+        title: RHEL 8 must disable the chrony daemon from acting as a server.
         rules:
             - chronyd_client_only
-        title: RHEL 8 must disable the chrony daemon from acting as a server.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-030742
         levels:
             - low
+        title: RHEL 8 must disable network management of the chrony daemon.
         rules:
             - chronyd_no_chronyc_network
-        title: RHEL 8 must disable network management of the chrony daemon.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040000
         levels:
             - high
+        title: RHEL 8 must not have the telnet-server package installed.
         rules:
             - package_telnet-server_removed
-        title: RHEL 8 must not have the telnet-server package installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040001
         levels:
             - medium
+        title: RHEL 8 must not have any automated bug reporting tools installed.
         rules:
             - package_abrt_removed
             - package_abrt-addon-ccpp_removed
@@ -2037,802 +2060,799 @@ controls:
             - package_abrt-plugin-logger_removed
             - package_abrt-plugin-rhtsupport_removed
             - package_abrt-plugin-sosreport_removed
-        title: RHEL 8 must not have any automated bug reporting tools installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040002
         levels:
             - medium
+        title: RHEL 8 must not have the sendmail package installed.
         rules:
             - package_sendmail_removed
-        title: RHEL 8 must not have the sendmail package installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040004
         levels:
             - low
+        title: RHEL 8 must enable mitigations against processor-based vulnerabilities.
         rules:
             - grub2_pti_argument
-        title: RHEL 8 must enable mitigations against processor-based vulnerabilities.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040010
         levels:
             - high
+        title: RHEL 8 must not have the rsh-server package installed.
         rules:
             - package_rsh-server_removed
-        title: RHEL 8 must not have the rsh-server package installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040020
         levels:
             - medium
         title: RHEL 8 must cover or disable the built-in or attached camera when not in
             use.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-040021
         levels:
             - low
+        title: RHEL 8 must disable the asynchronous transfer mode (ATM) protocol.
         rules:
             - kernel_module_atm_disabled
-        title: RHEL 8 must disable the asynchronous transfer mode (ATM) protocol.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040022
         levels:
             - low
+        title: RHEL 8 must disable the controller area network (CAN) protocol.
         rules:
             - kernel_module_can_disabled
-        title: RHEL 8 must disable the controller area network (CAN) protocol.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040023
         levels:
             - low
+        title: RHEL 8 must disable the stream control transmission protocol (SCTP).
         rules:
             - kernel_module_sctp_disabled
-        title: RHEL 8 must disable the stream control transmission protocol (SCTP).
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040024
         levels:
             - low
+        title: RHEL 8 must disable the transparent inter-process communication (TIPC) protocol.
         rules:
             - kernel_module_tipc_disabled
-        title: RHEL 8 must disable the transparent inter-process communication (TIPC) protocol.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040025
         levels:
             - low
+        title: RHEL 8 must disable mounting of cramfs.
         rules:
             - kernel_module_cramfs_disabled
-        title: RHEL 8 must disable mounting of cramfs.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040026
         levels:
             - low
+        title: RHEL 8 must disable IEEE 1394 (FireWire) Support.
         rules:
             - kernel_module_firewire-core_disabled
-        title: RHEL 8 must disable IEEE 1394 (FireWire) Support.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040030
         levels:
             - medium
-        rules:
-            - configure_firewalld_ports
         title: RHEL 8 must be configured to prohibit or restrict the use of functions, ports,
             protocols, and/or services, as defined in the Ports, Protocols, and Services Management
             (PPSM) Category Assignments List (CAL) and vulnerability assessments.
-        automated: 'yes'
+        rules:
+            - configure_firewalld_ports
+        status: automated
     -   id: RHEL-08-040070
         levels:
             - medium
+        title: The RHEL 8 file system automounter must be disabled unless required.
         rules:
             - service_autofs_disabled
-        title: The RHEL 8 file system automounter must be disabled unless required.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040080
         levels:
             - medium
+        title: RHEL 8 must be configured to disable USB mass storage.
         rules:
             - kernel_module_usb-storage_disabled
-        title: RHEL 8 must be configured to disable USB mass storage.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040090
         levels:
             - medium
         title: A RHEL 8 firewall must employ a deny-all, allow-by-exception policy for allowing
             connections to other systems.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-040100
         levels:
             - medium
+        title: A firewall must be installed on RHEL 8.
         rules:
             - package_firewalld_installed
-            - service_firewalld_enabled
-        title: A firewall must be installed on RHEL 8.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040110
         levels:
             - medium
+        title: RHEL 8 wireless network adapters must be disabled.
         rules:
             - wireless_disable_interfaces
-        title: RHEL 8 wireless network adapters must be disabled.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040111
         levels:
             - medium
+        title: RHEL 8 Bluetooth must be disabled.
         rules:
             - kernel_module_bluetooth_disabled
-        title: RHEL 8 Bluetooth must be disabled.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040120
         levels:
             - medium
+        title: RHEL 8 must mount /dev/shm with the nodev option.
         rules:
             - mount_option_dev_shm_nodev
-        title: RHEL 8 must mount /dev/shm with the nodev option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040121
         levels:
             - medium
+        title: RHEL 8 must mount /dev/shm with the nosuid option.
         rules:
             - mount_option_dev_shm_nosuid
-        title: RHEL 8 must mount /dev/shm with the nosuid option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040122
         levels:
             - medium
+        title: RHEL 8 must mount /dev/shm with the noexec option.
         rules:
             - mount_option_dev_shm_noexec
-        title: RHEL 8 must mount /dev/shm with the noexec option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040123
         levels:
             - medium
+        title: RHEL 8 must mount /tmp with the nodev option.
         rules:
             - mount_option_tmp_nodev
-        title: RHEL 8 must mount /tmp with the nodev option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040124
         levels:
             - medium
+        title: RHEL 8 must mount /tmp with the nosuid option.
         rules:
             - mount_option_tmp_nosuid
-        title: RHEL 8 must mount /tmp with the nosuid option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040125
         levels:
             - medium
+        title: RHEL 8 must mount /tmp with the noexec option.
         rules:
             - mount_option_tmp_noexec
-        title: RHEL 8 must mount /tmp with the noexec option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040126
         levels:
             - medium
+        title: RHEL 8 must mount /var/log with the nodev option.
         rules:
             - mount_option_var_log_nodev
-        title: RHEL 8 must mount /var/log with the nodev option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040127
         levels:
             - medium
+        title: RHEL 8 must mount /var/log with the nosuid option.
         rules:
             - mount_option_var_log_nosuid
-        title: RHEL 8 must mount /var/log with the nosuid option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040128
         levels:
             - medium
+        title: RHEL 8 must mount /var/log with the noexec option.
         rules:
             - mount_option_var_log_noexec
-        title: RHEL 8 must mount /var/log with the noexec option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040129
         levels:
             - medium
+        title: RHEL 8 must mount /var/log/audit with the nodev option.
         rules:
             - mount_option_var_log_audit_nodev
-        title: RHEL 8 must mount /var/log/audit with the nodev option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040130
         levels:
             - medium
+        title: RHEL 8 must mount /var/log/audit with the nosuid option.
         rules:
             - mount_option_var_log_audit_nosuid
-        title: RHEL 8 must mount /var/log/audit with the nosuid option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040131
         levels:
             - medium
+        title: RHEL 8 must mount /var/log/audit with the noexec option.
         rules:
             - mount_option_var_log_audit_noexec
-        title: RHEL 8 must mount /var/log/audit with the noexec option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040132
         levels:
             - medium
+        title: RHEL 8 must mount /var/tmp with the nodev option.
         rules:
             - mount_option_var_tmp_nodev
-        title: RHEL 8 must mount /var/tmp with the nodev option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040133
         levels:
             - medium
+        title: RHEL 8 must mount /var/tmp with the nosuid option.
         rules:
             - mount_option_var_tmp_nosuid
-        title: RHEL 8 must mount /var/tmp with the nosuid option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040134
         levels:
             - medium
+        title: RHEL 8 must mount /var/tmp with the noexec option.
         rules:
             - mount_option_var_tmp_noexec
-        title: RHEL 8 must mount /var/tmp with the noexec option.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040135
         levels:
             - medium
+        title: The RHEL 8 fapolicy module must be installed.
         rules:
             - package_fapolicyd_installed
-            - service_fapolicyd_enabled
-        title: The RHEL 8 fapolicy module must be installed.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040140
         levels:
             - medium
-        rules:
-            - package_usbguard_installed
-            - service_usbguard_enabled
-            - usbguard_generate_policy
         title: RHEL 8 must block unauthorized peripherals before establishing a connection.
-        automated: 'yes'
+        rules:
+            - usbguard_generate_policy
+        status: automated
     -   id: RHEL-08-040150
         levels:
             - medium
         title: A firewall must be able to protect against or limit the effects of Denial
             of Service (DoS) attacks by ensuring RHEL 8 can implement rate-limiting measures
             on impacted network interfaces.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-040160
         levels:
             - medium
-        rules:
-            - package_openssh-server_installed
-            - service_sshd_enabled
         title: All RHEL 8 networked systems must have and implement SSH to protect the confidentiality
             and integrity of transmitted and received information, as well as information
             during preparation for transmission.
-        automated: 'yes'
+        rules:
+            - service_sshd_enabled
+        status: automated
     -   id: RHEL-08-040161
         levels:
             - medium
-        rules:
-            - sshd_rekey_limit
         title: RHEL 8 must force a frequent session key renegotiation for SSH connections
             to the server.
-        automated: 'yes'
+        rules:
+            - sshd_rekey_limit
+        status: automated
     -   id: RHEL-08-040170
         levels:
             - high
+        title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 8.
         rules:
             - disable_ctrlaltdel_reboot
-        title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 8.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040171
         levels:
             - high
-        rules:
-            - dconf_gnome_disable_ctrlaltdel_reboot
         title: The x86 Ctrl-Alt-Delete key sequence in RHEL 8 must be disabled if a graphical
             user interface is installed.
-        automated: 'yes'
+        rules:
+            - dconf_gnome_disable_ctrlaltdel_reboot
+        status: automated
     -   id: RHEL-08-040172
         levels:
             - high
+        title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 8 must be disabled.
         rules:
             - disable_ctrlaltdel_burstaction
-        title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 8 must be disabled.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040180
         levels:
             - medium
+        title: The debug-shell systemd service must be disabled on RHEL 8.
         rules:
             - service_debug-shell_disabled
-        title: The debug-shell systemd service must be disabled on RHEL 8.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040190
         levels:
             - high
-        rules:
-            - package_tftp-server_removed
         title: The Trivial File Transfer Protocol (TFTP) server package must not be installed
             if not required for RHEL 8 operational support.
-        automated: 'yes'
+        rules:
+            - package_tftp-server_removed
+        status: automated
     -   id: RHEL-08-040200
         levels:
             - high
-        rules:
-            - accounts_no_uid_except_zero
         title: The root account must be the only account having unrestricted access to the
             RHEL 8 system.
-        automated: 'yes'
+        rules:
+            - accounts_no_uid_except_zero
+        status: automated
     -   id: RHEL-08-040210
         levels:
             - medium
-        rules:
-            - sysctl_net_ipv6_conf_default_accept_redirects
-            - sysctl_net_ipv4_conf_default_accept_redirects
         title: RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect
             messages from being accepted.
-        automated: 'yes'
+        rules:
+            - sysctl_net_ipv6_conf_default_accept_redirects
+        status: automated
     -   id: RHEL-08-040220
         levels:
             - medium
+        title: RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects.
         rules:
             - sysctl_net_ipv4_conf_all_send_redirects
-        title: RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040230
         levels:
             - medium
-        rules:
-            - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
         title: RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes
             sent to a broadcast address.
-        automated: 'yes'
+        rules:
+            - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+        status: automated
     -   id: RHEL-08-040240
         levels:
             - medium
+        title: RHEL 8 must not forward IPv6 source-routed packets.
         rules:
             - sysctl_net_ipv6_conf_all_accept_source_route
-            - sysctl_net_ipv4_conf_all_accept_source_route
-        title: RHEL 8 must not forward IPv6 source-routed packets.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040250
         levels:
             - medium
+        title: RHEL 8 must not forward IPv6 source-routed packets by default.
         rules:
             - sysctl_net_ipv6_conf_default_accept_source_route
-            - sysctl_net_ipv4_conf_default_accept_source_route
-        title: RHEL 8 must not forward IPv6 source-routed packets by default.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040260
         levels:
             - medium
+        title: RHEL 8 must not be performing packet forwarding unless the system is a router.
         rules:
             - sysctl_net_ipv4_ip_forward
-        title: RHEL 8 must not be performing packet forwarding unless the system is a router.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040261
         levels:
             - medium
+        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces.
         rules:
             - sysctl_net_ipv6_conf_all_accept_ra
-        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040262
         levels:
             - medium
+        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces by default.
         rules:
             - sysctl_net_ipv6_conf_default_accept_ra
-        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces by default.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040270
         levels:
             - medium
-        rules:
-            - sysctl_net_ipv4_conf_default_send_redirects
         title: RHEL 8 must not allow interfaces to perform Internet Control Message Protocol
             (ICMP) redirects by default.
-        automated: 'yes'
+        rules:
+            - sysctl_net_ipv4_conf_default_send_redirects
+        status: automated
     -   id: RHEL-08-040280
         levels:
             - medium
-        rules:
-            - sysctl_net_ipv6_conf_all_accept_redirects
-            - sysctl_net_ipv4_conf_all_accept_redirects
         title: RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect
             messages.
-        automated: 'yes'
+        rules:
+            - sysctl_net_ipv6_conf_all_accept_redirects
+        status: automated
     -   id: RHEL-08-040281
         levels:
             - medium
+        title: RHEL 8 must disable access to network bpf syscall from unprivileged processes.
         rules:
             - sysctl_kernel_unprivileged_bpf_disabled
-        title: RHEL 8 must disable access to network bpf syscall from unprivileged processes.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040282
         levels:
             - medium
+        title: RHEL 8 must restrict usage of ptrace to descendant  processes.
         rules:
             - sysctl_kernel_yama_ptrace_scope
-        title: RHEL 8 must restrict usage of ptrace to descendant  processes.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040283
         levels:
             - medium
+        title: RHEL 8 must restrict exposed kernel pointer addresses access.
         rules:
             - sysctl_kernel_kptr_restrict
-        title: RHEL 8 must restrict exposed kernel pointer addresses access.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040284
         levels:
             - medium
+        title: RHEL 8 must disable the use of user namespaces.
         rules:
             - sysctl_user_max_user_namespaces
-        title: RHEL 8 must disable the use of user namespaces.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040285
         levels:
             - medium
+        title: RHEL 8 must use reverse path filtering on all IPv4 interfaces.
         rules:
             - sysctl_net_ipv4_conf_all_rp_filter
-        title: RHEL 8 must use reverse path filtering on all IPv4 interfaces.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040290
         levels:
             - medium
+        title: RHEL 8 must be configured to prevent unrestricted mail relaying.
         rules:
             - postfix_prevent_unrestricted_relay
-        title: RHEL 8 must be configured to prevent unrestricted mail relaying.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040300
         levels:
             - low
+        title: The RHEL 8 file integrity tool must be configured to verify extended attributes.
         rules:
             - aide_verify_ext_attributes
-        title: The RHEL 8 file integrity tool must be configured to verify extended attributes.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040310
         levels:
             - low
-        rules:
-            - aide_verify_acls
         title: The RHEL 8 file integrity tool must be configured to verify Access Control
             Lists (ACLs).
-        automated: 'yes'
+        rules:
+            - aide_verify_acls
+        status: automated
     -   id: RHEL-08-040320
         levels:
             - medium
-        rules:
-            - package_xorg-x11-server-common_removed
-            - xwindows_remove_packages
         title: The graphical display manager must not be installed on RHEL 8 unless approved.
-        automated: 'yes'
+        rules:
+            - xwindows_remove_packages
+        status: automated
     -   id: RHEL-08-040330
         levels:
             - medium
+        title: RHEL 8 network interfaces must not be in promiscuous mode.
         rules:
             - network_sniffer_disabled
-        title: RHEL 8 network interfaces must not be in promiscuous mode.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-040340
         levels:
             - medium
-        rules:
-            - sshd_disable_x11_forwarding
         title: RHEL 8 remote X connections for interactive users must be disabled unless
             to fulfill documented and validated mission requirements.
-        automated: 'yes'
+        rules:
+            - sshd_disable_x11_forwarding
+        status: automated
     -   id: RHEL-08-040341
         levels:
             - medium
-        rules:
-            - sshd_x11_use_localhost
         title: The RHEL 8 SSH daemon must prevent remote hosts from connecting to the proxy
             display.
-        automated: 'yes'
+        rules:
+            - sshd_x11_use_localhost
+        status: automated
     -   id: RHEL-08-040350
         levels:
             - medium
-        rules:
-            - tftpd_uses_secure_mode
         title: If the Trivial File Transfer Protocol (TFTP) server is required, the RHEL
             8 TFTP daemon must be configured to operate in secure mode.
-        automated: 'yes'
+        rules:
+            - tftpd_uses_secure_mode
+        status: automated
     -   id: RHEL-08-040360
         levels:
             - high
-        rules:
-            - package_vsftpd_removed
         title: A File Transfer Protocol (FTP) server package must not be installed unless
             mission essential on RHEL 8.
-        automated: 'yes'
+        rules:
+            - package_vsftpd_removed
+        status: automated
     -   id: RHEL-08-040370
         levels:
             - medium
-        rules:
-            - package_gssproxy_removed
         title: The gssproxy package must not be installed unless mission essential on RHEL
             8.
-        automated: 'yes'
+        rules:
+            - package_gssproxy_removed
+        status: automated
     -   id: RHEL-08-040380
         levels:
             - medium
-        rules:
-            - package_iprutils_removed
         title: The iprutils package must not be installed unless mission essential on RHEL
             8.
-        automated: 'yes'
+        rules:
+            - package_iprutils_removed
+        status: automated
     -   id: RHEL-08-040390
         levels:
             - medium
-        rules:
-            - package_tuned_removed
         title: The tuned package must not be installed unless mission essential on RHEL
             8.
-        automated: 'yes'
+        rules:
+            - package_tuned_removed
+        status: automated
     -   id: RHEL-08-010163
         levels:
             - medium
         title: The krb5-server package must not be installed on RHEL 8.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010382
         levels:
             - medium
+        title: RHEL 8 must restrict privilege elevation to authorized personnel.
         rules:
             - sudo_restrict_privilege_elevation_to_authorized
-        title: RHEL 8 must restrict privilege elevation to authorized personnel.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010383
         levels:
             - medium
-        rules:
-            - sudoers_validate_passwd
         title: RHEL 8 must use the invoking user's password for privilege escalation when
             using "sudo".
-        automated: 'yes'
+        rules:
+            - sudoers_validate_passwd
+        status: automated
     -   id: RHEL-08-010384
         levels:
             - medium
+        title: RHEL 8 must require re-authentication when using the "sudo" command.
         rules:
             - sudo_require_reauthentication
-        title: RHEL 8 must require re-authentication when using the "sudo" command.
-        automated: 'yes'
+        status: automated
     -   id: RHEL-08-010049
         levels:
             - medium
         title: RHEL 8 must display a banner before granting local or remote access to the
             system via a graphical user logon.
-        automated: 'no'
-
+        rules:
+            - dconf_gnome_banner_enabled
+        status: automated
     -   id: RHEL-08-010131
         levels:
             - medium
         title: The RHEL 8 system-auth file must be configured to use a sufficient number
             of hashing rounds.
-        automated: 'no'
-
+        rules:
+            - accounts_password_pam_unix_rounds_system_auth
+        status: automated
     -   id: RHEL-08-010141
         levels:
             - medium
         title: RHEL 8 operating systems booted with United Extensible Firmware Interface
             (UEFI) must require a unique superusers name upon booting into single-user mode
             and maintenance.
-        automated: 'no'
-
+        rules:
+            - grub2_uefi_admin_username
+        status: automated
     -   id: RHEL-08-010149
         levels:
             - medium
         title: RHEL 8 operating systems booted with a BIOS must require  a unique superusers
             name upon booting into single-user and maintenance modes.
-        automated: 'no'
-
+        rules:
+            - grub2_admin_username
+        status: automated
     -   id: RHEL-08-010152
         levels:
             - medium
         title: RHEL 8 operating systems must require authentication upon booting into emergency
             mode.
-        automated: 'no'
-
+        rules:
+            - require_emergency_target_auth
+        status: automated
     -   id: RHEL-08-010159
         levels:
             - medium
         title: The RHEL 8 pam_unix.so module must be configured in the system-auth file
             to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010201
         levels:
             - medium
         title: The RHEL 8 SSH daemon must be configured with a timeout interval.
-        automated: 'no'
-
+        rules:
+            - sshd_set_idle_timeout
+        status: automated
     -   id: RHEL-08-010287
         levels:
             - medium
         title: The RHEL 8 SSH daemon must be configured to use system-wide crypto policies.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010472
         levels:
             - low
         title: RHEL 8 must have the packages required to use the hardware random number
             generator entropy gatherer service.
-        automated: 'no'
-
+        rules:
+            - package_rng-tools_installed
+        status: automated
     -   id: RHEL-08-010522
         levels:
             - medium
         title: The RHEL 8 SSH daemon must not allow GSSAPI authentication, except to fulfill
             documented and validated mission requirements.
-        automated: 'no'
-
+        rules:
+            - sshd_disable_gssapi_auth
+        status: automated
     -   id: RHEL-08-010544
         levels:
             - medium
         title: RHEL 8 must use a separate file system for /var/tmp.
-        automated: 'no'
-
+        rules:
+            - partition_for_var_tmp
+        status: automated
     -   id: RHEL-08-010572
         levels:
             - medium
         title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
             on the /boot/efi directory.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010731
         levels:
             - medium
         title: All RHEL 8 local interactive user home directory files must have mode 0750
             or less permissive.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-010741
         levels:
             - medium
         title: RHEL 8 must be configured so that all files and directories contained in
             local interactive user home directories are group-owned by a group of which the
             home directory owner is a member.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020025
         levels:
             - medium
         title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth
             file.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020026
         levels:
             - medium
         title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth
             file.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020031
         levels:
             - medium
         title: RHEL 8 must initiate a session lock for graphical user interfaces when the
             screensaver is activated.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020032
         levels:
             - medium
         title: RHEL 8 must disable the user list at logon for graphical user interfaces.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020039
         levels:
             - medium
         title: RHEL 8 must have the tmux package installed.
-        automated: 'no'
-
+        rules:
+            - package_tmux_installed
+        status: automated
     -   id: RHEL-08-020081
         levels:
             - medium
         title: RHEL 8 must prevent a user from overriding the session idle-delay setting
             for the graphical user interface.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020082
         levels:
             - medium
         title: RHEL 8 must prevent a user from overriding the screensaver lock-enabled setting
             for the graphical user interface.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-020331
         levels:
             - high
         title: RHEL 8 must not allow blank or null passwords in the system-auth file.
-        automated: 'no'
-
+        rules:
+            - no_empty_passwords
+        status: automated
     -   id: RHEL-08-020332
         levels:
             - high
         title: RHEL 8 must not allow blank or null passwords in the password-auth file.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-030181
         levels:
             - medium
         title: RHEL 8 audit records must contain information to establish what type of events
             occurred, the source of events, where events occurred, and the outcome of events.
-        automated: 'no'
-
+        rules:
+            - service_auditd_enabled
+        status: automated
     -   id: RHEL-08-030731
         levels:
             - medium
         title: RHEL 8 must notify the System Administrator (SA) and Information System Security
             Officer (ISSO) (at a minimum) when allocated audit record storage volume 75 percent
             utilization.
-        automated: 'no'
-
+        rules:
+            - auditd_data_retention_space_left_action
+        status: automated
     -   id: RHEL-08-040101
         levels:
             - medium
         title: A firewall must be active on RHEL 8.
-        automated: 'no'
-
+        rules:
+            - service_firewalld_enabled
+        status: automated
     -   id: RHEL-08-040136
         levels:
             - medium
         title: The RHEL 8 fapolicy module must be enabled.
-        automated: 'no'
-
+        rules:
+            - service_fapolicyd_enabled
+        status: automated
     -   id: RHEL-08-040137
         levels:
             - medium
         title: The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception
             policy to allow the execution of authorized software programs.
-        automated: 'no'
-
+        status: pending
     -   id: RHEL-08-040139
         levels:
             - medium
         title: RHEL 8 must have the USBGuard installed.
-        automated: 'no'
-
+        rules:
+            - package_usbguard_installed
+        status: automated
     -   id: RHEL-08-040141
         levels:
             - medium
         title: RHEL 8 must enable the USBGuard.
-        automated: 'no'
-
+        rules:
+            - service_usbguard_enabled
+        status: automated
     -   id: RHEL-08-040159
         levels:
             - medium
         title: All RHEL 8 networked systems must have SSH installed.
-        automated: 'no'
-
+        rules:
+            - package_openssh-server_installed
+        status: automated
     -   id: RHEL-08-040209
         levels:
             - medium
         title: RHEL 8 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect
             messages from being accepted.
-        automated: 'no'
-
+        rules:
+            - sysctl_net_ipv4_conf_default_accept_redirects
+        status: automated
     -   id: RHEL-08-040239
         levels:
             - medium
         title: RHEL 8 must not forward IPv4 source-routed packets.
-        automated: 'no'
-
+        rules:
+            - sysctl_net_ipv4_conf_all_accept_source_route
+        status: automated
     -   id: RHEL-08-040249
         levels:
             - medium
         title: RHEL 8 must not forward IPv4 source-routed packets by default.
-        automated: 'no'
-
+        rules:
+            - sysctl_net_ipv4_conf_default_accept_source_route
+        status: automated
     -   id: RHEL-08-040279
         levels:
             - medium
         title: RHEL 8 must ignore IPv4 Internet Control Message Protocol (ICMP) redirect
             messages.
-        automated: 'no'
-
+        rules:
+            - sysctl_net_ipv4_conf_all_accept_redirects
+        status: automated
     -   id: RHEL-08-040286
         levels:
             - medium
         title: RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time
             compiler.
-        automated: 'no'
-
+        rules:
+            - sysctl_net_core_bpf_jit_harden
+        status: automated
     -   id: RHEL-08-010001
         levels:
             - medium
         title: The RHEL 8 operating system must implement the Endpoint Security for Linux
             Threat Prevention tool.
-        automated: 'no'
-
+        rules:
+            - agent_mfetpd_running
+            - package_mcafeetp_installed
+        status: automated

--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -1,0 +1,2838 @@
+policy: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
+source: https://public.cyber.mil/stigs/downloads/
+title: Red Hat Enterprise Linux 8 Security Technical Implementation Guide
+id: stig_rhel8
+version: V1R3
+levels:
+  - id: high
+  - id: medium
+  - id: low
+
+controls:
+    -   id: RHEL-08-010000
+        levels:
+            - high
+        rules:
+            - installed_OS_is_vendor_supported
+        title: RHEL 8 must be a vendor-supported release.
+        automated: 'yes'
+    -   id: RHEL-08-010010
+        levels:
+            - medium
+        rules:
+            - security_patches_up_to_date
+        title: RHEL 8 vendor packaged system security patches and updates must be installed
+            and up to date.
+        automated: 'yes'
+    -   id: RHEL-08-010020
+        levels:
+            - high
+        rules:
+            - enable_fips_mode
+            - sysctl_crypto_fips_enabled
+        title: 'RHEL 8 must implement NIST FIPS-validated cryptography for the following:
+    to provision digital signatures, to generate cryptographic hashes, and to protect
+    data requiring data-at-rest protections in accordance with applicable federal
+    laws, Executive Orders, directives, policies, regulations, and standards.'
+        automated: 'yes'
+    -   id: RHEL-08-010030
+        levels:
+            - medium
+        rules:
+            - encrypt_partitions
+        title: All RHEL 8 local disk partitions must implement cryptographic mechanisms
+            to prevent unauthorized disclosure or modification of all information that requires
+            at rest protection.
+        automated: 'yes'
+    -   id: RHEL-08-010040
+        levels:
+            - medium
+        rules:
+            - sshd_enable_warning_banner
+        title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
+            before granting local or remote access to the system via a ssh logon.
+        automated: 'yes'
+    -   id: RHEL-08-010050
+        levels:
+            - medium
+        rules:
+            - dconf_gnome_banner_enabled
+            - dconf_gnome_login_banner_text
+        title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
+            before granting local or remote access to the system via a graphical user logon.
+        automated: 'yes'
+    -   id: RHEL-08-010060
+        levels:
+            - medium
+        rules:
+            - banner_etc_issue
+        title: RHEL 8 must display the Standard Mandatory DoD Notice and Consent Banner
+            before granting local or remote access to the system via a command line user logon.
+        automated: 'yes'
+    -   id: RHEL-08-010070
+        levels:
+            - medium
+        rules:
+            - rsyslog_remote_access_monitoring
+        title: All RHEL 8 remote access methods must be monitored.
+        automated: 'yes'
+    -   id: RHEL-08-010090
+        levels:
+            - medium
+        title: RHEL 8, for PKI-based authentication, must validate certificates by constructing
+            a certification path (which includes status information) to an accepted trust
+            anchor.
+        automated: 'no'
+
+    -   id: RHEL-08-010100
+        levels:
+            - medium
+        title: RHEL 8, for certificate-based authentication, must enforce authorized access
+            to the corresponding private key.
+        automated: 'no'
+
+    -   id: RHEL-08-010110
+        levels:
+            - medium
+        rules:
+            - set_password_hashing_algorithm_logindefs
+        title: RHEL 8 must encrypt all stored passwords with a FIPS 140-2 approved cryptographic
+            hashing algorithm.
+        automated: 'yes'
+    -   id: RHEL-08-010120
+        levels:
+            - medium
+        rules:
+            - accounts_password_all_shadowed_sha512
+        title: RHEL 8 must employ FIPS 140-2 approved cryptographic hashing algorithms for
+            all stored passwords.
+        automated: 'yes'
+    -   id: RHEL-08-010130
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_unix_rounds_password_auth
+            - accounts_password_pam_unix_rounds_system_auth
+        title: The RHEL 8 password-auth file must be configured to use a sufficient number
+            of hashing rounds.
+        automated: 'yes'
+    -   id: RHEL-08-010140
+        levels:
+            - high
+        rules:
+            - grub2_uefi_admin_username
+            - grub2_uefi_password
+        title: RHEL 8 operating systems booted with United Extensible Firmware Interface
+            (UEFI) must require authentication upon booting into single-user mode and maintenance.
+        automated: 'yes'
+    -   id: RHEL-08-010150
+        levels:
+            - high
+        rules:
+            - grub2_admin_username
+            - grub2_password
+        title: RHEL 8 operating systems booted with a BIOS must require authentication upon
+            booting into single-user and maintenance modes.
+        automated: 'yes'
+    -   id: RHEL-08-010151
+        levels:
+            - medium
+        rules:
+            - require_emergency_target_auth
+            - require_singleuser_auth
+        title: RHEL 8 operating systems must require authentication upon booting into rescue
+            mode.
+        automated: 'yes'
+    -   id: RHEL-08-010160
+        levels:
+            - medium
+        rules:
+            - set_password_hashing_algorithm_systemauth
+        title: The RHEL 8 pam_unix.so module must be configured in the password-auth file
+            to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
+        automated: 'yes'
+    -   id: RHEL-08-010161
+        levels:
+            - medium
+        rules:
+            - kerberos_disable_no_keytab
+        title: RHEL 8 must prevent system daemons from using Kerberos for authentication.
+        automated: 'yes'
+    -   id: RHEL-08-010162
+        levels:
+            - medium
+        rules:
+            - package_krb5-workstation_removed
+        title: The krb5-workstation package must not be installed on RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-010170
+        levels:
+            - medium
+        rules:
+            - selinux_state
+        title: RHEL 8 must use a Linux Security Module configured to enforce limits on system
+            services.
+        automated: 'yes'
+    -   id: RHEL-08-010171
+        levels:
+            - low
+        rules:
+            - package_policycoreutils_installed
+        title: RHEL 8 must have policycoreutils package installed.
+        automated: 'yes'
+    -   id: RHEL-08-010180
+        levels:
+            - medium
+        title: All RHEL 8 public directories must be owned by root or a system account to
+            prevent unauthorized and unintended information transferred via shared system
+            resources.
+        automated: 'no'
+
+    -   id: RHEL-08-010190
+        levels:
+            - medium
+        rules:
+            - dir_perms_world_writable_sticky_bits
+        title: A sticky bit must be set on all RHEL 8 public directories to prevent unauthorized
+            and unintended information transferred via shared system resources.
+        automated: 'yes'
+    -   id: RHEL-08-010200
+        levels:
+            - medium
+        rules:
+            - sshd_set_idle_timeout
+            - sshd_set_keepalive_0
+        title: RHEL 8 must be configured so that all network connections associated with
+            SSH traffic are terminated at the end of the session or after 10 minutes of inactivity,
+            except to fulfill documented and validated mission requirements.
+        automated: 'yes'
+    -   id: RHEL-08-010210
+        levels:
+            - medium
+        rules:
+            - file_permissions_var_log_messages
+        title: The RHEL 8 /var/log/messages file must have mode 0640 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010220
+        levels:
+            - medium
+        rules:
+            - file_owner_var_log_messages
+        title: The RHEL 8 /var/log/messages file must be owned by root.
+        automated: 'yes'
+    -   id: RHEL-08-010230
+        levels:
+            - medium
+        rules:
+            - file_groupowner_var_log_messages
+        title: The RHEL 8 /var/log/messages file must be group-owned by root.
+        automated: 'yes'
+    -   id: RHEL-08-010240
+        levels:
+            - medium
+        rules:
+            - file_permissions_var_log
+        title: The RHEL 8 /var/log directory must have mode 0755 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010250
+        levels:
+            - medium
+        rules:
+            - file_owner_var_log
+        title: The RHEL 8 /var/log directory must be owned by root.
+        automated: 'yes'
+    -   id: RHEL-08-010260
+        levels:
+            - medium
+        rules:
+            - file_groupowner_var_log
+        title: The RHEL 8 /var/log directory must be group-owned by root.
+        automated: 'yes'
+    -   id: RHEL-08-010290
+        levels:
+            - medium
+        rules:
+            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+            - harden_sshd_macs_openssh_conf_crypto_policy
+            - harden_sshd_macs_opensshserver_conf_crypto_policy
+        title: The RHEL 8 SSH server must be configured to use only Message Authentication
+            Codes (MACs) employing FIPS 140-2 validated cryptographic hash algorithms.
+        automated: 'yes'
+    -   id: RHEL-08-010291
+        levels:
+            - medium
+        rules:
+            - harden_sshd_ciphers_openssh_conf_crypto_policy
+        title: The RHEL 8 operating system must implement DoD-approved encryption to protect
+            the confidentiality of SSH server connections.
+        automated: 'yes'
+    -   id: RHEL-08-010292
+        levels:
+            - low
+        rules:
+            - sshd_use_strong_rng
+        title: RHEL 8 must ensure the SSH server uses strong entropy.
+        automated: 'yes'
+    -   id: RHEL-08-010293
+        levels:
+            - medium
+        rules:
+            - configure_openssl_crypto_policy
+        title: The RHEL 8 operating system must implement DoD-approved encryption in the
+            OpenSSL package.
+        automated: 'yes'
+    -   id: RHEL-08-010294
+        levels:
+            - medium
+        rules:
+            - configure_openssl_tls_crypto_policy
+        title: The RHEL 8 operating system must implement DoD-approved TLS encryption in
+            the OpenSSL package.
+        automated: 'yes'
+    -   id: RHEL-08-010295
+        levels:
+            - medium
+        rules:
+            - configure_gnutls_tls_crypto_policy
+        title: The RHEL 8 operating system must implement DoD-approved TLS encryption in
+            the GnuTLS package.
+        automated: 'yes'
+    -   id: RHEL-08-010300
+        levels:
+            - medium
+        rules:
+            - file_permissions_binary_dirs
+        title: RHEL 8 system commands must have mode 0755 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010310
+        levels:
+            - medium
+        rules:
+            - file_ownership_binary_dirs
+        title: RHEL 8 system commands must be owned by root.
+        automated: 'yes'
+    -   id: RHEL-08-010320
+        levels:
+            - medium
+        rules:
+            - file_groupownership_system_commands_dirs
+        title: RHEL 8 system commands must be group-owned by root or a system account.
+        automated: 'yes'
+    -   id: RHEL-08-010330
+        levels:
+            - medium
+        rules:
+            - file_permissions_library_dirs
+        title: RHEL 8 library files must have mode 0755 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010340
+        levels:
+            - medium
+        rules:
+            - file_ownership_library_dirs
+        title: RHEL 8 library files must be owned by root.
+        automated: 'yes'
+    -   id: RHEL-08-010350
+        levels:
+            - medium
+        rules:
+            - dir_group_ownership_library_dirs
+            - root_permissions_syslibrary_files
+        title: RHEL 8 library files must be group-owned by root or a system account.
+        automated: 'yes'
+    -   id: RHEL-08-010360
+        levels:
+            - medium
+        rules:
+            - aide_scan_notification
+            - package_aide_installed
+        title: The RHEL 8 file integrity tool must notify the system administrator when
+            changes to the baseline configuration or anomalies in the operation of any security
+            functions are discovered within an organizationally defined frequency.
+        automated: 'yes'
+    -   id: RHEL-08-010370
+        levels:
+            - high
+        rules:
+            - ensure_gpgcheck_globally_activated
+        title: RHEL 8 must prevent the installation of software, patches, service packs,
+            device drivers, or operating system components from a repository without verification
+            they have been digitally signed using a certificate that is issued by a Certificate
+            Authority (CA) that is recognized and approved by the organization.
+        automated: 'yes'
+    -   id: RHEL-08-010371
+        levels:
+            - high
+        rules:
+            - ensure_gpgcheck_local_packages
+        title: RHEL 8 must prevent the installation of software, patches, service packs,
+            device drivers, or operating system components of local packages without verification
+            they have been digitally signed using a certificate that is issued by a Certificate
+            Authority (CA) that is recognized and approved by the organization.
+        automated: 'yes'
+    -   id: RHEL-08-010372
+        levels:
+            - medium
+        rules:
+            - sysctl_kernel_kexec_load_disabled
+        title: RHEL 8 must prevent the loading of a new kernel for later execution.
+        automated: 'yes'
+    -   id: RHEL-08-010373
+        levels:
+            - medium
+        rules:
+            - sysctl_fs_protected_symlinks
+        title: RHEL 8 must enable kernel parameters to enforce discretionary access control
+            on symlinks.
+        automated: 'yes'
+    -   id: RHEL-08-010374
+        levels:
+            - medium
+        rules:
+            - sysctl_fs_protected_hardlinks
+        title: RHEL 8 must enable kernel parameters to enforce discretionary access control
+            on hardlinks.
+        automated: 'yes'
+    -   id: RHEL-08-010375
+        levels:
+            - low
+        rules:
+            - sysctl_kernel_dmesg_restrict
+        title: RHEL 8 must restrict access to the kernel message buffer.
+        automated: 'yes'
+    -   id: RHEL-08-010376
+        levels:
+            - low
+        rules:
+            - sysctl_kernel_perf_event_paranoid
+        title: RHEL 8 must prevent kernel profiling by unprivileged users.
+        automated: 'yes'
+    -   id: RHEL-08-010380
+        levels:
+            - medium
+        rules:
+            - sudo_remove_nopasswd
+        title: RHEL 8 must require users to provide a password for privilege escalation.
+        automated: 'yes'
+    -   id: RHEL-08-010381
+        levels:
+            - medium
+        rules:
+            - sudo_remove_no_authenticate
+        title: RHEL 8 must require users to reauthenticate for privilege escalation.
+        automated: 'yes'
+    -   id: RHEL-08-010390
+        levels:
+            - medium
+        rules:
+            - install_smartcard_packages
+        title: RHEL 8 must have the packages required for multifactor authentication installed.
+        automated: 'yes'
+    -   id: RHEL-08-010400
+        levels:
+            - medium
+        title: RHEL 8 must implement certificate status checking for multifactor authentication.
+        automated: 'no'
+
+    -   id: RHEL-08-010410
+        levels:
+            - medium
+        rules:
+            - package_opensc_installed
+        title: RHEL 8 must accept Personal Identity Verification (PIV) credentials.
+        automated: 'yes'
+    -   id: RHEL-08-010420
+        levels:
+            - medium
+        title: RHEL 8 must implement non-executable data to protect its memory from unauthorized
+            code execution.
+        automated: 'no'
+
+    -   id: RHEL-08-010421
+        levels:
+            - medium
+        rules:
+            - grub2_page_poison_argument
+        title: RHEL 8 must clear the page allocator to prevent use-after-free attacks.
+        automated: 'yes'
+    -   id: RHEL-08-010422
+        levels:
+            - medium
+        rules:
+            - grub2_vsyscall_argument
+        title: RHEL 8 must disable virtual syscalls.
+        automated: 'yes'
+    -   id: RHEL-08-010423
+        levels:
+            - medium
+        rules:
+            - grub2_slub_debug_argument
+        title: RHEL 8 must clear SLUB/SLAB objects to prevent use-after-free attacks.
+        automated: 'yes'
+    -   id: RHEL-08-010430
+        levels:
+            - medium
+        rules:
+            - sysctl_kernel_randomize_va_space
+        title: RHEL 8 must implement address space layout randomization (ASLR) to protect
+            its memory from unauthorized code execution.
+        automated: 'yes'
+    -   id: RHEL-08-010440
+        levels:
+            - low
+        rules:
+            - clean_components_post_updating
+        title: YUM must remove all software components after updated versions have been
+            installed on RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-010450
+        levels:
+            - medium
+        rules:
+            - selinux_policytype
+        title: RHEL 8 must enable the SELinux targeted policy.
+        automated: 'yes'
+    -   id: RHEL-08-010460
+        levels:
+            - high
+        rules:
+            - no_host_based_files
+        title: There must be no shosts.equiv files on the RHEL 8 operating system.
+        automated: 'yes'
+    -   id: RHEL-08-010470
+        levels:
+            - high
+        rules:
+            - no_user_host_based_files
+        title: There must be no .shosts files on the RHEL 8 operating system.
+        automated: 'yes'
+    -   id: RHEL-08-010471
+        levels:
+            - low
+        rules:
+            - service_rngd_enabled
+            - package_rng-tools_installed
+        title: RHEL 8 must enable the hardware random number generator entropy gatherer
+            service.
+        automated: 'yes'
+    -   id: RHEL-08-010480
+        levels:
+            - medium
+        rules:
+            - file_permissions_sshd_pub_key
+        title: The RHEL 8 SSH public host key files must have mode 0644 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010490
+        levels:
+            - medium
+        rules:
+            - file_permissions_sshd_private_key
+        title: The RHEL 8 SSH private host key files must have mode 0600 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010500
+        levels:
+            - medium
+        rules:
+            - sshd_enable_strictmodes
+        title: The RHEL 8 SSH daemon must perform strict mode checking of home directory
+            configuration files.
+        automated: 'yes'
+    -   id: RHEL-08-010510
+        levels:
+            - medium
+        rules:
+            - sshd_disable_compression
+        title: The RHEL 8 SSH daemon must not allow compression or must only allow compression
+            after successful authentication.
+        automated: 'yes'
+    -   id: RHEL-08-010520
+        levels:
+            - medium
+        rules:
+            - sshd_disable_user_known_hosts
+        title: "The RHEL 8 SSH daemon must not allow authentication using known host\u2019\
+    s authentication."
+        automated: 'yes'
+    -   id: RHEL-08-010521
+        levels:
+            - medium
+        rules:
+            - sshd_disable_gssapi_auth
+            - sshd_disable_kerb_auth
+        title: The RHEL 8 SSH daemon must not allow Kerberos authentication, except to fulfill
+            documented and validated mission requirements.
+        automated: 'yes'
+    -   id: RHEL-08-010540
+        levels:
+            - low
+        rules:
+            - partition_for_var
+        title: RHEL 8 must use a separate file system for /var.
+        automated: 'yes'
+    -   id: RHEL-08-010541
+        levels:
+            - low
+        rules:
+            - partition_for_var_log
+        title: RHEL 8 must use a separate file system for /var/log.
+        automated: 'yes'
+    -   id: RHEL-08-010542
+        levels:
+            - low
+        rules:
+            - partition_for_var_log_audit
+        title: RHEL 8 must use a separate file system for the system audit data path.
+        automated: 'yes'
+    -   id: RHEL-08-010543
+        levels:
+            - medium
+        rules:
+            - partition_for_tmp
+        title: A separate RHEL 8 filesystem must be used for the /tmp directory.
+        automated: 'yes'
+    -   id: RHEL-08-010550
+        levels:
+            - medium
+        rules:
+            - sshd_disable_root_login
+        title: RHEL 8 must not permit direct logons to the root account using remote access
+            via SSH.
+        automated: 'yes'
+    -   id: RHEL-08-010560
+        levels:
+            - medium
+        rules:
+            - service_auditd_enabled
+        title: The auditd service must be running in RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-010561
+        levels:
+            - medium
+        rules:
+            - service_rsyslog_enabled
+        title: The rsyslog service must be running in RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-010570
+        levels:
+            - medium
+        rules:
+            - mount_option_home_nosuid
+        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
+            on file systems that contain user home directories.
+        automated: 'yes'
+    -   id: RHEL-08-010571
+        levels:
+            - medium
+        rules:
+            - mount_option_boot_nosuid
+        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
+            on the /boot directory.
+        automated: 'yes'
+    -   id: RHEL-08-010580
+        levels:
+            - medium
+        rules:
+            - mount_option_nodev_nonroot_local_partitions
+        title: RHEL 8 must prevent special devices on non-root local partitions.
+        automated: 'yes'
+    -   id: RHEL-08-010590
+        levels:
+            - medium
+        rules:
+            - mount_option_home_noexec
+        title: RHEL 8 must prevent code from being executed on file systems that contain
+            user home directories.
+        automated: 'yes'
+    -   id: RHEL-08-010600
+        levels:
+            - medium
+        rules:
+            - mount_option_nodev_removable_partitions
+        title: RHEL 8 must prevent special devices on file systems that are used with removable
+            media.
+        automated: 'yes'
+    -   id: RHEL-08-010610
+        levels:
+            - medium
+        rules:
+            - mount_option_noexec_removable_partitions
+        title: RHEL 8 must prevent code from being executed on file systems that are used
+            with removable media.
+        automated: 'yes'
+    -   id: RHEL-08-010620
+        levels:
+            - medium
+        rules:
+            - mount_option_nosuid_removable_partitions
+        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
+            on file systems that are used with removable media.
+        automated: 'yes'
+    -   id: RHEL-08-010630
+        levels:
+            - medium
+        rules:
+            - mount_option_noexec_remote_filesystems
+        title: RHEL 8 must prevent code from being executed on file systems that are imported
+            via Network File System (NFS).
+        automated: 'yes'
+    -   id: RHEL-08-010640
+        levels:
+            - medium
+        rules:
+            - mount_option_nodev_remote_filesystems
+        title: RHEL 8 must prevent special devices on file systems that are imported via
+            Network File System (NFS).
+        automated: 'yes'
+    -   id: RHEL-08-010650
+        levels:
+            - medium
+        rules:
+            - mount_option_nosuid_remote_filesystems
+        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
+            on file systems that are imported via Network File System (NFS).
+        automated: 'yes'
+    -   id: RHEL-08-010660
+        levels:
+            - medium
+        rules:
+            - accounts_user_dot_no_world_writable_programs
+        title: Local RHEL 8 initialization files must not execute world-writable programs.
+        automated: 'yes'
+    -   id: RHEL-08-010670
+        levels:
+            - medium
+        rules:
+            - service_kdump_disabled
+        title: RHEL 8 must disable kernel dumps unless needed.
+        automated: 'yes'
+    -   id: RHEL-08-010671
+        levels:
+            - medium
+        rules:
+            - sysctl_kernel_core_pattern
+        title: RHEL 8 must disable the kernel.core_pattern.
+        automated: 'yes'
+    -   id: RHEL-08-010672
+        levels:
+            - medium
+        rules:
+            - service_systemd-coredump_disabled
+        title: RHEL 8 must disable acquiring, saving, and processing core dumps.
+        automated: 'yes'
+    -   id: RHEL-08-010673
+        levels:
+            - medium
+        rules:
+            - disable_users_coredumps
+        title: RHEL 8 must disable core dumps for all users.
+        automated: 'yes'
+    -   id: RHEL-08-010674
+        levels:
+            - medium
+        rules:
+            - coredump_disable_storage
+        title: RHEL 8 must disable storing core dumps.
+        automated: 'yes'
+    -   id: RHEL-08-010675
+        levels:
+            - medium
+        rules:
+            - coredump_disable_backtraces
+        title: RHEL 8 must disable core dump backtraces.
+        automated: 'yes'
+    -   id: RHEL-08-010680
+        levels:
+            - medium
+        rules:
+            - network_configure_name_resolution
+        title: For RHEL 8 systems using Domain Name Servers (DNS) resolution, at least two
+            name servers must be configured.
+        automated: 'yes'
+    -   id: RHEL-08-010690
+        levels:
+            - medium
+        rules:
+            - accounts_user_home_paths_only
+        title: Executable search paths within the initialization files of all local interactive
+            RHEL 8 users must only contain paths that resolve to the system default or the
+            users home directory.
+        automated: 'yes'
+    -   id: RHEL-08-010700
+        levels:
+            - medium
+        rules:
+            - dir_perms_world_writable_root_owned
+        title: All RHEL 8 world-writable directories must be owned by root, sys, bin, or
+            an application user.
+        automated: 'yes'
+    -   id: RHEL-08-010710
+        levels:
+            - medium
+        title: All RHEL 8 world-writable directories must be group-owned by root, sys, bin,
+            or an application group.
+        automated: 'no'
+
+    -   id: RHEL-08-010720
+        levels:
+            - medium
+        rules:
+            - accounts_user_interactive_home_directory_defined
+        title: All RHEL 8 local interactive users must have a home directory assigned in
+            the /etc/passwd file.
+        automated: 'yes'
+    -   id: RHEL-08-010730
+        levels:
+            - medium
+        rules:
+            - file_permissions_home_directories
+        title: All RHEL 8 local interactive user home directories must have mode 0750 or
+            less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010740
+        levels:
+            - medium
+        rules:
+            - file_groupownership_home_directories
+        title: "All RHEL 8 local interactive user home directories must be group-owned by\
+    \ the home directory owner\u2019s primary group."
+        automated: 'yes'
+    -   id: RHEL-08-010750
+        levels:
+            - medium
+        rules:
+            - accounts_user_interactive_home_directory_exists
+        title: All RHEL 8 local interactive user home directories defined in the /etc/passwd
+            file must exist.
+        automated: 'yes'
+    -   id: RHEL-08-010760
+        levels:
+            - medium
+        rules:
+            - accounts_have_homedir_login_defs
+        title: All RHEL 8 local interactive user accounts must be assigned a home directory
+            upon creation.
+        automated: 'yes'
+    -   id: RHEL-08-010770
+        levels:
+            - medium
+        rules:
+            - file_permission_user_init_files
+        title: All RHEL 8 local initialization files must have mode 0740 or less permissive.
+        automated: 'yes'
+    -   id: RHEL-08-010780
+        levels:
+            - medium
+        rules:
+            - no_files_unowned_by_user
+        title: All RHEL 8 local files and directories must have a valid owner.
+        automated: 'yes'
+    -   id: RHEL-08-010790
+        levels:
+            - medium
+        rules:
+            - file_permissions_ungroupowned
+        title: All RHEL 8 local files and directories must have a valid group owner.
+        automated: 'yes'
+    -   id: RHEL-08-010800
+        levels:
+            - medium
+        rules:
+            - partition_for_home
+        title: A separate RHEL 8 filesystem must be used for user home directories (such
+            as /home or an equivalent).
+        automated: 'yes'
+    -   id: RHEL-08-010820
+        levels:
+            - high
+        rules:
+            - gnome_gdm_disable_automatic_login
+        title: Unattended or automatic logon via the RHEL 8 graphical user interface must
+            not be allowed.
+        automated: 'yes'
+    -   id: RHEL-08-010830
+        levels:
+            - medium
+        rules:
+            - sshd_do_not_permit_user_env
+        title: RHEL 8 must not allow users to override SSH environment variables.
+        automated: 'yes'
+    -   id: RHEL-08-020000
+        levels:
+            - medium
+        rules:
+            - account_temp_expire_date
+        title: RHEL 8 temporary user accounts must be provisioned with an expiration time
+            of 72 hours or less.
+        automated: 'yes'
+    -   id: RHEL-08-020010
+        levels:
+            - medium
+        rules:
+            - accounts_passwords_pam_faillock_deny
+        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
+            occur.
+        automated: 'yes'
+    -   id: RHEL-08-020011
+        levels:
+            - medium
+        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
+            occur.
+        automated: 'no'
+
+    -   id: RHEL-08-020012
+        levels:
+            - medium
+        rules:
+            - accounts_passwords_pam_faillock_interval
+        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
+            occur during a 15-minute time period.
+        automated: 'yes'
+    -   id: RHEL-08-020013
+        levels:
+            - medium
+        title: RHEL 8 must automatically lock an account when three unsuccessful logon attempts
+            occur during a 15-minute time period.
+        automated: 'no'
+
+    -   id: RHEL-08-020014
+        levels:
+            - medium
+        rules:
+            - accounts_passwords_pam_faillock_unlock_time
+        title: RHEL 8 must automatically lock an account until the locked account is released
+            by an administrator when three unsuccessful logon attempts occur during a 15-minute
+            time period.
+        automated: 'yes'
+    -   id: RHEL-08-020015
+        levels:
+            - medium
+        title: RHEL 8 must automatically lock an account until the locked account is released
+            by an administrator when three unsuccessful logon attempts occur during a 15-minute
+            time period.
+        automated: 'no'
+
+    -   id: RHEL-08-020016
+        levels:
+            - medium
+        title: RHEL 8 must ensure account lockouts persist.
+        automated: 'no'
+
+    -   id: RHEL-08-020017
+        levels:
+            - medium
+        title: RHEL 8 must ensure account lockouts persist.
+        automated: 'no'
+
+    -   id: RHEL-08-020018
+        levels:
+            - medium
+        title: RHEL 8 must prevent system messages from being presented when three unsuccessful
+            logon attempts occur.
+        automated: 'no'
+
+    -   id: RHEL-08-020019
+        levels:
+            - medium
+        title: RHEL 8 must prevent system messages from being presented when three unsuccessful
+            logon attempts occur.
+        automated: 'no'
+
+    -   id: RHEL-08-020020
+        levels:
+            - medium
+        title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
+        automated: 'no'
+
+    -   id: RHEL-08-020021
+        levels:
+            - medium
+        title: RHEL 8 must log user name information when unsuccessful logon attempts occur.
+        automated: 'no'
+
+    -   id: RHEL-08-020022
+        levels:
+            - medium
+        rules:
+            - accounts_passwords_pam_faillock_deny_root
+        title: RHEL 8 must include root when automatically locking an account until the
+            locked account is released by an administrator when three unsuccessful logon attempts
+            occur during a 15-minute time period.
+        automated: 'yes'
+    -   id: RHEL-08-020023
+        levels:
+            - medium
+        title: RHEL 8 must include root when automatically locking an account until the
+            locked account is released by an administrator when three unsuccessful logon attempts
+            occur during a 15-minute time period.
+        automated: 'no'
+
+    -   id: RHEL-08-020024
+        levels:
+            - low
+        rules:
+            - accounts_max_concurrent_login_sessions
+        title: RHEL 8 must limit the number of concurrent sessions to ten for all accounts
+            and/or account types.
+        automated: 'yes'
+    -   id: RHEL-08-020030
+        levels:
+            - medium
+        rules:
+            - dconf_gnome_screensaver_lock_enabled
+        title: RHEL 8 must enable a user session lock until that user re-establishes access
+            using established identification and authentication procedures for graphical user
+            sessions.
+        automated: 'yes'
+    -   id: RHEL-08-020040
+        levels:
+            - medium
+        rules:
+            - configure_tmux_lock_command
+            - package_tmux_installed
+        title: RHEL 8 must enable a user session lock until that user re-establishes access
+            using established identification and authentication procedures for command line
+            sessions.
+        automated: 'yes'
+    -   id: RHEL-08-020041
+        levels:
+            - medium
+        rules:
+            - configure_bashrc_exec_tmux
+        title: RHEL 8 must ensure session control is automatically started at shell initialization.
+        automated: 'yes'
+    -   id: RHEL-08-020042
+        levels:
+            - low
+        rules:
+            - no_tmux_in_shells
+        title: RHEL 8 must prevent users from disabling session control mechanisms.
+        automated: 'yes'
+    -   id: RHEL-08-020050
+        levels:
+            - medium
+        rules:
+            - dconf_gnome_lock_screen_on_smartcard_removal
+        title: RHEL 8 must be able to initiate directly a session lock for all connection
+            types using smartcard when the smartcard is removed.
+        automated: 'yes'
+    -   id: RHEL-08-020060
+        levels:
+            - medium
+        rules:
+            - dconf_gnome_screensaver_idle_delay
+        title: RHEL 8 must automatically lock graphical user sessions after 15 minutes of
+            inactivity.
+        automated: 'yes'
+    -   id: RHEL-08-020070
+        levels:
+            - medium
+        rules:
+            - configure_tmux_lock_after_time
+        title: RHEL 8 must automatically lock command line user sessions after 15 minutes
+            of inactivity.
+        automated: 'yes'
+    -   id: RHEL-08-020080
+        levels:
+            - medium
+        title: RHEL 8 must prevent a user from overriding the session lock-delay setting
+            for the graphical user interface.
+        automated: 'no'
+
+    -   id: RHEL-08-020090
+        levels:
+            - medium
+        rules:
+            - sssd_enable_certmap
+        title: RHEL 8 must map the authenticated identity to the user or group account for
+            PKI-based authentication.
+        automated: 'yes'
+    -   id: RHEL-08-020100
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_retry
+        title: RHEL 8 must ensure a password complexity module is enabled.
+        automated: 'yes'
+    -   id: RHEL-08-020110
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_ucredit
+        title: RHEL 8 must enforce password complexity by requiring that at least one uppercase
+            character be used.
+        automated: 'yes'
+    -   id: RHEL-08-020120
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_lcredit
+        title: RHEL 8 must enforce password complexity by requiring that at least one lower-case
+            character be used.
+        automated: 'yes'
+    -   id: RHEL-08-020130
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_dcredit
+        title: RHEL 8 must enforce password complexity by requiring that at least one numeric
+            character be used.
+        automated: 'yes'
+    -   id: RHEL-08-020140
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_maxclassrepeat
+        title: RHEL 8 must require the maximum number of repeating characters of the same
+            character class be limited to four when passwords are changed.
+        automated: 'yes'
+    -   id: RHEL-08-020150
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_maxrepeat
+        title: RHEL 8 must require the maximum number of repeating characters be limited
+            to three when passwords are changed.
+        automated: 'yes'
+    -   id: RHEL-08-020160
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_minclass
+        title: RHEL 8 must require the change of at least four character classes when passwords
+            are changed.
+        automated: 'yes'
+    -   id: RHEL-08-020170
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_difok
+        title: RHEL 8 must require the change of at least 8 characters when passwords are
+            changed.
+        automated: 'yes'
+    -   id: RHEL-08-020180
+        levels:
+            - medium
+        rules:
+            - accounts_password_set_min_life_existing
+        title: RHEL 8 passwords must have a 24 hours/1 day minimum password lifetime restriction
+            in /etc/shadow.
+        automated: 'yes'
+    -   id: RHEL-08-020190
+        levels:
+            - medium
+        rules:
+            - accounts_minimum_age_login_defs
+        title: RHEL 8 passwords for new users or password changes must have a 24 hours/1
+            day minimum password lifetime restriction in /etc/logins.def.
+        automated: 'yes'
+    -   id: RHEL-08-020200
+        levels:
+            - medium
+        rules:
+            - accounts_maximum_age_login_defs
+        title: RHEL 8 user account passwords must have a 60-day maximum password lifetime
+            restriction.
+        automated: 'yes'
+    -   id: RHEL-08-020210
+        levels:
+            - medium
+        rules:
+            - accounts_password_set_max_life_existing
+        title: RHEL 8 user account passwords must be configured so that existing passwords
+            are restricted to a 60-day maximum lifetime.
+        automated: 'yes'
+    -   id: RHEL-08-020220
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_pwhistory_remember_password_auth
+            - accounts_password_pam_pwhistory_remember_system_auth
+            - accounts_password_pam_unix_remember
+        title: RHEL 8 passwords must be prohibited from reuse for a minimum of five generations.
+        automated: 'yes'
+    -   id: RHEL-08-020230
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_minlen
+        title: RHEL 8 passwords must have a minimum of 15 characters.
+        automated: 'yes'
+    -   id: RHEL-08-020231
+        levels:
+            - medium
+        rules:
+            - accounts_password_minlen_login_defs
+        title: RHEL 8 passwords for new users must have a minimum of 15 characters.
+        automated: 'yes'
+    -   id: RHEL-08-020240
+        levels:
+            - medium
+        title: RHEL 8 duplicate User IDs (UIDs) must not exist for interactive users.
+        automated: 'no'
+
+    -   id: RHEL-08-020250
+        levels:
+            - medium
+        rules:
+            - sssd_enable_smartcards
+        title: RHEL 8 must implement smart card logon for multifactor authentication for
+            access to interactive accounts.
+        automated: 'yes'
+    -   id: RHEL-08-020260
+        levels:
+            - medium
+        rules:
+            - account_disable_post_pw_expiration
+        title: RHEL 8 account identifiers (individuals, groups, roles, and devices) must
+            be disabled after 35 days of inactivity.
+        automated: 'yes'
+    -   id: RHEL-08-020270
+        levels:
+            - medium
+        rules:
+            - account_emergency_expire_date
+        title: RHEL 8 emergency accounts must be automatically removed or disabled after
+            the crisis is resolved or within 72 hours.
+        automated: 'yes'
+    -   id: RHEL-08-020280
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_ocredit
+        title: All RHEL 8 passwords must contain at least one special character.
+        automated: 'yes'
+    -   id: RHEL-08-020290
+        levels:
+            - medium
+        rules:
+            - sssd_offline_cred_expiration
+        title: RHEL 8 must prohibit the use of cached authentications after one day.
+        automated: 'yes'
+    -   id: RHEL-08-020300
+        levels:
+            - medium
+        rules:
+            - accounts_password_pam_dictcheck
+        title: RHEL 8 must prevent the use of dictionary words for passwords.
+        automated: 'yes'
+    -   id: RHEL-08-020310
+        levels:
+            - medium
+        rules:
+            - accounts_logon_fail_delay
+        title: RHEL 8 must enforce a delay of at least four seconds between logon prompts
+            following a failed logon attempt.
+        automated: 'yes'
+    -   id: RHEL-08-020320
+        levels:
+            - medium
+        rules:
+            - accounts_authorized_local_users
+        title: RHEL 8 must not have unnecessary accounts.
+        automated: 'yes'
+    -   id: RHEL-08-020330
+        levels:
+            - high
+        rules:
+            - sshd_disable_empty_passwords
+            - no_empty_passwords
+        title: RHEL 8 must not allow accounts configured with blank or null passwords.
+        automated: 'yes'
+    -   id: RHEL-08-020340
+        levels:
+            - low
+        rules:
+            - display_login_attempts
+        title: RHEL 8 must display the date and time of the last successful account logon
+            upon logon.
+        automated: 'yes'
+    -   id: RHEL-08-020350
+        levels:
+            - medium
+        rules:
+            - sshd_print_last_log
+        title: RHEL 8 must display the date and time of the last successful account logon
+            upon an SSH logon.
+        automated: 'yes'
+    -   id: RHEL-08-020351
+        levels:
+            - medium
+        rules:
+            - accounts_umask_etc_login_defs
+        title: RHEL 8 must define default permissions for all authenticated users in such
+            a way that the user can only read and modify their own files.
+        automated: 'yes'
+    -   id: RHEL-08-020352
+        levels:
+            - medium
+        rules:
+            - accounts_umask_interactive_users
+        title: RHEL 8 must set the umask value to 077 for all local interactive user accounts.
+        automated: 'yes'
+    -   id: RHEL-08-020353
+        levels:
+            - medium
+        rules:
+            - accounts_umask_etc_bashrc
+        title: RHEL 8 must define default permissions for logon and non-logon shells.
+        automated: 'yes'
+    -   id: RHEL-08-030000
+        levels:
+            - medium
+        rules:
+            - audit_rules_suid_privilege_function
+        title: The RHEL 8 audit system must be configured to audit the execution of privileged
+            functions and prevent all software from executing at higher privilege levels than
+            users executing the software.
+        automated: 'yes'
+    -   id: RHEL-08-030010
+        levels:
+            - medium
+        rules:
+            - rsyslog_cron_logging
+        title: Cron logging must be implemented in RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-030020
+        levels:
+            - medium
+        rules:
+            - auditd_data_retention_action_mail_acct
+        title: The RHEL 8 System Administrator (SA) and Information System Security Officer
+            (ISSO) (at a minimum) must be alerted of an audit processing failure event.
+        automated: 'yes'
+    -   id: RHEL-08-030030
+        levels:
+            - medium
+        rules:
+            - postfix_client_configure_mail_alias
+        title: The RHEL 8 Information System Security Officer (ISSO) and System Administrator
+            (SA) (at a minimum) must have mail aliases to be notified of an audit processing
+            failure.
+        automated: 'yes'
+    -   id: RHEL-08-030040
+        levels:
+            - medium
+        rules:
+            - auditd_data_disk_error_action
+        title: The RHEL 8 System must take appropriate action when an audit processing failure
+            occurs.
+        automated: 'yes'
+    -   id: RHEL-08-030050
+        levels:
+            - medium
+        rules:
+            - auditd_data_retention_max_log_file_action
+        title: The RHEL 8 System Administrator (SA) and Information System Security Officer
+            (ISSO) (at a minimum) must be alerted when the audit storage volume is full.
+        automated: 'yes'
+    -   id: RHEL-08-030060
+        levels:
+            - medium
+        rules:
+            - auditd_data_disk_full_action
+        title: The RHEL 8 audit system must take appropriate action when the audit storage
+            volume is full.
+        automated: 'yes'
+    -   id: RHEL-08-030061
+        levels:
+            - medium
+        rules:
+            - auditd_local_events
+        title: The RHEL 8 audit system must audit local events.
+        automated: 'yes'
+    -   id: RHEL-08-030062
+        levels:
+            - medium
+        rules:
+            - auditd_name_format
+        title: RHEL 8 must label all off-loaded audit logs before sending them to the central
+            log server.
+        automated: 'yes'
+    -   id: RHEL-08-030063
+        levels:
+            - low
+        rules:
+            - auditd_log_format
+        title: RHEL 8 must resolve audit information before writing to disk.
+        automated: 'yes'
+    -   id: RHEL-08-030070
+        levels:
+            - medium
+        rules:
+            - file_permissions_var_log_audit
+        title: RHEL 8 audit logs must have a mode of 0600 or less permissive to prevent
+            unauthorized read access.
+        automated: 'yes'
+    -   id: RHEL-08-030080
+        levels:
+            - medium
+        rules:
+            - file_ownership_var_log_audit
+            - file_ownership_var_log_audit_stig
+        title: RHEL 8 audit logs must be owned by root to prevent unauthorized read access.
+        automated: 'yes'
+    -   id: RHEL-08-030090
+        levels:
+            - medium
+        rules:
+            - file_group_ownership_var_log_audit
+        title: RHEL 8 audit logs must be group-owned by root to prevent unauthorized read
+            access.
+        automated: 'yes'
+    -   id: RHEL-08-030100
+        levels:
+            - medium
+        rules:
+            - directory_ownership_var_log_audit
+        title: RHEL 8 audit log directory must be owned by root to prevent unauthorized
+            read access.
+        automated: 'yes'
+    -   id: RHEL-08-030110
+        levels:
+            - medium
+        rules:
+            - directory_group_ownership_var_log_audit
+        title: RHEL 8 audit log directory must be group-owned by root to prevent unauthorized
+            read access.
+        automated: 'yes'
+    -   id: RHEL-08-030120
+        levels:
+            - medium
+        rules:
+            - directory_permissions_var_log_audit
+        title: RHEL 8 audit log directory must have a mode of 0700 or less permissive to
+            prevent unauthorized read access.
+        automated: 'yes'
+    -   id: RHEL-08-030121
+        levels:
+            - medium
+        rules:
+            - audit_rules_immutable
+        title: RHEL 8 audit system must protect auditing rules from unauthorized change.
+        automated: 'yes'
+    -   id: RHEL-08-030122
+        levels:
+            - medium
+        rules:
+            - audit_immutable_login_uids
+        title: RHEL 8 audit system must protect logon UIDs from unauthorized change.
+        automated: 'yes'
+    -   id: RHEL-08-030130
+        levels:
+            - medium
+        rules:
+            - audit_rules_usergroup_modification_shadow
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/shadow.
+        automated: 'yes'
+    -   id: RHEL-08-030140
+        levels:
+            - medium
+        rules:
+            - audit_rules_usergroup_modification_opasswd
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/security/opasswd.
+        automated: 'yes'
+    -   id: RHEL-08-030150
+        levels:
+            - medium
+        rules:
+            - audit_rules_usergroup_modification_passwd
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/passwd.
+        automated: 'yes'
+    -   id: RHEL-08-030160
+        levels:
+            - medium
+        rules:
+            - audit_rules_usergroup_modification_gshadow
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/gshadow.
+        automated: 'yes'
+    -   id: RHEL-08-030170
+        levels:
+            - medium
+        rules:
+            - audit_rules_usergroup_modification_group
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/group.
+        automated: 'yes'
+    -   id: RHEL-08-030171
+        levels:
+            - medium
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/sudoers.
+        automated: 'no'
+
+    -   id: RHEL-08-030172
+        levels:
+            - medium
+        rules:
+            - audit_rules_sysadmin_actions
+        title: RHEL 8 must generate audit records for all account creations, modifications,
+            disabling, and termination events that affect /etc/sudoers.d/.
+        automated: 'yes'
+    -   id: RHEL-08-030180
+        levels:
+            - medium
+        rules:
+            - package_audit_installed
+        title: The RHEL 8 audit package must be installed.
+        automated: 'yes'
+    -   id: RHEL-08-030190
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the su command in RHEL 8 must generate an
+            audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030200
+        levels:
+            - medium
+        title: The RHEL 8 audit system must be configured to audit any usage of the lremovexattr
+            system call.
+        automated: 'no'
+
+    -   id: RHEL-08-030210
+        levels:
+            - medium
+        title: The RHEL 8 audit system must be configured to audit any usage of the removexattr
+            system call.
+        automated: 'no'
+
+    -   id: RHEL-08-030220
+        levels:
+            - medium
+        title: The RHEL 8 audit system must be configured to audit any usage of the lsetxattr
+            system call.
+        automated: 'no'
+
+    -   id: RHEL-08-030230
+        levels:
+            - medium
+        title: The RHEL 8 audit system must be configured to audit any usage of the fsetxattr
+            system call.
+        automated: 'no'
+
+    -   id: RHEL-08-030240
+        levels:
+            - medium
+        title: The RHEL 8 audit system must be configured to audit any usage of the fremovexattr
+            system call.
+        automated: 'no'
+
+    -   id: RHEL-08-030250
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the chage command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030260
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the chcon command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030270
+        levels:
+            - medium
+        title: The RHEL 8 audit system must be configured to audit any usage of the setxattr
+            system call.
+        automated: 'no'
+
+    -   id: RHEL-08-030280
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the ssh-agent in RHEL 8 must generate an
+            audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030290
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the passwd command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030300
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the mount command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030301
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the umount command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030302
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the mount syscall in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030310
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the unix_update in RHEL 8 must generate an
+            audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030311
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of postdrop in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030312
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of postqueue in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030313
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of semanage in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030314
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of setfiles in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030315
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of userhelper in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030316
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of setsebool in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030317
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of unix_chkpwd in RHEL 8 must generate an audit
+            record.
+        automated: 'no'
+
+    -   id: RHEL-08-030320
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the ssh-keysign in RHEL 8 must generate an
+            audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030330
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the setfacl command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030340
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the pam_timestamp_check command in RHEL 8
+            must generate an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030350
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the newgrp command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030360
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the init_module command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030361
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the rename command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030362
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the renameat command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030363
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the rmdir command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030364
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the unlink command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030365
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the unlinkat command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030370
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the gpasswd command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030380
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the finit_module command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030390
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the delete_module command in RHEL 8 must
+            generate an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030400
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the crontab command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030410
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the chsh command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030420
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the truncate command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030430
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the openat system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030440
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the open system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030450
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the open_by_handle_at system call in RHEL
+            8 must generate an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030460
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the ftruncate command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030470
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the creat system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030480
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the chown command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030490
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the chmod command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030500
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the lchown system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030510
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the fchownat system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030520
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the fchown system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030530
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the fchmodat system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030540
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the fchmod system call in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030550
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the sudo command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030560
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the usermod command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030570
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the chacl command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030580
+        levels:
+            - medium
+        title: Successful/unsuccessful uses of the kmod command in RHEL 8 must generate
+            an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030590
+        levels:
+            - medium
+        title: Successful/unsuccessful modifications to the faillock log file in RHEL 8
+            must generate an audit record.
+        automated: 'no'
+
+    -   id: RHEL-08-030600
+        levels:
+            - medium
+        rules:
+            - audit_rules_login_events_lastlog
+        title: Successful/unsuccessful modifications to the lastlog file in RHEL 8 must
+            generate an audit record.
+        automated: 'yes'
+    -   id: RHEL-08-030601
+        levels:
+            - low
+        rules:
+            - grub2_audit_argument
+        title: RHEL 8 must enable auditing of processes that start prior to the audit daemon.
+        automated: 'yes'
+    -   id: RHEL-08-030602
+        levels:
+            - low
+        rules:
+            - grub2_audit_backlog_limit_argument
+        title: RHEL 8 must allocate an audit_backlog_limit of sufficient size to capture
+            processes that start prior to the audit daemon.
+        automated: 'yes'
+    -   id: RHEL-08-030603
+        levels:
+            - low
+        rules:
+            - configure_usbguard_auditbackend
+        title: RHEL 8 must enable Linux audit logging for the USBGuard daemon.
+        automated: 'yes'
+    -   id: RHEL-08-030610
+        levels:
+            - medium
+        rules:
+            - file_permissions_etc_audit_auditd
+            - file_permissions_etc_audit_rulesd
+        title: RHEL 8 must allow only the Information System Security Manager (ISSM) (or
+            individuals or roles appointed by the ISSM) to select which auditable events are
+            to be audited.
+        automated: 'yes'
+    -   id: RHEL-08-030620
+        levels:
+            - medium
+        title: RHEL 8 audit tools must have a mode of 0755 or less permissive.
+        automated: 'no'
+
+    -   id: RHEL-08-030630
+        levels:
+            - medium
+        title: RHEL 8 audit tools must be owned by root.
+        automated: 'no'
+
+    -   id: RHEL-08-030640
+        levels:
+            - medium
+        title: RHEL 8 audit tools must be group-owned by root.
+        automated: 'no'
+
+    -   id: RHEL-08-030650
+        levels:
+            - medium
+        title: RHEL 8 must use cryptographic mechanisms to protect the integrity of audit
+            tools.
+        automated: 'no'
+
+    -   id: RHEL-08-030660
+        levels:
+            - medium
+        rules:
+            - auditd_audispd_configure_sufficiently_large_partition
+        title: RHEL 8 must allocate audit record storage capacity to store at least one
+            week of audit records, when audit records are not immediately sent to a central
+            audit record storage facility.
+        automated: 'yes'
+    -   id: RHEL-08-030670
+        levels:
+            - medium
+        rules:
+            - package_rsyslog_installed
+        title: RHEL 8 must have the packages required for offloading audit logs installed.
+        automated: 'yes'
+    -   id: RHEL-08-030680
+        levels:
+            - medium
+        rules:
+            - package_rsyslog-gnutls_installed
+        title: RHEL 8 must have the packages required for encrypting offloaded audit logs
+            installed.
+        automated: 'yes'
+    -   id: RHEL-08-030690
+        levels:
+            - medium
+        rules:
+            - rsyslog_remote_loghost
+        title: The RHEL 8 audit records must be off-loaded onto a different system or storage
+            media from the system being audited.
+        automated: 'yes'
+    -   id: RHEL-08-030700
+        levels:
+            - medium
+        rules:
+            - auditd_overflow_action
+        title: RHEL 8 must take appropriate action when the internal event queue is full.
+        automated: 'yes'
+    -   id: RHEL-08-030710
+        levels:
+            - medium
+        rules:
+            - rsyslog_encrypt_offload_actionsendstreamdrivermode
+            - rsyslog_encrypt_offload_defaultnetstreamdriver
+        title: RHEL 8 must encrypt the transfer of audit records off-loaded onto a different
+            system or media from the system being audited.
+        automated: 'yes'
+    -   id: RHEL-08-030720
+        levels:
+            - medium
+        title: RHEL 8 must authenticate the remote logging server for off-loading audit
+            logs.
+        automated: 'no'
+
+    -   id: RHEL-08-030730
+        levels:
+            - medium
+        rules:
+            - auditd_data_retention_space_left
+            - auditd_data_retention_space_left_action
+        title: RHEL 8 must take action when allocated audit record storage volume reaches
+            75 percent of the repository maximum audit record storage capacity.
+        automated: 'yes'
+    -   id: RHEL-08-030740
+        levels:
+            - medium
+        rules:
+            - chronyd_or_ntpd_set_maxpoll
+        title: RHEL 8 must securely compare internal information system clocks at least
+            every 24 hours with a server synchronized to an authoritative time source, such
+            as the United States Naval Observatory (USNO) time servers, or a time server designated
+            for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning
+            System (GPS).
+        automated: 'yes'
+    -   id: RHEL-08-030741
+        levels:
+            - low
+        rules:
+            - chronyd_client_only
+        title: RHEL 8 must disable the chrony daemon from acting as a server.
+        automated: 'yes'
+    -   id: RHEL-08-030742
+        levels:
+            - low
+        rules:
+            - chronyd_no_chronyc_network
+        title: RHEL 8 must disable network management of the chrony daemon.
+        automated: 'yes'
+    -   id: RHEL-08-040000
+        levels:
+            - high
+        rules:
+            - package_telnet-server_removed
+        title: RHEL 8 must not have the telnet-server package installed.
+        automated: 'yes'
+    -   id: RHEL-08-040001
+        levels:
+            - medium
+        rules:
+            - package_abrt_removed
+            - package_abrt-addon-ccpp_removed
+            - package_abrt-addon-kerneloops_removed
+            - package_abrt-addon-python_removed
+            - package_abrt-cli_removed
+            - package_abrt-plugin-logger_removed
+            - package_abrt-plugin-rhtsupport_removed
+            - package_abrt-plugin-sosreport_removed
+        title: RHEL 8 must not have any automated bug reporting tools installed.
+        automated: 'yes'
+    -   id: RHEL-08-040002
+        levels:
+            - medium
+        rules:
+            - package_sendmail_removed
+        title: RHEL 8 must not have the sendmail package installed.
+        automated: 'yes'
+    -   id: RHEL-08-040004
+        levels:
+            - low
+        rules:
+            - grub2_pti_argument
+        title: RHEL 8 must enable mitigations against processor-based vulnerabilities.
+        automated: 'yes'
+    -   id: RHEL-08-040010
+        levels:
+            - high
+        rules:
+            - package_rsh-server_removed
+        title: RHEL 8 must not have the rsh-server package installed.
+        automated: 'yes'
+    -   id: RHEL-08-040020
+        levels:
+            - medium
+        title: RHEL 8 must cover or disable the built-in or attached camera when not in
+            use.
+        automated: 'no'
+
+    -   id: RHEL-08-040021
+        levels:
+            - low
+        rules:
+            - kernel_module_atm_disabled
+        title: RHEL 8 must disable the asynchronous transfer mode (ATM) protocol.
+        automated: 'yes'
+    -   id: RHEL-08-040022
+        levels:
+            - low
+        rules:
+            - kernel_module_can_disabled
+        title: RHEL 8 must disable the controller area network (CAN) protocol.
+        automated: 'yes'
+    -   id: RHEL-08-040023
+        levels:
+            - low
+        rules:
+            - kernel_module_sctp_disabled
+        title: RHEL 8 must disable the stream control transmission protocol (SCTP).
+        automated: 'yes'
+    -   id: RHEL-08-040024
+        levels:
+            - low
+        rules:
+            - kernel_module_tipc_disabled
+        title: RHEL 8 must disable the transparent inter-process communication (TIPC) protocol.
+        automated: 'yes'
+    -   id: RHEL-08-040025
+        levels:
+            - low
+        rules:
+            - kernel_module_cramfs_disabled
+        title: RHEL 8 must disable mounting of cramfs.
+        automated: 'yes'
+    -   id: RHEL-08-040026
+        levels:
+            - low
+        rules:
+            - kernel_module_firewire-core_disabled
+        title: RHEL 8 must disable IEEE 1394 (FireWire) Support.
+        automated: 'yes'
+    -   id: RHEL-08-040030
+        levels:
+            - medium
+        rules:
+            - configure_firewalld_ports
+        title: RHEL 8 must be configured to prohibit or restrict the use of functions, ports,
+            protocols, and/or services, as defined in the Ports, Protocols, and Services Management
+            (PPSM) Category Assignments List (CAL) and vulnerability assessments.
+        automated: 'yes'
+    -   id: RHEL-08-040070
+        levels:
+            - medium
+        rules:
+            - service_autofs_disabled
+        title: The RHEL 8 file system automounter must be disabled unless required.
+        automated: 'yes'
+    -   id: RHEL-08-040080
+        levels:
+            - medium
+        rules:
+            - kernel_module_usb-storage_disabled
+        title: RHEL 8 must be configured to disable USB mass storage.
+        automated: 'yes'
+    -   id: RHEL-08-040090
+        levels:
+            - medium
+        title: A RHEL 8 firewall must employ a deny-all, allow-by-exception policy for allowing
+            connections to other systems.
+        automated: 'no'
+
+    -   id: RHEL-08-040100
+        levels:
+            - medium
+        rules:
+            - package_firewalld_installed
+            - service_firewalld_enabled
+        title: A firewall must be installed on RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-040110
+        levels:
+            - medium
+        rules:
+            - wireless_disable_interfaces
+        title: RHEL 8 wireless network adapters must be disabled.
+        automated: 'yes'
+    -   id: RHEL-08-040111
+        levels:
+            - medium
+        rules:
+            - kernel_module_bluetooth_disabled
+        title: RHEL 8 Bluetooth must be disabled.
+        automated: 'yes'
+    -   id: RHEL-08-040120
+        levels:
+            - medium
+        rules:
+            - mount_option_dev_shm_nodev
+        title: RHEL 8 must mount /dev/shm with the nodev option.
+        automated: 'yes'
+    -   id: RHEL-08-040121
+        levels:
+            - medium
+        rules:
+            - mount_option_dev_shm_nosuid
+        title: RHEL 8 must mount /dev/shm with the nosuid option.
+        automated: 'yes'
+    -   id: RHEL-08-040122
+        levels:
+            - medium
+        rules:
+            - mount_option_dev_shm_noexec
+        title: RHEL 8 must mount /dev/shm with the noexec option.
+        automated: 'yes'
+    -   id: RHEL-08-040123
+        levels:
+            - medium
+        rules:
+            - mount_option_tmp_nodev
+        title: RHEL 8 must mount /tmp with the nodev option.
+        automated: 'yes'
+    -   id: RHEL-08-040124
+        levels:
+            - medium
+        rules:
+            - mount_option_tmp_nosuid
+        title: RHEL 8 must mount /tmp with the nosuid option.
+        automated: 'yes'
+    -   id: RHEL-08-040125
+        levels:
+            - medium
+        rules:
+            - mount_option_tmp_noexec
+        title: RHEL 8 must mount /tmp with the noexec option.
+        automated: 'yes'
+    -   id: RHEL-08-040126
+        levels:
+            - medium
+        rules:
+            - mount_option_var_log_nodev
+        title: RHEL 8 must mount /var/log with the nodev option.
+        automated: 'yes'
+    -   id: RHEL-08-040127
+        levels:
+            - medium
+        rules:
+            - mount_option_var_log_nosuid
+        title: RHEL 8 must mount /var/log with the nosuid option.
+        automated: 'yes'
+    -   id: RHEL-08-040128
+        levels:
+            - medium
+        rules:
+            - mount_option_var_log_noexec
+        title: RHEL 8 must mount /var/log with the noexec option.
+        automated: 'yes'
+    -   id: RHEL-08-040129
+        levels:
+            - medium
+        rules:
+            - mount_option_var_log_audit_nodev
+        title: RHEL 8 must mount /var/log/audit with the nodev option.
+        automated: 'yes'
+    -   id: RHEL-08-040130
+        levels:
+            - medium
+        rules:
+            - mount_option_var_log_audit_nosuid
+        title: RHEL 8 must mount /var/log/audit with the nosuid option.
+        automated: 'yes'
+    -   id: RHEL-08-040131
+        levels:
+            - medium
+        rules:
+            - mount_option_var_log_audit_noexec
+        title: RHEL 8 must mount /var/log/audit with the noexec option.
+        automated: 'yes'
+    -   id: RHEL-08-040132
+        levels:
+            - medium
+        rules:
+            - mount_option_var_tmp_nodev
+        title: RHEL 8 must mount /var/tmp with the nodev option.
+        automated: 'yes'
+    -   id: RHEL-08-040133
+        levels:
+            - medium
+        rules:
+            - mount_option_var_tmp_nosuid
+        title: RHEL 8 must mount /var/tmp with the nosuid option.
+        automated: 'yes'
+    -   id: RHEL-08-040134
+        levels:
+            - medium
+        rules:
+            - mount_option_var_tmp_noexec
+        title: RHEL 8 must mount /var/tmp with the noexec option.
+        automated: 'yes'
+    -   id: RHEL-08-040135
+        levels:
+            - medium
+        rules:
+            - package_fapolicyd_installed
+            - service_fapolicyd_enabled
+        title: The RHEL 8 fapolicy module must be installed.
+        automated: 'yes'
+    -   id: RHEL-08-040140
+        levels:
+            - medium
+        rules:
+            - package_usbguard_installed
+            - service_usbguard_enabled
+            - usbguard_generate_policy
+        title: RHEL 8 must block unauthorized peripherals before establishing a connection.
+        automated: 'yes'
+    -   id: RHEL-08-040150
+        levels:
+            - medium
+        title: A firewall must be able to protect against or limit the effects of Denial
+            of Service (DoS) attacks by ensuring RHEL 8 can implement rate-limiting measures
+            on impacted network interfaces.
+        automated: 'no'
+
+    -   id: RHEL-08-040160
+        levels:
+            - medium
+        rules:
+            - package_openssh-server_installed
+            - service_sshd_enabled
+        title: All RHEL 8 networked systems must have and implement SSH to protect the confidentiality
+            and integrity of transmitted and received information, as well as information
+            during preparation for transmission.
+        automated: 'yes'
+    -   id: RHEL-08-040161
+        levels:
+            - medium
+        rules:
+            - sshd_rekey_limit
+        title: RHEL 8 must force a frequent session key renegotiation for SSH connections
+            to the server.
+        automated: 'yes'
+    -   id: RHEL-08-040170
+        levels:
+            - high
+        rules:
+            - disable_ctrlaltdel_reboot
+        title: The x86 Ctrl-Alt-Delete key sequence must be disabled on RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-040171
+        levels:
+            - high
+        rules:
+            - dconf_gnome_disable_ctrlaltdel_reboot
+        title: The x86 Ctrl-Alt-Delete key sequence in RHEL 8 must be disabled if a graphical
+            user interface is installed.
+        automated: 'yes'
+    -   id: RHEL-08-040172
+        levels:
+            - high
+        rules:
+            - disable_ctrlaltdel_burstaction
+        title: The systemd Ctrl-Alt-Delete burst key sequence in RHEL 8 must be disabled.
+        automated: 'yes'
+    -   id: RHEL-08-040180
+        levels:
+            - medium
+        rules:
+            - service_debug-shell_disabled
+        title: The debug-shell systemd service must be disabled on RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-040190
+        levels:
+            - high
+        rules:
+            - package_tftp-server_removed
+        title: The Trivial File Transfer Protocol (TFTP) server package must not be installed
+            if not required for RHEL 8 operational support.
+        automated: 'yes'
+    -   id: RHEL-08-040200
+        levels:
+            - high
+        rules:
+            - accounts_no_uid_except_zero
+        title: The root account must be the only account having unrestricted access to the
+            RHEL 8 system.
+        automated: 'yes'
+    -   id: RHEL-08-040210
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv6_conf_default_accept_redirects
+            - sysctl_net_ipv4_conf_default_accept_redirects
+        title: RHEL 8 must prevent IPv6 Internet Control Message Protocol (ICMP) redirect
+            messages from being accepted.
+        automated: 'yes'
+    -   id: RHEL-08-040220
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv4_conf_all_send_redirects
+        title: RHEL 8 must not send Internet Control Message Protocol (ICMP) redirects.
+        automated: 'yes'
+    -   id: RHEL-08-040230
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+        title: RHEL 8 must not respond to Internet Control Message Protocol (ICMP) echoes
+            sent to a broadcast address.
+        automated: 'yes'
+    -   id: RHEL-08-040240
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv6_conf_all_accept_source_route
+            - sysctl_net_ipv4_conf_all_accept_source_route
+        title: RHEL 8 must not forward IPv6 source-routed packets.
+        automated: 'yes'
+    -   id: RHEL-08-040250
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv6_conf_default_accept_source_route
+            - sysctl_net_ipv4_conf_default_accept_source_route
+        title: RHEL 8 must not forward IPv6 source-routed packets by default.
+        automated: 'yes'
+    -   id: RHEL-08-040260
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv4_ip_forward
+        title: RHEL 8 must not be performing packet forwarding unless the system is a router.
+        automated: 'yes'
+    -   id: RHEL-08-040261
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv6_conf_all_accept_ra
+        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces.
+        automated: 'yes'
+    -   id: RHEL-08-040262
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv6_conf_default_accept_ra
+        title: RHEL 8 must not accept router advertisements on all IPv6 interfaces by default.
+        automated: 'yes'
+    -   id: RHEL-08-040270
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv4_conf_default_send_redirects
+        title: RHEL 8 must not allow interfaces to perform Internet Control Message Protocol
+            (ICMP) redirects by default.
+        automated: 'yes'
+    -   id: RHEL-08-040280
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv6_conf_all_accept_redirects
+            - sysctl_net_ipv4_conf_all_accept_redirects
+        title: RHEL 8 must ignore IPv6 Internet Control Message Protocol (ICMP) redirect
+            messages.
+        automated: 'yes'
+    -   id: RHEL-08-040281
+        levels:
+            - medium
+        rules:
+            - sysctl_kernel_unprivileged_bpf_disabled
+        title: RHEL 8 must disable access to network bpf syscall from unprivileged processes.
+        automated: 'yes'
+    -   id: RHEL-08-040282
+        levels:
+            - medium
+        rules:
+            - sysctl_kernel_yama_ptrace_scope
+        title: RHEL 8 must restrict usage of ptrace to descendant  processes.
+        automated: 'yes'
+    -   id: RHEL-08-040283
+        levels:
+            - medium
+        rules:
+            - sysctl_kernel_kptr_restrict
+        title: RHEL 8 must restrict exposed kernel pointer addresses access.
+        automated: 'yes'
+    -   id: RHEL-08-040284
+        levels:
+            - medium
+        rules:
+            - sysctl_user_max_user_namespaces
+        title: RHEL 8 must disable the use of user namespaces.
+        automated: 'yes'
+    -   id: RHEL-08-040285
+        levels:
+            - medium
+        rules:
+            - sysctl_net_ipv4_conf_all_rp_filter
+        title: RHEL 8 must use reverse path filtering on all IPv4 interfaces.
+        automated: 'yes'
+    -   id: RHEL-08-040290
+        levels:
+            - medium
+        rules:
+            - postfix_prevent_unrestricted_relay
+        title: RHEL 8 must be configured to prevent unrestricted mail relaying.
+        automated: 'yes'
+    -   id: RHEL-08-040300
+        levels:
+            - low
+        rules:
+            - aide_verify_ext_attributes
+        title: The RHEL 8 file integrity tool must be configured to verify extended attributes.
+        automated: 'yes'
+    -   id: RHEL-08-040310
+        levels:
+            - low
+        rules:
+            - aide_verify_acls
+        title: The RHEL 8 file integrity tool must be configured to verify Access Control
+            Lists (ACLs).
+        automated: 'yes'
+    -   id: RHEL-08-040320
+        levels:
+            - medium
+        rules:
+            - package_xorg-x11-server-common_removed
+            - xwindows_remove_packages
+        title: The graphical display manager must not be installed on RHEL 8 unless approved.
+        automated: 'yes'
+    -   id: RHEL-08-040330
+        levels:
+            - medium
+        rules:
+            - network_sniffer_disabled
+        title: RHEL 8 network interfaces must not be in promiscuous mode.
+        automated: 'yes'
+    -   id: RHEL-08-040340
+        levels:
+            - medium
+        rules:
+            - sshd_disable_x11_forwarding
+        title: RHEL 8 remote X connections for interactive users must be disabled unless
+            to fulfill documented and validated mission requirements.
+        automated: 'yes'
+    -   id: RHEL-08-040341
+        levels:
+            - medium
+        rules:
+            - sshd_x11_use_localhost
+        title: The RHEL 8 SSH daemon must prevent remote hosts from connecting to the proxy
+            display.
+        automated: 'yes'
+    -   id: RHEL-08-040350
+        levels:
+            - medium
+        rules:
+            - tftpd_uses_secure_mode
+        title: If the Trivial File Transfer Protocol (TFTP) server is required, the RHEL
+            8 TFTP daemon must be configured to operate in secure mode.
+        automated: 'yes'
+    -   id: RHEL-08-040360
+        levels:
+            - high
+        rules:
+            - package_vsftpd_removed
+        title: A File Transfer Protocol (FTP) server package must not be installed unless
+            mission essential on RHEL 8.
+        automated: 'yes'
+    -   id: RHEL-08-040370
+        levels:
+            - medium
+        rules:
+            - package_gssproxy_removed
+        title: The gssproxy package must not be installed unless mission essential on RHEL
+            8.
+        automated: 'yes'
+    -   id: RHEL-08-040380
+        levels:
+            - medium
+        rules:
+            - package_iprutils_removed
+        title: The iprutils package must not be installed unless mission essential on RHEL
+            8.
+        automated: 'yes'
+    -   id: RHEL-08-040390
+        levels:
+            - medium
+        rules:
+            - package_tuned_removed
+        title: The tuned package must not be installed unless mission essential on RHEL
+            8.
+        automated: 'yes'
+    -   id: RHEL-08-010163
+        levels:
+            - medium
+        title: The krb5-server package must not be installed on RHEL 8.
+        automated: 'no'
+
+    -   id: RHEL-08-010382
+        levels:
+            - medium
+        rules:
+            - sudo_restrict_privilege_elevation_to_authorized
+        title: RHEL 8 must restrict privilege elevation to authorized personnel.
+        automated: 'yes'
+    -   id: RHEL-08-010383
+        levels:
+            - medium
+        rules:
+            - sudoers_validate_passwd
+        title: RHEL 8 must use the invoking user's password for privilege escalation when
+            using "sudo".
+        automated: 'yes'
+    -   id: RHEL-08-010384
+        levels:
+            - medium
+        rules:
+            - sudo_require_reauthentication
+        title: RHEL 8 must require re-authentication when using the "sudo" command.
+        automated: 'yes'
+    -   id: RHEL-08-010049
+        levels:
+            - medium
+        title: RHEL 8 must display a banner before granting local or remote access to the
+            system via a graphical user logon.
+        automated: 'no'
+
+    -   id: RHEL-08-010131
+        levels:
+            - medium
+        title: The RHEL 8 system-auth file must be configured to use a sufficient number
+            of hashing rounds.
+        automated: 'no'
+
+    -   id: RHEL-08-010141
+        levels:
+            - medium
+        title: RHEL 8 operating systems booted with United Extensible Firmware Interface
+            (UEFI) must require a unique superusers name upon booting into single-user mode
+            and maintenance.
+        automated: 'no'
+
+    -   id: RHEL-08-010149
+        levels:
+            - medium
+        title: RHEL 8 operating systems booted with a BIOS must require  a unique superusers
+            name upon booting into single-user and maintenance modes.
+        automated: 'no'
+
+    -   id: RHEL-08-010152
+        levels:
+            - medium
+        title: RHEL 8 operating systems must require authentication upon booting into emergency
+            mode.
+        automated: 'no'
+
+    -   id: RHEL-08-010159
+        levels:
+            - medium
+        title: The RHEL 8 pam_unix.so module must be configured in the system-auth file
+            to use a FIPS 140-2 approved cryptographic hashing algorithm for system authentication.
+        automated: 'no'
+
+    -   id: RHEL-08-010201
+        levels:
+            - medium
+        title: The RHEL 8 SSH daemon must be configured with a timeout interval.
+        automated: 'no'
+
+    -   id: RHEL-08-010287
+        levels:
+            - medium
+        title: The RHEL 8 SSH daemon must be configured to use system-wide crypto policies.
+        automated: 'no'
+
+    -   id: RHEL-08-010472
+        levels:
+            - low
+        title: RHEL 8 must have the packages required to use the hardware random number
+            generator entropy gatherer service.
+        automated: 'no'
+
+    -   id: RHEL-08-010522
+        levels:
+            - medium
+        title: The RHEL 8 SSH daemon must not allow GSSAPI authentication, except to fulfill
+            documented and validated mission requirements.
+        automated: 'no'
+
+    -   id: RHEL-08-010544
+        levels:
+            - medium
+        title: RHEL 8 must use a separate file system for /var/tmp.
+        automated: 'no'
+
+    -   id: RHEL-08-010572
+        levels:
+            - medium
+        title: RHEL 8 must prevent files with the setuid and setgid bit set from being executed
+            on the /boot/efi directory.
+        automated: 'no'
+
+    -   id: RHEL-08-010731
+        levels:
+            - medium
+        title: All RHEL 8 local interactive user home directory files must have mode 0750
+            or less permissive.
+        automated: 'no'
+
+    -   id: RHEL-08-010741
+        levels:
+            - medium
+        title: RHEL 8 must be configured so that all files and directories contained in
+            local interactive user home directories are group-owned by a group of which the
+            home directory owner is a member.
+        automated: 'no'
+
+    -   id: RHEL-08-020025
+        levels:
+            - medium
+        title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/system-auth
+            file.
+        automated: 'no'
+
+    -   id: RHEL-08-020026
+        levels:
+            - medium
+        title: RHEL 8 must configure the use of the pam_faillock.so module in the /etc/pam.d/password-auth
+            file.
+        automated: 'no'
+
+    -   id: RHEL-08-020031
+        levels:
+            - medium
+        title: RHEL 8 must initiate a session lock for graphical user interfaces when the
+            screensaver is activated.
+        automated: 'no'
+
+    -   id: RHEL-08-020032
+        levels:
+            - medium
+        title: RHEL 8 must disable the user list at logon for graphical user interfaces.
+        automated: 'no'
+
+    -   id: RHEL-08-020039
+        levels:
+            - medium
+        title: RHEL 8 must have the tmux package installed.
+        automated: 'no'
+
+    -   id: RHEL-08-020081
+        levels:
+            - medium
+        title: RHEL 8 must prevent a user from overriding the session idle-delay setting
+            for the graphical user interface.
+        automated: 'no'
+
+    -   id: RHEL-08-020082
+        levels:
+            - medium
+        title: RHEL 8 must prevent a user from overriding the screensaver lock-enabled setting
+            for the graphical user interface.
+        automated: 'no'
+
+    -   id: RHEL-08-020331
+        levels:
+            - high
+        title: RHEL 8 must not allow blank or null passwords in the system-auth file.
+        automated: 'no'
+
+    -   id: RHEL-08-020332
+        levels:
+            - high
+        title: RHEL 8 must not allow blank or null passwords in the password-auth file.
+        automated: 'no'
+
+    -   id: RHEL-08-030181
+        levels:
+            - medium
+        title: RHEL 8 audit records must contain information to establish what type of events
+            occurred, the source of events, where events occurred, and the outcome of events.
+        automated: 'no'
+
+    -   id: RHEL-08-030731
+        levels:
+            - medium
+        title: RHEL 8 must notify the System Administrator (SA) and Information System Security
+            Officer (ISSO) (at a minimum) when allocated audit record storage volume 75 percent
+            utilization.
+        automated: 'no'
+
+    -   id: RHEL-08-040101
+        levels:
+            - medium
+        title: A firewall must be active on RHEL 8.
+        automated: 'no'
+
+    -   id: RHEL-08-040136
+        levels:
+            - medium
+        title: The RHEL 8 fapolicy module must be enabled.
+        automated: 'no'
+
+    -   id: RHEL-08-040137
+        levels:
+            - medium
+        title: The RHEL 8 fapolicy module must be configured to employ a deny-all, permit-by-exception
+            policy to allow the execution of authorized software programs.
+        automated: 'no'
+
+    -   id: RHEL-08-040139
+        levels:
+            - medium
+        title: RHEL 8 must have the USBGuard installed.
+        automated: 'no'
+
+    -   id: RHEL-08-040141
+        levels:
+            - medium
+        title: RHEL 8 must enable the USBGuard.
+        automated: 'no'
+
+    -   id: RHEL-08-040159
+        levels:
+            - medium
+        title: All RHEL 8 networked systems must have SSH installed.
+        automated: 'no'
+
+    -   id: RHEL-08-040209
+        levels:
+            - medium
+        title: RHEL 8 must prevent IPv4 Internet Control Message Protocol (ICMP) redirect
+            messages from being accepted.
+        automated: 'no'
+
+    -   id: RHEL-08-040239
+        levels:
+            - medium
+        title: RHEL 8 must not forward IPv4 source-routed packets.
+        automated: 'no'
+
+    -   id: RHEL-08-040249
+        levels:
+            - medium
+        title: RHEL 8 must not forward IPv4 source-routed packets by default.
+        automated: 'no'
+
+    -   id: RHEL-08-040279
+        levels:
+            - medium
+        title: RHEL 8 must ignore IPv4 Internet Control Message Protocol (ICMP) redirect
+            messages.
+        automated: 'no'
+
+    -   id: RHEL-08-040286
+        levels:
+            - medium
+        title: RHEL 8 must enable hardening for the Berkeley Packet Filter Just-in-time
+            compiler.
+        automated: 'no'
+
+    -   id: RHEL-08-010001
+        levels:
+            - medium
+        title: The RHEL 8 operating system must implement the Endpoint Security for Linux
+            Threat Prevention tool.
+        automated: 'no'
+

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -61,6 +61,14 @@ rules selected by another profile, run this command:
 This will result in a new YAML profile containing exclusive rules to the
 profile pointed by the `--profile1` option.
 
+## Generating Controls from DISA's XCCDF Files
+If you want a control file for product from DISA's XCCDF files you can run the following command:
+
+    $ ./utils/build_stig_control.py -p rhel8 -m shared/references/disa-stig-rhel8-v1r3-xccdf-manual.xml
+
+Where `-p` is the id the comes after `stigid@` in the `references` section of a rule and `-m` is the path to the
+XCCDF Manual file from DISA.
+
 ## Generating login banner regular expressions
 
 Rules like `banner_etc_issue` and `dconf_gnome_login_banner_text` will

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -113,9 +113,9 @@ def get_controls(known_rules, ns, root):
             control['title'] = stig.find('checklist:title', ns).text
             if stig_id in known_rules.keys():
                 control['rules'] = known_rules.get(stig_id)
-                control['automated'] = 'yes'
+                control['status'] = 'automated'
             else:
-                control['automated'] = 'no'
+                control['status'] = 'pending'
             controls.append(control)
     return controls
 

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import argparse
+import json
+import os
+import sys
+
+import xml.etree.ElementTree as ET
+import yaml
+
+import ssg.build_yaml
+import ssg.environment
+import ssg.rules
+import ssg.yaml
+
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+BUILD_OUTPUT = os.path.join(SSG_ROOT, "build", "stig_control.yml")
+RULES_JSON = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
+BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-r", "--root", type=str, action="store", default=SSG_ROOT,
+                        help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
+    parser.add_argument("-o", "--output", type=str, action="store", default=BUILD_OUTPUT,
+                        help="File to write yaml output to (defaults to build/stig_control.yml)")
+    parser.add_argument("-p", "--product", type=str, action="store", required=True,
+                        help="What product to get STIGs for")
+    parser.add_argument("-m", "--manual", type=str, action="store", required=True,
+                        help="Path to XML XCCDF manual file to use as the source of the STIGs")
+    parser.add_argument("-j", "--json", type=str, action="store", default=RULES_JSON,
+                        help="Path to the rules_dir.json (defaults to build/stig_control.json)")
+    parser.add_argument("-c", "--build-config-yaml", default=BUILD_CONFIG,
+                        help="YAML file with information about the build configuration. ")
+    parser.add_argument("-ref", "--reference", type=str, default="stigid",
+                        help="Reference system to check for, defaults to stigid")
+
+    return parser.parse_args()
+
+
+def handle_rule_yaml(args, rule_id, rule_dir, guide_dir, env_yaml):
+    rule_obj = {'id': rule_id, 'dir': rule_dir, 'guide': guide_dir}
+    rule_file = ssg.rules.get_rule_dir_yaml(rule_dir)
+
+    rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, env_yaml=env_yaml)
+    rule_yaml.normalize(args.product)
+    rule_obj['references'] = rule_yaml.references
+    return rule_obj
+
+
+def get_platform_rules(args):
+    rules_json_file = open(args.json, 'r')
+    rules_json = json.load(rules_json_file)
+    platform_rules = list()
+    for rule in rules_json.values():
+        if args.product in rule['products']:
+            platform_rules.append(rule)
+    if not rules_json_file.closed:
+        rules_json_file.close()
+    return platform_rules
+
+
+def get_implemented_stigs(args):
+    platform_rules = get_platform_rules(args)
+
+    product_dir = os.path.join(args.root, "products", args.product)
+    product_yaml_path = os.path.join(product_dir, "product.yml")
+    env_yaml = ssg.environment.open_environment(args.build_config_yaml, str(product_yaml_path))
+
+    known_rules = dict()
+    for rule in platform_rules:
+        try:
+            rule_obj = handle_rule_yaml(args, rule['id'],
+                                        rule['dir'], rule['guide'], env_yaml)
+        except ssg.yaml.DocumentationNotComplete:
+            sys.stderr.write('Rule %s throw DocumentationNotComplete' % rule['id'])
+            # Happens on non-debug build when a rule is "documentation-incomplete"
+            continue
+
+        if args.reference in rule_obj['references'].keys():
+            ref = rule_obj['references'][args.reference]
+            if ref in known_rules:
+                known_rules[ref].append(rule['id'])
+            else:
+                known_rules[ref] = [rule['id']]
+    return known_rules
+
+
+def check_files(args):
+    if not os.path.exists(args.json):
+        sys.stderr.write('Unable to find %s\n' % args.json)
+        sys.stderr.write('Hint: run ./utils/rule_dir_json.py\n')
+        exit(-1)
+
+    if not os.path.exists(args.build_config_yaml):
+        sys.stderr.write('Unable to find %s\n' % args.build_config_yaml)
+        sys.stderr.write('Hint: build the project,\n')
+        exit(-1)
+
+
+def get_controls(known_rules, ns, root):
+    controls = list()
+    for group in root.findall('checklist:Group', ns):
+        for stig in group.findall('checklist:Rule', ns):
+            stig_id = stig.find('checklist:version', ns).text
+            control = dict()
+            control['id'] = stig_id
+            control['levels'] = [stig.attrib['severity']]
+            control['title'] = stig.find('checklist:title', ns).text
+            if stig_id in known_rules.keys():
+                control['rules'] = known_rules.get(stig_id)
+                control['automated'] = 'yes'
+            else:
+                control['automated'] = 'no'
+            controls.append(control)
+    return controls
+
+
+def main():
+    args = parse_args()
+    check_files(args)
+
+    ns = {'checklist': 'http://checklists.nist.gov/xccdf/1.1'}
+    known_rules = get_implemented_stigs(args)
+    tree = ET.parse(args.manual)
+    root = tree.getroot()
+    output = dict()
+    output['policy'] = root.find('checklist:title', ns).text
+    output['title'] = root.find('checklist:title', ns).text
+    output['id'] = 'stig_%s' % args.product
+    output['source'] = 'https://public.cyber.mil/stigs/downloads/'
+    output['levels'] = list()
+    for level in ['high', 'medium', 'low']:
+        output['levels'].append({'id': level})
+    output['controls'] = get_controls(known_rules, ns, root)
+    with open(args.output, 'w') as f:
+        f.write(yaml.dump(output, sort_keys=False))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Description:

Provides a scripted method to create control files based on DISA's XCCDF files and gives RHEL8 as an example.

#### Rationale:

This allow us better find gaps in our coverage on STIGs.