### PR TITLE
OCP4: Also point out OAuth server unit conversion in the oauth_or_oauthclient_inactivity_timeout rule

### DIFF
--- a/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/rule.yml
@@ -25,6 +25,11 @@ description: |-
     spec:
        tokenConfig:
          accessTokenInactivityTimeout: 10m0s 
+    <pre>
+    Please note that the OAuth server converts the value internally to a human-readable format,
+    so that e.g. setting accessTokenInactivityTimeout=600s would be converted by the OAuth
+    server to accessTokenInactivityTimeout=10m0s.
+    </pre>
     </pre>
     For more information on configuring the OAuth server, consult the
     OpenShift documentation:


### PR DESCRIPTION
#### Description:

We pointed out that the OAuth server converts rules to human-readable
units in the auth_inactivity_timeout rule, but that one is rarely used
directly, but rather as part of a composite
oauth_or_oauthclient_inactivity_timeout rule. Let's document the same
note there as well for visibility.

#### Rationale:

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1983062