### PR TITLE
ssg/build_yaml.py: Remove unused import

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -17,7 +17,6 @@ from .build_cpe import CPEDoesNotExist
 from .constants import XCCDF_REFINABLE_PROPERTIES, SCE_SYSTEM
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 from .rule_yaml import parse_prodtype
-from .controls import Control
 
 from .cce import is_cce_format_valid, is_cce_value_valid
 from .yaml import DocumentationNotComplete, open_and_expand, open_and_macro_expand


### PR DESCRIPTION
when trying to use ssg.controls from another script, the fact that
build_yaml.py imported the `Controls` object resulted in a circular
dependency error. It turns out that the import wasn't actually being
used, so let's remove it.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>