### PR TITLE
Do not select "default" crypto policy value in RHEL8 CIS L1

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -553,7 +553,7 @@ controls:
     automated: yes
     rules:
       - configure_crypto_policy
-      - var_system_crypto_policy=default
+      - var_system_crypto_policy=default_policy
 
   # This rule works in conjunction with the configure_crypto_policy above.
   # If a system is remediated to CIS Level 1, just the rule above will apply

--- a/linux_os/guide/system/software/integrity/crypto/var_system_crypto_policy.var
+++ b/linux_os/guide/system/software/integrity/crypto/var_system_crypto_policy.var
@@ -13,6 +13,7 @@ interactive: false
 
 options:
     default: DEFAULT
+    default_policy: DEFAULT
     default_nosha1: "DEFAULT:NO-SHA1"
     fips: FIPS
     fips_ospp: "FIPS:OSPP"


### PR DESCRIPTION
#### Description:
- Do not select "default" crypto policy value in RHEL8 CIS L1
  - Using the "default" variable causes error and remediations are not
created properly. The default value is always used if there are no refined values.

#### Rationale:

- Fixes the followings:

```
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='var_system_crypto_policy'. Using null value instead. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy.c:2171]
Could not resolve xccdf:sub/@idref='var_system_crypto_policy'! [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_substitute.c:106]
A fix for Rule/@id="configure_crypto_policy" was skipped: Text substitution failed. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_remediate.c:760]
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='var_system_crypto_policy'. Using null value instead. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy.c:2171]
Could not resolve xccdf:sub/@idref='var_system_crypto_policy'! [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_substitute.c:106]
A fix for Rule/@id="configure_crypto_policy" was skipped: Text substitution failed. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_remediate.c:760]
[106/121] [rhel8-playbooks] generating Ansible Playbooks for all profiles in ssg-rhel8-xccdf.xml
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='var_system_crypto_policy'. Using null value instead. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy.c:2171]
Could not resolve xccdf:sub/@idref='var_system_crypto_policy'! [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_substitute.c:106]
A fix for Rule/@id="configure_crypto_policy" was skipped: Text substitution failed. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_remediate.c:760]
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='var_system_crypto_policy'. Using null value instead. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy.c:2171]
Could not resolve xccdf:sub/@idref='var_system_crypto_policy'! [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_substitute.c:106]
A fix for Rule/@id="configure_crypto_policy" was skipped: Text substitution failed. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_remediate.c:760]
```

Empty bash:
```
###############################################################################
# BEGIN fix (3 / 183) for 'configure_crypto_policy'
###############################################################################
(>&2 echo "Remediating rule 3/183: 'configure_crypto_policy'")
(>&2 echo "FIX FOR THIS RULE 'configure_crypto_policy' IS MISSING!")

# END fix for 'configure_crypto_policy'
```
and empty ansible remediation.


Running `oscap xccdf generate fix` also triggers the problem:
```
oscap xccdf generate fix --fix-type bash --profile xccdf_org.ssgproject.content_profile_cis_workstation_l1 build/ssg-rhel8-ds.xml > a
WARNING: Datastream component 'scap_org.open-scap_cref_security-data-oval-com.redhat.rhsa-RHEL8.xml' points out to the remote 'https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml'. Use '--fetch-remote-resources' option to download it.
WARNING: Skipping 'https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml' file which is referenced from datastream
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='xccdf_org.ssgproject.content_value_var_system_crypto_policy'. Using null value instead. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy.c:2171]
Could not resolve xccdf:sub/@idref='xccdf_org.ssgproject.content_value_var_system_crypto_policy'! [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_substitute.c:106]
A fix for Rule/@id="xccdf_org.ssgproject.content_rule_configure_crypto_policy" was skipped: Text substitution failed. [/builddir/build/BUILD/openscap-1.3.5/src/XCCDF_POLICY/xccdf_policy_remediate.c:760]
```