### PR TITLE
Rule SLES-15-030310 - a typo correction

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -56,7 +56,7 @@ references:
     stigid@ol7: OL07-00-030430
     stigid@rhel7: RHEL-07-030430
     stigid@sle12: SLES-12-020480
-    stigid@sle15: SLES-12-030310
+    stigid@sle15: SLES-15-030310
     stigid@ubuntu2004: UBTU-20-010154
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940
 


### PR DESCRIPTION
#### Description:

- _Review/validation required_

#### Rationale:

- _A typo error. Instead of SLES-15-030310 the code SLES-12-030310 was used in references_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
