### PR TITLE
controls: Implement status parsing and replace `automated` key

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -136,7 +136,7 @@ controls:
     description: >-
       The activities of the running system and services must be logged and
       archived on an external, non-local system.
-    automated: yes
+    status: automated
     rules:
     # The default remote loghost is logcollector.
     # Change the default value to the hostname or IP of the system to send the logs to
@@ -147,7 +147,7 @@ controls:
     - minimal
     title: Regular updates
     notes: Check the vendor CVE feed and configure automatic install of security related updates.
-    automated: yes
+    status: automated
     rules:
     - security_patches_up_to_date
     - package_dnf-automatic_installed
@@ -177,7 +177,7 @@ controls:
     title: 32 and 64 bit architecture
     description: When the machine supports 64-bit operating systems, prefer it.
     notes: This requirement can be checked, but remediation requires manual reinstall of the OS.
-    automated: yes
+    status: automated
     rules:
      - prefer_64bit_os
 
@@ -189,7 +189,7 @@ controls:
       The iommu = force directive must be added to the list of kernel parameters
       during startup in addition to those already present in the configuration
       files of the bootloader (/boot/grub/menu.lst or /etc/default/grub).
-    automated: yes
+    status: automated
     rules:
     - grub2_enable_iommu_force
 
@@ -314,7 +314,7 @@ controls:
     description: >-
       A boot loader to protect the password boot must be to be privileged.
       This password must prevent any user from changing their configuration options.
-    automated: yes # without remediation
+    status: automated # without remediation
     rules:
     - grub2_password
     - grub2_uefi_password
@@ -377,7 +377,7 @@ controls:
       Users will first login, then escalate to privileged (root) access.
       Change of privilege operations must be based on executables to monitor the activities
       performed (for example sudo).
-    automated: yes
+    status: automated
     rules:
     - no_direct_root_logins
     - sshd_disable_root_login
@@ -424,7 +424,7 @@ controls:
     levels:
     - intermediary
     title: Setting up network sysctl
-    automated: yes
+    status: automated
     rules:
     # No routing between interfaces
     # net.ipv4.ip_forward = 0
@@ -540,7 +540,7 @@ controls:
     levels:
     - intermediary
     title: Setting up system sysctl
-    automated: yes
+    status: automated
     rules:
     # Disabling SysReq
     # kernel.sysrq = 0
@@ -593,7 +593,7 @@ controls:
       sysctl kernel.modules_disabledconf:
       Prohibition of loading modules (except those already loaded to this point)
       kernel.modules_disabled = 1
-    automated: yes # without remediation
+    status: automated # without remediation
     rules:
     - sysctl_kernel_modules_disabled
 
@@ -605,7 +605,7 @@ controls:
       It is recommended to load the Yama security module at startup (by example
       passing the security = yama argument to the kernel) and configure the
       sysctl kernel.yama.ptrace_scope to a value of at least 1.
-    automated: yes
+    status: automated
     rules:
     - sysctl_kernel_yama_ptrace_scope
 
@@ -661,7 +661,7 @@ controls:
       The semantics of "ClientAliveCountMax 0" has changed from "disconnect on first timeout" to
       "don't disconnect network inactive sessions". The server either probes for the client liveness
       or keeps inactive sessions connected.
-    automated: yes
+    status: automated
     rules:
     - accounts_tmout
     - var_accounts_tmout=10_min
@@ -691,7 +691,7 @@ controls:
     description: Any password must be protected by cryptographic mechanisms.
     notes: >-
       The selection of rules doesn't cover the use of hardware devices to protect the passwords.
-    automated: yes
+    status: automated
     rules:
     # ENCRYPT_METHOD, system default is SHA512
     - set_password_hashing_algorithm_systemauth
@@ -740,7 +740,7 @@ controls:
     title: Rights to access sensitive content files
     levels:
     - intermediary
-    automated: yes
+    status: automated
     rules:
     - file_owner_etc_shadow
     - file_permissions_etc_shadow
@@ -760,7 +760,7 @@ controls:
       recognized and authorized repositories (covered in R15).
       The remediation resets the sticky bit to intended value by vendor/developer, any finding after remediation
       should be reviewed.
-    automated: yes
+    status: automated
     rules:
     - file_permissions_unauthorized_suid
     - file_permissions_unauthorized_sgid
@@ -783,7 +783,7 @@ controls:
       Each user or service account must have its own temporary directory
       and dispose of it exclusively.
     notes: The approach of the selected rules is to use and configure pam_namespace module.
-    automated: yes
+    status: automated
     rules:
     - enable_pam_namespace
     - accounts_polyinstantiated_tmp
@@ -795,7 +795,7 @@ controls:
     levels:
     - intermediary
     title: Sticky bit and write access rights
-    automated: yes
+    status: automated
     rules:
     - dir_perms_world_writable_sticky_bits
     - dir_perms_world_writable_root_owned
@@ -883,7 +883,7 @@ controls:
     - intermediary
     title: Dedicated partition for logs
     notes: This assumes that syslog stores its logs locally in "/var/log/audit".
-    automated: yes
+    status: automated
     rules:
       - partition_for_var_log_audit
 
@@ -891,7 +891,7 @@ controls:
     levels:
     - intermediary
     title: Configuring the local messaging service
-    automated: yes
+    status: automated
     rules:
     - postfix_network_listening_disabled
 
@@ -923,7 +923,7 @@ controls:
       This includes: directories containing executables, libraries,
       configuration files, as well as any files that may contain sensitive
       elements (cryptographic keys, passwords, confidential data).
-    automated: yes
+    status: automated
     rules:
     - package_aide_installed
     - aide_build_database
@@ -997,7 +997,7 @@ controls:
     notes: >-
       The rules below create and configure a group named sudogrp, to change the group customize the
       value of var_sudo_dedicated_group.
-    automated: yes
+    status: automated
     rules:
     - sudo_dedicated_group
     - var_sudo_dedicated_group=sudogrp
@@ -1024,7 +1024,7 @@ controls:
     title: User authentication running sudo
     description: >-
       The calling user must be authenticated before running any command with sudo.
-    automated: yes
+    status: automated
     rules:
     - sudo_remove_nopasswd
     - sudo_remove_no_authenticate
@@ -1034,7 +1034,7 @@ controls:
     - intermediary
     title: Privileges of target sudo users
     description: The targeted users of a rule should be, as much as possible, non privileged users.
-    automated: yes
+    status: automated
     rules:
     - sudoers_no_root_target
 
@@ -1055,7 +1055,7 @@ controls:
     - intermediary
     title: Good use of negation in a sudoers file
     description: The sudoers configuration rules should not involve negation.
