### PR TITLE
Fix combined mode execution in SSGTS

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -85,6 +85,8 @@ class CombinedChecker(rule.RuleChecker):
 def perform_combined_check(options):
     checker = CombinedChecker(options.test_env)
 
+    # These options are static between different runs under different
+    # profiles.
     checker.datastream = options.datastream
     checker.benchmark_id = options.benchmark_id
     checker.remediate_using = options.remediate_using
@@ -93,20 +95,23 @@ def perform_combined_check(options):
     checker.manual_debug = False
     checker.benchmark_cpes = options.benchmark_cpes
     checker.scenarios_regex = options.scenarios_regex
-    # Let's keep track of originaly targeted profile
-    checker.profile = options.target
 
-    profile = options.target
-    # check if target is a complete profile ID, if not prepend profile prefix
-    if not profile.startswith(OSCAP_PROFILE):
-        profile = OSCAP_PROFILE+profile
-    logging.info("Performing combined test using profile: {0}".format(profile))
+    for target in options.target:
+        # Let's keep track of originally targeted profile separately from the
+        # resolved profile name.
+        checker.profile = target
 
-    # Fetch target list from rules selected in profile
-    target_rules = xml_operations.get_all_rule_ids_in_profile(
-            options.datastream, options.benchmark_id,
-            profile, logging)
-    logging.debug("Profile {0} expanded to following list of "
-                  "rules: {1}".format(profile, target_rules))
+        profile = target
+        # check if target is a complete profile ID, if not prepend profile prefix
+        if not profile.startswith(OSCAP_PROFILE):
+            profile = OSCAP_PROFILE+profile
+        logging.info("Performing combined test using profile: {0}".format(profile))
 
-    checker.test_target(target_rules)
+        # Fetch target list from rules selected in profile
+        target_rules = xml_operations.get_all_rule_ids_in_profile(
+                options.datastream, options.benchmark_id,
+                profile, logging)
+        logging.debug("Profile {0} expanded to following list of "
+                      "rules: {1}".format(profile, target_rules))
+
+        checker.test_target(target_rules)

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -295,6 +295,15 @@ def datastream_in_stash(current_location):
 
 def normalize_passed_arguments(options):
     targets = []
+
+    # From here on out, we're assuming options.target is a list of targets,
+    # for all execution types (combined, rule, profile). If it isn't, coerce
+    # it to a list with a single item in it. Otherwise, when we iterate over
+    # options.target, if it remains a string, we'll iterate per-character,
+    # which isn't what we want.
+    if isinstance(options.target, str):
+        options.target = [options.target]
+
     for target in options.target:
         if ',' in target:
             targets.extend(target.split(","))


### PR DESCRIPTION
While enabling GH-action based execution of the SSGTS, an option for
executing multiple rules was added, allowing for comma-separated rules
to be passed via the command line. This doesn't behave well with
combined mode, which expected a single target (a string) versus a list.

Update combined mode to understand multiple arguments via the CLI and
execute each profile separately.

`Signed-off-by: Alexander Scheel <alex.scheel@canonical.com>`
