### PR TITLE
Select sysctl_net_core_bpf_jit_harden for RHEL-08-040286

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/rule.yml
@@ -19,8 +19,11 @@ identifiers:
     cce@rhel9: CCE-83966-2
 
 references:
+    disa: CCI-000366
+    nist: CM-6b
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000480-GPOS-00227
+    stigid@rhel8: RHEL-08-040286
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.core.bpf_jit_harden", value="2") }}}
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -1149,6 +1149,9 @@ selections:
     # RHEL-08-040285
     - sysctl_net_ipv4_conf_all_rp_filter
 
+    # RHEL-08-040286
+    - sysctl_net_core_bpf_jit_harden
+
     # RHEL-08-040290
     # /etc/postfix/main.cf does not exist on default installation resulting in error during remediation
     # there needs to be a new platform check to identify when postfix is installed or not

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -359,6 +359,7 @@ selections:
 - sysctl_kernel_randomize_va_space
 - sysctl_kernel_unprivileged_bpf_disabled
 - sysctl_kernel_yama_ptrace_scope
+- sysctl_net_core_bpf_jit_harden
 - sysctl_net_ipv4_conf_all_accept_redirects
 - sysctl_net_ipv4_conf_all_accept_source_route
 - sysctl_net_ipv4_conf_all_rp_filter

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -370,6 +370,7 @@ selections:
 - sysctl_kernel_randomize_va_space
 - sysctl_kernel_unprivileged_bpf_disabled
 - sysctl_kernel_yama_ptrace_scope
+- sysctl_net_core_bpf_jit_harden
 - sysctl_net_ipv4_conf_all_accept_redirects
 - sysctl_net_ipv4_conf_all_accept_source_route
 - sysctl_net_ipv4_conf_all_rp_filter


### PR DESCRIPTION
#### Description:

Added `sysctl_net_core_bpf_jit_harden` to RHE8 STIG profile. Added NIST and DSIA references as well.

#### Rationale:
New in V1R3, STIG not online yet.
