### PR TITLE
SLE15 add sssd_enable_smartcards to PCI-DSS rule

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = medium
 - name: "Test for domain group"
-  command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
+  command: grep '^\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
   ignore_errors: yes
   changed_when: False

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,rhcos4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,rhcos4,sle15
 
 title: 'Enable Smartcards in SSSD'
 
@@ -33,7 +33,8 @@ identifiers:
     cce@rhel7: CCE-80570-5
     cce@rhel8: CCE-80909-5
     cce@rhel9: CCE-89155-6
-
+    cce@sle15: CCE-85826-6
+    
 references:
     disa: CCI-001954,CCI-000765
     ism: 0421,0422,0431,0974,1173,1401,1504,1505,1546,1557,1558,1559,1560,1561

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -98,3 +98,4 @@ selections:
     - set_password_hashing_algorithm_libuserconf
     - sshd_set_idle_timeout
     - sshd_set_keepalive_0
+    - sssd_enable_smartcards


### PR DESCRIPTION
#### Description:

- Add sssd_enable_smartcards to SLE15 PCI-DSS profile

#### Rationale:

- Make patch to ansible remediation, so sssd domain section in configuration file is edited only if not commented
