### PR TITLE
Fix typo in var_sshd_set_maxstartups.var

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/var_sshd_set_maxstartups.var
+++ b/linux_os/guide/services/ssh/ssh_server/var_sshd_set_maxstartups.var
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'SSH MaxStartups setting'
 
-description: 'Configure parameters for maximum concurrent unauthenticatd connections to the SSH daemon.'
+description: 'Configure parameters for maximum concurrent unauthenticated connections to the SSH daemon.'
 
 type: string
 


### PR DESCRIPTION
Fix typo in var_sshd_set_maxstartups.var.