### PR TITLE
Update RHEL 8 CIS references to match benchmark 1.0.1

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.9
-    cis@rhel8: 6.1.8
+    cis@rhel8: 6.1.9
     cis@ubuntu2004: 6.1.8
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group-", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.6
-    cis@rhel8: 6.1.9
+    cis@rhel8: 6.1.7
     cis@ubuntu2004: 6.1.3
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.3
-    cis@rhel8: 6.1.6
+    cis@rhel8: 6.1.3
     cis@ubuntu2004: 6.1.6
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd-", group="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.5
-    cis@rhel8: 6.1.7
+    cis@rhel8: 6.1.5
     cis@ubuntu2004: 6.1.7
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow-", group=target_group) }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 references:
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.8
-    cis@rhel8: 6.1.4
+    cis@rhel8: 6.1.8
     cis@ubuntu2004: 6.1.5
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 references:
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.7
-    cis@rhel8: 6.1.5
+    cis@rhel8: 6.1.6
     cis@ubuntu2004: 6.1.9
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
     isa-62443-2009: 4.3.3.7.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 references:
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.4
-    cis@rhel8: 6.1.3
+    cis@rhel8: 6.1.4
     cis@ubuntu2004: 6.1.4
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.9
-    cis@rhel8: 6.1.8
+    cis@rhel8: 6.1.9
     cis@ubuntu2004: 6.1.8
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group-", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
@@ -17,7 +17,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.6
-    cis@rhel8: 6.1.9
+    cis@rhel8: 6.1.7
     cis@ubuntu2004: 6.1.3
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow-", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.3
-    cis@rhel8: 6.1.6
+    cis@rhel8: 6.1.3
     cis@ubuntu2004: 6.1.6
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd-", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.5
-    cis@rhel8: 6.1.7
+    cis@rhel8: 6.1.5
     cis@ubuntu2004: 6.1.7
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow-", owner="root") }}}'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 references:
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.8
-    cis@rhel8: 6.1.4
+    cis@rhel8: 6.1.8
     cis@sle15: 6.1.6
     cis@ubuntu2004: 6.1.5
     cjis: 5.5.2.2

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -19,7 +19,7 @@ references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.7
-    cis@rhel8: 6.1.5
+    cis@rhel8: 6.1.6
     cis@ubuntu2004: 6.1.9
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
     isa-62443-2009: 4.3.3.7.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -22,7 +22,7 @@ references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.4
-    cis@rhel8: 6.1.3
+    cis@rhel8: 6.1.4
     cis@ubuntu2004: 6.1.4
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.9
-    cis@rhel8: 6.1.8
+    cis@rhel8: 6.1.9
     cis@sle15: 6.1.9
     cis@ubuntu2004: 6.1.8
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
@@ -26,7 +26,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.6
-    cis@rhel8: 6.1.9
+    cis@rhel8: 6.1.7
     cis@sle15: 6.1.3
     cis@ubuntu2004: 6.1.3
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
@@ -19,7 +19,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.3
-    cis@rhel8: 6.1.6
+    cis@rhel8: 6.1.3
     cis@sle15: 6.1.7
     cis@ubuntu2004: 6.1.6
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -27,7 +27,7 @@ identifiers:
 
 references:
     cis@rhel7: 6.1.5
-    cis@rhel8: 6.1.7
+    cis@rhel8: 6.1.5
     cis@sle15: 6.1.8
     cis@ubuntu2004: 6.1.7
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -20,7 +20,7 @@ references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.8
-    cis@rhel8: 6.1.4
+    cis@rhel8: 6.1.8
     cis@sle15: 6.1.6
     cis@ubuntu2004: 6.1.5
     cjis: 5.5.2.2

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
@@ -28,7 +28,7 @@ references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.7
-    cis@rhel8: 6.1.5
+    cis@rhel8: 6.1.6
     cis@sle15: 6.1.2
     cis@ubuntu2004: 6.1.9
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -31,7 +31,7 @@ references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
     cis@rhel7: 6.1.4
-    cis@rhel8: 6.1.3
+    cis@rhel8: 6.1.4
     cis@sle15: 6.1.5
     cis@ubuntu2004: 6.1.4
     cjis: 5.5.2.2


### PR DESCRIPTION
#### Description:

- In the CIS benchmark release 1.0.1, CIS swapped around a number of the rule identifiers in Section 6.1
- This PR fixes the identifiers so they accurately track the 1.0.1 benchmark

#### Rationale:

- This PR fixes the identifiers so they accurately track the 1.0.1 benchmark
- This is part of the uplift to CIS benchmark 1.0.1 compatibility that's part of PR #6976 

cc @vojtapolasek 