### PR TITLE
Create /etc/audit/rules.d/ folder in audit_time_rules tests

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
@@ -2,5 +2,6 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
+mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
@@ -2,5 +2,6 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
+mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
@@ -2,5 +2,6 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
+mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S clock_settime -F a0=0x1 -k time-change" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S clock_settime -F a0=0x1 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
@@ -2,5 +2,6 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
+mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S stime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S stime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+mkdir -p /etc/audit/rules.d/
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
 	echo "-a always,exit -F arch=b32 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules
 	echo "-a always,exit -F arch=b64 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-
+mkdir -p /etc/audit/rules.d/
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+mkdir -p /etc/audit/rules.d/
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
 	echo "-a always,exit -F arch=b32 -S stime -k audit_time_rules" >> /etc/audit/rules.d/time.rules
 fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
-
+mkdir -p /etc/audit/rules.d/
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules


### PR DESCRIPTION
#### Description:
If the folder doesn't exist, it causes:
```
ERROR - Failed to execute 'cd /root/ssgts/audit_rules_time_stime; SHARED=/root/ssgts/shared bash -x line_not_there.fail.sh' on root@localhost: Command '('ssh', '-o', 'Port=42159', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'root@localhost', 'cd /root/ssgts/audit_rules_time_stime; SHARED=/root/ssgts/shared bash -x line_not_there.fail.sh')' returned non-zero exit status 2.
```
