### PR TITLE
Reflect availability of rear on s390x in RHEL8.5

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_rear_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rear_installed/rule.yml
@@ -22,7 +22,8 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="rear") }}}'
 
-platform: not_s390x_arch
+# The package is not available for s309x on RHEL<8.5
+# platform: not_s390x_arch
 
 template:
     name: package_installed


### PR DESCRIPTION
I have kept the information about possible absence of the package in the rule yaml.

See https://bugzilla.redhat.com/show_bug.cgi?id=1958939

Reverts #7261