### PR TITLE
SUSE SLE15 service chronyd or ntpd enabled pci dss

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
@@ -1,0 +1,29 @@
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+    manager: auto
+
+- name: Print the package facts
+  ansible.builtin.debug:
+    var: ansible_facts.packages
+
+
+- name: Start ntpd service if ntp installed
+  service:
+    name: "ntpd"
+    enabled: "yes"
+    state: "started"
+    masked: "no"
+  when: "'ntp' in ansible_facts.packages"
+  ignore_errors: yes
+
+
+- name: Start chronyd service if chrony or chronyd installed
+  service:
+    name: "chronyd"
+    enabled: "yes"
+    state: "started"
+    masked: "no"
+  when: ('chrony' in ansible_facts.packages) or ('chronyd' in ansible_facts.packages)
+  ignore_errors: yes

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 if {{{ bash_package_installed("chrony") }}} ; then
     if ! /usr/sbin/pidof ntpd ; then

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,ubuntu2004
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,ubuntu2004,sle12,sle15
 
 title: 'Enable the NTP Daemon'
 
@@ -16,6 +16,8 @@ description: |-
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
     {{% elif product == "ol8" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/ol-nettime.html") }}}
+    {{% elif product in ["sle12", "sle15"] %}}
+        {{{ weblink(link="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-ntp.html") }}}
     {{% else %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
     {{% endif %}}
@@ -41,6 +43,7 @@ identifiers:
     cce@rhcos4: CCE-82682-6
     cce@rhel7: CCE-27444-9
     cce@rhel8: CCE-80874-1
+    cce@sle15: CCE-85836-5
 
 references:
     cis-csc: 1,14,15,16,3,5,6

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -43,7 +43,7 @@ identifiers:
     cce@rhcos4: CCE-82682-6
     cce@rhel7: CCE-27444-9
     cce@rhel8: CCE-80874-1
-    cce@sle15: CCE-85836-5
+    cce@sle15: CCE-85835-7
 
 references:
     cis-csc: 1,14,15,16,3,5,6

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -90,6 +90,7 @@ selections:
     - rpm_verify_hashes
     - rpm_verify_permissions
     - service_auditd_enabled
+    - service_chronyd_or_ntpd_enabled
     - service_pcscd_enabled
     - set_password_hashing_algorithm_libuserconf
     - sshd_set_idle_timeout


### PR DESCRIPTION
#### Description:

- Add service_chronyd_or_ntpd_enabled rule to SUSE SLE15 PCI-DSS profile

#### Rationale:

- Add SUSE support for bash remediation
- Add ansible remediation

