### PR TITLE
SLES-12-010599 - remove rule from the STIG

### DIFF
--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
@@ -16,7 +16,6 @@ severity: medium
 
 identifiers:
     cce@rhel7: CCE-80368-4
-    cce@sle12: CCE-83071-1
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
@@ -31,7 +30,6 @@ references:
     srg: SRG-OS-000191-GPOS-00080,SRG-OS-000196,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020019
     stigid@rhel7: RHEL-07-020019
-    stigid@sle12: SLES-12-010599
 
 ocil_clause: 'the HBSS HIPS module is not installed'
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -208,7 +208,6 @@ selections:
     - package_aide_installed
     - package_audit-audispd-plugins_installed
     - package_audit_installed
-    - package_MFEhiplsm_installed
     - package_pam_apparmor_installed
     - package_SuSEfirewall2_installed
     - package_telnet-server_removed


### PR DESCRIPTION
#### Description:

- _Remove SLES-12-010599 from the stig.profile_

#### Rationale:

- _DISA corrected the rule SLES-12-010599 in its Version 2 Release 4 on 23-7-2021. With this update we cover DISA's correction   _

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
