### PR TITLE
UBTU-20-010057: Add missing rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Install pam_pwquality Package'
+
+description: |-
+    {{{ describe_package_install(package="libpam-pwquality") }}}
+
+rationale: |-
+    Use of a complex password helps to increase the time and resources required
+    to compromise the password. Password complexity, or strength, is a measure
+    of the effectiveness of a password in resisting attempts at guessing and
+    brute-force attacks. "pwquality" enforces complex password construction
+    configuration and has the ability to limit brute-force attacks on the
+    system.
+
+severity: medium
+
+references:
+    disa: CCI-000366
+    srg: SRG-OS-000480-GPOS-00225
+    stigid@ubuntu2004: UBTU-20-010057
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="libpam-pwquality") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: libpam-pwquality

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/rule.yml
@@ -1,0 +1,51 @@
+documentation_complete: true
+ 
+prodtype: ubuntu2004
+ 
+title: 'Ensure PAM Enforces Password Requirements - Enforcing'
+
+description: |-
+    Verify that the operating system uses "pwquality" to enforce the
+    password complexity rules.
+    
+    Verify the pwquality module is being enforced by operating system by
+    running the following command:
+    <pre>
+    $ grep -i enforcing /etc/security/pwquality.conf
+    enforcing = 1
+    </pre>
+
+    If the value of "enforcing" is not "1" or the line is commented out,
+    this is a finding.
+
+rationale: |-
+    Use of a complex password helps to increase the time and resources
+    required to compromise the password. Password complexity, or strength,
+    is a measure of the effectiveness of a password in resisting attempts at
+    guessing and brute-force attacks. Using enforcing=1 ensures "pwquality"
+    enforces complex password construction configuration and has the ability
+    to limit brute-force attacks on the system.
+
+severity: medium
+
+references:
+    disa: CCI-000366
+    srg: SRG-OS-000480-GPOS-00225
+    stigid@ubuntu2004: UBTU-20-010057
+
+ocil_clause: 'enforcing is not uncommented or configured correctly'
+
+ocil: |-
+    To verify that enforcing is correctly applied, run the following command:
+    <pre>$ grep -i enforcing /etc/security/pwquality.conf</pre>
+    The output should return <tt>enforcing = 1</tt> uncommented.
+
+platform: pam
+
+template:
+    name: "lineinfile"
+    vars:
+        text: "enforcing = 1"
+        path: "/etc/security/pwquality.conf"
+    oval_extend_definitions:
+        - accounts_password_pam_pwquality

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -116,6 +116,8 @@ selections:
 
     # UBTU-20-010057 The Ubuntu operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.
     - var_password_pam_retry=3
+    - package_pam_pwquality_installed
+    - accounts_password_pam_enforcing
     - accounts_password_pam_retry
 
     # UBTU-20-010060 The Ubuntu operating system, for PKI-based authentication, must validate certificates by constructing a certification path (which includes status information) to an accepted trust anchor.


### PR DESCRIPTION
#### Description:

- We currently don't have a rule to install pam-pwquality (libpam-pwquality in Ubuntu's case).
- This stig rule also needs to check if pwquality is being enforced:
```$ grep -i enforcing /etc/security/pwquality.conf
enforcing = 1
```
