### PR TITLE
Move a SLES-12-010380 requirement from one rule to another

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable GDM Automatic Login'
 
@@ -23,7 +23,6 @@ identifiers:
     cce@rhel7: CCE-80104-3
     cce@rhel8: CCE-80823-8
     cce@rhel9: CCE-89663-9
-    cce@sle12: CCE-83016-6
 
 references:
     cis-csc: 11,3,9
@@ -40,7 +39,6 @@ references:
     stigid@ol7: OL07-00-010440
     stigid@rhel7: RHEL-07-010440
     stigid@rhel8: RHEL-08-010820
-    stigid@sle12: SLES-12-010380
 
 ocil_clause: 'GDM allows users to automatically login'
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/rule.yml
@@ -28,8 +28,8 @@ references:
     disa: CCI-000366
     nist: CM-6(b),CM-6.1(iv)
     srg: SRG-OS-000480-GPOS-00229
-    stigid@sle15: SLES-15-040430
     stigid@sle12: SLES-12-010380
+    stigid@sle15: SLES-15-040430
 
 ocil_clause: 'GDM allows users to automatically login or unattended login'
 

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_unattended_automatic_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle12,sle15
 
 title: 'Disable GDM Unattended or Automatic Login'
 
@@ -21,6 +21,7 @@ rationale: |-
 severity: high
 
 identifiers:
+    cce@sle12: CCE-83245-1
     cce@sle15: CCE-85723-5
 
 references:
@@ -28,6 +29,7 @@ references:
     nist: CM-6(b),CM-6.1(iv)
     srg: SRG-OS-000480-GPOS-00229
     stigid@sle15: SLES-15-040430
+    stigid@sle12: SLES-12-010380
 
 ocil_clause: 'GDM allows users to automatically login or unattended login'
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -185,7 +185,7 @@ selections:
     - file_permissions_system_commands_dirs
     - file_permission_user_init_files
     - ftp_present_banner
-    - gnome_gdm_disable_automatic_login
+    #   gnome_gdm_disable_automatic_login
     - dconf_gnome_screensaver_idle_delay
     - grub2_password
     - grub2_uefi_password

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -185,7 +185,7 @@ selections:
     - file_permissions_system_commands_dirs
     - file_permission_user_init_files
     - ftp_present_banner
-    #   gnome_gdm_disable_automatic_login
+    - gnome_gdm_disable_unattended_automatic_login
     - dconf_gnome_screensaver_idle_delay
     - grub2_password
     - grub2_uefi_password


### PR DESCRIPTION
#### Description:

- _With this update I moved SLES-12-030310 from one rule to another_

#### Rationale:

- _SLES-12-030310 was defined in rule gnome_gdm_disable_automatic_login, but according to its definition its correct place is in the rule gnome_gdm_disable_unattended_automatic_login_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
