### PR TITLE
Fix a failing test scenarios

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/no_cron_logging.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/no_cron_logging.fail.sh
@@ -9,5 +9,6 @@ touch $RSYSLOG_CONF
 sed -i '/^[[:space:]]*cron\.\*/d' $RSYSLOG_CONF
 for rsyslog_d_file in $RSYSLOG_D_FILES
 do
+	[ -e "$rsyslog_d_file" ] || continue
 	sed -i '/^[[:space:]]*cron\.\*/d' $rsyslog_d_file
 done


### PR DESCRIPTION
This prevents situation when the /etc/rsyslog.d/ directory is empty.

Addressing:
ERROR - Failed to execute 'cd /root/ssgts/rsyslog_cron_logging; SHARED=/root/ssgts/shared bash -x no_cron_logging.fail.sh' on root@192.168.122.70: Command '('ssh', '-o', 'StrictHostKeyChecking=no', '-o', 'UserKnownHostsFile=/dev/null', 'root@192.168.122.70', 'cd /root/ssgts/rsyslog_cron_logging; SHARED=/root/ssgts/shared bash -x no_cron_logging.fail.sh')' returned non-zero exit status 2.
