### PR TITLE
Handle sshd directory config basenames better

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/conflict.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/conflict.fail.sh
@@ -11,5 +11,5 @@ else
 	echo "# PubkeyAuthentication no" >> /etc/ssh/sshd_config
 fi
 
-echo "PubkeyAuthentication no" > /etc/ssh/sshd_config.d/good_config
-echo "PubkeyAuthentication yes" > /etc/ssh/sshd_config.d/rogue_config
+echo "PubkeyAuthentication no" > /etc/ssh/sshd_config.d/good_config.conf
+echo "PubkeyAuthentication yes" > /etc/ssh/sshd_config.d/rogue_config.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/correct_value_directory.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_pubkey_auth/tests/correct_value_directory.pass.sh
@@ -11,4 +11,4 @@ else
 	echo "# PubkeyAuthentication no" >> /etc/ssh/sshd_config
 fi
 
-echo "PubkeyAuthentication no" > /etc/ssh/sshd_config.d/correct
+echo "PubkeyAuthentication no" > /etc/ssh/sshd_config.d/correct.conf

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -227,7 +227,7 @@
 {{%- endmacro %}}
 
 {{%- macro oval_line_in_directory_object(path='', section='', prefix_regex='^[ \\t]*', parameter='', separator_regex='[ \\t]+', missing_parameter_pass=false, multi_value=false) -%}}
-{{{- oval_line_in_file_object(path=path, section=section, prefix_regex=prefix_regex, parameter=parameter, separator_regex=separator_regex, missing_parameter_pass=missing_parameter_pass, multi_value=multi_value, filepath_regex=".*", id_stem=rule_id ~ "_config_dir") -}}}
+{{{- oval_line_in_file_object(path=path, section=section, prefix_regex=prefix_regex, parameter=parameter, separator_regex=separator_regex, missing_parameter_pass=missing_parameter_pass, multi_value=multi_value, filepath_regex=".*\.conf$", id_stem=rule_id ~ "_config_dir") -}}}
 {{%- endmacro %}}
 
 {{%- macro oval_line_in_directory_state(value='', multi_value='', quotes='') -%}}

--- a/shared/templates/sshd_lineinfile/bash.template
+++ b/shared/templates/sshd_lineinfile/bash.template
@@ -11,8 +11,9 @@ mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/hardening
 {{{ lineinfile_absent("/etc/ssh/sshd_config", line_regex, insensitive=true) }}}
 {{{ lineinfile_absent_in_directory("/etc/ssh/sshd_config.d", line_regex, insensitive=true) }}}
+{{%- set hardening_config_basename = "00-complianceascode-hardening.conf" %}}
 {{{ set_config_file(
-        path="/etc/ssh/sshd_config.d/hardening",
+        path="/etc/ssh/sshd_config.d/" ~ hardening_config_basename,
         parameter=PARAMETER,
         value=VALUE,
         create=true,


### PR DESCRIPTION
The check should consider only files matching `.*\.conf`.

The default basename should be valid as well - on Red Hat systems, there is `50-redhat.conf`, so `60-complianceascode.conf` seems to be a generally good fit.

Fixes: #7408 