### PR TITLE
Add ensure_logrotate_activated rule to SLES15 PCI-DSS

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/rule.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel7: CCE-80195-1
     cce@rhel8: CCE-80794-1
     cce@rhel9: CCE-83993-6
+    cce@sle15: CCE-85850-6
 
 references:
     anssi: BP28(R43),NT12(R18)

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -69,6 +69,7 @@ selections:
     - audit_rules_usergroup_modification_shadow
     - audit_rules_sysadmin_actions
     - display_login_attempts
+    - ensure_logrotate_activated
     - file_groupowner_grub2_cfg
     - file_owner_grub2_cfg
     - gid_passwd_group_same


### PR DESCRIPTION
#### Description:

- Add ensure_logrotate_activated rule to SLES15 PCI-DSS

#### Rationale:

- Assign ensure_logrotate_activated rule to SLES15 cce Id and add it to the PCI-DSS profile
