### PR TITLE
`disable_ctrlaltdel_reboot`: disable service before masking during test scenario setup

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora
 
+systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target


### PR DESCRIPTION
#### Description:

- disable_ctrlaltdel_reboot: disable service before masking during test scenario setup

#### Rationale:

- Fixes:
```
ERROR - Failed to execute 'cd /root/ssgts/disable_ctrlaltdel_reboot; SHARED=/root/ssgts/shared bash -x masked.pass.sh' on root@192.168.122.225: Command '('ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', '-o', 'IdentityFile=/root/.ssh/ssg_id_ecdsa', 'root@192.168.122.225', 'cd /root/ssgts/disable_ctrlaltdel_reboot; SHARED=/root/ssgts/shared bash -x masked.pass.sh')' returned non-zero exit status 1.
ERROR - Terminating due to error: Failed to execute 'cd /root/ssgts/disable_ctrlaltdel_reboot; SHARED=/root/ssgts/shared bash -x masked.pass.sh' on root@192.168.122.225.
```
