### PR TITLE
Add s390x CPE platform

### DIFF
--- a/linux_os/guide/system/bootloader-zipl/group.yml
+++ b/linux_os/guide/system/bootloader-zipl/group.yml
@@ -8,4 +8,4 @@ description: |-
     options to it.
     The default {{{ full_name }}} boot loader for s390x systems is called zIPL.
 
-platform: zipl
+platform: s390x_arch

--- a/shared/applicability/arch.yml
+++ b/shared/applicability/arch.yml
@@ -1,0 +1,12 @@
+cpes:
+
+  - not_s390x_arch:
+      name: "cpe:/a:not_s390x_arch"
+      title: "System architecture is not S390X"
+      check_id: proc_sys_kernel_osrelease_arch_not_s390x
+
+  - s390x_arch:
+      name: "cpe:/a:s390x_arch"
+      title: "System architecture is S390X"
+      check_id: proc_sys_kernel_osrelease_arch_s390x
+

--- a/shared/applicability/bootloaders.yml
+++ b/shared/applicability/bootloaders.yml
@@ -4,8 +4,3 @@ cpes:
       name: "cpe:/a:grub2"
       title: "Package grub2 is installed"
       check_id: installed_env_has_grub2_package
-
-  - zipl:
-      name: "cpe:/a:zipl"
-      title: "System uses zipl"
-      check_id: installed_env_has_zipl_package

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -24,11 +24,6 @@ cpes:
       title: "Package net-snmp is installed"
       check_id: installed_env_has_net-snmp_package
 
-  - not_s390x_arch:
-      name: "cpe:/a:not_s390x_arch"
-      title: "System architecture is not S390X"
-      check_id: proc_sys_kernel_osrelease_arch_not_s390x
-
   - nss-pam-ldapd:
       name: "cpe:/a:nss-pam-ldapd"
       title: "Package nss-pam-ldapd is installed"

--- a/shared/checks/oval/proc_sys_kernel_osrelease_arch_not_s390x.xml
+++ b/shared/checks/oval/proc_sys_kernel_osrelease_arch_not_s390x.xml
@@ -9,26 +9,8 @@
       <description>Check that architecture of kernel in /proc/sys/kernel/osrelease is not s390x</description>
     </metadata>
     <criteria>
-      <criterion comment="Architecture is not s390x"
-      test_ref="test_proc_sys_kernel_osrelease_arch_s390x" negate="true"/>
+      <extend_definition comment="Architecture is not s390x"
+      definition_ref="proc_sys_kernel_osrelease_arch_s390x" negate="true"/>
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
-      comment="proc_sys_kernel is for s390x architecture"
-      id="test_proc_sys_kernel_osrelease_arch_s390x"
-  version="1">
-    <ind:object object_ref="object_proc_sys_kernel_osrelease_arch_s390x" />
-    <ind:state state_ref="state_proc_sys_kernel_osrelease_arch_s390x" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="object_proc_sys_kernel_osrelease_arch_s390x" version="1">
-    <ind:filepath>/proc/sys/kernel/osrelease</ind:filepath>
-    <ind:pattern operation="pattern match">^.*\.(.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_state id="state_proc_sys_kernel_osrelease_arch_s390x" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^s390x$</ind:subexpression>
-  </ind:textfilecontent54_state>
-
 </def-group>

--- a/shared/checks/oval/proc_sys_kernel_osrelease_arch_s390x.xml
+++ b/shared/checks/oval/proc_sys_kernel_osrelease_arch_s390x.xml
@@ -1,0 +1,33 @@
+<def-group>
+  <definition class="inventory" id="proc_sys_kernel_osrelease_arch_s390x"
+  version="1">
+    <metadata>
+      <title>Test for different architecture than s390x</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check that architecture of kernel in /proc/sys/kernel/osrelease is s390x</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Architecture is s390x"
+      test_ref="test_proc_sys_kernel_osrelease_arch_s390x" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="proc_sys_kernel is for s390x architecture"
+      id="test_proc_sys_kernel_osrelease_arch_s390x"
+  version="1">
+    <ind:object object_ref="object_proc_sys_kernel_osrelease_arch_s390x" />
+    <ind:state state_ref="state_proc_sys_kernel_osrelease_arch_s390x" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_proc_sys_kernel_osrelease_arch_s390x" version="1">
+    <ind:filepath>/proc/sys/kernel/osrelease</ind:filepath>
+    <ind:pattern operation="pattern match">^.*\.(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_proc_sys_kernel_osrelease_arch_s390x" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^s390x$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>


### PR DESCRIPTION
#### Description:

- Add CPE platform `s390x_arch` 
  - Move the arch platform definitions to their own file
  - Define the `not_s390x_arch` check as a negation of the `s390x_arch` check.
- Remove CPE platform `zipl`

#### Rationale:

- The package names for `zipl` changed a bit recently.
  Let's define zipl rules applicability based on the system arch.
