### PR TITLE
OCP4: Don't use variables for kubelet threshold checks

### DIFF
--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>imagefs.available</tt> is not set in <tt>evictionHard</tt> sec
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionHard."imagefs.available"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionhard_imagefs_available") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionHard['imagefs.available']"
-    xccdf_variable: var_kubelet_evictionhard_imagefs_available
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>imagefs.inodesFree</tt> is not set in <tt>evictionHard</tt> se
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionHard."imagefs.inodesFree"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionhard_imagefs_inodesfree") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionHard['imagefs.inodesFree']"
-    xccdf_variable: var_kubelet_evictionhard_imagefs_inodesfree
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>memory.available</tt> is not set in <tt>evictionHard</tt> sect
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionHard."memory.available"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionhard_memory_available") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionHard['memory.available']"
-    xccdf_variable: var_kubelet_evictionhard_memory_available
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>nodefs.available</tt> is not set in <tt>evictionHard</tt> sect
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionHard."nodefs.available"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionhard_nodefs_available") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionHard['nodefs.available']"
-    xccdf_variable: var_kubelet_evictionhard_nodefs_available
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>nodefs.inodesFree</tt> is not set in <tt>evictionHard</tt> sec
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionHard."nodefs.inodesFree"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionhard_nodefs_inodesfree") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionHard['nodefs.inodesFree']"
-    xccdf_variable: var_kubelet_evictionhard_nodefs_inodesfree
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>imagefs.available</tt> is not set in <tt>evictionSoft</tt> sec
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionSoft."imagefs.available"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionsoft_imagefs_available") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionSoft['imagefs.available']"
-    xccdf_variable: var_kubelet_evictionsoft_imagefs_available
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>imagefs.inodesFree</tt> is not set in <tt>evictionSoft</tt> se
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionSoft."imagefs.inodesFree"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionsoft_imagefs_inodesfree") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionSoft['imagefs.inodesFree']"
-    xccdf_variable: var_kubelet_evictionsoft_imagefs_inodesfree
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>memory.available</tt> is not set in <tt>evictionSoft</tt> sect
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionSoft."memory.available"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionsoft_memory_available") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionSoft['memory.available']"
-    xccdf_variable: var_kubelet_evictionsoft_memory_available
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>nodefs.available</tt> is not set in <tt>evictionSoft</tt> sect
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionSoft."nodefs.available"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionsoft_nodefs_available") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionSoft['nodefs.available']"
-    xccdf_variable: var_kubelet_evictionsoft_nodefs_available
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
@@ -63,12 +63,14 @@ ocil_clause: '<tt>nodefs.inodesFree</tt> is not set in <tt>evictionSoft</tt> sec
 ocil: |-
   Run the following command on the kubelet node(s):
   <pre>$ oc debug -q node/$NODE -- jq -r '.evictionSoft."nodefs.inodesFree"' /host/etc/kubernetes/kubelet.conf</pre>
-  and make sure it outputs
-  <pre>{{{ xccdf_value("var_kubelet_evictionsoft_nodefs_inodesfree") }}}</pre>
+  and make sure it outputs a value.
 
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".evictionSoft['nodefs.inodesFree']"
-    xccdf_variable: var_kubelet_evictionsoft_nodefs_inodesfree
+    check_existence: "only_one_exists"
+    values:
+      - value: ".*"
+        operation: "pattern match"


### PR DESCRIPTION
#### Description:
This PR removes the use of variables from the kubelet threshold checks.

#### Rationale:

While the idea of using variables is good, at the moment, variables are
not really exposed and thus visible well through the compliance
operator, which means that the admins don't really know what to do to
make the rules pass.

Let's just check for any value in the kubelet threshold checks for the
moment.

I think long term the variables are a good idea and hopefully we'll be
able to get back to using them in the future once we merge the
remediation templating, which is why I haven't removed the variable
definitions in the ".var" files completely yet.