### PR TITLE
Improve Ansible playbook linters test times

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -357,13 +357,13 @@ macro(ssg_build_remediations PRODUCT)
                 if (ANSIBLE_LINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
                     add_test(
                         NAME "ansible-playbook-per-profile-ansible-lint-check-${PRODUCT}"
-                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${CMAKE_SOURCE_DIR}/tests/ansible-lint_config.yml"
+                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${CMAKE_SOURCE_DIR}/tests/ansible-lint_config.yml" "${PRODUCT}"
                     )
                 endif()
                 if (YAMLLINT_EXECUTABLE AND "${OSCAP_VERSION}" VERSION_GREATER "1.2.16")
                     add_test(
                         NAME "ansible-playbook-per-profile-yamllint-check-${PRODUCT}"
-                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
+                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ansible" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml" "${PRODUCT}"
                     )
                 endif()
             endif()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -343,13 +343,13 @@ macro(ssg_build_remediations PRODUCT)
                 if (ANSIBLE_LINT_EXECUTABLE)
                     add_test(
                         NAME "ansible-playbook-per-rule-ansible-lint-check-${PRODUCT}"
-                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks" "${CMAKE_SOURCE_DIR}/tests/ansible-lint_config.yml"
+                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${ANSIBLE_LINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all" "${CMAKE_SOURCE_DIR}/tests/ansible-lint_config.yml"
                     )
                 endif()
                 if (YAMLLINT_EXECUTABLE)
                     add_test(
                         NAME "ansible-playbook-per-rule-yamllint-check-${PRODUCT}"
-                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
+                        COMMAND "${CMAKE_SOURCE_DIR}/tests/ansible_playbook_check.sh" "${YAMLLINT_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/playbooks/all" "${CMAKE_SOURCE_DIR}/tests/yamllint_config.yml"
                     )
                 endif()
             endif()

--- a/tests/ansible_playbook_check.sh
+++ b/tests/ansible_playbook_check.sh
@@ -6,10 +6,11 @@ DIRS="" # directories which might contain playbooks
 for dir in `find . -type d`
 do
 	# tries to find which directories contain valid playbooks
-	FILES=$(ls $dir/*.yml 2> /dev/null | wc -l)
+	# The fourth parameter, when provided, is the product name.
+	FILES=$(ls $dir/$4*.yml 2> /dev/null | wc -l)
 	if [ ! "$FILES" -eq "0" ]; then
 		CONTAINS_VALID_FILES=1
-		DIRS="$DIRS $dir/*.yml"
+		DIRS="$DIRS $dir/$4*.yml"
 	fi
 done
 


### PR DESCRIPTION
#### Description:

- 100024a Fixes a bug where every product built tested all profile playbooks built.
- 18175d3 Reduces the scope per rule playbook Ansible and yaml linters to the `all` profile.
  - This drastically reduces the scope of playbooks tested and greatly reduces the test time.
  - The only differences, if any, between `all` and other profiles playbooks should be selected variables.

#### Rationale:

- The lint checkers take too long to run `ctest -R -lint-check --output-on-failure`
When all products are built, these are the test times  on my machine before this patch:
`Total Test time (real) = 24100.07 sec`
And after this patch:
`Total Test time (real) = 2150.24 sec`