### PR TITLE
Add couple of chronyd/ntpd rules to SUSE SLE15 PCI-DSS profile

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/ansible/shared.yml
@@ -1,0 +1,37 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("var_multiple_time_servers") }}}
+
+- name: "Detect if chrony configuration file is present"
+  find:
+    path: /etc
+    patterns: chrony.conf
+  register: chrony_server_config
+
+- name: "Configure multiple time servers in chrony config"
+  lineinfile:
+    path: /etc/chrony.conf
+    line: 'server {{ item }}'
+    state: present
+    create: True
+  loop: '{{ var_multiple_time_servers.split(",") }}'
+  when: chrony_server_config.matched == 1
+
+
+- name: "Detect if NTP configuration file is present"
+  find:
+    path: /etc
+    patterns: ntp.conf
+  register: ntp_server_config
+
+- name: "Configure multiple time servers in NTP config"
+  lineinfile:
+    path: /etc/chrony.conf
+    line: 'pool {{ item }}'
+    state: present
+    create: True
+  loop: '{{ var_multiple_time_servers.split(",") }}'
+  when: ntp_server_config.matched == 1

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("var_multiple_time_servers") }}}
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
 
 title: 'Specify Additional Remote NTP Servers'
 
@@ -93,6 +93,7 @@ identifiers:
     cce@rhcos4: CCE-82685-9
     cce@rhel7: CCE-27012-4
     cce@rhel8: CCE-80764-4
+    cce@sle15: CCE-85834-0
 
 references:
     cis-csc: 1,14,15,16,3,5,6

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
@@ -32,11 +32,10 @@ references:
     cis@rhel7: 2.2.1.2
     cis@rhel8: 2.2.1.2
     cis@ubuntu2004: 2.2.1.3
-    ism: 0988,1405
-    pcidss: Req-10.4.3
-    nist: CM-6(a),AU-8(1)(a)
     disa:  CCI-000160,CCI-001891
-
+    ism: 0988,1405
+    nist: CM-6(a),AU-8(1)(a)
+    pcidss: Req-10.4.3
 
 ocil_clause: 'a remote time server is not configured'
 

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel7: CCE-83418-4
     cce@rhel8: CCE-82873-1
     cce@rhel9: CCE-84218-7
+    cce@sle15: CCE-85833-2
 
 references:
     anssi: BP28(R43)
@@ -32,6 +33,10 @@ references:
     cis@rhel8: 2.2.1.2
     cis@ubuntu2004: 2.2.1.3
     ism: 0988,1405
+    pcidss: Req-10.4.3
+    nist: CM-6(a),AU-8(1)(a)
+    disa:  CCI-000160,CCI-001891
+
 
 ocil_clause: 'a remote time server is not configured'
 

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -13,3 +13,4 @@ options:
     fedora: "0.fedora.pool.ntp.org,1.fedora.pool.ntp.org,2.fedora.pool.ntp.org,3.fedora.pool.ntp.org"
     rhel: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
     ol: "0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org"
+    suse: "0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org"

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -21,6 +21,7 @@ selections:
     - var_sshd_set_keepalive=0
     - sshd_idle_timeout_value=15_minutes
     - var_auditd_action_mail_acct=root
+    - var_multiple_time_servers=suse
     ### Rules:
     - account_disable_post_pw_expiration
     - account_unique_name
@@ -72,6 +73,7 @@ selections:
     - dconf_db_up_to_date
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_idle_delay
+    - chronyd_or_ntpd_specify_multiple_servers
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_mode_blank
     - display_login_attempts

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -74,6 +74,7 @@ selections:
     - dconf_gnome_screensaver_lock_enabled
     - dconf_gnome_screensaver_idle_delay
     - chronyd_or_ntpd_specify_multiple_servers
+    - chronyd_specify_remote_server
     - dconf_gnome_screensaver_idle_activation_enabled
     - dconf_gnome_screensaver_mode_blank
     - display_login_attempts


### PR DESCRIPTION
#### Description:

- Add chronyd_specify_remote_server anf chronyd_or_ntpd_specify_multiple_servers to SUSE SLE15 PCI-DSS profile

#### Rationale:

- Add definition of var_multiple_time_servers for SUSE
- Add ansible remediation and enable bash for chronyd_or_ntpd_specify_multiple_servers
- Add rules to profile