-    automated: yes
+    status: automated
     rules:
     - sudoers_no_command_negation
 
@@ -1063,7 +1063,7 @@ controls:
     levels:
     - intermediary
     title: Explicit arguments in sudo specifications
-    automated: yes
+    status: automated
     rules:
     - sudoers_explicit_command_args
 
@@ -1094,7 +1094,7 @@ controls:
     description: >-
       It is recommended to enable the targeted policy when the distribution
       support it and that it does not operate another security module than SELinux.
-    automated: yes
+    status: automated
     rules:
     - selinux_policytype
     - var_selinux_policy_name=targeted
@@ -1114,7 +1114,7 @@ controls:
       In RHEL, the SELinux boolean allow_execheap is renamed to selinuxuser_execheap, and the
       boolean allow_execstack is renamed to selinuxuser_execstack. And allow_execmem is not
       available, deny_execmem provides the same functionality.
-    automated: yes
+    status: automated
     rules:
     - var_selinuxuser_execheap=off
     - sebool_selinuxuser_execheap
@@ -1133,7 +1133,7 @@ controls:
     description: >-
       SELinux policy manipulation and debugging tools should not be installed
       on a machine in production.
-    automated: yes
+    status: automated
     rules:
     - package_setroubleshoot_removed
     - package_setroubleshoot-server_removed

--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -24,7 +24,7 @@ controls:
       Only the components strictly necessary to the service provided by the system should
       be installed.
       Those whose presence can not be justified should be disabled, removed or deleted.
-    automated: partially  # The list of essential services is not objective.
+    status: partial  # The list of essential services is not objective.
     notes: >-
       Performing a minimal install is a good starting point, but doesn't provide any assurance
       over any package installed later.
@@ -67,7 +67,7 @@ controls:
       The services and executables available on the system must be analyzed in order to
       know the privileges they require, and must then be configured and integrated to use
       the bare necessities.
-    automated: partially # The system can be restricted even more with selinux-booleans or other technologies
+    status: partial # The system can be restricted even more with selinux-booleans or other technologies
     notes: >-
       SELinux policies limit the privileges of services and daemons to only what they require.
     rules:
@@ -84,7 +84,7 @@ controls:
     notes: >-
       Other partitioning mechanisms can include chroot and containers and are not contemplated
       in this requirement.
-    automated: partially
+    status: partial
     rules:
     - selinux_state
     - var_selinux_state=enforcing
@@ -96,7 +96,7 @@ controls:
     description: >-
       Under Unix and derivatives, defense in depth must be based on a combination of
       barriers that must be kept independent of each other.
-    automated: partially
+    status: partial
     notes: >-
       Defense in-depth can be broadly divided into three areas - physical, technical and
       administrative. The security profile is best suited to protect the technical area.
@@ -165,7 +165,7 @@ controls:
       Configurations recommended for this requirement are to be performed at the BIOS level.
       The content automation cannot really configure the BIOS, but can in some cases,
       check settings that are visible to the OS. Like for example the NX/DX setting.
-    automated: partially
+    status: partial
     rules:
     - sysctl_kernel_exec_shield
     - bios_enable_execution_restrictions
@@ -199,7 +199,7 @@ controls:
     title: Partitioning type
     notes: >- 
       The rule for the /proc file system is not implemented
-    automated: partially
+    status: partial
     rules:
     # this covers nodev options
     - mount_option_nodev_nonroot_local_partitions
@@ -287,7 +287,7 @@ controls:
       We cannot draw conclusions from the repo name or URL of the repo (as they can be arbitrary or behind a proxy).
       One approach to check the origin of installed packages is to check the signature of the packages.
       If the public key of a repository is not installed, the repo is not trusted.
-    automated: partially
+    status: partial
     rules:
     - ensure_gpgcheck_never_disabled
     - ensure_gpgcheck_globally_activated
