### PR TITLE
Make EFI path explicit and documented

### DIFF
--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -10,7 +10,9 @@ pkg_manager: "dnf"
 
 init_system: "systemd"
 
+# EFI and non-EFI configs are stored in same path, see https://fedoraproject.org/wiki/Changes/UnifyGrubConfig
 grub2_boot_path: "/boot/grub2"
+grub2_uefi_boot_path: "/boot/grub2"
 
 dconf_gdm_dir: "distro.d"
 

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -20,6 +20,7 @@ release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
 oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"
 
+grub2_boot_path: "/boot/grub2"
 grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 
 cpes_root: "../../shared/applicability"

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -10,7 +10,9 @@ pkg_manager: "dnf"
 
 init_system: "systemd"
 
+# EFI and non-EFI configs are stored in same path, see https://fedoraproject.org/wiki/Changes/UnifyGrubConfig
 grub2_boot_path: "/boot/grub2"
+grub2_uefi_boot_path: "/boot/grub2"
 
 dconf_gdm_dir: "distro.d"
 


### PR DESCRIPTION
#### Description:

-  Explicitly set the path explicit and point to documentation.

#### Rationale:

- This is a change that can easily lead to confusion.
