### PR TITLE
Fix RHEL7 documentation links

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/group.yml
+++ b/linux_os/guide/services/ldap/openldap_client/group.yml
@@ -13,7 +13,7 @@ description: |-
     files, which is useful when trying to use SSL cleanly across several protocols.
     Installation and configuration of OpenLDAP on {{{ full_name }}} is available at
     {{% if product == "rhel7" %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html") }}}.
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/openldap") }}}.
     {{% elif product == "ol7" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/ol7-auth.html#ol7-s9-auth") }}}.
     {{% endif %}}

--- a/linux_os/guide/services/ldap/openldap_server/group.yml
+++ b/linux_os/guide/services/ldap/openldap_server/group.yml
@@ -7,5 +7,5 @@ description: |-
     for an OpenLDAP server.
     {{% if product == "rhel7" %}}
     Installation and configuration of OpenLDAP on Red Hat Enterprise Linux 7 is available at:
-    {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/openldap.html") }}}.
+    {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/openldap") }}}.
     {{% endif %}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -14,7 +14,7 @@ description: |-
     {{% elif product == "ol8" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% else %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
     {{% endif %}}
     for more detailed comparison of the features of both of the choices, and for
     further guidance how to choose between the two NTP daemons.

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -14,7 +14,7 @@ description: |-
      {{% elif product == "ol8" %}}
          {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% else %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
     {{% endif %}}
     for more detailed comparison of the features of both of the choices, and for
     further guidance how to choose between the two NTP daemons.

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -54,7 +54,7 @@ description: |-
     {{% elif product == "ol8" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% elif product == "rhel7" %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
     {{% elif "ubuntu" in product  %}}
         {{{ weblink(link="https://help.ubuntu.com/lts/serverguide/NTP.html") }}}
     {{% elif "debian" in product %}}

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -17,7 +17,7 @@ description: |-
     {{% elif product == "ol8" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
     {{% else %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System_Administrators_Guide/ch-Configuring_NTP_Using_the_chrony_Suite.html") }}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
     {{% endif %}}
     for guidance which NTP daemon to choose depending on the environment used.
 

--- a/linux_os/guide/services/sssd/group.yml
+++ b/linux_os/guide/services/sssd/group.yml
@@ -11,7 +11,7 @@ description: |-
     <br /><br />
     For more information, see
     {{%- if product == "rhel7" -%}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/SSSD.html") }}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/sssd") }}}
     {{%- elif product == "rhel8" -%}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/installing_identity_management/installing-an-ipa-client-basic-scenario_installing-identity-management#sssd-deployment-operations_install-client-basic") }}}
     {{%- elif product == "ol7" -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -8,9 +8,7 @@ description: |-
     To enable smart card authentication, consult the documentation at:
     <ul>
     {{% if product == "rhel7" %}}
-    <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
-    {{% elif product == "rhel8" %}}
-    <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/smartcards.html#authconfig-smartcards") }}}</b></li>
+    <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/smartcards.html#authconfig-smartcards") }}}</b></li>
     {{% elif product == "ol7" %}}
     <li><b>{{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/ol7-auth.html#ol7-s4-auth") }}}</b></li>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/group.yml
+++ b/linux_os/guide/system/auditing/group.yml
@@ -38,7 +38,7 @@ description: |-
     Examining some example audit records demonstrates how the Linux audit system
     satisfies common requirements.
     The following example from Fedora Documentation available at
-    <tt>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide/sect-Security-Enhanced_Linux-Troubleshooting-Fixing_Problems.html#sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages") }}}</tt>
+    <tt>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/selinux_users_and_administrators_guide/index#sect-Security-Enhanced_Linux-Fixing_Problems-Raw_Audit_Messages") }}}</tt>
     shows the substantial amount of information captured in a
     two typical "raw" audit messages, followed by a breakdown of the most important
     fields. In this example the message is SELinux-related and reports an AVC

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -38,7 +38,7 @@ description: |-
     {{% elif product in ["sle12", "sle15"] %}}
         {{{ weblink(link="https://www.suse.com/documentation/sled-12/book_security/data/sec_security_cryptofs_y2.html") }}}
     {{% elif product == "rhel7" %}}
-        {{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Security_Guide/sec-Encryption.html") }}}.
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-encryption") }}}.
     {{% else %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/encrypting-block-devices-using-luks_security-hardening") }}}.
     {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/group.yml
@@ -14,5 +14,5 @@ description: |-
     the man page <tt>dconf(1)</tt>.
     {{% else %}}
     For more information about enforcing preferences in the GNOME3 environment using the DConf
-    configuration system, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Desktop_Migration_and_Administration_Guide/index.html") }}}/></b> and the man page <tt>dconf(1)</tt>.
+    configuration system, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/desktop_migration_and_administration_guide") }}}/></b> and the man page <tt>dconf(1)</tt>.
     {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fix RHEL7 documentation links.


In linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml the incorrect RHEL8 link was completely removed because this rule doesn't apply on RHEL8 system.

Fixes: #7404