### PR TITLE
Mark agent_mfetpd_running as machine only

### DIFF
--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/group.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/group.yml
@@ -5,3 +5,5 @@ title: 'McAfee Endpoint Security for Linux (ENSL)'
 description: |-
     McAfee Endpoint Security for Linux (ENSL) is a suite of software applications
     used to monitor, detect, and defend computer networks and systems.
+
+platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
@@ -37,8 +37,6 @@ warnings:
         Due to McAfee Endpoint Security for Linux (ENSL) being 3rd party software,
         automated remediation is not available for this configuration check.
 
-platform: machine
-
 template:
     name: package_installed
     vars:


### PR DESCRIPTION
#### Description:

- Mark agent_mfetpd_running as machine only.

#### Rationale:

- Services shouldn't be applicable to containers.