### PR TITLE
OL8 was prevent build all from working

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/oval/shared.xml
@@ -2,7 +2,9 @@
   <definition class="compliance" id="smartcard_configure_cert_checking" version="4">
     {{{ oval_metadata("Enable Smart Card Login") }}}
     <criteria comment="smart card authentication is configured" operator="AND">
+      {{% if product not in ['ol8'] %}}
       <extend_definition comment="pam_pkcs11 package is installed" definition_ref="install_smartcard_packages" />
+      {{% endif %}}
       <criterion comment="cert_policy directive contains ocsp_on" test_ref="test_pam_pkcs11_all_cert_policy_ocsp_on" />
     </criteria>
   </definition>


### PR DESCRIPTION
This issue was created in b773be3a0e8042f62fe136a55ef1bdea5dda5287. This prevent the nightly builds from working. This quick fix to make the build work.

