### PR TITLE
Remove package applicability from s390x_arch generated remediations

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -353,6 +353,7 @@ XCCDF_PLATFORM_TO_PACKAGE = {
   "uefi": None,
   "non-uefi": None,
   "not_s390x_arch": None,
+  "s390x_arch": None,
 }
 
 # _version_name_map = {


### PR DESCRIPTION
#### Description:
- Remove package applicability from s390x_arch generated remediations.
  - This makes sure that there will be no package applicability check in the
remediations of rules that use the s390x_arch platform applicability,
since the check is made by checking a line in file instead. At this
moment the build system does not allow doing such checks. The side
effect is that Bash and Ansible roles will apply this remediation even
on a system that is not s390_arch, so using OpenSCAP scanner is highly
recommended.
