### PR TITLE
Add RHEL7 specific test kickstart

### DIFF
--- a/tests/kickstarts/test_suite_rhel7.cfg
+++ b/tests/kickstarts/test_suite_rhel7.cfg
@@ -1,0 +1,149 @@
+# SCAP Security Guide SCAP Test Suite node
+# This kickstart is known to apply for:
+# - Red Hat Enterprise Linux 7 Server
+# - Red Hat Enterprise Linux 8 - when using additional repository AppStream
+# - CentOS 7
+# - Fedora
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Installation_Guide/sect-kickstart-syntax.html
+# http://usgcb.nist.gov/usgcb/content/configuration/workstation-ks.cfg
+
+# To enable custom repositories for the machine after installation use:
+#repo --name=myrepo --baseurl=http://...
+&&YUM_EXTRA_REPO&&
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# --enableshadow       enable shadowed passwords by default
+# --passalgo           hash / crypt algorithm for new passwords
+# See the manual page for authconfig for a complete list of possible options.
+authconfig --enableshadow --passalgo=sha512
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+# Refer to e.g.
+#   https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw
+# to see how to create encrypted password form for different plaintext password
+bootloader --location=mbr --append="audit=1 audit_backlog_limit=8192 slub_debug=P page_poison=1 vsyscall=none"
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+#
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+part /boot --fstype=xfs --size=512 --fsoptions="nosuid,noexec"
+part pv.01 --grow --size=1
+
+# Create a Logical Volume Management (LVM) group (optional)
+volgroup VolGroup --pesize=4096 pv.01
+
+# Create particular logical volumes (optional)
+logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
+# Ensure /usr Located On Separate Partition
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5512 --fsoptions="nodev"
+# Ensure /opt Located On Separate Partition
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+# Ensure /srv Located On Separate Partition
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
+# Ensure /home Located On Separate Partition
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+# Ensure /tmp Located On Separate Partition
+logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/tmp Located On Separate Partition
+logvol /var/tmp --fstype=xfs --name=vartmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var Located On Separate Partition
+logvol /var --fstype=xfs --name=var --vgname=VolGroup --size=3072 --fsoptions="nodev"
+# Ensure /var/log Located On Separate Partition
+logvol /var/log --fstype=xfs --name=log --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
+# Ensure /var/log/audit Located On Separate Partition
+logvol /var/log/audit --fstype=xfs --name=audit --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid,noexec"
+logvol swap --name=swap --vgname=VolGroup --size=2016
+
+# Packages selection (%packages section is required)
+%packages
+openscap-scanner
+tar
+qemu-guest-agent
+openssh-clients
+openssh-server
+%end # End of %packages section
+
+%post --log /root/post-install.log --interpreter /bin/bash
+
+# initialize guest agent for SSG Test Suite
+systemctl enable qemu-guest-agent.service
+
+mkdir -p /root/.ssh
+printf "%s\n" "&&HOST_PUBLIC_KEY&&" >> /root/.ssh/authorized_keys
+chmod og-rw /root/.ssh /root/.ssh/authorized_keys
+systemctl enable sshd
+
+# create yum/dnf repository from URL if replaced by install_vm.py
+if ! [[ '&&YUM_REPO_URL&&' =~ YUM_REPO_URL ]]; then
+	cat > /etc/yum.repos.d/inst-ks.repo <<EOF
+[inst-ks]
+name=Installation repo from kickstart
+baseurl=&&YUM_REPO_URL&&
+enabled=1
+gpgcheck=0
+EOF
+fi
+# create yum/dnf repository from URL if replaced by install_vm.py
+if ! [[ '&&YUM_EXTRA_REPO_URL&&' =~ YUM_EXTRA_REPO_URL ]]; then
+	cat >> /etc/yum.repos.d/inst-ks.repo <<EOF
+[inst-ks-2]
+name=Extra repo from kickstart
+baseurl=&&YUM_EXTRA_REPO_URL&&
+enabled=1
+gpgcheck=0
+EOF
+fi
+
+%end
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
#### Description:
Add test kickstart for rhel7 installation. New kickstart is similar to the general one, but uses `authconfig` instead of `authselect`. 

#### Rationale:

Recently updated test kickstart  #7281 doesn't work on rhel7.
```
anaconda 21.48.22.159-1 for Red Hat Enterprise Linux 7.9 started.
 * installation log files are stored in /tmp during the installation[1;24r[H[3B[1;23r[H[3B * shell is available on TTY2
 * if the graphical installation interface fails to start, try again with the
   inst.text bootoption to start text installation
 * when reporting a bug add logs from /tmp as separate text/plain attachments[1;24r[H[7B[1;23r[H[7BThe following problem occurred on line 50 of the kickstart file:[1;24r[H[8;65H[1;23r[H[9BUnknown command: authselect[1;24r[H[11B[1;23r[H[23;1H[1mPane is dead[H[m(Banaconda 21.48.22.159-1 for Red Hat Enterprise Linux 7.9 started.[K
 * installation log files are stored in /tmp during the installation[K
 * shell is available on TTY2[K
 * if the graphical installation interface fails to start, try again with the[K
   inst.text bootoption to start text installation[K
 * when reporting a bug add logs from /tmp as separate text/plain attachments[K
The following problem occurred on line 50 of the kickstart file:[K
[K
Unknown command: authselect[K
```
