### PR TITLE
Enable bash remediation of audit_rules_dac_modification for SLE

### DIFF
--- a/shared/templates/audit_rules_dac_modification/bash.template
+++ b/shared/templates/audit_rules_dac_modification/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system


### PR DESCRIPTION

#### Description:

- Enable bash remediation support of audit_rules_dac_modification rules for SLE platforms

#### Rationale:

- Enable all SLE platforms support for bash remediations in audit_rules_dac_modification template
