### PR TITLE
Fix up for the fix_rules.py script in add-cce command

### DIFF
--- a/ssg/cce.py
+++ b/ssg/cce.py
@@ -1,4 +1,6 @@
 import re
+import random
+import os
 
 
 CCE_POOLS = dict()

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -525,7 +525,7 @@ def fix_file_prompt(path, product_yaml, func, args):
 
 def add_cce(args, product_yaml):
     directory = os.path.join(args.root, args.subdirectory)
-    cce_pool = cce.CCE_POOLS[args.cce_pool]
+    cce_pool = cce.CCE_POOLS[args.cce_pool]()
     return _add_cce(directory, cce_pool, args.rule, product_yaml, args)
 
 


### PR DESCRIPTION
#### Description:

- Fix up for the fix_rules.py script in add-cce command

#### Rationale:

Fix following tracebacks:
```
Traceback (most recent call last):
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 759, in <module>
    __main__()
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 755, in __main__
    args.func(args, subst_dict)
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 529, in add_cce
    return _add_cce(directory, cce_pool, args.rule, product_yaml, args)
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 548, in _add_cce
    cce = cce_pool.random_cce()
TypeError: random_cce() missing 1 required positional argument: 'self'
```

```
Traceback (most recent call last):
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 759, in <module>
    __main__()
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 755, in __main__
    args.func(args, subst_dict)
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 528, in add_cce
    cce_pool = cce.CCE_POOLS[args.cce_pool]()
  File "/home/ggasparb/workspace/github/content/ssg/cce.py", line 12, in __init__
    project_root = os.path.join(
NameError: name 'os' is not defined
```
