### PR TITLE
Allow audit syscall rules remediations to group the syscalls

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
@@ -76,3 +76,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: chmod
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
@@ -74,3 +74,8 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: chown
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
@@ -74,3 +74,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: fchmod
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -74,3 +74,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: fchmodat
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
@@ -77,3 +77,8 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: fchown
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
@@ -74,3 +74,8 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: fchownat
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -93,3 +93,10 @@ template:
         attr: fremovexattr
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        syscall_grouping:
+          - fremovexattr
+          - lremovexattr
+          - removexattr
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -88,3 +88,10 @@ template:
         attr: fsetxattr
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        syscall_grouping:
+          - fremovexattr
+          - lremovexattr
+          - removexattr
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -74,3 +74,8 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: lchown
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -93,3 +93,10 @@ template:
         attr: lremovexattr
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        syscall_grouping:
+          - fremovexattr
+          - lremovexattr
+          - removexattr
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -86,3 +86,10 @@ template:
         attr: lsetxattr
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        syscall_grouping:
+          - fremovexattr
+          - lremovexattr
+          - removexattr
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -92,3 +92,10 @@ template:
         attr: removexattr
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        syscall_grouping:
+          - fremovexattr
+          - lremovexattr
+          - removexattr
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -88,3 +88,10 @@ template:
         attr: setxattr
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        syscall_grouping:
+          - fremovexattr
+          - lremovexattr
+          - removexattr
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
@@ -9,11 +9,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F auid>={{{ auid }}} -F auid!=unset -k *"
-	# Use escaped BRE regex to specify rule group
-	GROUP="\(rmdir\|unlink\|rename\)"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid>={{{ auid }}} -F auid!=unset -k delete"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	SYSCALL="rmdir unlink unlinkat rename renameat"
+	KEY="delete"
+	SYSCALL_GROUPING="rmdir unlink unlinkat rename renameat"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -59,3 +59,9 @@ template:
     name: audit_rules_file_deletion_events
     vars:
         name: rename
+        syscall_grouping:
+          - unlink
+          - unlinkat
+          - rename
+          - renameat
+          - rmdir

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -59,3 +59,9 @@ template:
     name: audit_rules_file_deletion_events
     vars:
         name: renameat
+        syscall_grouping:
+          - unlink
+          - unlinkat
+          - rename
+          - renameat
+          - rmdir

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -57,3 +57,9 @@ template:
     name: audit_rules_file_deletion_events
     vars:
         name: rmdir
+        syscall_grouping:
+          - unlink
+          - unlinkat
+          - rename
+          - renameat
+          - rmdir

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -59,3 +59,9 @@ template:
     name: audit_rules_file_deletion_events
     vars:
         name: unlink
+        syscall_grouping:
+          - unlink
+          - unlinkat
+          - rename
+          - renameat
+          - rmdir

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -59,3 +59,9 @@ template:
     name: audit_rules_file_deletion_events
     vars:
         name: unlinkat
+        syscall_grouping:
+          - unlink
+          - unlinkat
+          - rename
+          - renameat
+          - rmdir

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -12,7 +12,7 @@ do
 
 	# First fix the -EACCES requirement
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
-	OTHER_FILTERS="-F exit=EACCES"
+	OTHER_FILTERS="-F exit=-EACCES"
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
 	KEY="access"
@@ -24,7 +24,7 @@ do
 	# Then fix the -EPERM requirement
 	# No need to change content of $GROUP variable - it's the same as for -EACCES case above
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
-	OTHER_FILTERS="-F exit=EPERM"
+	OTHER_FILTERS="-F exit=-EPERM"
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
 	KEY="access"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -11,20 +11,26 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 
 	# First fix the -EACCES requirement
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -k *"
-	# Use escaped BRE regex to specify rule group
-	GROUP="\(creat\|open\|truncate\)"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -k access"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-F exit=EACCES"
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
+	KEY="access"
+	SYSCALL_GROUPING="creat open openat open_by_handle_at truncate ftruncate"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 
 	# Then fix the -EPERM requirement
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -k *"
 	# No need to change content of $GROUP variable - it's the same as for -EACCES case above
-	FULL_RULE="-a always,exit -F arch=$ARCH -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -k access"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-F exit=EPERM"
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	SYSCALL="creat open openat open_by_handle_at truncate ftruncate"
+	KEY="access"
+	SYSCALL_GROUPING="creat open openat open_by_handle_at truncate ftruncate"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chmod/rule.yml
@@ -51,3 +51,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: chmod
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_chown/rule.yml
@@ -51,3 +51,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: chown
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -79,3 +79,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: creat
+        syscall_grouping:
+          - creat
+          - ftruncate
+          - truncate
+          - open
+          - openat
+          - open_by_handle_at

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmod/rule.yml
@@ -51,3 +51,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: fchmod
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchmodat/rule.yml
@@ -51,3 +51,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: fchmodat
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchown/rule.yml
@@ -51,3 +51,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: fchown
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fchownat/rule.yml
@@ -51,3 +51,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: fchownat
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_fsetxattr/rule.yml
@@ -51,3 +51,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: fsetxattr
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -82,3 +82,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: ftruncate
+        syscall_grouping:
+          - creat
+          - ftruncate
+          - truncate
+          - open
+          - openat
+          - open_by_handle_at

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lchown/rule.yml
@@ -55,3 +55,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: lchown
+        syscall_grouping:
+          - chown
+          - fchown
+          - fchownat
+          - lchown

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_lsetxattr/rule.yml
@@ -51,3 +51,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: lsetxattr
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -82,3 +82,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: open
+        syscall_grouping:
+          - creat
+          - ftruncate
+          - truncate
+          - open
+          - openat
+          - open_by_handle_at

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -78,3 +78,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: open_by_handle_at
+        syscall_grouping:
+          - creat
+          - ftruncate
+          - truncate
+          - open
+          - openat
+          - open_by_handle_at

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -82,3 +82,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: openat
+        syscall_grouping:
+          - creat
+          - ftruncate
+          - truncate
+          - open
+          - openat
+          - open_by_handle_at

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -64,3 +64,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: rename
+        syscall_grouping:
+          - rename
+          - renameat
+          - unlink
+          - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -64,3 +64,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: renameat
+        syscall_grouping:
+          - rename
+          - renameat
+          - unlink
+          - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
@@ -49,3 +49,9 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: renameat2
+        syscall_grouping:
+          - rename
+          - renameat
+          - renameat2
+          - unlink
+          - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_setxattr/rule.yml
@@ -51,3 +51,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: setxattr
+        syscall_grouping:
+          - chmod
+          - fchmod
+          - fchmodat
+          - fsetxattr
+          - lsetxattr
+          - setxattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -81,3 +81,10 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: truncate
+        syscall_grouping:
+          - creat
+          - ftruncate
+          - truncate
+          - open
+          - openat
+          - open_by_handle_at

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -66,3 +66,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: unlink
+        syscall_grouping:
+          - rename
+          - renameat
+          - unlink
+          - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -66,3 +66,8 @@ template:
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: unlinkat
+        syscall_grouping:
+          - rename
+          - renameat
+          - unlink
+          - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -15,11 +15,39 @@
 
 - name: Perform remediation of Audit rules for kernel module loading for x86 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=audit_syscalls, key="modules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=audit_syscalls, key="modules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=audit_syscalls,
+      key="modules",
+      syscall_grouping=audit_syscalls,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=audit_syscalls,
+      key="modules",
+      syscall_grouping=audit_syscalls,
+      )|indent(4) }}}
 
 - name: Perform remediation of Audit rules for kernel module loading for x86_64 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=audit_syscalls, key="modules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=audit_syscalls, key="modules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=audit_syscalls,
+      key="modules",
+      syscall_grouping=audit_syscalls,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=audit_syscalls,
+      key="modules",
+      syscall_grouping=audit_syscalls,
+      )|indent(4) }}}
   when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
@@ -13,10 +13,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-        GROUP="modules"
-        PATTERN="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module \(-F key=\|-k \).*"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -S delete_module -S finit_module -k modules"
+        ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+        OTHER_FILTERS=""
+        AUID_FILTERS=""
+        SYSCALL="init_module finit_module delete_module"
+        KEY="modules"
+        SYSCALL_GROUPING="init_module finit_module delete_module"
         # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-        fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-        fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+        fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+        fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
@@ -10,7 +10,7 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for delete_module for x86 platform
+- name: Perform remediation of Audit rules for delete_module for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -29,7 +29,7 @@
       syscall_grouping=[],
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for delete_module for x86_64 platform
+- name: Perform remediation of Audit rules for delete_module for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
@@ -10,54 +10,41 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-# Inserts/replaces the rule in /etc/audit/rules.d
+- name: Perform remediattion of Audit rules for delete_module for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["delete_module"],
+      key="module-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["delete_module"],
+      key="module-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
 
