### PR TITLE
Update STIG mapping table to reflect statistics of coverage.

### DIFF
--- a/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
+++ b/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
@@ -28,26 +28,47 @@
       <xsl:variable name="overlay_ref" select="@disa"/>
       <xsl:variable name="overlay_title" select="xccdf:title/@text"/>
 
-      <xsl:for-each select="$rules">
-        <xsl:if test="@id=$overlay_rule">
-		  <Group id="V-{$overlay_id}">
-		    <title>SRG-OS-ID</title>
-		    <description></description>
-            <Rule id="{$overlay_rule}" severity="{$overlay_severity}" >
-			<version><xsl:value-of select="$overlay_version"/></version>
-          	<title><xsl:value-of select="$overlay_title"/></title>
-          	<description><xsl:copy-of select="xccdf:rationale/node()" /></description>
-          	<check system="C-{$overlay_id}_chk">
-              <check-content>
-					      <xsl:apply-templates select="xccdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/>
-              </check-content>
-          	</check>
-		  	<ident system="https://public.cyber.mil/stigs/cci"><xsl:value-of select="$overlay_ref" /></ident>
-          	<fixtext><xsl:copy-of select="xccdf:description/node()" /></fixtext>
-          </Rule> 
+      <xsl:choose>
+        <xsl:when test="$overlay_rule='XXXX'">
+          <Group id="V-{$overlay_id}">
+            <title>SRG-OS-ID</title>
+            <description></description>
+                <Rule id="Missing Rule" severity="{$overlay_severity}" >
+          <version><xsl:value-of select="$overlay_version"/></version>
+                <title><xsl:value-of select="$overlay_title"/></title>
+                <description></description>
+                <check system="C-{$overlay_id}_chk">
+                  <check-content>
+                  </check-content>
+                </check>
+                <ident></ident>
+                <fixtext></fixtext>
+              </Rule>
           </Group>
-        </xsl:if>
-      </xsl:for-each> 
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:for-each select="$rules">
+            <xsl:if test="@id=$overlay_rule">
+          <Group id="V-{$overlay_id}">
+            <title>SRG-OS-ID</title>
+            <description></description>
+                <Rule id="{$overlay_rule}" severity="{$overlay_severity}" >
+          <version><xsl:value-of select="$overlay_version"/></version>
+                <title><xsl:value-of select="$overlay_title"/></title>
+                <description><xsl:copy-of select="xccdf:rationale/node()" /></description>
+                <check system="C-{$overlay_id}_chk">
+                  <check-content>
+                    <xsl:apply-templates select="xccdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/>
+                  </check-content>
+                </check>
+            <ident system="https://public.cyber.mil/stigs/cci"><xsl:value-of select="$overlay_ref" /></ident>
+                <fixtext><xsl:copy-of select="xccdf:description/node()" /></fixtext>
+              </Rule>
+              </Group>
+            </xsl:if>
+          </xsl:for-each>
+        </xsl:otherwise>
+    </xsl:choose>
 
     </xsl:for-each> 
     </xsl:copy>

--- a/shared/transforms/shared_xccdf2table-stig.xslt
+++ b/shared/transforms/shared_xccdf2table-stig.xslt
@@ -20,6 +20,34 @@
 			</div>
 			<br/>
 			<br/>
+
+			<div>
+			<table>
+				<thead>
+				  <tr>
+					<th>Total</th>
+					<th>Missing</th>
+					<th>Implemented</th>
+					<th>Coverage</th>
+					<th>STIG ids missing rule</th>
+				  </tr>
+				</thead>
+				<tbody>
+				  <tr>
+					<td><xsl:value-of select="number(count(/cdf:Benchmark/cdf:Group/cdf:Rule))"/></td>
+					<td><xsl:value-of select="number(count(/cdf:Benchmark/cdf:Group/cdf:Rule[@id='Missing Rule']))"/></td>
+					<td><xsl:value-of select="number(count(/cdf:Benchmark/cdf:Group/cdf:Rule[@id!='Missing Rule']))"/></td>
+					<td><xsl:value-of select="format-number(count(/cdf:Benchmark/cdf:Group/cdf:Rule[@id!='Missing Rule']) div count(/cdf:Benchmark/cdf:Group/cdf:Rule)*100, '#.00')"/>%</td>
+					<td>
+						<xsl:for-each select="/cdf:Benchmark/cdf:Group/cdf:Rule[@id='Missing Rule']">
+							<xsl:value-of select="cdf:version/node()"/><xsl:text>&#xd;</xsl:text>
+						</xsl:for-each>
+					</td>
+				  </tr>
+				</tbody>
+				</table>
+			</div>
+
 			<xsl:apply-templates select="cdf:Benchmark"/>
 		</body>
 		</html>


### PR DESCRIPTION
#### Description:

- The XSLT transformation was updated to generate statistics about coverage of STIG items.

Before: https://jenkins.complianceascode.io/job/scap-security-guide-stats/HTML_20Mapping_20Tables/table-rhel8-stig.html

Preview - download and remove the .txt extension to open the HTML page.
[table-rhel8-stig.html.txt](https://github.com/ComplianceAsCode/content/files/6939588/table-rhel8-stig.html.txt)

