### PR TITLE
Fix test scenarios which should remove libselinux package

### DIFF
--- a/linux_os/guide/system/selinux/package_libselinux_installed/tests/package-installed-removed.fail.sh
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/tests/package-installed-removed.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# Package libselinux cannot be uninstalled normally
+# as it would cause removal of sudo package which is
+# protected and package manager returns error in such
+# case. If the package would be removed forcefully it
+# would make the system unusable. Therefore, we will
+# remove the existing rpmdb and we will create a fake
+# empty one without libselinux package.
+rm -rf /var/lib/rpm/*
+rpm --initdb
+if grep -q "rhel" /etc/os-release; then
+    yum install -y redhat-release
+else
+    dnf install -y fedora-release
+fi

--- a/linux_os/guide/system/selinux/package_libselinux_installed/tests/package-removed.fail.sh
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/tests/package-removed.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# Package libselinux cannot be uninstalled normally
+# as it would cause removal of sudo package which is
+# protected and package manager returns error in such
+# case. If the package would be removed forcefully it
+# would make the system unusable. Therefore, we will
+# remove the existing rpmdb and we will create a fake
+# empty one without libselinux package.
+rm -rf /var/lib/rpm/*
+rpm --initdb
+if grep -q "rhel" /etc/os-release; then
+    yum install -y redhat-release
+else
+    dnf install -y fedora-release
+fi


### PR DESCRIPTION
Templated test scenarios cannot be used in this case.
Package libselinux cannot be uninstalled normally
as it would cause removal of `sudo` package which is
protected and package manager returns error in such
case. If the package would be removed forcefully it
would make the system unusable. Therefore, we will
remove the existing rpmdb and we will create a fake
empty one without libselinux package.