-- name: Search /etc/audit/rules.d for audit rule entries
-  find:
-    paths: /etc/audit/rules.d
-    recurse: false
-    contains: ^.*delete_module.*$
-    patterns: '*.rules'
-  register: find_delete_module
-
-- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
-  set_fact:
-    all_files:
-    - /etc/audit/rules.d/privileged.rules
-  when: find_delete_module.matched is defined and find_delete_module.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-    - '{{ find_delete_module.files | map(attribute=''path'') | list | first }}'
-  when: find_delete_module.matched is defined and find_delete_module.matched > 0
-
-- name: Inserts/replaces the delete_module rule in rules.d
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: '-a always,exit -F arch=b32 -S delete_module -k module-change'
-    state: present
-    create: true
-
-- name: Inserts/replaces the delete_module rule in rules.d on x86_64
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: '-a always,exit -F arch=b64 -S delete_module -k module-change'
-    state: present
-    create: true
-  when: audit_arch is defined and audit_arch == 'b64'
-
-# Inserts/replaces the delete_modules rule in /etc/audit/audit.rules
-
-- name: Inserts/replaces the delete_module rule in audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F arch=b32 -S delete_module -k module-change'
-    create: true
-
-- name: Inserts/replaces the delete_module rule in audit.rules when on x86_64
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F arch=b64 -S delete_module -k module-change'
-    create: true
-  when: audit_arch is defined and audit_arch == 'b64'
+- name: Perform remediattion of Audit rules for delete_module for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["delete_module"],
+      key="module-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["delete_module"],
+      key="module-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/bash/shared.sh
@@ -13,10 +13,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S delete_module \(-F key=\|-k \).*"
-	GROUP="modules"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S delete_module -k modules"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS=""
+	SYSCALL="delete_module"
+	KEY="modules"
+	SYSCALL_GROUPING="delete_module"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
@@ -10,7 +10,7 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for finit_module for x86 platform
+- name: Perform remediation of Audit rules for finit_module for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -29,7 +29,7 @@
       syscall_grouping=["init_module","finit_module"],
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for finit_module for x86_64 platform
+- name: Perform remediation of Audit rules for finit_module for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
@@ -10,54 +10,41 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-# Inserts/replaces the rule in /etc/audit/rules.d
+- name: Perform remediattion of Audit rules for finit_module for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["finit_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["finit_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
 
-- name: Search /etc/audit/rules.d for audit rule entries
-  find:
-    paths: /etc/audit/rules.d
-    recurse: false
-    contains: ^.*finit_module.*$
-    patterns: '*.rules'
-  register: find_finit_module
-
-- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
-  set_fact:
-    all_files:
-    - /etc/audit/rules.d/privileged.rules
-  when: find_finit_module.matched is defined and find_finit_module.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-    - '{{ find_finit_module.files | map(attribute=''path'') | list | first }}'
-  when: find_finit_module.matched is defined and find_finit_module.matched > 0
-
-- name: Inserts/replaces the finit_module rule in rules.d
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: '-a always,exit -F arch=b32 -S finit_module -k module-change'
-    state: present
-    create: true
-
-- name: Inserts/replaces the finit_module rule in rules.d on x86_64
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: '-a always,exit -F arch=b64 -S finit_module -k module-change'
-    state: present
-    create: true
-  when: audit_arch is defined and audit_arch == 'b64'
-
-# Inserts/replaces the finit_modules rule in /etc/audit/audit.rules
-
-- name: Inserts/replaces the finit_module rule in audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F arch=b32 -S finit_module -k module-change'
-    create: true
-
-- name: Inserts/replaces the finit_module rule in audit.rules when on x86_64
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F arch=b64 -S finit_module -k module-change'
-    create: true
-  when: audit_arch is defined and audit_arch == 'b64'
+- name: Perform remediattion of Audit rules for finit_module for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["finit_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["finit_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/bash/shared.sh
@@ -13,10 +13,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S finit_module \(-F key=\|-k \).*"
-	GROUP="modules"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S finit_module -k modules"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS=""
+	SYSCALL="finit_module"
+	KEY="modules"
+	SYSCALL_GROUPING="init_module finit_module"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
@@ -10,53 +10,41 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-# Inserts/replaces the rule in /etc/audit/rules.d
+- name: Perform remediattion of Audit rules for init_module for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["init_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["init_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
 
-- name: Search /etc/audit/rules.d for audit rule entries
-  find:
-    paths: /etc/audit/rules.d
-    recurse: false
-    contains: ^.*init_module.*$
-    patterns: '*.rules'
-  register: find_init_module
-
-- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
-  set_fact:
-    all_files:
-    - /etc/audit/rules.d/privileged.rules
-  when: find_init_module.matched is defined and find_init_module.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-    - '{{ find_init_module.files | map(attribute=''path'') | list | first }}'
-  when: find_init_module.matched is defined and find_init_module.matched > 0
-
-- name: Inserts/replaces the init_module rule in rules.d
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: '-a always,exit -F arch=b32 -S init_module -k module-change'
-    state: present
-    create: true
-
-- name: Inserts/replaces the init_module rule in rules.d on x86_64
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: '-a always,exit -F arch=b64 -S init_module -k module-change'
-    state: present
-    create: true
-  when: audit_arch is defined and audit_arch == 'b64'
-
-# Inserts/replaces the init_modules rule in /etc/audit/audit.rules
-
-- name: Inserts/replaces the init_module rule in audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F arch=b32 -S init_module -k module-change'
-    create: true
-- name: Inserts/replaces the init_module rule in audit.rules when on x86_64
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F arch=b64 -S init_module -k module-change'
-    create: true
-  when: audit_arch is defined and audit_arch == 'b64'
+- name: Perform remediattion of Audit rules for init_module for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["init_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["init_module"],
+      key="module-change",
+      syscall_grouping=["init_module","finit_module"],
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
@@ -10,7 +10,7 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for init_module for x86 platform
+- name: Perform remediation of Audit rules for init_module for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -29,7 +29,7 @@
       syscall_grouping=["init_module","finit_module"],
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for init_module for x86_64 platform
+- name: Perform remediation of Audit rules for init_module for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/bash/shared.sh
@@ -13,10 +13,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S init_module \(-F key=\|-k \).*"
-	GROUP="modules"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S init_module -k modules"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS=""
+	SYSCALL="init_module"
+	KEY="modules"
+	SYSCALL_GROUPING="init_module finit_module"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
@@ -13,13 +13,41 @@
 
 - name: Remediate audit rules for network configuration for x86
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["sethostname", "setdomainname"], key="audit_rules_networkconfig_modification")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["sethostname", "setdomainname"], key="audit_rules_networkconfig_modification")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["sethostname", "setdomainname"],
+      key="audit_rules_networkconfig_modification",
+      syscall_grouping=["sethostname", "setdomainname"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["sethostname", "setdomainname"],
+      key="audit_rules_networkconfig_modification",
+      syscall_grouping=["sethostname", "setdomainname"],
+      )|indent(4) }}}
 
 - name: Remediate audit rules for network configuration for x86_64
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["sethostname", "setdomainname"], key="audit_rules_networkconfig_modification")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["sethostname", "setdomainname"], key="audit_rules_networkconfig_modification")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["sethostname", "setdomainname"],
+      key="audit_rules_networkconfig_modification",
+      syscall_grouping=["sethostname", "setdomainname"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["sethostname", "setdomainname"],
+      key="audit_rules_networkconfig_modification",
+      syscall_grouping=["sethostname", "setdomainname"],
+      )|indent(4) }}}
   when: audit_arch == "b64"
 
 # remediate watches

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/bash/shared.sh
@@ -9,13 +9,15 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S .* -k *"
-	# Use escaped BRE regex to specify rule group
-	GROUP="set\(host\|domain\)name"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S sethostname -S setdomainname -k audit_rules_networkconfig_modification"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS=""
+	SYSCALL="sethostname setdomainname"
+	KEY="audit_rules_networkconfig_modification"
+	SYSCALL_GROUPING="sethostname setdomainname"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done
 
 # Then perform the remediations for the watch rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
@@ -9,20 +9,26 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S execve -C uid!=euid -F euid=0"
-	GROUP="privileged"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S execve -C uid!=euid -F euid=0 -k setuid"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-C uid!=euid -F euid=0"
+	AUID_FILTERS=""
+	SYSCALL="execve"
+	KEY="setuid"
+	SYSCALL_GROUPING=""
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S execve -C gid!=egid -F egid=0"
-	GROUP="privileged"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S execve -C gid!=egid -F egid=0 -k setgid"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-C gid!=egid -F egid=0"
+	AUID_FILTERS=""
+	SYSCALL="execve"
+	KEY="setgid"
+	SYSCALL_GROUPING=""
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
@@ -30,7 +30,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_uid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -39,7 +39,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_uid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -48,7 +48,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_uid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -57,7 +57,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_uid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+-k[\s]setuid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -66,7 +66,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_gid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_gid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -84,7 +84,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_gid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -93,7 +93,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_gid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+-k[\s]setgid[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/ansible/shared.yml
@@ -10,11 +10,39 @@
 
 - name: Perform remediation of Audit rules for adjtimex for x86 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["adjtimex"], key="audit_time_rules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["adjtimex"], key="audit_time_rules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["adjtimex"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["adjtimex"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
 
 - name: Perform remediation of Audit rules for adjtimex for x86_64 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["adjtimex"], key="audit_time_rules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["adjtimex"], key="audit_time_rules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["adjtimex"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["adjtimex"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
   when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/ansible/shared.yml
@@ -12,11 +12,39 @@
 
 - name: Perform remediation of Audit rules for clock_settime for x86 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["clock_settime"], key="time-change", fields=["a0=0x0"])|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["clock_settime"], key="time-change", fields=["a0=0x0"])|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="-F a0=0x0",
+      auid_filters="",
+      syscalls=["clock_settime"],
+      key="time-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="-F a0=0x0",
+      auid_filters="",
+      syscalls=["clock_settime"],
+      key="time-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
 
 - name: Perform remediation of Audit rules for clock_settime for x86_64 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["clock_settime"], key="time-change", fields=["a0=0x0"])|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["clock_settime"], key="time-change", fields=["a0=0x0"])|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F a0=0x0",
+      auid_filters="",
+      syscalls=["clock_settime"],
+      key="time-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F a0=0x0",
+      auid_filters="",
+      syscalls=["clock_settime"],
+      key="time-change",
+      syscall_grouping=[],
+      )|indent(4) }}}
   when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/bash/shared.sh
