### PR TITLE
locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml: sles15 fix

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -16,3 +16,15 @@
     dest: /etc/pam.d/system-auth
     regexp: '^password\s+sufficient\s+pam_unix\.so\s(?!.*remember\s*=\s*).*$'
     replace: '\g<0> remember={{ var_password_pam_unix_remember }}'
+
+- name: "Do not allow users to reuse recent passwords - system-auth (change)"
+  replace:
+    dest: /etc/pam.d/system-auth
+    regexp: '^(password\s+(?:(?:requisite)|(?:required))\s+pam_pwhistory\.so\s.*remember\s*=\s*)(\S+)(.*)$'
+    replace: '\g<1>{{ var_password_pam_unix_remember }}\g<3>'
+
+- name: "Do not allow users to reuse recent passwords - system-auth (add)"
+  replace:
+    dest: /etc/pam.d/system-auth
+    regexp: '^password\s+(?:(?:requisite)|(?:required))\s+pam_pwhistory\.so\s(?!.*remember\s*=\s*).*$'
+    replace: '\g<0> remember={{ var_password_pam_unix_remember }}'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -7,9 +7,14 @@ AUTH_FILES[1]="/etc/pam.d/password-auth"
 
 for pamFile in "${AUTH_FILES[@]}"
 do
-	if grep -q "remember=" $pamFile; then
+	if grep -q "pam_unix.so.*remember=" $pamFile; then
 		sed -i --follow-symlinks "s/\(^password.*sufficient.*pam_unix.so.*\)\(\(remember *= *\)[^ $]*\)/\1remember=$var_password_pam_unix_remember/" $pamFile
 	else
 		sed -i --follow-symlinks "/^password[[:space:]]\+sufficient[[:space:]]\+pam_unix.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
+	fi
+	if grep -q "pam_pwhistory.so.*remember=" $pamFile; then
+		sed -i --follow-symlinks "s/\(^password.*\)\(\(remember *= *\)[^ $]*\)/\1remember=$var_password_pam_unix_remember/" $pamFile
+	else
+		sed -i --follow-symlinks "/^password[[:space:]]\+\(requisite\|required\)[[:space:]]\+pam_pwhistory.so/ s/$/ remember=$var_password_pam_unix_remember/" $pamFile
 	fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -28,7 +28,11 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember" version="1">
+{{% if product in [ "sle15" ] %}}
+    <ind:filepath>/etc/pam.d/common-password</ind:filepath>
+{{% else %}}
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+{{% endif %}}
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:requisite)|(?:required))\s+pam_pwhistory\.so.*remember=([0-9]*).*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
#### Description:


The STIG manual for SLES-15-020250 says:
    
Check that the SUSE operating system prohibits the reuse of a password for a minimum of five generations with the following command:

```
> grep pam_pwhistory.so /etc/pam.d/common-password
   password requisite pam_pwhistory.so remember=5 use_authtok
```

but the check is looking for /etc/pam.d/system-auth, so update the check to use the right file for sle15.
