### PR TITLE
Option --no-reports for SSGTS rule and combined modes

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -107,6 +107,7 @@ def perform_combined_check(options):
     checker.benchmark_id = options.benchmark_id
     checker.remediate_using = options.remediate_using
     checker.dont_clean = options.dont_clean
+    checker.no_reports = options.no_reports
     # No debug option is provided for combined mode
     checker.manual_debug = False
     checker.benchmark_cpes = options.benchmark_cpes

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -266,6 +266,7 @@ class GenericRunner(object):
         self.stage = 'undefined'
 
         self.clean_files = False
+        self.create_reports = True
         self.manual_debug = False
         self._filenames_to_clean_afterwards = set()
 
@@ -392,7 +393,8 @@ class GenericRunner(object):
         raise NotImplementedError()
 
     def initial(self):
-        self.command_options += ['--results', self.results_path]
+        if self.create_reports:
+            self.command_options += ['--results', self.results_path]
         result = self.make_oscap_call()
         return result
 
@@ -400,7 +402,8 @@ class GenericRunner(object):
         raise NotImplementedError()
 
     def final(self):
-        self.command_options += ['--results', self.results_path]
+        if self.create_reports:
+            self.command_options += ['--results', self.results_path]
         result = self.make_oscap_call()
         return result
 
@@ -461,7 +464,7 @@ class ProfileRunner(GenericRunner):
 class RuleRunner(GenericRunner):
     def __init__(
             self, environment, profile, datastream, benchmark_id,
-            rule_id, script_name, dont_clean, manual_debug):
+            rule_id, script_name, dont_clean, no_reports, manual_debug):
         super(RuleRunner, self).__init__(
             environment, profile, datastream, benchmark_id,
         )
@@ -470,6 +473,7 @@ class RuleRunner(GenericRunner):
         self.context = None
         self.script_name = script_name
         self.clean_files = not dont_clean
+        self.create_reports = not no_reports
         self.manual_debug = manual_debug
 
         self._oscap_output = ''
@@ -489,7 +493,8 @@ class RuleRunner(GenericRunner):
 
     def make_oscap_call(self):
         self.prepare_online_scanning_arguments()
-        self._generate_report_file()
+        if self.create_reports:
+            self._generate_report_file()
         self.command_options.extend(
             ['--rule', self.rule_id])
         returncode, self._oscap_output = self.environment.scan(

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -143,7 +143,7 @@ class RuleChecker(oscap.Checker):
         runner_cls = oscap.REMEDIATION_RULE_RUNNERS[self.remediate_using]
         runner = runner_cls(
             self.test_env, oscap.process_profile_id(profile), self.datastream, self.benchmark_id,
-            rule_id, scenario.script, self.dont_clean, self.manual_debug)
+            rule_id, scenario.script, self.dont_clean, self.no_reports, self.manual_debug)
         initial_scan_res = self._initial_scan_went_ok(runner, rule_id, scenario.context)
         if not initial_scan_res:
             return False
@@ -452,6 +452,7 @@ def perform_rule_check(options):
     checker.benchmark_id = options.benchmark_id
     checker.remediate_using = options.remediate_using
     checker.dont_clean = options.dont_clean
+    checker.no_reports = options.no_reports
     checker.manual_debug = options.manual_debug
     checker.benchmark_cpes = options.benchmark_cpes
     checker.scenarios_regex = options.scenarios_regex

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -179,6 +179,10 @@ def parse_args():
                              dest="dont_clean",
                              action="store_true",
                              help="Do not remove html reports of successful runs")
+    parser_rule.add_argument("--no-reports",
+                             dest="no_reports",
+                             action="store_true",
+                             help="Do not run oscap with --report and --results options")
     parser_rule.add_argument("--scenarios",
                              dest="scenarios_regex",
                              default=None,
@@ -199,6 +203,10 @@ def parse_args():
                                  dest="dont_clean",
                                  action="store_true",
                                  help="Do not remove html reports of successful runs")
+    parser_combined.add_argument("--no-reports",
+                                 dest="no_reports",
+                                 action="store_true",
+                                 help="Do not run oscap with --report and --results options")
     parser_combined.add_argument("--scenarios",
                                  dest="scenarios_regex",
                                  default=None,


### PR DESCRIPTION
#### Description:
New `--no-reports` option turns off generating openscap HTML and XML reports (`--report` and `--results` options).

Default behavior remains the same - SSGTS will generate for reports for each test scenario for each rule. With the option, no such report is generated.

#### Rationale:
SSGTS in rule mode and in combined mode consumes a lot of time just with generating reports for each test scenario. The new option optimizes run length when reports are not essential.

```
[mlysonek@localhost content]$ time python3 tests/test_suite.py rule --libvirt qemu:///system test-suite-rhel8 --datast
ream build/ssg-rhel8-ds.xml mount_option_var_tmp_noexec
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/mlysonek/SCAP/content/logs/rule-custom-2021-09-09-1238/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_mount_option_var_tmp_noexec
INFO - Script fstab.fail.sh using profile (all) OK
INFO - Script runtime.pass.sh using profile (all) OK
INFO - Script separate.fail.sh using profile (all) OK

real    2m8.072s
user    0m22.150s
sys     0m1.485s
[mlysonek@localhost content]$ 
[mlysonek@localhost content]$ time python3 tests/test_suite.py rule --no-reports --libvirt qemu:///system test-suite-r
hel8 --datastream build/ssg-rhel8-ds.xml mount_option_var_tmp_noexec
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/mlysonek/SCAP/content/logs/rule-custom-2021-09-09-1240/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_mount_option_var_tmp_noexec
INFO - Script fstab.fail.sh using profile (all) OK
INFO - Script runtime.pass.sh using profile (all) OK
INFO - Script separate.fail.sh using profile (all) OK

real    1m6.063s
user    0m22.960s
sys     0m1.484s
```

In profile mode, such option is not needed because the reports are created only 3 times (initial scan, remediate scan - `--results` is not created in this phase, final scan) and compared to rule/combined mode it's negligible time.