### PR TITLE
Fix function call introduced by PR #7488

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
@@ -2,4 +2,4 @@
 . /usr/share/scap-security-guide/remediation_functions
 {{{ bash_instantiate_variables("var_password_pam_unix_remember") }}}
 
-ensure_pam_module_options '/etc/pam.d/common-password' 'password' '[success=1 default=ignore]' 'pam_unix.so' 'obsecure sha512 shadow remember' $var_password_pam_unix_remember $var_password_pam_unix_remember
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-password', 'password', '[success=1 default=ignore]', 'pam_unix.so', 'obsecure sha512 shadow remember', "$var_password_pam_unix_remember", "$var_password_pam_unix_remember") }}}


### PR DESCRIPTION
#### Description:

- With the change from bash function to macro function the remediation of accounts_password_pam_unix_remember were broken for Ubuntu.