### PR TITLE
OCP4: Kickstart PCI-DSS profile

### DIFF
--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -28,3 +28,4 @@ references:
     cis@ocp4: 5.3.1
     nerc-cip: CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
+    pcidss: Req-1.1.4,Req-1.2

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -21,6 +21,7 @@ references:
     cis@ocp4: 5.3.2
     nerc-cip: CIP-003-3 R4,CIP-003-3 R4.2,CIP-003-3 R5,CIP-003-3 R6,CIP-004-3 R2.2.4,CIP-004-3 R3,CIP-007-3 R2,CIP-007-3 R2.1,CIP-007-3 R2.2,CIP-007-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: AC-4,AC-4(21),CA-3(5),CM-6,CM-6(1),CM-7,CM-7(1),SC-7,SC-7(3),SC-7(5),SC-7(8),SC-7(12),SC-7(13),SC-7(18)
+    pcidss: Req-1.1.4,Req-1.2
 
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies?limit=500' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces?limit=500' %}}

--- a/products/ocp4/profiles/pci-dss.profile
+++ b/products/ocp4/profiles/pci-dss.profile
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+platform: ocp4
+
+metadata:
+    SMEs:
+        - JAORMX
+        - jhrozek
+        - mrogers950
+
+reference: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+
+title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4'
+
+description: |-
+    Ensures PCI-DSS v3.2.1 security configuration settings are applied.
+
+selections:
+    - configure_network_policies
+    - configure_network_policies_namespaces


### PR DESCRIPTION
This starts the PCI-DSS profile by adding a couple of rules with their
respective references.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>