### PR TITLE
Add sort prodtypes to fix_rules

### DIFF
--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -108,6 +108,7 @@ These sub-commands are:
  - `duplicate_subkeys`: finds (but doesn't fix!) any rules with duplicated
    `identifiers` or `references`.
  - `sort_subkeys`: sorts all subkeys under `identifiers` and `references`.
+ - `sort_prodtypes`: "sorts the products in prodtype"
 
 To execute:
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_multiple_servers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
 
 title: 'Specify Additional Remote NTP Servers'
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4
 
 title: 'Specify a Remote NTP Server'
 

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: fedora,rhel7
 
 title: 'Configure server restrictions for ntpd'
 

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,fedora
+prodtype: fedora,rhel7
 
 title: 'Configure ntpd To Run As ntp User'
 

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,ubuntu2004,sle12,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable the NTP Daemon'
 

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Remove Host-Based Authentication Files'
 

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Remove User Host-Based Authentication Files'
 

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_rekey_limit/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_rekey_limit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhel9,rhcos4
+prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure session renegotiation for SSH client'
 

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,rhcos4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable Smartcards in SSSD'
 

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol8,rhel8
+prodtype: fedora,ol8,rhcos4,rhel8
 
 title: 'Configure SSSD to run as user sssd'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,sle12,sle15,fedora,rhel7,rhel8
+prodtype: fedora,ol7,rhel7,rhel8,sle12,sle15
 
 title: 'Only Authorized Local User Accounts Exist on Operating System'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019,fedora
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure Home Directories are Created for New Users'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'User Initialization Files Must Not Run World-Writable Programs'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_home_paths_only/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_home_paths_only/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure that Users Path Contains Only Local Directories'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'All Interactive Users Must Have A Home Directory Defined'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
 
 title: 'All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary User'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
 
 title: 'All User Files and Directories In The Home Directory Must Be Owned By The Primary User'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle15,wrlinux1019
 
 title: 'All User Files and Directories In The Home Directory Must Have Mode 0750 Or Less Permissive'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'System Audit Logs Must Have Mode 0640 or Less Permissive'
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_forwarding/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15,sle12
+prodtype: sle12,sle15
 
 title: 'Disable Kernel Parameter for IPv6 Forwarding by default'
 

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle15
 
 title: 'Ensure IPv6 is disabled through kernel boot parameter'
 

--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhv4,rhcos4
+prodtype: fedora,rhcos4,rhel7,rhel8,rhv4
 
 title: 'Disable Bluetooth Service'
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,wrlinux1019,sle12,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure All World-Writable Directories Are Group Owned by a System Account'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,rhel8,fedora
+prodtype: fedora,rhel8,sle12,sle15
 
 title: 'Verify that Shared Library Directories Have Root Group Ownership'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,rhel8,fedora
+prodtype: fedora,rhel8,sle12,sle15
 
 title: |-
     Verify the system-wide library files in directories

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_FIPS_certified/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux8,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu1604,ubuntu1804,ubuntu2004,wrlinux1019,wrlinux8
 
 title: 'The Installed Operating System Is FIPS 140-2 Certified'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,fedora
+prodtype: fedora,rhel8
 
 title: 'Configure GnuTLS library to use DoD-approved TLS Encryption'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhcos4
+prodtype: rhcos4,rhel8
 
 title: 'Harden OpenSSL Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,sle12,sle15,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
 
 title: 'Harden SSHD Crypto Policy'
 

--- a/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/etc_system_fips_exists/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: Ensure '/etc/system-fips' exists
 

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,rhel7,wrlinux1019
+prodtype: ol7,rhcos4,rhel7,wrlinux1019
 
 title: 'Enable FIPS Mode in GRUB2'
 

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,rhel7,wrlinux1019
+prodtype: ol7,rhcos4,rhel7,wrlinux1019
 
 title: 'Install the dracut-fips-aesni Package'
 

--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,ol7,rhel7,wrlinux1019
+prodtype: ol7,rhcos4,rhel7,wrlinux1019
 
 title: 'Install the dracut-fips Package'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004,rhel8,fedora
+prodtype: fedora,rhel8,sle12,sle15,ubuntu2004
 
 title: 'Configure AIDE to Verify the Audit Tools'
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -122,6 +122,13 @@ add_test(
 set_tests_properties("fix_rules-sort_subkeys" PROPERTIES LABELS quick)
 set_tests_properties("fix_rules-sort_subkeys" PROPERTIES DEPENDS "test-rule-dir-json")
 
+add_test(
+    NAME "fix_rules-sort_prodtypes"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "sort_prodtypes"
+)
+set_tests_properties("fix_rules-sort_subkeys" PROPERTIES LABELS quick)
+set_tests_properties("fix_rules-sort_subkeys" PROPERTIES DEPENDS "test-rule-dir-json")
+
 if (PY_YAMLPATH)
     if (PY_PYTEST)
         add_test(


### PR DESCRIPTION
#### Description:

This adds `sort_prodtypes` to `./utils/fix_rules`. This ensures that prodtypes are in alphabetical order.

#### Rationale:

To help make the rule files easier to read.


