### PR TITLE
Add ISM Official kickstarts

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-ism_o-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-ism_o-ks.cfg
@@ -1,0 +1,116 @@
+# SCAP Security Guide ISM Official profile kickstart for Red Hat Enterprise Linux 8 Server
+# Version: 0.0.1
+# Date: 2021-08-16
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+#
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet"
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+autopart
+
+# Harden installation with Essential Eight profile
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+%addon org_fedora_oscap
+        content-type = scap-security-guide
+        profile = xccdf_org.ssgproject.content_profile_ism_o
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject

--- a/products/rhel9/kickstart/ssg-rhel9-ism_o-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ism_o-ks.cfg
@@ -1,0 +1,116 @@
+# SCAP Security Guide ISM Official profile kickstart for Red Hat Enterprise Linux 9 Server
+# Version: 0.0.1
+# Date: 2021-08-16
+#
+# Based on:
+# https://pykickstart.readthedocs.io/en/latest/
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#performing_an_automated_installation_using_kickstart
+
+# Specify installation method to use for installation
+# To use a different one comment out the 'url' one below, update
+# the selected choice with proper options & un-comment it
+#
+# Install from an installation tree on a remote server via FTP or HTTP:
+# --url		the URL to install from
+#
+# Example:
+#
+# url --url=http://192.168.122.1/image
+#
+# Modify concrete URL in the above example appropriately to reflect the actual
+# environment machine is to be installed in
+#
+# Other possible / supported installation methods:
+# * install from the first CD-ROM/DVD drive on the system:
+#
+# cdrom
+#
+# * install from a directory of ISO images on a local drive:
+#
+# harddrive --partition=hdb2 --dir=/tmp/install-tree
+#
+# * install from provided NFS server:
+#
+# nfs --server=<hostname> --dir=<directory> [--opts=<nfs options>]
+#
+
+# Set language to use during installation and the default language to use on the installed system (required)
+lang en_US.UTF-8
+
+# Set system keyboard type / layout (required)
+keyboard us
+
+# Configure network information for target system and activate network devices in the installer environment (optional)
+# --onboot	enable device at a boot time
+# --device	device to be activated and / or configured with the network command
+# --bootproto	method to obtain networking configuration for device (default dhcp)
+# --noipv6	disable IPv6 on this device
+#
+#
+network --onboot yes --device eth0 --bootproto dhcp --noipv6
+
+# Set the system's root password (required)
+# Plaintext password is: server
+# Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
+# encrypted password form for different plaintext password
+rootpw --iscrypted $6$/0RYeeRdK70ynvYz$jH2ZN/80HM6DjndHMxfUF9KIibwipitvizzXDH1zW.fTjyD3RD3tkNdNUaND18B/XqfAUW3vy1uebkBybCuIm0
+
+# The selected profile will restrict root login
+# Add a user that can login and escalate privileges
+# Plaintext password is: admin123
+user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUafQM9jyHCY9BiE5/ahXLNWUMiVQnFGblu0WWGZ1e6icTaCGO4GNgZNtspp1Let/qpM7FMVB0 --iscrypted
+
+# Configure firewall settings for the system (optional)
+# --enabled	reject incoming connections that are not in response to outbound requests
+# --ssh		allow sshd service through the firewall
+firewall --enabled --ssh
+
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
+# State of SELinux on the installed system (optional)
+# Defaults to enforcing
+selinux --enforcing
+
+# Set the system time zone (required)
+timezone --utc America/New_York
+
+# Specify how the bootloader should be installed (required)
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet"
+
+# Initialize (format) all disks (optional)
+zerombr
+
+# The following partition layout scheme assumes disk of size 20GB or larger
+# Modify size of partitions appropriately to reflect actual machine's hardware
+# 
+# Remove Linux partitions from the system prior to creating new ones (optional)
+# --linux	erase all Linux partitions
+# --initlabel	initialize the disk label to the default based on the underlying architecture
+clearpart --linux --initlabel
+
+# Create primary system partitions (required for installs)
+autopart
+
+# Harden installation with Essential Eight profile
+# For more details and configuration options see
+# https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_an_advanced_rhel_installation/index#addon-org_fedora_oscap_kickstart-commands-for-addons-supplied-with-the-rhel-installation-program
+%addon com_redhat_oscap
+        content-type = scap-security-guide
+        profile = xccdf_org.ssgproject.content_profile_ism_o
+%end
+
+# Packages selection (%packages section is required)
+%packages
+
+# Require @Base
+@Base
+
+%end # End of %packages section
+
+# Reboot after the installation is complete (optional)
+# --eject	attempt to eject CD or DVD media before rebooting
+reboot --eject


### PR DESCRIPTION
Kickstarts are based on their e8 siblibgs. The e8 profile requires Grub password, which I believe is not needed by any rule, so the ISM profile disables this.