@@ -329,7 +329,7 @@ controls:
       (https://www.ssi.gouv.fr/administration/precautions-elementaires/calculer-la-force-dun-mot-de-passe/).
 
       The baseline should be reviewed and tailored to the system's use case and needs.
-    automated: partially
+    status: partial
     rules:
     # Renew passwords every 90 days
     - var_accounts_maximum_age_login_defs=90
@@ -413,7 +413,7 @@ controls:
       basic integrity checking. System logs are configured as part of R43.
       Hardening of particular services should be done on a case by case basis and is
       not automated by this content.
-    automated: partially
+    status: partial
     rules:
     - selinux_state
     - var_selinux_state=enforcing
@@ -729,7 +729,7 @@ controls:
       The different values are set in a conditional clause in a shell script
       (e.g. /etc/profile or /etc/bashrc).
       The current implementation checks and fixes both umask to the same value.
-    automated: partially
+    status: partial
     rules:
     - var_accounts_user_umask=077
     - accounts_umask_etc_login_defs
@@ -828,7 +828,7 @@ controls:
       A lot of recommendations and requirements from the DAT-NT-012 document are administrative and hard to automate.
       The rules selected below address a few of the aspects that can be covered, keep in mind that these configurations should
       be customized for the systems deployment requirements.
-    automated: partially
+    status: partial
     rules:
     # Based on DAT-NT-012 R3
     - package_chrony_installed
@@ -899,7 +899,7 @@ controls:
     levels:
     - intermediary
     title: Messaging Aliases for Service Accounts
-    automated: partially # it is hard to define what are "service accounts"
+    status: partial # it is hard to define what are "service accounts"
     notes: >-
       Only the alias for root user is currently covered.
     rules:
@@ -954,7 +954,7 @@ controls:
       strict minimum, especially when it comes to files, processes or network.
     notes: >-
       SELinux policies limit the privileges of services and daemons just to those which are required.
-    automated: partially
+    status: partial
     rules:
     - selinux_policytype
     - var_selinux_policy_name=targeted
@@ -1006,7 +1006,7 @@ controls:
     levels:
     - intermediary
     title: Sudo configuration guidelines
-    automated: partially
+    status: partial
     rules:
     - sudo_add_noexec
     - sudo_add_requiretty

--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -23,7 +23,7 @@ controls:
     - l2_workstation
     notes: <-
       This is a helper rule to reload Dconf datbase correctly.
-    automated: yes
+    status: automated
     rules:
     - dconf_db_up_to_date
 
@@ -32,7 +32,7 @@ controls:
     levels:
     - l1_workstation
     - l1_server
-    automated: yes
+    status: automated
     rules:
     - kernel_module_cramfs_disabled
 
@@ -41,7 +41,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - kernel_module_squashfs_disabled
 
@@ -50,7 +50,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - kernel_module_udf_disabled
 
@@ -59,7 +59,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - partition_for_tmp
 
@@ -68,7 +68,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_tmp_noexec
 
@@ -77,7 +77,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_tmp_nodev
 
@@ -86,7 +86,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_tmp_nosuid
 
@@ -102,7 +102,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_dev_shm_noexec
 
@@ -111,7 +111,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_dev_shm_nodev
 
@@ -120,7 +120,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_dev_shm_nosuid
 
@@ -129,7 +129,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - partition_for_var
 
@@ -138,7 +138,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - partition_for_var_tmp
 
@@ -147,7 +147,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_var_tmp_noexec
 
@@ -156,7 +156,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_var_tmp_nodev
 
@@ -165,7 +165,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_var_tmp_nosuid
 
@@ -174,7 +174,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - partition_for_var_log
 
@@ -183,7 +183,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - partition_for_var_log_audit
 
@@ -192,7 +192,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - partition_for_home
 
@@ -201,7 +201,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_home_nodev
 
@@ -210,7 +210,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_noexec_removable_partitions
 
@@ -219,7 +219,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_nodev_removable_partitions
 
@@ -228,7 +228,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - mount_option_nosuid_removable_partitions
 
@@ -237,7 +237,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - dir_perms_world_writable_sticky_bits
 
@@ -246,7 +246,7 @@ controls:
     levels:
     - l1_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - service_autofs_disabled
 
@@ -255,7 +255,7 @@ controls:
     levels:
     - l1_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - kernel_module_usb-storage_disabled
 
@@ -278,7 +278,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
@@ -309,7 +309,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_aide_installed
     - aide_build_database
@@ -319,7 +319,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - aide_periodic_cron_checking
 
@@ -328,7 +328,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - grub2_password
     - grub2_uefi_password
@@ -338,7 +338,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_grub2_cfg
     - file_owner_grub2_cfg
@@ -352,7 +352,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - require_emergency_target_auth
     - require_singleuser_auth
@@ -362,7 +362,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - disable_users_coredumps
     - sysctl_fs_suid_dumpable
@@ -386,7 +386,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_kernel_randomize_va_space
 
@@ -406,7 +406,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_libselinux_installed
 
@@ -415,7 +415,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - grub2_enable_selinux # the rule does not check for uefi configuration
 
@@ -424,7 +424,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - selinux_policytype
     - var_selinux_policy_name=targeted
@@ -434,7 +434,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     notes: >-
       The SELinux mode is set to "enforcing" by default.
       Configuring the "permissive" mode greatly lowers security of the system.
@@ -448,7 +448,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - selinux_confinement_of_daemons
 
@@ -456,7 +456,7 @@ controls:
     title: Ensure SETroubleshoot is not installed (Automated)
     levels:
     - l1_server
-    automated: yes
+    status: automated
     rules:
     - package_setroubleshoot_removed
 
@@ -465,7 +465,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_mcstrans_removed
 
@@ -474,7 +474,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - banner_etc_motd
     - login_banner_text=usgcb_default
@@ -484,7 +484,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - banner_etc_issue
     - login_banner_text=usgcb_default
@@ -501,7 +501,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_etc_motd
     - file_owner_etc_motd
@@ -512,7 +512,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_etc_issue
     - file_owner_etc_issue
@@ -536,7 +536,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - dconf_gnome_banner_enabled
     - dconf_gnome_login_banner_text
@@ -547,7 +547,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - dconf_gnome_disable_user_list
 
@@ -556,7 +556,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - gnome_gdm_disable_xdmcp
 
@@ -572,7 +572,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_xinetd_removed
 
@@ -588,7 +588,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - chronyd_specify_remote_server
     - var_multiple_time_servers=rhel
@@ -599,7 +599,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - service_ntpd_enabled
     - ntpd_configure_restrictions
@@ -610,7 +610,7 @@ controls:
     title: Ensure X11 Server components are not installed (Automated)
     levels:
     - l1_server
-    automated: yes
+    status: automated
     notes: >-
       The rule also configures correct run level to prevent unbootable system.
     rules:
@@ -636,7 +636,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_dhcp_removed
 
@@ -645,7 +645,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_openldap-servers_removed
 
@@ -654,7 +654,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_bind_removed
 
@@ -663,7 +663,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_vsftpd_removed
 
@@ -672,7 +672,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_httpd_removed
 
@@ -681,7 +681,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_dovecot_removed
 
@@ -690,7 +690,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_samba_removed
 
@@ -699,7 +699,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_squid_removed
 
@@ -708,7 +708,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_net-snmp_removed
 
@@ -717,7 +717,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_ypserv_removed
 
@@ -726,7 +726,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_telnet-server_removed
 
@@ -735,7 +735,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - postfix_network_listening_disabled
     - var_postfix_inet_interfaces=loopback-only
@@ -745,7 +745,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_nfs-utils_removed
 
@@ -763,7 +763,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - service_rsyncd_disabled
 
@@ -772,7 +772,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_ypbind_removed
 
@@ -781,7 +781,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_rsh_removed
 
@@ -790,7 +790,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_talk_removed
 
@@ -799,7 +799,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_telnet_removed
 
@@ -808,7 +808,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_openldap-clients_removed
 
@@ -831,7 +831,7 @@ controls:
     levels:
     - l1_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - wireless_disable_interfaces # the rule remediation is not exactly on par with the benchmark
 
@@ -840,7 +840,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_ip_forward
     - sysctl_net_ipv6_conf_all_forwarding
@@ -851,7 +851,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_conf_all_send_redirects
     - sysctl_net_ipv4_conf_default_send_redirects
@@ -861,7 +861,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_conf_all_accept_source_route
     - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
@@ -877,7 +877,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_conf_all_accept_redirects
     - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
@@ -893,7 +893,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_conf_all_secure_redirects
     - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
@@ -905,7 +905,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_conf_all_log_martians
     - sysctl_net_ipv4_conf_all_log_martians_value=enabled
@@ -917,7 +917,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
     - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
@@ -927,7 +927,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
     - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
@@ -937,7 +937,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_conf_all_rp_filter
     - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
@@ -949,7 +949,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv4_tcp_syncookies
     - sysctl_net_ipv4_tcp_syncookies_value=enabled
@@ -959,7 +959,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sysctl_net_ipv6_conf_all_accept_ra
     - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
@@ -971,7 +971,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - kernel_module_dccp_disabled
 
@@ -980,7 +980,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - kernel_module_sctp_disabled
 
@@ -989,7 +989,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_iptables_installed
     - package_firewalld_installed
@@ -1022,7 +1022,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - set_firewalld_default_zone
 
@@ -1246,7 +1246,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - service_auditd_enabled
 
@@ -1255,7 +1255,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - grub2_audit_argument
 
@@ -1264,7 +1264,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - auditd_data_retention_max_log_file
     - var_auditd_max_log_file=6
@@ -1274,7 +1274,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - auditd_data_retention_max_log_file_action
     - var_auditd_max_log_file_action=keep_logs
@@ -1284,7 +1284,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - auditd_data_retention_space_left_action
     - var_auditd_space_left_action=email
@@ -1298,7 +1298,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     notes: <-
       Note that currently the value is hardcoded to 8192
     rules:
@@ -1321,7 +1321,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_usergroup_modification_group
     - audit_rules_usergroup_modification_gshadow
@@ -1334,7 +1334,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_networkconfig_modification
 
@@ -1352,7 +1352,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_login_events_faillock
     - audit_rules_login_events_lastlog
@@ -1362,7 +1362,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_session_events
 
@@ -1371,7 +1371,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_dac_modification_fchmod
     - audit_rules_dac_modification_fchmodat
@@ -1392,7 +1392,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_unsuccessful_file_modification_creat
     - audit_rules_unsuccessful_file_modification_open
@@ -1412,7 +1412,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_media_export
 
@@ -1421,7 +1421,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_file_deletion_events_rename
     - audit_rules_file_deletion_events_renameat
@@ -1433,7 +1433,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_sysadmin_actions
 
@@ -1449,7 +1449,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_privileged_commands_insmod
     - audit_rules_privileged_commands_rmmod
@@ -1462,7 +1462,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - audit_rules_immutable
 
@@ -1471,7 +1471,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_rsyslog_installed
 
@@ -1480,7 +1480,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - service_rsyslog_enabled
 
@@ -1554,7 +1554,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - service_crond_enabled
 
@@ -1563,7 +1563,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_crontab
     - file_owner_crontab
@@ -1574,7 +1574,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_cron_hourly
     - file_owner_cron_hourly
@@ -1585,7 +1585,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_cron_daily
     - file_owner_cron_daily
@@ -1596,7 +1596,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_cron_weekly
     - file_owner_cron_weekly
@@ -1607,7 +1607,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_cron_monthly
     - file_owner_cron_monthly
@@ -1618,7 +1618,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_cron_d
     - file_owner_cron_d
@@ -1646,7 +1646,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - package_sudo_installed
 
@@ -1655,7 +1655,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sudo_add_use_pty
 
@@ -1664,7 +1664,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sudo_custom_logfile
     - var_sudo_logfile=var_log_sudo_log
@@ -1674,7 +1674,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_sshd_config
     - file_owner_sshd_config
@@ -1711,7 +1711,7 @@ controls:
     notes: <-
       The default rule is configured to enforce the "verbose" log level. Use
       tailoring to change it to "info" level.
-    automated: yes # we have two rules either for info or verbose, no way to select
+    status: automated # we have two rules either for info or verbose, no way to select
     related_rules:
     - sshd_set_loglevel_info
     rules:
@@ -1722,7 +1722,7 @@ controls:
     levels:
     - l2_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_disable_x11_forwarding
 
@@ -1731,7 +1731,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_set_max_auth_tries
     - sshd_max_auth_tries_value=4
@@ -1741,7 +1741,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_disable_rhosts
 
@@ -1750,7 +1750,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - disable_host_auth
 
@@ -1759,7 +1759,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_disable_root_login
 
@@ -1768,7 +1768,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_disable_empty_passwords
 
@@ -1777,7 +1777,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_do_not_permit_user_env
 
@@ -1786,7 +1786,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     notes: <-
       The rule checks for default list of ciphers provided in the benchmark.
     rules:
@@ -1798,7 +1798,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     notes: <-
       The rule checks for default list of MACs provided in the benchmark.
     rules:
@@ -1817,7 +1817,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_set_idle_timeout
     - sshd_idle_timeout_value=15_minutes
@@ -1850,7 +1850,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_disable_tcp_forwarding
 
@@ -1859,7 +1859,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_set_maxstartups
     - var_sshd_set_maxstartups=10:30:60
@@ -1869,7 +1869,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - sshd_set_max_sessions
     - var_sshd_max_sessions=10
@@ -1920,7 +1920,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     notes: |-
       Usage of pam_unix.so module together with "remember" option is deprecated and is not supported by this policy interpretation.
       See here for more details about pam_unix.so:
@@ -2044,7 +2044,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_etc_passwd
     - file_owner_etc_passwd
@@ -2055,7 +2055,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_backup_etc_passwd
     - file_owner_backup_etc_passwd
@@ -2066,7 +2066,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_etc_shadow
     - file_owner_etc_shadow
@@ -2077,7 +2077,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_backup_etc_shadow
     - file_owner_backup_etc_shadow
@@ -2088,7 +2088,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_backup_etc_gshadow
     - file_owner_backup_etc_gshadow
@@ -2099,7 +2099,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_etc_gshadow
     - file_owner_etc_gshadow
@@ -2110,7 +2110,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_etc_group
     - file_owner_etc_group
@@ -2121,7 +2121,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_groupowner_backup_etc_group
     - file_owner_backup_etc_group
@@ -2132,7 +2132,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_permissions_unauthorized_world_writable
 
@@ -2141,7 +2141,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - no_files_unowned_by_user
 
@@ -2150,7 +2150,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - file_permissions_ungroupowned
 
@@ -2173,7 +2173,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - accounts_password_all_shadowed
 
@@ -2189,7 +2189,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - gid_passwd_group_same
 
@@ -2205,7 +2205,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - account_unique_name
 
@@ -2221,7 +2221,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - account_unique_id
 
@@ -2237,7 +2237,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - accounts_no_uid_except_zero
 
@@ -2246,7 +2246,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - accounts_root_path_dirs_no_write
     - root_path_no_dot
@@ -2297,7 +2297,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     notes: <-
       The rule is checking only for existence of files, not for their permissions.
     rules:

--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -374,7 +374,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially
+    status: partial
     notes: >-
       Automatic remediation of these rules is not available.
     rules:
@@ -395,7 +395,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially
+    status: partial
     notes: >-
       The rule to remove prelink package is missing.
     rules:
@@ -621,7 +621,7 @@ controls:
     levels:
     - l1_server
     - l2_workstation
-    automated: partially # rule for package removal is missing
+    status: partial # rule for package removal is missing
     rules:
     - service_avahi-daemon_disabled
 
@@ -754,7 +754,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially
+    status: partial
     rules:
     - service_rpcbind_disabled
 
@@ -1013,7 +1013,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # only checking systemd service, not running "firewall-cmd --state"
+    status: partial # only checking systemd service, not running "firewall-cmd --state"
     rules:
     - service_firewalld_enabled
 
@@ -1237,7 +1237,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: partially # we do not check for audit-libs package
+    status: partial # we do not check for audit-libs package
     rules:
     - package_audit_installed
 
@@ -1309,7 +1309,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: partially # we do not have rule for clock_settime
+    status: partial # we do not have rule for clock_settime
     rules:
     - audit_rules_time_adjtimex
     - audit_rules_time_settimeofday
@@ -1343,7 +1343,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: partially # rule for checking audit watch on /usr/share/selinux is missing
+    status: partial # rule for checking audit watch on /usr/share/selinux is missing
     rules:
     - audit_rules_mac_modification
 
@@ -1629,7 +1629,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # rules for removing cron.deny and checking permissions of cron.allow are missing
+    status: partial # rules for removing cron.deny and checking permissions of cron.allow are missing
     rules:
     - file_groupowner_cron_allow
     - file_owner_cron_allow
@@ -1692,7 +1692,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # missing rules for ownership
+    status: partial # missing rules for ownership
     rules:
     - file_permissions_sshd_pub_key
 
@@ -1879,7 +1879,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # rule checking for retry needs modification and we are missing rule for try_first_pass
+    status: partial # rule checking for retry needs modification and we are missing rule for try_first_pass
     notes: <-
       There are two ways how to check this control.
       One way is to check for minclass, this is currently selected.
@@ -1911,7 +1911,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # our rule does not check for password-auth
+    status: partial # our rule does not check for password-auth
     rules:
     - set_password_hashing_algorithm_systemauth
 
@@ -1936,7 +1936,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # missing rule for checking of /etc/shadow
+    status: partial # missing rule for checking of /etc/shadow
     rules:
     - accounts_maximum_age_login_defs
     - var_accounts_maximum_age_login_defs=365
@@ -1946,7 +1946,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # missing rule for checking of /etc/shadow
+    status: partial # missing rule for checking of /etc/shadow
     rules:
     - accounts_minimum_age_login_defs
     - var_accounts_minimum_age_login_defs=1
@@ -1956,7 +1956,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # missing rule for checking of /etc/shadow
+    status: partial # missing rule for checking of /etc/shadow
     rules:
     - accounts_password_warn_age_login_defs
     - var_accounts_password_warn_age_login_defs=7
@@ -1966,7 +1966,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # we do not check /et/shadow
+    status: partial # we do not check /et/shadow
     rules:
     - account_disable_post_pw_expiration
     - var_account_disable_post_pw_expiration=30
@@ -1983,7 +1983,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # missing rule for locking of accounts
+    status: partial # missing rule for locking of accounts
     rules:
     - no_shelllogin_for_systemaccounts
 
@@ -1999,7 +1999,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # we check only for value of tmout variable, no export or readonly and we do not check /etc/bashrc
+    status: partial # we check only for value of tmout variable, no export or readonly and we do not check /etc/bashrc
     rules:
     - accounts_tmout
     - var_accounts_tmout=15_min
@@ -2009,7 +2009,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially # checking only for numeric umask and we do not check for user_enab in /etc/login.defs
+    status: partial # checking only for numeric umask and we do not check for user_enab in /etc/login.defs
     rules:
     - accounts_umask_etc_bashrc
     - accounts_umask_etc_login_defs
@@ -2028,7 +2028,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: partially  # we check only for usage of use_uid with pam_su, not for the group
+    status: partial  # we check only for usage of use_uid with pam_su, not for the group
     rules:
     - use_pam_wheel_for_su
 

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -351,7 +351,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # This rule, as implemented here, does not check for a user.cfg file
+    status: partial  # This rule, as implemented here, does not check for a user.cfg file
     rules:
       - file_groupowner_efi_grub2_cfg
       - file_groupowner_grub2_cfg
@@ -1282,7 +1282,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: partially  # The CAC rule audit_rules_time_settimeofday uses additional parameters compared to the CIS benchmark and so is not used here. As a result, automated coverage is only partial for this control.
+    status: partial  # The CAC rule audit_rules_time_settimeofday uses additional parameters compared to the CIS benchmark and so is not used here. As a result, automated coverage is only partial for this control.
     rules:
       - audit_rules_time_adjtimex
       - audit_rules_time_clock_settime
@@ -1297,7 +1297,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: partially
+    status: partial
     rules:
       - audit_rules_mac_modification
 
@@ -1637,7 +1637,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially
+    status: partial
     rules:
       - file_permissions_sshd_pub_key
 
@@ -1840,7 +1840,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially
+    status: partial
     rules:
       - accounts_password_pam_minclass
       - accounts_password_pam_minlen
@@ -1878,7 +1878,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The rule below does not check the /etc/pam.d/password-auth file mentioned in the benchmark.
+    status: partial  # The rule below does not check the /etc/pam.d/password-auth file mentioned in the benchmark.
     rules:
       - set_password_hashing_algorithm_systemauth
 
@@ -1887,7 +1887,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The rule below does not validate whether all current users' PASS_MAX_DAYS setting conforms to the control.
+    status: partial  # The rule below does not validate whether all current users' PASS_MAX_DAYS setting conforms to the control.
     rules:
       - accounts_maximum_age_login_defs
       - var_accounts_maximum_age_login_defs=365
@@ -1897,7 +1897,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The rule below does not validate whether all current users' PASS_MIN_DAYS setting conforms to the control.
+    status: partial  # The rule below does not validate whether all current users' PASS_MIN_DAYS setting conforms to the control.
     rules:
       - accounts_minimum_age_login_defs
       - var_accounts_minimum_age_login_defs=7
@@ -1907,7 +1907,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The rule below does not validate whether all current users' PASS_WARN_AGE setting conforms to the control.
+    status: partial  # The rule below does not validate whether all current users' PASS_WARN_AGE setting conforms to the control.
     rules:
       - accounts_password_warn_age_login_defs
       - var_accounts_password_warn_age_login_defs=7
@@ -1917,7 +1917,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The rule below does not validate wheter all current users' INACTIVE setting conforms to the control.
+    status: partial  # The rule below does not validate wheter all current users' INACTIVE setting conforms to the control.
     rules:
       - account_disable_post_pw_expiration
       - var_account_disable_post_pw_expiration=30
@@ -1939,7 +1939,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially
+    status: partial
     rules:
       - no_shelllogin_for_systemaccounts
 
@@ -1948,7 +1948,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The remediation for this rule does not implement the "TMOUT" variable as readonly so does not align fully with the benchmark
+    status: partial  # The remediation for this rule does not implement the "TMOUT" variable as readonly so does not align fully with the benchmark
     rules:
       - accounts_tmout
       - var_accounts_tmout=15_min
@@ -1967,7 +1967,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially  # The rules below do not take /etc/profile.d/* into account so are not perfectly aligned with the benchmark
+    status: partial  # The rules below do not take /etc/profile.d/* into account so are not perfectly aligned with the benchmark
     rules:
       - accounts_umask_etc_bashrc
       - accounts_umask_etc_login_defs
@@ -1991,7 +1991,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: partially
+    status: partial
     rules:
       - use_pam_wheel_for_su
 

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -22,7 +22,7 @@ controls:
       - l1_workstation
     notes: <-
       This is a helper rule to reload Dconf datbase correctly.
-    automated: yes
+    status: automated
     rules:
       - dconf_db_up_to_date
 
@@ -31,7 +31,7 @@ controls:
     levels:
       - l1_workstation
       - l1_server
-    automated: yes
+    status: automated
     rules:
       - kernel_module_cramfs_disabled
 
@@ -49,7 +49,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_squashfs_disabled
 
@@ -58,7 +58,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_udf_disabled
 
@@ -67,7 +67,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - partition_for_tmp
 
@@ -76,7 +76,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_tmp_nodev
 
@@ -85,7 +85,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_tmp_nosuid
 
@@ -94,7 +94,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_tmp_noexec
 
@@ -103,7 +103,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - partition_for_var
 
@@ -112,7 +112,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - partition_for_var_tmp
 
@@ -121,7 +121,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_var_tmp_nodev
 
@@ -130,7 +130,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_var_tmp_nosuid
 
@@ -139,7 +139,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_var_tmp_noexec
 
@@ -148,7 +148,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - partition_for_var_log
 
@@ -157,7 +157,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - partition_for_var_log_audit
 
@@ -166,7 +166,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - partition_for_home
 
@@ -175,7 +175,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_home_nodev
 
@@ -184,7 +184,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_dev_shm_nodev
 
@@ -193,7 +193,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_dev_shm_nosuid
 
@@ -202,7 +202,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - mount_option_dev_shm_noexec
 
@@ -238,7 +238,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - dir_perms_world_writable_sticky_bits
 
@@ -247,7 +247,7 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - service_autofs_disabled
 
@@ -256,7 +256,7 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_usb-storage_disabled
 
@@ -290,7 +290,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - ensure_gpgcheck_globally_activated
 
@@ -306,7 +306,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_sudo_installed
 
@@ -315,7 +315,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sudo_add_use_pty
 
@@ -324,7 +324,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sudo_custom_logfile
 
@@ -333,7 +333,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_aide_installed
 
@@ -342,7 +342,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - aide_periodic_cron_checking
 
@@ -365,7 +365,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - grub2_password
       - grub2_uefi_password
@@ -375,7 +375,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - require_singleuser_auth
       - require_emergency_target_auth
@@ -385,7 +385,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - disable_users_coredumps
       - sysctl_fs_suid_dumpable
@@ -397,7 +397,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_kernel_randomize_va_space
 
@@ -406,7 +406,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - package_libselinux_installed
 
@@ -415,7 +415,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - grub2_enable_selinux
 
@@ -424,7 +424,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - var_selinux_policy_name=targeted
       - selinux_policytype
@@ -434,7 +434,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - var_selinux_state=enforcing
       - selinux_state
@@ -444,7 +444,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - selinux_confinement_of_daemons
 
@@ -452,7 +452,7 @@ controls:
     title: Ensure SETroubleshoot is not installed (Automated)
     levels:
       - l2_server
-    automated: yes
+    status: automated
     rules:
       - package_setroubleshoot_removed
 
@@ -461,7 +461,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - package_mcstrans_removed
 
@@ -470,7 +470,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - banner_etc_motd
       - login_banner_text=usgcb_default
@@ -480,7 +480,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - banner_etc_issue
       - login_banner_text=usgcb_default
@@ -499,7 +499,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_etc_motd
       - file_owner_etc_motd
@@ -510,7 +510,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_etc_issue
       - file_owner_etc_issue
@@ -530,7 +530,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - dconf_gnome_banner_enabled
       - dconf_gnome_login_banner_text
@@ -550,7 +550,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - configure_crypto_policy
       - var_system_crypto_policy=default_policy
@@ -566,7 +566,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - var_system_crypto_policy=future
 
@@ -575,7 +575,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_xinetd_removed
 
@@ -593,7 +593,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - chronyd_specify_remote_server
       - chronyd_run_as_chrony_user
@@ -603,7 +603,7 @@ controls:
     title: Ensure X Window System is not installed (Automated)
     levels:
       - l1_server
-    automated: yes
+    status: automated
     rules:
       - xwindows_remove_packages
 
@@ -612,7 +612,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_rsyncd_disabled
 
@@ -621,7 +621,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_avahi-daemon_disabled
 
@@ -630,7 +630,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_snmpd_disabled
 
@@ -639,7 +639,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_squid_disabled
 
@@ -648,7 +648,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_smb_disabled
 
@@ -657,7 +657,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_dovecot_disabled
 
@@ -666,7 +666,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_httpd_disabled
 
@@ -675,7 +675,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_vsftpd_disabled
 
@@ -684,7 +684,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_named_disabled
 
@@ -693,7 +693,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_nfs_disabled
 
@@ -702,7 +702,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_rpcbind_disabled
 
@@ -720,7 +720,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_dhcpd_disabled
 
@@ -729,7 +729,7 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - service_cups_disabled
 
@@ -747,7 +747,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - postfix_network_listening_disabled
       - var_postfix_inet_interfaces=loopback-only
@@ -757,7 +757,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_ypbind_removed
 
@@ -766,7 +766,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_telnet_removed
 
@@ -775,7 +775,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_openldap-clients_removed
 
@@ -784,7 +784,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_ip_forward
       - sysctl_net_ipv6_conf_all_forwarding
@@ -795,7 +795,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_conf_all_send_redirects
       - sysctl_net_ipv4_conf_default_send_redirects
@@ -805,7 +805,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_conf_all_accept_source_route
       - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
@@ -821,7 +821,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_conf_all_accept_redirects
       - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
@@ -837,7 +837,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_conf_all_secure_redirects
       - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
@@ -849,7 +849,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_conf_all_log_martians
       - sysctl_net_ipv4_conf_all_log_martians_value=enabled
@@ -861,7 +861,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
       - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
@@ -871,7 +871,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
       - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
@@ -881,7 +881,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_conf_all_rp_filter
       - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
@@ -893,7 +893,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv4_tcp_syncookies
       - sysctl_net_ipv4_tcp_syncookies_value=enabled
@@ -903,7 +903,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sysctl_net_ipv6_conf_all_accept_ra
       - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
@@ -915,7 +915,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_dccp_disabled
 
@@ -924,7 +924,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_sctp_disabled
 
@@ -933,7 +933,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_rds_disabled
 
@@ -942,7 +942,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - kernel_module_tipc_disabled
 
@@ -955,7 +955,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_firewalld_installed
 
@@ -964,7 +964,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_firewalld_enabled
 
@@ -991,7 +991,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - set_firewalld_default_zone
 
@@ -1168,7 +1168,7 @@ controls:
     levels:
       - l1_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - wireless_disable_interfaces
 
@@ -1184,7 +1184,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - package_audit_installed
 
@@ -1193,7 +1193,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - service_auditd_enabled
 
@@ -1202,7 +1202,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - grub2_audit_argument
 
@@ -1211,7 +1211,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - grub2_audit_backlog_limit_argument
 
@@ -1220,7 +1220,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - auditd_data_retention_max_log_file
       - var_auditd_max_log_file=6
@@ -1230,7 +1230,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - auditd_data_retention_max_log_file_action
       - var_auditd_max_log_file_action=keep_logs
@@ -1240,7 +1240,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - auditd_data_retention_action_mail_acct
       - auditd_data_retention_admin_space_left_action
@@ -1254,7 +1254,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_sysadmin_actions
 
@@ -1263,7 +1263,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_login_events_faillock
       - audit_rules_login_events_lastlog
@@ -1273,7 +1273,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_session_events
 
@@ -1306,7 +1306,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_networkconfig_modification
 
@@ -1315,7 +1315,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_dac_modification_chmod
       - audit_rules_dac_modification_chown
@@ -1336,7 +1336,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_unsuccessful_file_modification_creat
       - audit_rules_unsuccessful_file_modification_ftruncate
@@ -1349,7 +1349,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_usergroup_modification_group
       - audit_rules_usergroup_modification_gshadow
@@ -1362,7 +1362,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_media_export
 
@@ -1381,7 +1381,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_file_deletion_events_rename
       - audit_rules_file_deletion_events_renameat
@@ -1393,7 +1393,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_kernel_module_loading_delete
       - audit_rules_kernel_module_loading_init
@@ -1415,7 +1415,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - audit_rules_immutable
 
@@ -1424,7 +1424,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - package_rsyslog_installed
 
@@ -1433,7 +1433,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_rsyslog_enabled
 
@@ -1521,7 +1521,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - service_crond_enabled
 
@@ -1530,7 +1530,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_crontab
       - file_owner_crontab
@@ -1541,7 +1541,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_cron_hourly
       - file_owner_cron_hourly
@@ -1552,7 +1552,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_cron_daily
       - file_owner_cron_daily
@@ -1563,7 +1563,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_cron_weekly
       - file_owner_cron_weekly
@@ -1574,7 +1574,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_cron_monthly
       - file_owner_cron_monthly
@@ -1585,7 +1585,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_cron_d
       - file_owner_cron_d
@@ -1605,7 +1605,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_sshd_config
       - file_owner_sshd_config
@@ -1646,7 +1646,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     # The CIS benchmark is not opinionated about which loglevel is selected
     # here. Here, this profile uses VERBOSE by default, as it allows for
     # the capture of login and logout activity as well as key fingerprints.
@@ -1660,7 +1660,7 @@ controls:
     levels:
       - l2_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_disable_x11_forwarding
 
@@ -1669,7 +1669,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_max_auth_tries_value=4
       - sshd_set_max_auth_tries
@@ -1679,7 +1679,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_disable_rhosts
 
@@ -1688,7 +1688,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - disable_host_auth
 
@@ -1697,7 +1697,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_disable_root_login
 
@@ -1706,7 +1706,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_disable_empty_passwords
 
@@ -1715,7 +1715,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_do_not_permit_user_env
 
@@ -1724,7 +1724,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_idle_timeout_value=15_minutes
       - sshd_set_idle_timeout
@@ -1765,7 +1765,7 @@ controls:
     levels:
       - l2_server
       - l2_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_disable_tcp_forwarding
 
@@ -1774,7 +1774,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_set_maxstartups
       - var_sshd_set_maxstartups=10:30:60
@@ -1791,7 +1791,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - sshd_set_max_sessions
       - var_sshd_max_sessions=4
@@ -1801,7 +1801,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - configure_ssh_crypto_policy
 
@@ -1862,7 +1862,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     notes: |-
       Usage of pam_unix.so module together with "remember" option is deprecated and is not supported by this policy interpretation.
       See here for more details about pam_unix.so:
@@ -2010,7 +2010,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_etc_passwd
       - file_owner_etc_passwd
@@ -2021,7 +2021,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_backup_etc_passwd
       - file_owner_backup_etc_passwd
@@ -2032,7 +2032,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_owner_etc_shadow
       - file_groupowner_etc_shadow
@@ -2043,7 +2043,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_backup_etc_shadow
       - file_owner_backup_etc_shadow
@@ -2054,7 +2054,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_etc_gshadow
       - file_owner_etc_gshadow
@@ -2065,7 +2065,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_backup_etc_gshadow
       - file_owner_backup_etc_gshadow
@@ -2076,7 +2076,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_etc_group
       - file_owner_etc_group
@@ -2087,7 +2087,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_groupowner_backup_etc_group
       - file_owner_backup_etc_group
@@ -2098,7 +2098,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_permissions_unauthorized_world_writable
 
@@ -2107,7 +2107,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - no_files_unowned_by_user
 
@@ -2116,7 +2116,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - file_permissions_ungroupowned
 
@@ -2152,7 +2152,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - no_legacy_plus_entries_etc_passwd
 
@@ -2161,7 +2161,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - accounts_root_path_dirs_no_write
       - root_path_no_dot
@@ -2171,7 +2171,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - no_legacy_plus_entries_etc_shadow
 
@@ -2180,7 +2180,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - no_legacy_plus_entries_etc_group
 
@@ -2189,7 +2189,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - accounts_no_uid_except_zero
 
@@ -2236,7 +2236,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - no_netrc_files
 
@@ -2254,7 +2254,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - no_rsh_trust_files
 
@@ -2290,7 +2290,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - account_unique_name
 

--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -55,7 +55,7 @@ controls:
   levels:
   - base
   notes: ''
-  automated: yes
+  status: automated
   rules:
     - configure_network_policies
     - configure_network_policies_namespaces
@@ -100,7 +100,7 @@ controls:
   levels:
   - base
   notes: ''
-  automated: yes
+  status: automated
   rules:
     - configure_network_policies
     - configure_network_policies_namespaces

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -440,9 +440,9 @@ can be automated by SCAP and scanning, the status will be `automated`.
 The `status` key is just for informational purposes and does not have any
 impact on the processing.
 
-The `automated` key was avaliable, which defines whether a control can be
-checked for using SCAP atomation. However, the `status` key is preferred as
-it provides more information.
+The  `status` key deprecates the `automated` key -
+`automated: yes` translates to `status: automated`, and so on.
+The `status` key is preferred as it it is capable to reflect the control state more accurately.
 
 When XCCDF rules exist, we will assign them to the controls. We will distinguish
 between XCCDF rules which directly implement the given controls (represented by

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -434,10 +434,15 @@ related to this control.
 * R3 can be automatically scanned by SCAP but unfortunately we don’t have any
 rules implemented yet.
 
-For each control we will add the `automated` key, which describes whether the
-control requirement can be automated by SCAP and scanning. Possible values are:
-`yes`, `no`, `partially`. The `automated` key is just for informational purposes
-and does not have any impact on the processing.
+For each control we will add the `status` key, which describes the current
+implementation status of the control. For instance, if the control requirement
+can be automated by SCAP and scanning, the status will be `automated`.
+The `status` key is just for informational purposes and does not have any
+impact on the processing.
+
+The `automated` key was avaliable, which defines whether a control can be
+checked for using SCAP atomation. However, the `status` key is preferred as
+it provides more information.
 
 When XCCDF rules exist, we will assign them to the controls. We will distinguish
 between XCCDF rules which directly implement the given controls (represented by
@@ -466,7 +471,7 @@ controls:
     description: |-
       Remote user sessions must be closed after a certain
       period of inactivity.
-    automated: yes
+    status: automated
     rules:
     - sshd_set_idle_timeout
     - accounts_tmout
@@ -479,7 +484,7 @@ controls:
     description: |-
       The features configured at the level of launched services
       should be limited to the strict minimum.
-    automated: no
+    status: supported
     note: |-
       This is individual depending on the system workload
       therefore needs to be audited manually.
@@ -490,7 +495,7 @@ controls:
     description: |-
       It is recommended to enable SELinux in enforcing mode
       and to use the targeted policy.
-    automated: yes
+    status: automated
 ```
 
 Notice that each section identifier is a reference in the standard's benchmark.
@@ -585,6 +590,9 @@ The `status` key may hold the following values:
 * `automated`: The control is addressed by the product and can be automatically
                checked for.
 
+Note that if the `status` key is missing from a control definition, the default
+status will be `pending`.
+
 When there is work on-going to address a specific control, it may be portrayed
 via the `tickets` key. The aforementioned key shall contain a list of URLs that
 may help the reader track what work needs to be done to address a specific
@@ -663,7 +671,7 @@ controls:
     description: >-
       Remote user sessions must be closed after a certain
       period of inactivity.
-    automated: yes
+    status: automated
     rules:
     - sshd_set_idle_timeout
     - accounts_tmout
@@ -676,7 +684,7 @@ controls:
     description: >-
       The features configured at the level of launched services
       should be limited to the strict minimum.
-    automated: no
+    status: supported
     note: >-
       This is individual depending on the system workload
       therefore needs to be audited manually.
@@ -687,7 +695,7 @@ controls:
     description: >-
       It is recommended to enable SELinux in enforcing mode
       and to use the targeted policy.
-    automated: yes
+    status: automated
     rules:
       - selinux_state
   - id: R4
@@ -698,14 +706,14 @@ controls:
     controls:
       - id: R4.a
         title: Disable administrator accounts
-        automated: yes
+        status: automated
         levels:
         - low
         rules:
           -  accounts_passwords_pam_faillock_deny_root
       - id: R4.b
         title: Enforce password quality standards
-        automated: yes
+        status: automated
         levels:
         - high
         rules:

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -11,6 +11,49 @@ import ssg.utils
 from ssg.rules import get_rule_path_by_id
 
 
+class InvalidStatus(Exception):
+    pass
+
+class Status():
+    def __init__(self, status):
+        self.status = status
+
+    @classmethod
+    def from_control_info(cls, ctrl, status):
+        if status is None:
+            return "pending"
+
+        valid_statuses = [
+            "pending",
+            "not applicable",
+            "inherently met",
+            "documentation",
+            "planned",
+            "partial",
+            "supported",
+            "automated",
+        ]
+
+        if status not in valid_statuses:
+            raise InvalidStatus(
+                    "The given status '{given}' in the control '{control}' "
+                    "was invalid. Please use one of "
+                    "the following: {valid}".format(given=status,
+                                                    control=ctrl,
+                                                    valid=valid_statuses))
+        return status
+
+    def __str__(self):
+        return self.status
+
+    def __eq__(self, other):
+        if isinstance(other, Status):
+            return self.status == other.status
+        elif isinstance(other, str):
+            return self.status == other
+        return False
+
+
 class Control():
     def __init__(self):
         self.id = None
@@ -21,6 +64,7 @@ class Control():
         self.title = ""
         self.description = ""
         self.automated = ""
+        self.status = None
 
     @classmethod
     def from_control_dict(cls, control_dict, env_yaml=None, default_level=["default"]):
@@ -28,7 +72,10 @@ class Control():
         control.id = ssg.utils.required_key(control_dict, "id")
         control.title = control_dict.get("title")
         control.description = control_dict.get("description")
+        control.status = Status.from_control_info(control.id, control_dict.get("status", None))
         control.automated = control_dict.get("automated", "yes")
+        if control.status == "automated":
+            control.automated = "yes"
         if control.automated not in ["yes", "no", "partially"]:
             msg = (
                 "Invalid value '%s' of automated key in control "

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -73,7 +73,7 @@ class Control():
         control.title = control_dict.get("title")
         control.description = control_dict.get("description")
         control.status = Status.from_control_info(control.id, control_dict.get("status", None))
-        control.automated = control_dict.get("automated", "yes")
+        control.automated = control_dict.get("automated", "no")
         if control.status == "automated":
             control.automated = "yes"
         if control.automated not in ["yes", "no", "partially"]:


### PR DESCRIPTION
This implements parsing the status key in **ssg/controls.py**, making
the `status` key take precedence ver the `automated` key. The
documentation was updated to reflect this preference.

The `automated` key was also replaced in several profiles to favor the `status`
key instead. Note that only `yes` and `partially` instances were replaced, as
`no` needs to be verified manually.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>