### PR TITLE
Fix test scenarios which should remove sudo package

### DIFF
--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/package-installed-removed.fail.sh
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/package-installed-removed.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# sudo is a special package which cannot be normally
+# removed so we need to remove it using rpm and without
+# removing other dependencies.
+rpm -e --nodeps sudo

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/tests/package-removed.fail.sh
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/tests/package-removed.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# sudo is a special package which cannot be normally
+# removed so we need to remove it using rpm and without
+# removing other dependencies.
+rpm -e --nodeps sudo


### PR DESCRIPTION
Templated test scenarios cannot be used in this case.
`sudo` is a special package which cannot be normally
removed so we need to remove it using rpm and without
removing other dependencies.