### PR TITLE
Enable bash remediation of audit_rules_privileged_commands for SLE

### DIFF
--- a/shared/templates/audit_rules_privileged_commands/bash.template
+++ b/shared/templates/audit_rules_privileged_commands/bash.template
@@ -1,7 +1,7 @@
 {{%- if product in ["rhel8", "rhel9", "sle12", "sle15"] %}}
   {{%- set perm_x=" -F perm=x" %}}
 {{%- endif %}}
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 ACTION_ARCH_FILTERS="-a always,exit"
 OTHER_FILTERS="-F path={{{ PATH }}}{{{ perm_x }}}"


### PR DESCRIPTION
#### Description:

- Enable bash remediation support of audit_rules_privileged_commands rules for SLE platforms

#### Rationale:

- Enable all SLE platforms support for bash remediation in audit_rules_privileged_commands template