### PR TITLE
Allows logging stderr for remote commands in ssg_test_suite

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -227,13 +227,15 @@ def run_with_stdout_logging(command, args, log_file):
     log_file.write("{0} {1}\n".format(command, " ".join(args)))
     result = subprocess.run(
             (command,) + args, encoding="utf-8", stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, check=True)
+            stderr=subprocess.PIPE, check=False)
     if result.stdout:
         log_file.write("STDOUT: ")
         log_file.write(result.stdout)
     if result.stderr:
         log_file.write("STDERR: ")
         log_file.write(result.stderr)
+    if result.returncode:
+        raise RuntimeError("'%s' command returned non-zero." % command)
     return result.stdout
 
 


### PR DESCRIPTION
#### Description:

To prepare a container or a VM for ssg_test_suite remote commands are executed via ssh. Since they are actually executed remotely, in case of an error in the remote host or container, the information in the logfiles is very limited, making troubleshooting harder.

Here is a clear example, where we can see that the ssh command failed, but we have no clue about the failure cause without manual investigation:
https://github.com/ComplianceAsCode/content/pull/7514/checks?check_run_id=3544704088 (logs found in Artifacts)

We can't see detailed output because we are calling the `subprocess.run` function and its `check` parameter as `True`.
It means that if the command returns non-zero inside this subprocess function, it will raise an exception there, outside ssg_test_suite logic and consequently skipping to log the exception on ssg_test_suite logs.

In this PR I changed the `subprocess.run` function parameter `check` to `False` and treated the exception inside the ssg_test_suite to make sure we have the most valuable information for troubleshooting.

#### Rationale:

This simple update doesn't bring impacts in performance or the relevant logic of ssg_test_suites. Instead, it allows us to save a lot of time with troubleshooting for cases like this mentioned in the description or any other which may appear in the future.
