### PR TITLE
OCP4: Wait longer for the File Integrity Operator to be available

### DIFF
--- a/applications/openshift/integrity/file_integrity_exists/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/integrity/file_integrity_exists/tests/ocp4/e2e-remediation.sh
@@ -12,7 +12,7 @@ while [ -z "$(oc get -n openshift-file-integrity --ignore-not-found deployment/f
 done
 
 echo "waiting for file-integrity-operator deployment to be ready"
-oc wait -n openshift-file-integrity --for=condition=Available  --timeout=120s \
+oc wait -n openshift-file-integrity --for=condition=Available  --timeout=300s \
     deployment/file-integrity-operator
 
 echo "installing file-integrity instance"


### PR DESCRIPTION
CI is failing constantly as the FIO deployment takes too long. This
ensures we wait longer to avoid these issues.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>