### PR TITLE
SLE15 Add password hashing rules to PCI DSS profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("var_password_hashing_algorithm") }}}
 

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -99,6 +99,8 @@ selections:
     - service_auditd_enabled
     - service_chronyd_or_ntpd_enabled
     - service_pcscd_enabled
+    - set_password_hashing_algorithm_commonauth
     - set_password_hashing_algorithm_libuserconf
+    - set_password_hashing_algorithm_logindefs
     - sshd_set_idle_timeout
     - sshd_set_keepalive_0


### PR DESCRIPTION
#### Description:

- Add set_password_hashing_algorithm_commonauth and set_password_hashing_algorithm_logindefs to PCI-DSS profile of SLE15

#### Rationale:

- Add rule to the pci_dss profile and make sure remediation script are SLE15 compatible
