### PR TITLE
OCP4: Update OpenShift CIS Benchmark version

### DIFF
--- a/products/ocp4/profiles/cis-node.profile
+++ b/products/ocp4/profiles/cis-node.profile
@@ -12,7 +12,7 @@ metadata:
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V0.3, currently unreleased.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V1.1.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -12,7 +12,7 @@ metadata:
 
 description: |-
     This profile defines a baseline that aligns to the Center for Internet Security®
-    Red Hat OpenShift Container Platform 4 Benchmark™, V0.3, currently unreleased.
+    Red Hat OpenShift Container Platform 4 Benchmark™, V1.1.
 
     This profile includes Center for Internet Security®
     Red Hat OpenShift Container Platform 4 CIS Benchmarks™ content.


### PR DESCRIPTION
The official benchmark has been released and so we can now refer to the
version we're using.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>