### PR TITLE
Allow HID USB in the ISM profile

### DIFF
--- a/products/rhel8/profiles/ism_o.profile
+++ b/products/rhel8/profiles/ism_o.profile
@@ -52,6 +52,7 @@ selections:
   ## Identifiers 1418
   - package_usbguard_installed
   - service_usbguard_enabled
+  - usbguard_allow_hid_and_hub
 
   ## Authentication hardening
   ## Identifiers 1546 / 0974 / 1173 / 1504 / 1505 / 1401 / 1559 / 1560

--- a/products/rhel9/profiles/ism_o.profile
+++ b/products/rhel9/profiles/ism_o.profile
@@ -52,6 +52,7 @@ selections:
   ## Identifiers 1418
   - package_usbguard_installed
   - service_usbguard_enabled
+  - usbguard_allow_hid_and_hub
 
   ## Authentication hardening
   ## Identifiers 1546 / 0974 / 1173 / 1504 / 1505 / 1401 / 1559 / 1560


### PR DESCRIPTION
The usbguard is too strict without this rule, and its default setting blocks keyboard and mouse.