### PR TITLE
SLE15 add package_aide_installed to PCI-DSS profile

### DIFF
--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -90,6 +90,7 @@ selections:
     - gid_passwd_group_same
     - install_hids
     - no_empty_passwords
+    - package_aide_installed
     - package_strongswan_installed
     - rpm_verify_hashes
     - rpm_verify_permissions


### PR DESCRIPTION
#### Description:

- Add package_aide_installed to SLE15 PCI-DSS

#### Rationale:

- Add rule to PCI-DSS profile
