### PR TITLE
UBTU-20-010070: Add ubuntu specific bash and oval to accounts_password_pam_unix_remember

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+. /usr/share/scap-security-guide/remediation_functions
+{{{ bash_instantiate_variables("var_password_pam_unix_remember") }}}
+
+ensure_pam_module_options '/etc/pam.d/common-password' 'password' '[success=1 default=ignore]' 'pam_unix.so' 'obsecure sha512 shadow remember' $var_password_pam_unix_remember $var_password_pam_unix_remember

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/ubuntu.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="accounts_password_pam_unix_remember" version="2">
+    {{{ oval_metadata("The passwords to remember should be set correctly.") }}}
+    <criteria comment="remember parameter of pam_unix.so is set correctly" operator="AND">
+      <criterion comment="remember parameter of pam_unix.so is set correctly" test_ref="test_accounts_password_pam_unix_remember" />
+    </criteria>
+  </definition>
+
+  <!-- Check the pam_unix.so remember case -->
+  <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember" check="all" check_existence="all_exist"
+  comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/common-password" version="1">
+    <ind:object object_ref="object_accounts_password_pam_unix_remember" />
+    <ind:state state_ref="state_accounts_password_pam_unix_remember" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_password_pam_unix_remember" version="1">
+    <ind:filepath>/etc/pam.d/common-password</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*password\s+\[.*\]\s+pam_unix\.so.*remember=([0-9]*).*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_accounts_password_pam_unix_remember" version="1">
+    <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_unix_remember" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="number of passwords that should be remembered" datatype="int" id="var_password_pam_unix_remember" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -4,12 +4,18 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004,wrlinux1019
 
 title: 'Limit Password Reuse'
 
+{{% if 'ubuntu' not in product %}}
+{{% set configFile = "/etc/pam.d/system-auth" %}}
+{{% else %}}
+{{% set configFile = "/etc/pam.d/common-password" %}}
+{{% endif %}}
+
 description: |-
     Do not allow users to reuse recent passwords. This can be
     accomplished by using the <tt>remember</tt> option for the <tt>pam_unix</tt>
     or <tt>pam_pwhistory</tt> PAM modules.
     <br /><br />
-    In the file <tt>/etc/pam.d/system-auth</tt>, append <tt>remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</tt>
+    In the file <tt>{{{ configFile }}}</tt>, append <tt>remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</tt>
     to the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module, as shown below:
     <ul>
     <li>for the <tt>pam_unix.so</tt> case:
@@ -58,7 +64,7 @@ ocil_clause: 'the value of remember is not set equal to or greater than the expe
 
 ocil: |-
     To verify the password reuse setting is compliant, run the following command:
-    <pre>$ grep remember /etc/pam.d/system-auth</pre>
+    <pre>$ grep remember {{{ configFile }}}</pre>
     The output should show the following at the end of the line:
     <pre>remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</pre>
 


### PR DESCRIPTION
#### Description:

- Ubuntu differs in config file location and also the config line arguments.

#### Rationale:

- Configure the Ubuntu operating system to prevent passwords from being reused for a minimum of five generations.
Add or modify the "remember" parameter value to the following line in "/etc/pam.d/common-password" file:
password [success=1 default=ignore] pam_unix.so obsecure sha512 shadow remember=5 rounds=5000