@@ -9,10 +9,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S clock_settime -F a0=.* \(-F key=\|-k \).*"
-	GROUP="clock_settime"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S clock_settime -F a0=0x0 -k time-change"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-F a0=0x0"
+	AUID_FILTERS=""
+	SYSCALL="clock_settime"
+	KEY="time-change"
+	SYSCALL_GROUPING=""
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/ansible/shared.yml
@@ -10,11 +10,39 @@
 
 - name: Perform remediation of Audit rules for settimeofday for x86 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["settimeofday"], key="audit_time_rules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["settimeofday"], key="audit_time_rules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["settimeofday"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["settimeofday"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
 
 - name: Perform remediation of Audit rules for settimeofday for x86_64 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b64", syscalls=["settimeofday"], key="audit_time_rules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b64", syscalls=["settimeofday"], key="audit_time_rules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["settimeofday"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="",
+      syscalls=["settimeofday"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
   when: audit_arch == "b64"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/ansible/shared.yml
@@ -6,5 +6,19 @@
 
 - name: Perform remediation of Audit rules for stime syscall for x86 platform
   block:
-    {{{ ansible_audit_augenrules_add_syscall_rule(arch="b32", syscalls=["stime"], key="audit_time_rules")|indent(4) }}}
-    {{{ ansible_audit_auditctl_add_syscall_rule(arch="b32", syscalls=["stime"], key="audit_time_rules")|indent(4) }}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["stime"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="",
+      syscalls=["stime"],
+      key="audit_time_rules",
+      syscall_grouping=["adjtimex", "settimeofday", "stime"],
+      )|indent(4) }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
@@ -3,36 +3,21 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Search /etc/audit/rules.d for audit rule entries
-  find:
-    paths: /etc/audit/rules.d
-    recurse: false
-    contains: ^.*dir=/var/log/audit/.*$
-    patterns: '*.rules'
-  register: find_var_log_audit
-
-- name: Use /etc/audit/rules.d/access-audit-trail.rules as the recipient for the rule
-  set_fact:
-    all_files:
-    - /etc/audit/rules.d/access-audit-trail.rules
-  when: find_var_log_audit.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-    - '{{ find_var_log_audit.files | map(attribute=''path'') | list | first }}'
-  when: find_var_log_audit.matched > 0
-
-- name: Inserts/replaces the /var/log/audit/ rule in rules.d
-  lineinfile:
-    path: '{{ all_files[0] }}'
-    line: -a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset
-      -F key=access-audit-trail
-    create: true
-
-- name: Inserts/replaces the /var/log/audit/ rule in audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: -a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset
-      -F key=access-audit-trail
-    create: true
+- name: Perform remediattion of Audit rules for /var/log/audit
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit",
+      other_filters="-F dir=/var/log/audit/ -F perm=r",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=[],
+      key="access-audit-trail",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit",
+      other_filters="-F dir=/var/log/audit/ -F perm=r",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=[],
+      key="access-audit-trail",
+      syscall_grouping=[],
+      )|indent(4) }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/ansible/shared.yml
@@ -3,7 +3,7 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Perform remediattion of Audit rules for /var/log/audit
+- name: Perform remediation of Audit rules for /var/log/audit
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
@@ -3,9 +3,12 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-PATTERN="-a always,exit -F path=/var/log/audit/\\s\\+.*"
-GROUP="access-audit-trail"
-FULL_RULE="-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ auid }}} -F auid!=unset -F key=access-audit-trail"
+ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+OTHER_FILTERS="-F dir=/var/log/audit/ -F perm=r"
+AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+SYSCALL=""
+KEY="access-audit-trail"
+SYSCALL_GROUPING=""
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/bash/shared.sh
@@ -3,7 +3,7 @@
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+ACTION_ARCH_FILTERS="-a always,exit"
 OTHER_FILTERS="-F dir=/var/log/audit/ -F perm=r"
 AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 SYSCALL=""

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -10,40 +10,48 @@
 #
 # for further details.
 #
-# Expects five arguments (each of them is required) in the form of:
+# Expects seven arguments (each of them is required) in the form of:
 # * audit tool				tool used to load audit rules,
 # 					either 'auditctl', or 'augenrules
-# * audit rules' pattern		audit rule skeleton for same syscall
-# * syscall group			greatest common string this rule shares
-# 					with other rules from the same group
-# * architecture			architecture this rule is intended for
-# * full form of new rule to add	expected full form of audit rule as to be
-# 					added into audit.rules file
+# * action_arch_filters		The action and arch filters of the rule
+#					For example, "-a always,exit -F arch=b64"
+# * other_filters			Other filters that may characterize the rule:
+#					For example, "-F a2&03 -F path=/etc/passwd"
+# * auid_filters			The auid filters of the rule
+#					For example, "-F auid>=1000 -F auid!=unset"
+# * syscall					The syscall to ensure presense among audit rules
+#					For example, "chown"
+# * syscall_groupings		Other syscalls that can be grouped with 'syscall'
+#					as a space separated list.
+#					For example, "fchown lchown fchownat"
+# * key						The key to use when appending a new rule
 #
-# Note: The 2-th up to 4-th arguments are used to determine how many existing
+# Notes:
+# - The 2-nd up to 4-th arguments are used to determine how many existing
 # audit rules will be inspected for resemblance with the new audit rule
-# (5-th argument) the function is going to add. The rule's similarity check
-# is performed to optimize audit.rules definition (merge syscalls of the same
-# group into one rule) to avoid the "single-syscall-per-audit-rule" performance
-# penalty.
-#
-# Example call:
-#
-#	See e.g. 'audit_rules_file_deletion_events.sh' remediation script
-#
+# the function is going to add.
+# - The function's similarity check uses the 5-th argument to optimize audit
+# rules definitions (merge syscalls of the same group into one rule) to avoid
+# the "single-syscall-per-audit-rule" performance penalty.
+# - The key argument (7-th argument) is not used when the syscall is grouped to an
+# existing audit rule. The audit rule will retain the key it already had.
+
 function fix_audit_syscall_rule {
 
 # Load function arguments into local variables
 local tool="$1"
-local pattern="$2"
-local group="$3"
-local arch="$4"
-local full_rule="$5"
+local action_arch_filters="$2"
+local other_filters="$3"
+local auid_filters="$4"
+local syscall="$5"
+local syscall_grouping
+read -a syscall_grouping <<< "$6"
+local key="$7"
 
 # Check sanity of the input
-if [ $# -ne "5" ]
+if [ $# -ne "7" ]
 then
-	echo "Usage: fix_audit_syscall_rule 'tool' 'pattern' 'group' 'arch' 'full rule'"
+	echo "Usage: fix_audit_syscall_rule 'tool' 'action_arch_filters' 'other_filters' 'auid_filters' 'syscall' 'syscall_grouping' 'key'"
 	echo "Aborting."
 	exit 1
 fi
@@ -74,16 +82,17 @@ then
 # file to the list of files to be inspected
 elif [ "$tool" == 'auditctl' ]
 then
+	default_file="/etc/audit/audit.rules"
 	files_to_inspect+=('/etc/audit/audit.rules' )
 # If audit tool is 'augenrules', then check if the audit rule is defined
 # If rule is defined, add '/etc/audit/rules.d/*.rules' to the list for inspection
 # If rule isn't defined yet, add '/etc/audit/rules.d/$key.rules' to the list for inspection
 elif [ "$tool" == 'augenrules' ]
 then
-	# Extract audit $key from audit rule so we can use it later
 	matches=()
-	key=$(expr "$full_rule" : '.*-k[[:space:]]\([^[:space:]]\+\)' '|' "$full_rule" : '.*-F[[:space:]]key=\([^[:space:]]\+\)')
-	readarray -t matches < <(sed -s -n -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d;F" /etc/audit/rules.d/*.rules)
+	default_file="/etc/audit/rules.d/${key}.rules"
+	# As other_filters may include paths, lets use a different delimiter for it
+	readarray -t matches < <(sed -s -n -e "/${action_arch_filters}/!d" -e "\#${other_filters}#!d" -e "/${auid_filters}/!d" /etc/audit/rules.d/*.rules)
 	if [ $? -ne 0 ]
 	then
 		retval=1
@@ -106,115 +115,88 @@ then
 fi
 
 #
-# Indicator that we want to append $full_rule into $audit_file by default
+# Indicator that we want to append $full_rule into $audit_file or edit a rule in it
 local append_expected_rule=0
 
 for audit_file in "${files_to_inspect[@]}"
 do
-	# Filter existing $audit_file rules' definitions to select those that:
-	# * follow the rule pattern, and
-	# * meet the hardware architecture requirement, and
-	# * are current syscall group specific
-	readarray -t existing_rules < <(sed -e "\;${pattern};!d" -e "/${arch}/!d" -e "/${group}/!d"  "$audit_file")
+	# Filter existing $audit_file rules' definitions to select those that satisfy the rule pattern,
+	# i.e, collect rules that match:
+	# * the action, list and arch, (2-nd argument)
+	# * the other filters, (3-rd argument)
+	# * the auid filters, (4-rd argument)
+	readarray -t similar_rules < <(sed -e "/${action_arch_filters}/!d"  -e "\#${other_filters}#!d" -e "/${auid_filters}/!d" "$audit_file")
 	if [ $? -ne 0 ]
 	then
 		retval=1
 	fi
 
-	# Process rules found case-by-case
-	for rule in "${existing_rules[@]}"
+	local candidate_rules=()
+	# Filter out rules that have more fields then required. This will remove rules more specific than the required scope
+	for s_rule in "${similar_rules[@]}"
 	do
-		# Found rule is for same arch & key, but differs (e.g. in count of -S arguments)
-		if [ "${rule}" != "${full_rule}" ]
+		# Strip all the options and fields we know of,
+		# than check if there was any field left over
+		extra_fields=$(sed -E -e "s/${action_arch_filters}//"  -e "s#${other_filters}##" -e "s/${auid_filters}//" -e "s/((:?-S [[:alnum:],]+)+)//g" -e "s/-F key=\w+|-k \w+//"<<< "$s_rule")
+		grep -q -- "-F" <<< "$extra_fields"
+		if [ $? -ne 0 ]
 		then
-			# If so, isolate just '(-S \w)+' substring of that rule
-			rule_syscalls=$(echo "$rule" | grep -o -P '(-S \w+ )+')
-			# Check if list of '-S syscall' arguments of that rule is subset
-			# of '-S syscall' list of expected $full_rule
-			if grep -q -- "$rule_syscalls" <<< "$full_rule"
-			then
-				# Rule is covered (i.e. the list of -S syscalls for this rule is
-				# subset of -S syscalls of $full_rule => existing rule can be deleted
-				# Thus delete the rule from audit.rules & our array
-				sed -i -e "\;${rule};d" "$audit_file"
-				if [ $? -ne 0 ]
-				then
-					retval=1
-				fi
-				existing_rules=("${existing_rules[@]//$rule/}")
-			else
-				# Rule isn't covered by $full_rule - it besides -S syscall arguments
-				# for this group contains also -S syscall arguments for other syscall
-				# group. Example: '-S lchown -S fchmod -S fchownat' => group='chown'
-				# since 'lchown' & 'fchownat' share 'chown' substring
-				# Therefore:
-				# * 1) delete the original rule from audit.rules
-				# (original '-S lchown -S fchmod -S fchownat' rule would be deleted)
-				# * 2) delete the -S syscall arguments for this syscall group, but
-				# keep those not belonging to this syscall group
-				# (original '-S lchown -S fchmod -S fchownat' would become '-S fchmod'
-				# * 3) append the modified (filtered) rule again into audit.rules
-				# if the same rule not already present
-				#
-				# 1) Delete the original rule
-				sed -i -e "\;${rule};d" "$audit_file"
-				if [ $? -ne 0 ]
-				then
-					retval=1
-				fi
-
-				# 2) Delete syscalls for this group, but keep those from other groups
-				# Convert current rule syscall's string into array splitting by '-S' delimiter
-				IFS_BKP="$IFS"
-				IFS=$'-S'
-				read -a rule_syscalls_as_array <<< "$rule_syscalls"
-				# Reset IFS back to default
-				IFS="$IFS_BKP"
-				# Splitting by "-S" can't be replaced by the readarray functionality easily
-
-				# Declare new empty string to hold '-S syscall' arguments from other groups
-				new_syscalls_for_rule=''
-				# Walk through existing '-S syscall' arguments
-				for syscall_arg in "${rule_syscalls_as_array[@]}"
-				do
-					# Skip empty $syscall_arg values
-					if [ "$syscall_arg" == '' ]
-					then
-						continue
-					fi
-					# If the '-S syscall' doesn't belong to current group add it to the new list
-					# (together with adding '-S' delimiter back for each of such item found)
-					if grep -q -v -- "$group" <<< "$syscall_arg"
-					then
-						new_syscalls_for_rule="$new_syscalls_for_rule -S $syscall_arg"
-					fi
-				done
-				# Replace original '-S syscall' list with the new one for this rule
-				updated_rule=${rule//$rule_syscalls/$new_syscalls_for_rule}
-				# Squeeze repeated whitespace characters in rule definition (if any) into one
-				updated_rule=$(echo "$updated_rule" | tr -s '[:space:]')
-				# 3) Append the modified / filtered rule again into audit.rules
-				#    (but only in case it's not present yet to prevent duplicate definitions)
-				if ! grep -q -- "$updated_rule" "$audit_file"
-				then
-					echo "$updated_rule" >> "$audit_file"
-				fi
-			fi
-		else
-			# $audit_file already contains the expected rule form for this
-			# architecture & key => don't insert it second time
-			append_expected_rule=1
+			candidate_rules+=("$s_rule")
 		fi
 	done
 
-	# We deleted all rules that were subset of the expected one for this arch & key.
-	# Also isolated rules containing system calls not from this system calls group.
-	# Now append the expected rule if it's not present in $audit_file yet
-	if [[ ${append_expected_rule} -eq "0" ]]
-	then
-		echo "$full_rule" >> "$audit_file"
-	fi
+	# Check if the syscall we want is present in any of the similar existing rules
+	for rule in "${candidate_rules[@]}"
+	do
+		rule_syscalls=$(echo "$rule" | grep -o -P '(-S [\w,]+)+' | xargs)
+		grep -q -- "\b${syscall}\b" <<< "$rule_syscalls"
+		if [ $? -eq 0 ]
+		then
+			# We found a rule with the syscall we want
+			return $retval
+		fi
+
+		# Check if this rule can be grouped with our target syscall and keep track of it
+		for syscall_g in "${syscall_grouping[@]}"
+		do
+			if grep -q -- "\b${syscall_g}\b" <<< "$rule_syscalls"
+			then
+				local file_to_edit=${audit_file}
+				local rule_to_edit=${rule}
+				local rule_syscalls_to_edit=${rule_syscalls}
+			fi
+		done
+	done
 done
+
+
+# We checked all rules that matched the expected resemblance patter (action, arch & auid)
+# At this point we know if we need to either append the $full_rule or group
+# the syscall together with an exsiting rule
+
+# Append the full_rule if it cannot be grouped to any other rule
+if [ -z ${rule_to_edit+x} ]
+then
+	# Build full_rule while avoid adding double spaces when other_filters is empty
+	local full_rule="$action_arch_filters -S $syscall $([[ $other_filters ]] && echo "$other_filters ")$auid_filters -F key=$key"
+	echo "$full_rule" >> "$default_file"
+else
+	# Check if the syscalls are declared as a comma separated list or
+	# as multiple -S parameters
+	if grep -q -- "," <<< "${rule_syscalls_to_edit}"
+	then
+		new_grouped_syscalls="${rule_syscalls_to_edit},${syscall}"
+	else
+		new_grouped_syscalls="${rule_syscalls_to_edit} -S ${syscall}"
+	fi
+
+	# Group the syscall in the rule
+	sed -i -e "\#${rule_to_edit}#s#${rule_syscalls_to_edit}#${new_grouped_syscalls}#" "$file_to_edit"
+	if [ $? -ne 0 ]
+	then
+		retval=1
+	fi
+fi
 
 return $retval
 

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -194,13 +194,15 @@ then
 	# Build full_rule while avoid adding double spaces when other_filters is empty
 	if [[ ${syscall_a} ]]
 	then
-		local syscall_filters=""
+		local syscall_string=""
 		for syscall in "${syscall_a[@]}"
 		do
-			syscall_filters+="-S $syscall "
+			syscall_string+=" -S $syscall"
 		done
 	fi
-	local full_rule="$action_arch_filters $([[ $syscall_filters ]] && echo "$syscall_filters")$([[ $other_filters ]] && echo "$other_filters ")$auid_filters -F key=$key"
+	local other_string=$([[ $other_filters ]] && echo " $other_filters")
+	local auid_string=$([[ $auid_filters ]] && echo " $auid_filters")
+	local full_rule="${action_arch_filters}${syscall_string}${other_string}${auid_string} -F key=${key}"
 	echo "$full_rule" >> "$default_file"
 else
 	# Check if the syscalls are declared as a comma separated list or

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -1,4 +1,3 @@
-# Function to fix syscall audit rule for given system call. It is
 # based on example audit syscall rule definitions as outlined in
 # /usr/share/doc/audit-2.3.7/stig.rules file provided with the audit
 # package. It will combine multiple system calls belonging to the same
@@ -89,18 +88,14 @@ then
 # If rule isn't defined yet, add '/etc/audit/rules.d/$key.rules' to the list for inspection
 elif [ "$tool" == 'augenrules' ]
 then
-	matches=()
 	default_file="/etc/audit/rules.d/${key}.rules"
 	# As other_filters may include paths, lets use a different delimiter for it
-	readarray -t matches < <(sed -s -n -e "/${action_arch_filters}/!d" -e "\#${other_filters}#!d" -e "/${auid_filters}/!d" /etc/audit/rules.d/*.rules)
+	# The "F" script expression tells sed to print the filenames where the expressions matched
+	readarray -t files_to_inspect < <(sed -s -n -e "/${action_arch_filters}/!d" -e "\#${other_filters}#!d" -e "/${auid_filters}/!d" -e "F" /etc/audit/rules.d/*.rules)
 	if [ $? -ne 0 ]
 	then
 		retval=1
 	fi
-	for match in "${matches[@]}"
-	do
-		files_to_inspect+=("${match}")
-	done
 	# Case when particular rule isn't defined in /etc/audit/rules.d/*.rules yet
 	if [ ${#files_to_inspect[@]} -eq "0" ]
 	then

--- a/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
+++ b/shared/bash_remediation_functions/fix_audit_syscall_rule.sh
@@ -204,6 +204,7 @@ then
 	local auid_string=$([[ $auid_filters ]] && echo " $auid_filters")
 	local full_rule="${action_arch_filters}${syscall_string}${other_string}${auid_string} -F key=${key}"
 	echo "$full_rule" >> "$default_file"
+	chmod o-rwx ${default_file}
 else
 	# Check if the syscalls are declared as a comma separated list or
 	# as multiple -S parameters

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -414,7 +414,7 @@ The macro requires following parameters:
     syscalls: {{{ syscalls }}}
     syscall_grouping: {{{ syscall_grouping }}}
 
-- name: Check existence of syscalls for in /etc/audit/rules.d/
+- name: Check existence of {{{ syscalls | join(", ") }}} in /etc/audit/rules.d/
   find:
     paths: /etc/audit/rules.d
     contains: '{{{ action_arch_filters }}}(( -S |,)\w+)*(( -S |,){{ item }})+(( -S |,)\w+)*{{{ other_filters }}}{{{ auid_filters }}} (-k\s+|-F\s+key=)\S+\s*$'
@@ -498,7 +498,7 @@ The macro requires following parameters:
     syscalls: {{{ syscalls }}}
     syscall_grouping: {{{ syscall_grouping }}}
 
-- name: Check existence of syscalls for in /etc/audit/rules.d/
+- name: Check existence of {{{ syscalls | join(", ") }}} in /etc/audit/audit.rules
   find:
     paths: /etc/audit
     contains: '{{{ action_arch_filters }}}(( -S |,)\w+)*(( -S |,){{ item }})+(( -S |,)\w+)*{{{ other_filters }}}{{{ auid_filters }}} (-k\s+|-F\s+key=)\S+\s*$'
@@ -506,7 +506,7 @@ The macro requires following parameters:
   register: find_command
   loop: '{{ (syscall_grouping + syscalls) | unique }}'
 
-- name: Set path to /etc/audit/rules.d/{{{ key }}}.rules
+- name: Set path to /etc/audit/audit.rules
   set_fact: audit_file="/etc/audit/audit.rules"
 
 - name: Declare found syscalls

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -467,6 +467,7 @@ The macro requires following parameters:
     path: '{{ audit_file }}'
     line: "{{{ action_arch_filters }}}{{{ syscall_flag }}}{{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
     create: true
+    mode: o-rwx
     state: present
   when: syscalls_found | length == 0
 {{%- endmacro %}}
@@ -535,6 +536,7 @@ The macro requires following parameters:
     path: '{{ audit_file }}'
     line: "{{{ action_arch_filters }}}{{{ syscall_flag }}}{{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
     create: true
+    mode: o-rwx
     state: present
   when: syscalls_found | length == 0
 {{%- endmacro %}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -385,135 +385,147 @@ The macro requires following parameters:
 {{#
 The following macro remediates Audit syscall rule in /etc/audit/rules.d directory.
 The macro requires following parameters:
-- arch: an architecture to be used in the Audit rule (b32, b64)
-- syscalls: list of syscalls supplied as a list ["syscall1", "syscall2"] etc.
-- key: a key to use as rule identifier.
-- fields (optional): list of syscall fields to add (e.g.: auid=unset, exit=-EPERM, a0&0100);
-  Add them in the order you expect them to be in the audit rule.
-Note that if there  already exists a rule wit the same key in the /etc/audit/rules.d directory, the rule will be placed in the same file.
+- action_arch_filters:  The action and arch filters of the rule
+                        For example, "-a always,exit -F arch=b64"
+- other_filters:        Other filters that may characterize the rule:
+                        For example, "-F a2&03 -F path=/etc/passwd"
+- auid_filters:         The auid filters of the rule
+                        For example, "-F auid>=1000 -F auid!=unset"
+- syscalls:             List of syscalls to ensure presense among audit rules
+                        For example, "['fchown', 'lchown', 'fchownat']"
+- syscall_groupings:    List of other syscalls that can be grouped with 'syscalls'
+                        For example, "['fchown', 'lchown', 'fchownat']"
+- key:                  The key to use when appending a new rule
 #}}
-{{% macro ansible_audit_augenrules_add_syscall_rule(arch="", syscalls=[], key="", fields=[]) -%}}
-- name: Declare list of syscals
+{{% macro ansible_audit_augenrules_add_syscall_rule(action_arch_filters="", other_filters="", auid_filters="", syscalls=[], key="", syscall_grouping=[]) -%}}
+{{% if other_filters != "" %}}
+    {{% set other_filters = " " ~ other_filters %}}
+{{% endif %}}
+{{% if auid_filters != "" %}}
+    {{% set auid_filters = " " ~ auid_filters %}}
+{{% endif %}}
+- name: Declare list of syscalls
   set_fact:
     syscalls: {{{ syscalls }}}
+    syscall_grouping: {{{ syscall_grouping }}}
 
-- name: Declare number of syscalls
-  set_fact: audit_syscalls_number_of_syscalls="{{ syscalls|length|int }}"
-
-{{#
-This dictionary is a Jinja2 trick to allow loops to change variables defined out of its scope.
-See official documentation: https://jinja.palletsprojects.com/en/2.11.x/templates/#assignments
-#}}
-{{% set fields_data = { 'regex' : "", 'plain_text': "" } %}}
-{{% for field in fields %}}
-    {{% set not_used = fields_data.update({'regex': fields_data.regex + '(?:-F[\s]+' + field + '[\s]+)'}) %}}
-    {{% set not_used = fields_data.update({'plain_text': fields_data.plain_text + ' -F ' + field }) %}}
-{{% endfor %}}
-
-- name: Check existence of syscalls for architecture {{{ arch }}} in /etc/audit/rules.d/
+- name: Check existence of syscalls for in /etc/audit/rules.d/
   find:
-    paths: "/etc/audit/rules.d"
-    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch={{{ arch }}}[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*{{{ fields_data.regex }}}(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
-    patterns: "*.rules"
-  register: audit_syscalls_found_{{{ arch }}}_rules_d
-  loop: "{{ syscalls }}"
+    paths: /etc/audit/rules.d
+    contains: '{{{ action_arch_filters }}}(( -S |,)\w+)*(( -S |,){{ item }})+(( -S |,)\w+)*{{{ other_filters }}}{{{ auid_filters }}} (-k\s+|-F\s+key=)\S+\s*$'
+    patterns: '*.rules'
+  register: find_command
+  loop: '{{ syscall_grouping }}'
 
-- name: Get number of matched syscalls for architecture {{{ arch }}} in /etc/audit/rules.d/
-  set_fact: audit_syscalls_matched_{{{ arch }}}_rules_d="{{ audit_syscalls_found_{{{ arch }}}_rules_d.results|sum(attribute='matched')|int }}"
+- name: Declare syscalls found per file
+  set_fact: syscalls_per_file="{{ syscalls_per_file | default({}) | combine( {item.files[0].path :[item.item]+(syscalls_per_file | default({})).get(item.files[0].path, []) } ) }}"
+  loop: "{{ find_command.results | selectattr('matched') | list}}"
 
-- name: Search /etc/audit/rules.d for other rules with the key {{{ key }}}
-  find:
-    paths: "/etc/audit/rules.d"
-    contains: '^.*(?:-F key=|-k\s+){{{ key }}}$'
-    patterns: "*.rules"
-  register: find_syscalls_files
+- name: Declare files where syscalls where found
+  set_fact: found_paths="{{ find_command.results | map(attribute='files') | flatten | map(attribute='path') | list }}"
 
-- name: Use /etc/audit/rules.d/{{{ key }}}.rules as the recipient for the rule
+- name: Count occurrences of syscalls in paths
+  set_fact: found_paths_dict="{{ found_paths_dict | default({}) | combine({ item:1+(found_paths_dict | default({})).get(item, 0) }) }}"
+  loop: "{{ find_command.results | map(attribute='files') | flatten | map(attribute='path') | list }}"
+
+- name: Get path with most syscalls
+  set_fact: audit_file="{{ (found_paths_dict | dict2items() | sort(attribute='value') | last).key }}"
+  when: found_paths | length >= 1
+
+- name: No file with syscall found, set path to /etc/audit/rules.d/{{{ key }}}.rules
+  set_fact: audit_file="/etc/audit/rules.d/{{{ key }}}.rules"
+  when: found_paths | length == 0
+
+- name: Declare found syscalls
+  set_fact: syscalls_found="{{ find_command.results | selectattr('matched') | map(attribute='item') | list }}"
+
+- name: Declare missing syscalls
   set_fact:
-    all_files:
-      - /etc/audit/rules.d/{{{ key }}}.rules
-  when: find_syscalls_files.matched is defined and find_syscalls_files.matched == 0
+    missing_syscalls="{{ syscalls | difference(syscalls_found) }}"
 
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_syscalls_files.files | map(attribute='path') | list | first }}"
-  when: find_syscalls_files.matched is defined and find_syscalls_files.matched > 0
+- name: Replace the audit rule in {{ audit_file }}
+  lineinfile:
+    path: '{{ audit_file }}'
+    regexp: '({{{ action_arch_filters }}})(?=.*(?:(?:-S |,)(?:{{ syscalls_per_file[audit_file] | join("|") }}))\b)((?:( -S |,)\w+)+)({{{ other_filters }}}{{{ auid_filters }}} (?:-k |-F key=)\w+)'
+    line: '\1\2\3{{ missing_syscalls | join("\3") }}\4'
+    backrefs: yes
+    state: present
+  when: syscalls_found | length > 0 and missing_syscalls | length > 0
 
-- name: "Insert the syscall rule in {{ all_files[0] }}"
-  block:
-    - name: "Construct rule: add rule list, action and arch"
-      set_fact: tmpline="-a always,exit -F arch={{{ arch }}}"
-    - name: "Construct rule: add syscalls"
-      set_fact: tmpline="{{ tmpline + ' -S ' + item.item }}"
-      loop: "{{ audit_syscalls_found_{{{ arch }}}_rules_d.results }}"
-      when: item.matched is defined and item.matched == 0
-    - name: "Construct rule: add fields and key"
-      set_fact: tmpline="{{ tmpline + '{{{ fields_data.plain_text }}} -k {{{ key }}}' }}"
-    - name: "Insert the line in {{ all_files[0] }}"
-      lineinfile:
-        path: "{{ all_files[0] }}"
-        line: "{{ tmpline }}"
-        create: true
-        state: present
-  when: audit_syscalls_matched_{{{ arch }}}_rules_d < audit_syscalls_number_of_syscalls
+- name: Add the audit rule to {{ audit_file }}
+  lineinfile:
+    path: '{{ audit_file }}'
+    line: "{{{ action_arch_filters }}} -S {{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
+    create: true
+    state: present
+  when: syscalls_found | length == 0
 {{%- endmacro %}}
 
 {{#
 The following macro remediates Audit syscall rule in /etc/audit/audit.rules file.
 The macro requires following parameters:
-- arch: an architecture to be used in the Audit rule (b32, b64)
-- syscalls: list of syscalls supplied as a list ["syscall1", "syscall2"] etc.
-- key: a key to use as rule identifier.
-- fields (optional): list of syscall fields to add (e.g.: auid=unset, exit=-EPERM, a0&0100);
-  Add them in the order you expect them to be in the audit rule.
+- action_arch_filters:  The action and arch filters of the rule
+                        For example, "-a always,exit -F arch=b64"
+- other_filters:        Other filters that may characterize the rule:
+                        For example, "-F a2&03 -F path=/etc/passwd"
+- auid_filters:         The auid filters of the rule
+                        For example, "-F auid>=1000 -F auid!=unset"
+- syscalls:             List of syscalls to ensure presense among audit rules
+                        For example, "['fchown', 'lchown', 'fchownat']"
+- syscall_groupings:    List of other syscalls that can be grouped with 'syscalls'
+                        For example, "['fchown', 'lchown', 'fchownat']"
+- key:                  The key to use when appending a new rule
 #}}
-{{% macro ansible_audit_auditctl_add_syscall_rule(arch="", syscalls=[], key="", fields=[]) -%}}
+{{% macro ansible_audit_auditctl_add_syscall_rule(action_arch_filters="", other_filters="", auid_filters="", syscalls=[], key="", syscall_grouping=[]) -%}}
+{{% if other_filters!= "" %}}
+    {{% set other_filters = " " ~ other_filters %}}
+{{% endif %}}
+{{% if auid_filters!= "" %}}
+    {{% set auid_filters = " " ~ auid_filters %}}
+{{% endif %}}
+- name: Declare list of syscalls
+  set_fact:
+    syscalls: {{{ syscalls }}}
+    syscall_grouping: {{{ syscall_grouping }}}
+
+- name: Check existence of syscalls for in /etc/audit/rules.d/
+  find:
+    paths: /etc/audit
+    contains: '{{{ action_arch_filters }}}(( -S |,)\w+)*(( -S |,){{ item }})+(( -S |,)\w+)*{{{ other_filters }}}{{{ auid_filters }}} (-k\s+|-F\s+key=)\S+\s*$'
+    patterns: 'audit.rules'
+  register: find_command
+  loop: '{{ syscall_grouping }}'
+
+- name: Set path to /etc/audit/rules.d/{{{ key }}}.rules
+  set_fact: audit_file="/etc/audit/audit.rules"
+
+- name: Declare found syscalls
+  set_fact: syscalls_found="{{ find_command.results | selectattr('matched') | map(attribute='item') | list }}"
+
+- name: Declare missing syscalls
+  set_fact:
+    missing_syscalls="{{ syscalls | difference(syscalls_found) }}"
+
+- name: Replace the audit rule in {{ audit_file }}
+  lineinfile:
+    path: '{{ audit_file }}'
+    regexp: '({{{ action_arch_filters }}})(?=.*(?:(?:-S |,)(?:{{ syscalls_found | join("|") }}))\b)((?:( -S |,)\w+)+)({{{ other_filters }}}{{{ auid_filters }}} (?:-k |-F key=)\w+)'
+    line: '\1\2\3{{ missing_syscalls | join("\3") }}\4'
+    backrefs: yes
+    state: present
+  when: syscalls_found | length > 0 and missing_syscalls | length > 0
+
+- name: Add the audit rule to {{ audit_file }}
+  lineinfile:
+    path: '{{ audit_file }}'
+    line: "{{{ action_arch_filters }}} -S {{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
+    create: true
+    state: present
+  when: syscalls_found | length == 0
 - name: Declare list of syscals
   set_fact:
     syscalls: {{{ syscalls }}}
 
-- name: Declare number of syscalls
-  set_fact: audit_syscalls_number_of_syscalls="{{ syscalls|length|int }}"
-
-{{#
-This dictionary is a Jinja2 trick to allow loops to change variables defined out of its scope.
-See official documentation: https://jinja.palletsprojects.com/en/2.11.x/templates/#assignments
-#}}
-{{% set fields_data = { 'regex' : "", 'plain_text': "" } %}}
-{{% for field in fields %}}
-    {{% set not_used = fields_data.update({'regex': fields_data.regex + '(?:-F[\s]+' + field + '[\s]+)'}) %}}
-    {{% set not_used = fields_data.update({'plain_text': fields_data.plain_text + ' -F ' + field }) %}}
-{{% endfor %}}
-
-- name: Check existence of syscalls for architecture {{{ arch }}} in /etc/audit/audit.rules
-  find:
-    paths: "/etc/audit"
-    contains: '^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch={{{ arch }}}[\s]+)(?:.*(-S[\s]+{{ item }}[\s]+|([\s]+|[,]){{ item }}([\s]+|[,]))).*{{{ fields_data.regex }}}(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$'
-    patterns: "audit.rules"
-  register: audit_syscalls_found_{{{ arch }}}_audit_rules
-  loop: "{{ syscalls }}"
-
-- name: Get number of matched syscalls for architecture {{{ arch }}} in /etc/audit/audit.rules
-  set_fact: audit_syscalls_matched_{{{ arch }}}_audit_rules="{{ audit_syscalls_found_{{{ arch }}}_audit_rules.results|sum(attribute='matched')|int }}"
-
-- name: Insert the syscall rule in /etc/audit/audit.rules
-  block:
-    - name: "Construct rule: add rule list, action and arch"
-      set_fact: tmpline="-a always,exit -F arch={{{ arch }}}"
-    - name: "Construct rule: add syscalls"
-      set_fact: tmpline="{{ tmpline + ' -S ' + item.item }}"
-      loop: "{{ audit_syscalls_found_{{{ arch }}}_audit_rules.results }}"
-      when: item.matched is defined and item.matched == 0
-    - name: "Construct rule: add fields and key"
-      set_fact: tmpline="{{ tmpline + '{{{ fields_data.plain_text }}} -k {{{ key }}}' }}"
-    - name: Insert the line in /etc/audit/audit.rules
-      lineinfile:
-        path: "/etc/audit/audit.rules"
-        line: "{{ tmpline }}"
-        create: true
-        state: present
-  when: audit_syscalls_matched_{{{ arch }}}_audit_rules < audit_syscalls_number_of_syscalls
 {{%- endmacro %}}
 
 {{% macro ansible_sssd_ldap_config(parameter, value) -%}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -422,15 +422,20 @@ The macro requires following parameters:
   register: find_command
   loop: '{{ (syscall_grouping + syscalls) | unique }}'
 
+- name: Reset syscalls found per file
+  set_fact:
+    syscalls_per_file: {}
+    found_paths_dict: {}
+
 - name: Declare syscalls found per file
-  set_fact: syscalls_per_file="{{ syscalls_per_file | default({}) | combine( {item.files[0].path :[item.item]+(syscalls_per_file | default({})).get(item.files[0].path, []) } ) }}"
+  set_fact: syscalls_per_file="{{ syscalls_per_file | combine( {item.files[0].path :[item.item] + syscalls_per_file.get(item.files[0].path, []) } ) }}"
   loop: "{{ find_command.results | selectattr('matched') | list}}"
 
 - name: Declare files where syscalls where found
   set_fact: found_paths="{{ find_command.results | map(attribute='files') | flatten | map(attribute='path') | list }}"
 
 - name: Count occurrences of syscalls in paths
-  set_fact: found_paths_dict="{{ found_paths_dict | default({}) | combine({ item:1+(found_paths_dict | default({})).get(item, 0) }) }}"
+  set_fact: found_paths_dict="{{ found_paths_dict | combine({ item:1+found_paths_dict.get(item, 0) }) }}"
   loop: "{{ find_command.results | map(attribute='files') | flatten | map(attribute='path') | list }}"
 
 - name: Get path with most syscalls

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -431,7 +431,7 @@ The macro requires following parameters:
   set_fact: syscalls_per_file="{{ syscalls_per_file | combine( {item.files[0].path :[item.item] + syscalls_per_file.get(item.files[0].path, []) } ) }}"
   loop: "{{ find_command.results | selectattr('matched') | list}}"
 
-- name: Declare files where syscalls where found
+- name: Declare files where syscalls were found
   set_fact: found_paths="{{ find_command.results | map(attribute='files') | flatten | map(attribute='path') | list }}"
 
 - name: Count occurrences of syscalls in paths

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -429,7 +429,7 @@ The macro requires following parameters:
 
 - name: Declare syscalls found per file
   set_fact: syscalls_per_file="{{ syscalls_per_file | combine( {item.files[0].path :[item.item] + syscalls_per_file.get(item.files[0].path, []) } ) }}"
-  loop: "{{ find_command.results | selectattr('matched') | list}}"
+  loop: "{{ find_command.results | selectattr('matched') | list }}"
 
 - name: Declare files where syscalls were found
   set_fact: found_paths="{{ find_command.results | map(attribute='files') | flatten | map(attribute='path') | list }}"

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -420,7 +420,7 @@ The macro requires following parameters:
     contains: '{{{ action_arch_filters }}}(( -S |,)\w+)*(( -S |,){{ item }})+(( -S |,)\w+)*{{{ other_filters }}}{{{ auid_filters }}} (-k\s+|-F\s+key=)\S+\s*$'
     patterns: '*.rules'
   register: find_command
-  loop: '{{ syscall_grouping }}'
+  loop: '{{ (syscall_grouping + syscalls) | unique }}'
 
 - name: Declare syscalls found per file
   set_fact: syscalls_per_file="{{ syscalls_per_file | default({}) | combine( {item.files[0].path :[item.item]+(syscalls_per_file | default({})).get(item.files[0].path, []) } ) }}"
@@ -504,7 +504,7 @@ The macro requires following parameters:
     contains: '{{{ action_arch_filters }}}(( -S |,)\w+)*(( -S |,){{ item }})+(( -S |,)\w+)*{{{ other_filters }}}{{{ auid_filters }}} (-k\s+|-F\s+key=)\S+\s*$'
     patterns: 'audit.rules'
   register: find_command
-  loop: '{{ syscall_grouping }}'
+  loop: '{{ (syscall_grouping + syscalls) | unique }}'
 
 - name: Set path to /etc/audit/rules.d/{{{ key }}}.rules
   set_fact: audit_file="/etc/audit/audit.rules"
@@ -532,10 +532,6 @@ The macro requires following parameters:
     create: true
     state: present
   when: syscalls_found | length == 0
-- name: Declare list of syscals
-  set_fact:
-    syscalls: {{{ syscalls }}}
-
 {{%- endmacro %}}
 
 {{% macro ansible_sssd_ldap_config(parameter, value) -%}}

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -404,6 +404,11 @@ The macro requires following parameters:
 {{% if auid_filters != "" %}}
     {{% set auid_filters = " " ~ auid_filters %}}
 {{% endif %}}
+{{% if syscalls == [] %}}
+    {{% set syscall_flag = "" %}}
+{{% else %}}
+    {{% set syscall_flag = " -S " %}}
+{{% endif %}}
 - name: Declare list of syscalls
   set_fact:
     syscalls: {{{ syscalls }}}
@@ -455,7 +460,7 @@ The macro requires following parameters:
 - name: Add the audit rule to {{ audit_file }}
   lineinfile:
     path: '{{ audit_file }}'
-    line: "{{{ action_arch_filters }}} -S {{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
+    line: "{{{ action_arch_filters }}}{{{ syscall_flag }}}{{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
     create: true
     state: present
   when: syscalls_found | length == 0
@@ -482,6 +487,11 @@ The macro requires following parameters:
 {{% endif %}}
 {{% if auid_filters!= "" %}}
     {{% set auid_filters = " " ~ auid_filters %}}
+{{% endif %}}
+{{% if syscalls == [] %}}
+    {{% set syscall_flag = "" %}}
+{{% else %}}
+    {{% set syscall_flag = " -S " %}}
 {{% endif %}}
 - name: Declare list of syscalls
   set_fact:
@@ -518,7 +528,7 @@ The macro requires following parameters:
 - name: Add the audit rule to {{ audit_file }}
   lineinfile:
     path: '{{ audit_file }}'
-    line: "{{{ action_arch_filters }}} -S {{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
+    line: "{{{ action_arch_filters }}}{{{ syscall_flag }}}{{ syscalls | join(',') }}{{{ other_filters }}}{{{ auid_filters}}} -F key={{{ key }}}"
     create: true
     state: present
   when: syscalls_found | length == 0

--- a/shared/templates/audit_rules_dac_modification/ansible.template
+++ b/shared/templates/audit_rules_dac_modification/ansible.template
@@ -7,11 +7,11 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit {{{ ATTR }}} tasks
+- name: Set architecture for audit {{{ ATTR | join(", ") }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for {{{ ATTR }}} for x86 platform
+- name: Perform remediattion of Audit rules for {{{ ATTR | join(", ") }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -48,7 +48,7 @@
       )|indent(4) }}}
 {{%- endif %}}
 
-- name: Perform remediattion of Audit rules for {{{ ATTR }}} for x86_64 platform
+- name: Perform remediattion of Audit rules for {{{ ATTR | join(", ") }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_dac_modification/ansible.template
+++ b/shared/templates/audit_rules_dac_modification/ansible.template
@@ -11,91 +11,77 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-#
-# Inserts/replaces the rule in /etc/audit/rules.d
-#
-- name: Search /etc/audit/rules.d for other DAC audit rules
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: "-F key=perm_mod$"
-    patterns: "*.rules"
-  register: find_{{{ ATTR }}}
-
-- name: If existing DAC ruleset not found, use /etc/audit/rules.d/privileged.rules as the recipient for the rule
-  set_fact:
-    all_files:
-      - /etc/audit/rules.d/privileged.rules
-  when: find_{{{ ATTR }}}.matched is defined and find_{{{ ATTR }}}.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_{{{ ATTR }}}.files | map(attribute='path') | list | first }}"
-  when: find_{{{ ATTR }}}.matched is defined and find_{{{ ATTR }}}.matched > 0
-
-- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
-    create: yes
-
+- name: Perform remediattion of Audit rules for {{{ ATTR }}} for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 {{%- if CHECK_ROOT_USER %}}
-- name: Inserts/replaces the {{{ ATTR }}} rule with auid=0 in rules.d when on x86
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F key=perm_mod"
-    create: yes
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid=0",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid=0",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 {{%- endif %}}
 
-- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86_64
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
-    create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
-
+- name: Perform remediattion of Audit rules for {{{ ATTR }}} for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 {{%- if CHECK_ROOT_USER %}}
-- name: Inserts/replaces the {{{ ATTR }}} rule with auid=0 in rules.d when on x86_64
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid=0 -F key=perm_mod"
-    create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="-F auid=0",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="-F auid=0",
+      syscalls=ATTR,
+      key="perm_mod",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 {{%- endif %}}
-#   
-# Inserts/replaces the rule in /etc/audit/audit.rules
-#
-- name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/audit.rules when on x86
-  lineinfile:
-    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-
-{{%- if CHECK_ROOT_USER %}}
-- name: Inserts/replaces the {{{ ATTR }}} rule with auid=0 in /etc/audit/audit.rules when on x86
-  lineinfile:
-    line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F key=perm_mod"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-{{%- endif %}}
-
-- name: Inserts/replaces the {{{ ATTR }}} rule in audit.rules when on x86_64
-  lineinfile:
-    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
-
-{{%- if CHECK_ROOT_USER %}}
-- name: Inserts/replaces the {{{ ATTR }}} rule with auid=0 in audit.rules when on x86_64
-  lineinfile:
-    line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
-{{%- endif %}}
+  when: audit_arch == "b64"

--- a/shared/templates/audit_rules_dac_modification/ansible.template
+++ b/shared/templates/audit_rules_dac_modification/ansible.template
@@ -11,7 +11,7 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for {{{ ATTR | join(", ") }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ ATTR | join(", ") }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -48,7 +48,7 @@
       )|indent(4) }}}
 {{%- endif %}}
 
-- name: Perform remediattion of Audit rules for {{{ ATTR | join(", ") }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ ATTR | join(", ") }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_dac_modification/bash.template
+++ b/shared/templates/audit_rules_dac_modification/bash.template
@@ -9,25 +9,31 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid>=.*"
-	GROUP="perm_mod"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=unset -F key=perm_mod"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	SYSCALL="{{{ ATTR }}}"
+	KEY="perm_mod"
+	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done
 
 
 {{% if CHECK_ROOT_USER %}}
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid=0.*"
-	GROUP="perm_mod"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ ATTR }}} -F auid=0 -F key=perm_mod"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS="-F auid=0"
+	SYSCALL="{{{ ATTR }}}"
+	KEY="perm_mod"
+	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done
 {{% endif %}}

--- a/shared/templates/audit_rules_dac_modification/template.py
+++ b/shared/templates/audit_rules_dac_modification/template.py
@@ -7,5 +7,12 @@ def preprocess(data, lang):
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
+    elif lang == "ansible":
+        if "attr" in data:
+            # Tranform the syscall into a Ansible list
+            data["attr"] = [ data["attr"] ]
+        if "syscall_grouping" not in data:
+            # Ensure that syscall_grouping is a list
+            data["syscall_grouping"] = []
 
     return data

--- a/shared/templates/audit_rules_dac_modification/template.py
+++ b/shared/templates/audit_rules_dac_modification/template.py
@@ -10,7 +10,7 @@ def preprocess(data, lang):
     elif lang == "ansible":
         if "attr" in data:
             # Tranform the syscall into a Ansible list
-            data["attr"] = [ data["attr"] ]
+            data["attr"] = [data["attr"]]
         if "syscall_grouping" not in data:
             # Ensure that syscall_grouping is a list
             data["syscall_grouping"] = []

--- a/shared/templates/audit_rules_file_deletion_events/ansible.template
+++ b/shared/templates/audit_rules_file_deletion_events/ansible.template
@@ -7,11 +7,11 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit {{{ NAME| join(", ")  }}} tasks
+- name: Set architecture for audit {{{ NAME | join(", ") }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediation of Audit rules for {{{ NAME| join(", ")  }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +30,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for {{{ NAME| join(", ")  }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_file_deletion_events/ansible.template
+++ b/shared/templates/audit_rules_file_deletion_events/ansible.template
@@ -11,55 +11,41 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-#
-# Inserts/replaces the rule in /etc/audit/rules.d
-#
-- name: Search /etc/audit/rules.d for other DAC audit rules
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: "-F key=delete$"
-    patterns: "*.rules"
-  register: find_{{{ NAME }}}
+- name: Perform remediattion of Audit rules for {{{ NAME }}} for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="delete",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="delete",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 
-- name: If existing DAC ruleset not found, use /etc/audit/rules.d/delete.rules as the recipient for the rule
-  set_fact:
-    all_files:
-      - /etc/audit/rules.d/delete.rules
-  when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
-  when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched > 0
-
-- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
-    create: yes
-
-- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
-    create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
-#   
-# Inserts/replaces the rule in /etc/audit/audit.rules
-#
-- name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules when on x86
-  lineinfile:
-    line: "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-
-- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
-  lineinfile:
-    line: "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  when: audit_arch is defined and audit_arch == 'b64'
+- name: Perform remediattion of Audit rules for {{{ NAME }}} for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="delete",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="delete",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/shared/templates/audit_rules_file_deletion_events/ansible.template
+++ b/shared/templates/audit_rules_file_deletion_events/ansible.template
@@ -7,11 +7,11 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit {{{ NAME }}} tasks
+- name: Set architecture for audit {{{ NAME| join(", ")  }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for {{{ NAME }}} for x86 platform
+- name: Perform remediattion of Audit rules for {{{ NAME| join(", ")  }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +30,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for {{{ NAME }}} for x86_64 platform
+- name: Perform remediattion of Audit rules for {{{ NAME| join(", ")  }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_file_deletion_events/ansible.template
+++ b/shared/templates/audit_rules_file_deletion_events/ansible.template
@@ -11,7 +11,7 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for {{{ NAME| join(", ")  }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ NAME| join(", ")  }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +30,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for {{{ NAME| join(", ")  }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ NAME| join(", ")  }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_file_deletion_events/bash.template
+++ b/shared/templates/audit_rules_file_deletion_events/bash.template
@@ -9,10 +9,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}}.*"
-	GROUP="delete"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F auid>={{{ auid }}} -F auid!=unset -F key=delete"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS=""
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	SYSCALL="{{{ NAME }}}"
+	KEY="delete"
+	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/shared/templates/audit_rules_file_deletion_events/template.py
+++ b/shared/templates/audit_rules_file_deletion_events/template.py
@@ -1,11 +1,14 @@
-from ssg.utils import parse_template_boolean_value
+import ssg.utils
 
 
-def preprocess(data, lang):
-    data["check_root_user"] = parse_template_boolean_value(data, parameter="check_root_user", default_value=False)
+def _audit_rules_file_deletion_events(data, lang):
     if lang == "bash":
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
-
     return data
+
+
+def preprocess(data, lang):
+    return _audit_rules_file_deletion_events(data, lang)
+

--- a/shared/templates/audit_rules_file_deletion_events/template.py
+++ b/shared/templates/audit_rules_file_deletion_events/template.py
@@ -10,7 +10,7 @@ def _audit_rules_file_deletion_events(data, lang):
         if "name" in data:
             # Tranform the syscall into a Ansible list
             # The syscall is under 'name'
-            data["name"] = [ data["name"] ]
+            data["name"] = [data["name"]]
         if "syscall_grouping" not in data:
             # Ensure that syscall_grouping is a list
             data["syscall_grouping"] = []
@@ -19,4 +19,3 @@ def _audit_rules_file_deletion_events(data, lang):
 
 def preprocess(data, lang):
     return _audit_rules_file_deletion_events(data, lang)
-

--- a/shared/templates/audit_rules_file_deletion_events/template.py
+++ b/shared/templates/audit_rules_file_deletion_events/template.py
@@ -6,6 +6,14 @@ def _audit_rules_file_deletion_events(data, lang):
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
+    elif lang == "ansible":
+        if "name" in data:
+            # Tranform the syscall into a Ansible list
+            # The syscall is under 'name'
+            data["name"] = [ data["name"] ]
+        if "syscall_grouping" not in data:
+            # Ensure that syscall_grouping is a list
+            data["syscall_grouping"] = []
     return data
 
 

--- a/shared/templates/audit_rules_path_syscall/ansible.template
+++ b/shared/templates/audit_rules_path_syscall/ansible.template
@@ -11,7 +11,7 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for {{{ SYSCALL | join(", ") }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ SYSCALL | join(", ") }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +30,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for {{{ SYSCALL | join(", ") }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ SYSCALL | join(", ") }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_path_syscall/ansible.template
+++ b/shared/templates/audit_rules_path_syscall/ansible.template
@@ -11,67 +11,41 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-#
-# Inserts/replaces the rule in /etc/audit/rules.d
-#
-- name: Search /etc/audit/rules.d for other DAC audit rules
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: ".*{{{ SYSCALL }}}(,[\\S]+)?[\\s]+-F[\\s]+{{{ POS }}}&03[\\s]+-F[\\s]+path={{{ PATH }}}.*"
-    patterns: "*.rules"
-  register: find_{{{ SYSCALL }}}
+- name: Perform remediattion of Audit rules for {{{ SYSCALL }}} for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="-F "~POS~"&03 -F path="~PATH,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="modify",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="-F "~POS~"&03 -F path="~PATH,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="modify",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 
-- name: If existing DAC ruleset not found, use /etc/audit/rules.d/modify.rules as the recipient for the rule
-  set_fact:
-    all_files:
-      - /etc/audit/rules.d/modify.rules
-  when: find_{{{ SYSCALL }}}.matched is defined and find_{{{ SYSCALL }}}.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_{{{ SYSCALL }}}.files | map(attribute='path') | list | first }}"
-  when: find_{{{ SYSCALL }}}.matched is defined and find_{{{ SYSCALL }}}.matched > 0
-
-- name: Inserts/replaces the {{{ SYSCALL }}} rule in rules.d when on x86
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "{{ item }}"
-    create: yes
-    regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
-  with_items:
-    - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
-
-- name: Inserts/replaces the {{{ SYSCALL }}} rule in rules.d when on x86_64
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "{{ item }}"
-    create: yes
-    regexp: "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
-  with_items:
-    - "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
-  when: audit_arch is defined and audit_arch == 'b64'
-#   
-# Inserts/replaces the rule in /etc/audit/audit.rules
-#
-- name: Inserts/replaces the {{{ SYSCALL }}} rule in /etc/audit/audit.rules when on x86
-  lineinfile:
-    line: "{{ item }}"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-    regexp: "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
-  with_items:
-    - "-a always,exit -F arch=b32 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
-
-- name: Inserts/replaces the {{{ SYSCALL }}} rule in audit.rules when on x86_64
-  lineinfile:
-    line: "{{ item }}"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-    regexp: "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=[\\S]+"
-  with_items:
-    - "-a always,exit -F arch=b64 -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
-  when: audit_arch is defined and audit_arch == 'b64'
+- name: Perform remediattion of Audit rules for {{{ SYSCALL }}} for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F "~POS~"&03 -F path="~PATH,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="modify",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F "~POS~"&03 -F path="~PATH,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="modify",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+  when: audit_arch == "b64"

--- a/shared/templates/audit_rules_path_syscall/ansible.template
+++ b/shared/templates/audit_rules_path_syscall/ansible.template
@@ -7,11 +7,11 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit {{{ SYSCALL }}} tasks
+- name: Set architecture for audit {{{ SYSCALL | join(", ") }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-- name: Perform remediattion of Audit rules for {{{ SYSCALL }}} for x86 platform
+- name: Perform remediattion of Audit rules for {{{ SYSCALL | join(", ") }}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +30,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for {{{ SYSCALL }}} for x86_64 platform
+- name: Perform remediattion of Audit rules for {{{ SYSCALL | join(", ") }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_path_syscall/bash.template
+++ b/shared/templates/audit_rules_path_syscall/bash.template
@@ -9,10 +9,13 @@
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}}.*"
-	GROUP="modify"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ SYSCALL }}} -F {{{ POS }}}&03 -F path={{{ PATH }}} -F auid>={{{ auid }}} -F auid!=unset -F key=modify"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-F {{{ POS }}}&03 -F path={{{ PATH }}}"
+	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+	SYSCALL="{{{ SYSCALL }}}"
+	KEY="user-modify"
+	SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/shared/templates/audit_rules_path_syscall/template.py
+++ b/shared/templates/audit_rules_path_syscall/template.py
@@ -11,4 +11,11 @@ def preprocess(data, lang):
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
+    elif lang == "ansible":
+        if "syscall" in data:
+            # Tranform the syscall into a Ansible list
+            data["syscall"] = [ data["syscall"] ]
+        if "syscall_grouping" not in data:
+            # Ensure that syscall_grouping is a list
+            data["syscall_grouping"] = []
     return data

--- a/shared/templates/audit_rules_path_syscall/template.py
+++ b/shared/templates/audit_rules_path_syscall/template.py
@@ -7,4 +7,8 @@ def preprocess(data, lang):
         # remove root slash made into '_'
         pathid = pathid[1:]
         data["pathid"] = pathid
+    elif lang == "bash":
+        if "syscall_grouping" in data:
+            # Make it easier to tranform the syscall_grouping into a Bash array
+            data["syscall_grouping"] = " ".join(data["syscall_grouping"])
     return data

--- a/shared/templates/audit_rules_path_syscall/template.py
+++ b/shared/templates/audit_rules_path_syscall/template.py
@@ -14,7 +14,7 @@ def preprocess(data, lang):
     elif lang == "ansible":
         if "syscall" in data:
             # Tranform the syscall into a Ansible list
-            data["syscall"] = [ data["syscall"] ]
+            data["syscall"] = [data["syscall"]]
         if "syscall_grouping" not in data:
             # Ensure that syscall_grouping is a list
             data["syscall_grouping"] = []

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -1,5 +1,5 @@
 {{%- if product in ["rhel8", "rhel9", "sle12", "sle15"] %}}
-  {{%- set perm_x="-F perm=x " %}}
+  {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
@@ -7,39 +7,21 @@
 # complexity = low
 # disruption = low
 
-# Inserts/replaces the rule in /etc/audit/rules.d
-
-- name: Search /etc/audit/rules.d for audit rule entries
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: "^.*path={{{ PATH }}}.*$"
-    patterns: "*.rules"
-  register: find_{{{ NAME }}}
-
-- name: Use /etc/audit/rules.d/privileged.rules as the recipient for the rule
-  set_fact:
-    all_files:
-      - /etc/audit/rules.d/privileged.rules
-  when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
-  when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched > 0
-
-
-- name: Inserts/replaces the {{{ NAME }}} rule in rules.d
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: '-a always,exit -F path={{{ PATH }}} {{{ perm_x }}}-F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
-    create: yes
-
-# Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules
-
-- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{{ PATH }}} {{{ perm_x }}}-F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
-    create: yes
+- name: Perform remediattion of Audit rules for {{{ PATH }}}
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit",
+      other_filters="-F path="~PATH~perm_x,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="privileged",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit",
+      other_filters="-F path="~PATH~perm_x,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=SYSCALL,
+      key="privileged",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}

--- a/shared/templates/audit_rules_privileged_commands/ansible.template
+++ b/shared/templates/audit_rules_privileged_commands/ansible.template
@@ -7,7 +7,7 @@
 # complexity = low
 # disruption = low
 
-- name: Perform remediattion of Audit rules for {{{ PATH }}}
+- name: Perform remediation of Audit rules for {{{ PATH }}}
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit",

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,16 +1,17 @@
 {{%- if product in ["rhel8", "rhel9", "sle12", "sle15"] %}}
-  {{%- set perm_x="-F perm=x " %}}
+  {{%- set perm_x=" -F perm=x " %}}
 {{%- endif %}}
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 
-PATTERN="-a always,exit -F path={{{ PATH }}}\\s\\+.*"
-GROUP="privileged"
-# Although the fix doesn't use ARCH, we reset it because it could have been set by some other remediation
-ARCH=""
-FULL_RULE="-a always,exit -F path={{{ PATH }}} {{{ perm_x }}}-F auid>={{{ auid }}} -F auid!=unset -F key=privileged"
+ACTION_ARCH_FILTERS="-a always,exit"
+OTHER_FILTERS="-F path={{{ PATH }}}{{{ perm_x }}}"
+AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+SYSCALL="{{{ ATTR }}}"
+KEY="privileged"
+SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,5 +1,5 @@
 {{%- if product in ["rhel8", "rhel9", "sle12", "sle15"] %}}
-  {{%- set perm_x=" -F perm=x " %}}
+  {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 

--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -9,7 +9,7 @@
 ACTION_ARCH_FILTERS="-a always,exit"
 OTHER_FILTERS="-F path={{{ PATH }}}{{{ perm_x }}}"
 AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
-SYSCALL="{{{ ATTR }}}"
+SYSCALL=""
 KEY="privileged"
 SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'

--- a/shared/templates/audit_rules_privileged_commands/template.py
+++ b/shared/templates/audit_rules_privileged_commands/template.py
@@ -15,4 +15,8 @@ def preprocess(data, lang):
         if npath[0] == '_':
             npath = npath[1:]
         data["normalized_path"] = npath
+    elif lang == "bash":
+        if "syscall_grouping" in data:
+            # Make it easier to tranform the syscall_grouping into a Bash array
+            data["syscall_grouping"] = " ".join(data["syscall_grouping"])
     return data

--- a/shared/templates/audit_rules_privileged_commands/template.py
+++ b/shared/templates/audit_rules_privileged_commands/template.py
@@ -19,4 +19,8 @@ def preprocess(data, lang):
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
+    elif lang == "ansible":
+        # This template does not use the 'syscall' parameters
+        data["syscall"] = []
+        data["syscall_grouping"] = []
     return data

--- a/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
@@ -7,12 +7,12 @@
 #
 # What architecture are we on?
 #
-- name: Set architecture for audit {{{ NAME }}} tasks
+- name: Set architecture for audit {{{ NAME | join(", ") }}} tasks
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
 {{% for EXIT_CODE in ["EACCES","EPERM"] %}}
-- name: Perform remediation of Audit rules for {{{ NAME }}} {{{ EXIT_CODE}}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE}}} for x86 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -31,7 +31,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for {{{ NAME }}} {{{ EXIT_CODE }}} for x86_64 platform
+- name: Perform remediattion of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
@@ -11,67 +11,43 @@
   set_fact:
     audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
 
-#
-# Inserts/replaces the rule in /etc/audit/rules.d
-#
-- name: Search /etc/audit/rules.d for other DAC audit rules
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: "-F key=perm_mod$"
-    patterns: "*.rules"
-  register: find_{{{ NAME }}}
+{{% for EXIT_CODE in ["EACCES","EPERM"] %}}
+- name: Perform remediation of Audit rules for {{{ NAME }}} {{{ EXIT_CODE}}} for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="-F exit=-"~EXIT_CODE,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="access",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="-F exit=-"~EXIT_CODE,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="access",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
 
-- name: If existing DAC ruleset not found, use /etc/audit/rules.d/access.rules as the recipient for the rule
-  set_fact:
-    all_files:
-      - /etc/audit/rules.d/access.rules
-  when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched == 0
-
-- name: Use matched file as the recipient for the rule
-  set_fact:
-    all_files:
-      - "{{ find_{{{ NAME }}}.files | map(attribute='path') | list | first }}"
-  when: find_{{{ NAME }}}.matched is defined and find_{{{ NAME }}}.matched > 0
-
-- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "{{ item }}"
-    create: yes
-  with_items:
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-
-- name: Inserts/replaces the {{{ NAME }}} rule in rules.d when on x86_64
-  lineinfile:
-    path: "{{ all_files[0] }}"
-    line: "{{ item }}"
-    create: yes
-  with_items:
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-  when: audit_arch is defined and audit_arch == 'b64'
-#   
-# Inserts/replaces the rule in /etc/audit/audit.rules
-#
-- name: Inserts/replaces the {{{ NAME }}} rule in /etc/audit/audit.rules when on x86
-  lineinfile:
-    line: "{{ item }}"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  with_items:
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-
-- name: Inserts/replaces the {{{ NAME }}} rule in audit.rules when on x86_64
-  lineinfile:
-    line: "{{ item }}"
-    state: present
-    dest: /etc/audit/audit.rules
-    create: yes
-  with_items:
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-    - "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-  when: audit_arch is defined and audit_arch == 'b64'
+- name: Perform remediattion of Audit rules for {{{ NAME }}} {{{ EXIT_CODE }}} for x86_64 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F exit=-"~EXIT_CODE,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="access",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b64",
+      other_filters="-F exit=-"~EXIT_CODE,
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=NAME,
+      key="access",
+      syscall_grouping=SYSCALL_GROUPING,
+      )|indent(4) }}}
+  when: audit_arch == "b64"
+{{% endfor %}}

--- a/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
@@ -31,7 +31,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediattion of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE }}} for x86_64 platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_unsuccessful_file_modification/bash.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/bash.template
@@ -7,22 +7,25 @@
 # Retrieve hardware architecture of the underlying system
 [ "$(getconf LONG_BIT)" = "32" ] && RULE_ARCHS=("b32") || RULE_ARCHS=("b32" "b64")
 
+AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+SYSCALL="{{{ NAME }}}"
+KEY="access"
+SYSCALL_GROUPING="{{{ SYSCALL_GROUPING }}}"
+
 for ARCH in "${RULE_ARCHS[@]}"
 do
-	PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES.*"
-	GROUP="access"
-	FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=access"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-F exit=-EACCES"
 	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-	fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-	fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done
 
 for ARCH in "${RULE_ARCHS[@]}"
 do
-        PATTERN="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM.*"
-        GROUP="access"
-        FULL_RULE="-a always,exit -F arch=$ARCH -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ auid }}} -F auid!=unset -F key=access"
-        # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-        fix_audit_syscall_rule "auditctl" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
-        fix_audit_syscall_rule "augenrules" "$PATTERN" "$GROUP" "$ARCH" "$FULL_RULE"
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	OTHER_FILTERS="-F exit=-EPERM"
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	fix_audit_syscall_rule "augenrules" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
+	fix_audit_syscall_rule "auditctl" "$ACTION_ARCH_FILTERS" "$OTHER_FILTERS" "$AUID_FILTERS" "$SYSCALL" "$SYSCALL_GROUPING" "$KEY"
 done

--- a/shared/templates/audit_rules_unsuccessful_file_modification/template.py
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/template.py
@@ -6,6 +6,14 @@ def _audit_rules_unsuccessful_file_modification(data, lang):
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
+    elif lang == "ansible":
+        if "name" in data:
+            # Tranform the syscall into a Ansible list
+            # The syscall is under 'name'
+            data["name"] = [ data["name"] ]
+        if "syscall_grouping" not in data:
+            # Ensure that syscall_grouping is a list
+            data["syscall_grouping"] = []
     return data
 
 

--- a/shared/templates/audit_rules_unsuccessful_file_modification/template.py
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/template.py
@@ -10,7 +10,7 @@ def _audit_rules_unsuccessful_file_modification(data, lang):
         if "name" in data:
             # Tranform the syscall into a Ansible list
             # The syscall is under 'name'
-            data["name"] = [ data["name"] ]
+            data["name"] = [data["name"]]
         if "syscall_grouping" not in data:
             # Ensure that syscall_grouping is a list
             data["syscall_grouping"] = []
@@ -19,4 +19,3 @@ def _audit_rules_unsuccessful_file_modification(data, lang):
 
 def preprocess(data, lang):
     return _audit_rules_unsuccessful_file_modification(data, lang)
-

--- a/shared/templates/audit_rules_unsuccessful_file_modification/template.py
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/template.py
@@ -1,11 +1,14 @@
-from ssg.utils import parse_template_boolean_value
+import ssg.utils
 
 
-def preprocess(data, lang):
-    data["check_root_user"] = parse_template_boolean_value(data, parameter="check_root_user", default_value=False)
+def _audit_rules_unsuccessful_file_modification(data, lang):
     if lang == "bash":
         if "syscall_grouping" in data:
             # Make it easier to tranform the syscall_grouping into a Bash array
             data["syscall_grouping"] = " ".join(data["syscall_grouping"])
-
     return data
+
+
+def preprocess(data, lang):
+    return _audit_rules_unsuccessful_file_modification(data, lang)
+


### PR DESCRIPTION
#### Description:

- Improve and extend rule skeleton matching with more explicit rule options for `action`, `list`, `arch`, `auid` and other filters.
- Make explicit the syscalls that can through the `syscall_groupings` parameter.
  - When `syscall_groupings` is empty, it will always add a new rule if not found.
- Make they key to use more explicit, instead of implicit through  'group'.
- [X] Update the Ansible remediations (8af4ced71baa5794bfa9be2cfcf9a9519066e597)
- [ ] ~Add tests for `fix_audit_syscall_rule`~ I think the unit tests are not suited for this function. The function directly edits the rule files in `/etc/audit` and would be better run on a VM. If will need a VM anyway, I'd rather check and improve the test scenarios if needed.
- [X] Improve/adapt test scenarios (I believe the current test scenarios served pretty well to find bugs).

#### Rationale:

- The function actually separated the syscalls into individual lines.
