### PR TITLE
Fix the offline remediation of firewalld

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/bash/shared.sh
@@ -1,4 +1,9 @@
-# platform = Red Hat Enterprise Linux 7,multi_platform_wrlinux,multi_platform_ol
+# platform = multi_platform_all
 
-firewall-cmd --permanent --direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES
-firewall-cmd --reload
+common_firewalld_ratelimit_args=(--direct --add-rule ipv4 filter INPUT_direct 0 -p tcp -m limit --limit 25/minute --limit-burst 100  -j INPUT_ZONES)
+if {{{ in_chrooted_environment }}}; then
+    firewall-offline-cmd "${common_firewalld_ratelimit_args[@]}"
+else
+    firewall-cmd --permanent "${common_firewalld_ratelimit_args[@]}"
+    firewall-cmd --reload
+fi

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -61,6 +61,8 @@ else
 fi
 {{%- endmacro -%}}
 
+{{%- set in_chrooted_environment = 'test "$(stat -c %d:%i /)" != "$(stat -c %d:%i /proc/1/root/.)"' -%}}
+
 {{%- macro bash_shell_file_set(path, parameter, value, no_quotes=false) -%}}
 {{% if no_quotes -%}}
   {{% if "$" in value %}}


### PR DESCRIPTION
When the service is not running, we use the `firewall-offline-cmd`, and we also don't reload the config.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1812180