### PR TITLE
Add SRGs for accounts_password_pam_dictcheck and sssd_enable_certmap

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
    disa: CCI-000187
    nist: IA-5 (2) (c)
+   srg: SRG-OS-000068-GPOS-00036
    stigid@rhel8: RHEL-08-020090
 
 warnings:

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     disa: CCI-000366
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
+    srg: SRG-OS-000480-GPOS-00225
     stigid@rhel8: RHEL-08-020300
 
 ocil_clause: 'dictcheck is not found or not equal to the required value'


### PR DESCRIPTION
#### Description:
accounts_password_pam_dictcheck - #7289 - https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_8_security_technical_implementation_guide/V-230377

sssd_enable_certmap - #7313 - https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_8_security_technical_implementation_guide/V-230355
