### PR TITLE
Add audit_rules_dac_modification_umount specific

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/ansible/shared.yml
@@ -1,0 +1,43 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+
+- name: Perform remediation of Audit rules for umount for x86 platform
+  block:
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=["umount"],
+      key="perm_mod",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid>="~auid~" -F auid!=unset",
+      syscalls=["umount"],
+      key="perm_mod",
+      syscall_grouping=[]
+      )|indent(4) }}}
+{{%- if CHECK_ROOT_USER %}}
+    {{{ ansible_audit_augenrules_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid=0",
+      syscalls=["umount"],
+      key="perm_mod",
+      syscall_grouping=[],
+      )|indent(4) }}}
+    {{{ ansible_audit_auditctl_add_syscall_rule(
+      action_arch_filters="-a always,exit -F arch=b32",
+      other_filters="",
+      auid_filters="-F auid=0",
+      syscalls=["umount"],
+      key="perm_mod",
+      syscall_grouping=[]
+      )|indent(4) }}}
+{{%- endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/bash/shared.sh
@@ -1,0 +1,25 @@
+# platform = multi_platform_all
+
+ACTION_ARCH_FILTERS="-a always,exit -F arch=b32"
+OTHER_FILTERS=""
+AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+SYSCALL="umount"
+KEY="perm_mod"
+SYSCALL_GROUPING=""
+
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+
+{{% if CHECK_ROOT_USER %}}
+	ACTION_ARCH_FILTERS="-a always,exit -F arch=b32"
+	OTHER_FILTERS=""
+	AUID_FILTERS="-F auid=0"
+	SYSCALL="umount"
+	KEY="perm_mod"
+	SYSCALL_GROUPING=""
+
+	# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+	{{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+	{{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") }}}
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/oval/shared.xml
@@ -1,0 +1,70 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_dac_modification_umount" version="1">
+    {{{ oval_metadata("The changing of file permissions and attributes should be audited.") }}}
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules 32-bit umount" test_ref="test_32bit_ardm_umount_augenrules" />
+{{% if CHECK_ROOT_USER %}}
+        <criterion comment="audit augenrules 32-bit umount" test_ref="test_32bit_ardm_umount_augenrules_auid_0" />
+{{% endif %}}
+      </criteria>
+
+      <!-- OR test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl 32-bit umount" test_ref="test_32bit_ardm_umount_auditctl" />
+{{% if CHECK_ROOT_USER %}}
+        <criterion comment="audit auditctl 32-bit umount" test_ref="test_32bit_ardm_umount_auditctl_auid_0" />
+{{% endif %}}
+      </criteria>
+
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit umount" id="test_32bit_ardm_umount_augenrules" version="1">
+    <ind:object object_ref="object_32bit_ardm_umount_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_umount_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+umount[\s]+|([\s]+|[,])umount([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit umount" id="test_32bit_ardm_umount_auditctl" version="1">
+    <ind:object object_ref="object_32bit_ardm_umount_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_umount_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+umount[\s]+|([\s]+|[,])umount([\s]+|[,])))(?:.*-F\s+auid>={{{ auid }}}[\s]+)(?:.*-F\s+auid!=(?:4294967295|unset)[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+{{% if CHECK_ROOT_USER %}}
+
+  <ind:textfilecontent54_test check="all" comment="audit augenrules 32-bit umount auid=0" id="test_32bit_ardm_umount_augenrules_auid_0" version="1">
+    <ind:object object_ref="object_32bit_ardm_umount_augenrules_auid_0" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_umount_augenrules_auid_0" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+umount[\s]+|([\s]+|[,])umount([\s]+|[,])))(?:.*-F\s+auid=0[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+
+  <ind:textfilecontent54_test check="all" comment="audit auditctl 32-bit umount" id="test_32bit_ardm_umount_auditctl_auid_0" version="1">
+    <ind:object object_ref="object_32bit_ardm_umount_auditctl_auid_0" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_32bit_ardm_umount_auditctl_auid_0" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+umount[\s]+|([\s]+|[,])umount([\s]+|[,])))(?:.*-F\s+auid=0[\s]+).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+{{% endif %}}
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
@@ -41,8 +41,3 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping these system
         calls with others as identifying earlier in this guide is more efficient.
-
-template:
-    name: audit_rules_dac_modification
-    vars:
-        attr: umount


### PR DESCRIPTION

#### Description:

- Modify audit_rules_dac_modification_umount rule definition to use a special case on the audit_rules_dac_modification template to check/apply only 32bit relevant rules


#### Rationale:

- Fixes #7386

