### PR TITLE
Make accounts_password_pam_retry work in Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/commented.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '# enforcing = 1' > /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'enforcing = 1' > /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/tests/wrong_value.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'enforcing = 0' > /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/ubuntu.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+. /usr/share/scap-security-guide/remediation_functions
+{{{ bash_instantiate_variables("var_password_pam_retry") }}}
+
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-password', 'password', 'requisite', 'pam_pwquality.so', 'retry', "$var_password_pam_retry", "$var_password_pam_retry") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -2,7 +2,11 @@
   <definition class="compliance" id="accounts_password_pam_retry" version="1">
     {{{ oval_metadata("The password retry should meet minimum requirements") }}}
     <criteria operator="AND" comment="Conditions for retry are satisfied">
+      {{% if 'ubuntu' not in product %}}
       <criterion comment="pam_pwquality system-auth" test_ref="test_password_pam_pwquality_retry_system_auth" />
+      {{% else %}}
+      <criterion comment="pam_pwquality common-password" test_ref="test_password_pam_pwquality_retry_common_password" />
+      {{% endif %}}
       {{% if product == "rhel8" -%}}
       <criterion comment="pam_pwquality password-auth" test_ref="test_password_pam_pwquality_retry_password_auth" />
       {{%- endif %}}
@@ -17,7 +21,11 @@
   </ind:textfilecontent54_test>
   {{% endmacro %}}
 
+  {{% if 'ubuntu' not in product %}}
   {{{ test_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_system_auth") }}}
+  {{% else %}}
+  {{{ test_pwquality_retry( path="/etc/pam.d/common-password", test_ref="password_pam_pwquality_retry_common_password") }}}
+  {{% endif %}}
   {{% if product == "rhel8" -%}}
   {{{ test_pwquality_retry( path="/etc/pam.d/password-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
   {{%- endif %}}
@@ -30,7 +38,11 @@
   </ind:textfilecontent54_object>
   {{% endmacro %}}
 
+  {{% if 'ubuntu' not in product %}}
   {{{ object_pwquality_retry( path="/etc/pam.d/system-auth", test_ref="password_pam_pwquality_retry_system_auth") }}}
+  {{% else %}}
+  {{{ object_pwquality_retry( path="/etc/pam.d/common-password", test_ref="password_pam_pwquality_retry_common_password") }}}
+  {{% endif %}}
   {{% if product == "rhel8" -%}}
   {{{ object_pwquality_retry( path="/etc/pam.d/password-auth", test_ref="password_pam_pwquality_retry_password_auth") }}}
   {{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -7,8 +7,12 @@ title: 'Ensure PAM Enforces Password Requirements - Authentication Retry Prompts
 description: |-
     To configure the number of retry prompts that are permitted per-session:
     Edit the <tt>pam_pwquality.so</tt> statement in
+    {{% if 'ubuntu' not in product %}}
     <tt>/etc/pam.d/system-auth</tt> {{% if product == "rhel8" %}} and
     <tt>/etc/pam.d/password-auth</tt> {{% endif %}} to show
+    {{% else %}}
+    <tt>/etc/pam.d/common-password</tt> to show
+    {{% endif %}}
     <tt>retry={{{xccdf_value("var_password_pam_retry") }}}</tt>, or a lower value if site
     policy is more restrictive. The DoD requirement is a maximum of 3 prompts
     per session.
@@ -50,7 +54,11 @@ ocil_clause: 'it is not the required value'
 
 ocil: |-
     To check how many retry attempts are permitted on a per-session basis, run the following command:
+    {{% if 'ubuntu' in product %}}
+    <pre>$ grep pam_pwquality /etc/pam.d/common-password</pre>
+    {{% else %}}
     <pre>$ grep pam_pwquality /etc/pam.d/system-auth {{% if product == "rhel8" %}}/etc/pam.d/password-auth{{% endif %}}</pre>
+    {{% endif %}}
     The <tt>retry</tt> parameter will indicate how many attempts are permitted.
     The DoD required value is less than or equal to 3.
     This would appear as <tt>retry=3</tt>, or a lower value.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/argument_missing.fail.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux,multi_platform_ubuntu
 
+{{% if 'ubuntu' not in product %}}
 config_file="/etc/pam.d/system-auth"
+{{% else %}}
+config_file="/etc/pam.d/common-password"
+{{% endif %}}
 
 if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
 	sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*//" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux,multi_platform_ubuntu
 
 retry_cnt=3
+{{% if 'ubuntu' not in product %}}
 config_file="/etc/pam.d/system-auth"
+{{% else %}}
+config_file="/etc/pam.d/common-password"
+echo "password requisite pam_pwquality.so" > $config_file
+{{% endif %}}
 
 if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
 	sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*/\1$retry_cnt/" $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux,multi_platform_ubuntu
 
 retry_cnt=7
+{{% if 'ubuntu' not in product %}}
 config_file="/etc/pam.d/system-auth"
+{{% else %}}
+config_file="/etc/pam.d/common-password"
+{{% endif %}}
 
 if grep -q "pam_pwquality\.so.*retry=" "$config_file" ; then
 	sed -i --follow-symlinks "/pam_pwquality\.so/ s/\(retry *= *\).*/\1$retry_cnt/" $config_file


### PR DESCRIPTION
#### Description:

- Adapt rule description
- Alter oval for Ubuntu
- Add Ubuntu specific bash
- Make tests platform generic
- Add tests for accounts_password_pam_enforcing