### PR TITLE
Add package_strongswan_installed rule to SUSE SLE15 PCI-DSS profile

### DIFF
--- a/linux_os/guide/system/network/network-ipsec/package_strongswan_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/package_strongswan_installed/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+prodtype: sle12,sle15 
+
+title: 'Install strongswan Package'
+
+description: |-
+    The Strongswan package provides an implementation of IPsec
+    and IKE, which permits the creation of secure tunnels over
+    untrusted networks. {{{ describe_package_install(package="strongswan") }}}
+
+rationale: |-
+    Providing the ability for remote users or systems
+    to initiate a secure VPN connection protects information when it is
+    transmitted over a wide area network.
+
+severity: medium
+
+identifiers:
+     cce@sle15: CCE-85836-5
+
+references:
+    cis-csc: 12,15,3,5,8
+    cobit5: APO13.01,DSS01.04,DSS05.02,DSS05.03,DSS05.04
+    disa: CCI-001130,CCI-001131
+    isa-62443-2009: 4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8
+    isa-62443-2013: 'SR 1.13,SR 2.6,SR 3.1,SR 3.5,SR 3.8,SR 4.1,SR 4.3,SR 5.1,SR 5.2,SR 5.3,SR 7.1,SR 7.6'
+    iso27001-2013: A.11.2.4,A.11.2.6,A.13.1.1,A.13.2.1,A.14.1.3,A.15.1.1,A.15.2.1,A.6.2.1,A.6.2.2
+    nist: CM-6(a)
+    nist-csf: PR.AC-3,PR.MA-2,PR.PT-4
+    pcidss: Req-4.1
+    srg: SRG-OS-000480-GPOS-00227,SRG-OS-000120-GPOS-00061
+    
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="strongswan") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: strongswan

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -85,6 +85,7 @@ selections:
     - gid_passwd_group_same
     - install_hids
     - no_empty_passwords
+    - package_strongswan_installed
     - rpm_verify_hashes
     - rpm_verify_permissions
     - service_auditd_enabled


### PR DESCRIPTION
#### Description:

- Add package_strongswan_installed rule 

#### Rationale:

- Implement package_strongswan_installed rule as part of the requirement to have secure VPN connections. For other linux distros libreswan was used to provide this functionality