### PR TITLE
Add bash remediation for sle15

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol,multi_platform_sle
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("var_time_service_set_maxpoll") }}}
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("login_banner_text") }}}
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 AUTH_FILES[0]="/etc/pam.d/system-auth"
 AUTH_FILES[1]="/etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 
 {{{ bash_replace_or_append('/etc/systemd/system.conf', '^CtrlAltDelBurstAction=', 'none', '@CCENUM@', '%s=%s') }}}

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_sle
 {{% if init_system == "systemd" -%}}
 systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_sle
 
 # Install required packages
 if ! rpm --quiet -q pam_pkcs11; then yum -y -d 1 install pam_pkcs11; fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/system-auth
 sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol,multi_platform_sle
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_rhel,multi_platform_sle
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/sudoers", "wa", "actions") }}}

--- a/linux_os/guide/system/logging/ensure_rtc_utc_configuration/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rtc_utc_configuration/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ubuntu
+# platform = multi_platform_ubuntu,multi_platform_sle
 
 if timedatectl status | grep -i "time zone" | grep -iv 'UTC\|GMT'; then
     timedatectl set-timezone UTC

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_sle
 # Include source function library.
 . /usr/share/scap-security-guide/remediation_functions
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle
 DIRS="/bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -exec chmod go-w '{}' \;

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_sle
 
 {{{ bash_package_install("aide") }}}
 

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 if grep --silent ^clean_requirements_on_remove /etc/yum.conf ; then
         sed -i "s/^clean_requirements_on_remove.*/clean_requirements_on_remove=1/g" /etc/yum.conf

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = unknown
 # complexity = low


### PR DESCRIPTION
#### Description:
- Adding bash remediation for:
- accounts_umask_etc_login_defs
- aide_periodic_cron_checking
- audit_rules_suid_privilege_function
- audit_rules_sysadmin_actions
- banner_etc_issue
- chronyd_or_ntpd_set_maxpoll
- clean_components_post_updating
- dconf_gnome_screensaver_idle_delay
- dconf_gnome_screensaver_lock_enabled
- disable_ctrlaltdel_burstaction
- disable_ctrlaltdel_reboot
- ensure_gpgcheck_globally_activated
- ensure_rtc_utc_configuration
- file_permissions_binary_dirs
- no_empty_passwords
- rsyslog_remote_loghost
- security_patches_up_to_date
- set_password_hashing_algorithm_logindefs
- set_password_hashing_algorithm_systemauth
- smartcard_configure_cert_checking
- sshd_disable_compression
- sssd_memcache_timeout

#### Rationale:


