### PR TITLE
Add to  sle15  PCI-DSS profile rules for account uniqueness and grub config ownership

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_name/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_name/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-80208-2
     cce@rhel8: CCE-80674-5
     cce@rhel9: CCE-83628-8
+    cce@sle15: CCE-85845-6
 
 references:
     cis@rhel8: 6.2.17

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/rule.yml
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-27352-4
     cce@rhel8: CCE-80651-3
     cce@rhel9: CCE-83618-9
+    cce@sle15: CCE-85846-4
 
 references:
     cis-csc: 1,12,15,16,5

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
@@ -15,6 +15,7 @@ identifiers:
     cce@rhel7: CCE-27503-2
     cce@rhel8: CCE-80822-0
     cce@rhel9: CCE-83613-0
+    cce@sle15: CCE-85847-2
 
 references:
     cis-csc: 1,12,15,16,5

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-82023-3
     cce@rhel8: CCE-80800-6
     cce@rhel9: CCE-83848-2
+    cce@sle15: CCE-85849-8
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel7: CCE-82026-6
     cce@rhel8: CCE-80805-5
     cce@rhel9: CCE-83845-8
+    cce@sle15: CCE-85848-0
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5

--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -12,6 +12,8 @@ pkg_manager: "zypper"
 pkg_manager_config_file: "/etc/zypp/zypp.conf"
 oval_feed_url: "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml"
 
+grub2_boot_path: "/boot/grub2"
+
 cpes_root: "../../shared/applicability"
 cpes:
   - sle15-server:

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -65,6 +65,7 @@ selections:
     - audit_rules_usergroup_modification_shadow
     - audit_rules_sysadmin_actions
     - display_login_attempts
+    - file_groupowner_grub2_cfg
     - file_owner_grub2_cfg
     - gid_passwd_group_same
     - no_empty_passwords

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -23,6 +23,7 @@ selections:
     - var_auditd_action_mail_acct=root
     ### Rules:
     - account_disable_post_pw_expiration
+    - account_unique_name
     - accounts_maximum_age_login_defs
     - accounts_password_pam_lcredit
     - accounts_password_pam_unix_remember

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -25,6 +25,7 @@ selections:
     - account_disable_post_pw_expiration
     - account_unique_name
     - accounts_maximum_age_login_defs
+    - accounts_password_all_shadowed
     - accounts_password_pam_lcredit
     - accounts_password_pam_unix_remember
     - accounts_passwords_pam_faillock_deny

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -65,6 +65,7 @@ selections:
     - audit_rules_usergroup_modification_shadow
     - audit_rules_sysadmin_actions
     - display_login_attempts
+    - file_owner_grub2_cfg
     - gid_passwd_group_same
     - no_empty_passwords
     - service_auditd_enabled

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -65,6 +65,7 @@ selections:
     - audit_rules_usergroup_modification_shadow
     - audit_rules_sysadmin_actions
     - display_login_attempts
+    - gid_passwd_group_same
     - no_empty_passwords
     - service_auditd_enabled
     - service_pcscd_enabled


### PR DESCRIPTION
#### Description:

- Add to  sle15  PCI-DSS profile rules for account uniqueness and grub config ownership

#### Rationale:
- Add file_groupowner_grub2_cfg to SLES15 PCI-DSS
- Add file_owner_grub2_cfg to SLES15 PCI-DSS
- Add gid_passwd_group_same to SLES15 PCI-DS
- Add accounts_password_all_shadowed to SLES15 PCI-DSS
- Add account_unique_name to SLES15 PCI-DSS

