### PR TITLE
Add script to get statistics out of a control file

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -813,8 +813,10 @@ the resulting SCAP source data stream.
 
 ### Presentation of data
 
-Apart to the build system, the controls files can be also processed by the
-`render-policy.py` utility. It creates a HTML file where the controls are
+Apart to the build system, the controls files can be also processed by
+different utilities.
+
+The `render-policy.py` utility creates a HTML file where the controls are
 resolved in the context of a given product. The file contains links to rule
 definitions in the upstream repository. The generated file can be distributed to
 subject matter experts for a review.
@@ -824,3 +826,14 @@ $ utils/render-policy.py --output doc.html rhel8 controls/abcd.yml
 ```
 
 For more details about the `render_policy.py` tool, run `utils/render-policy.py --help`.
+
+The `controleval.py` utility creates statistics that show the current progress
+in implementing a certain level from the controls file. These are derived from
+the different status options that were documented earlier in this
+documentation.
+
+```
+$ utils/controleval.py stats -i cis_rhel7 -l l2_server
+```
+
+For more details about the `controleval.py` too, run `utils/controleval.py --help`.

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -15,23 +15,32 @@ class InvalidStatus(Exception):
     pass
 
 class Status():
+    PENDING = "pending"
+    PLANNED = "planned"
+    NOT_APPLICABLE = "not applicable"
+    INHERENTLY_MET = "inherently met"
+    DOCUMENTATION = "documentation"
+    PARTIAL = "partial"
+    SUPPORTED = "supported"
+    AUTOMATED = "automated"
+
     def __init__(self, status):
         self.status = status
 
     @classmethod
     def from_control_info(cls, ctrl, status):
         if status is None:
-            return "pending"
+            return cls.PENDING
 
         valid_statuses = [
-            "pending",
-            "not applicable",
-            "inherently met",
-            "documentation",
-            "planned",
-            "partial",
-            "supported",
-            "automated",
+            cls.PENDING,
+            cls.PLANNED,
+            cls.NOT_APPLICABLE,
+            cls.INHERENTLY_MET,
+            cls.DOCUMENTATION,
+            cls.PARTIAL,
+            cls.SUPPORTED,
+            cls.AUTOMATED,
         ]
 
         if status not in valid_statuses:
@@ -65,6 +74,11 @@ class Control():
         self.description = ""
         self.automated = ""
         self.status = None
+
+    def __hash__(self):
+        """ Controls are meant to be unique, so using the
+        ID should suffice"""
+        return hash(self.id)
 
     @classmethod
     def from_control_dict(cls, control_dict, env_yaml=None, default_level=["default"]):

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+import collections
+import argparse
+
+from ssg import controls
+
+
+def print_options(opts):
+    if len(opts) > 0:
+        print("Available options are:\n - " + "\n - ".join(opts))
+    else:
+        print("The controls file is not written appropriately.")
+
+
+def validate_args(ctrlmgr, args):
+    """ Validates that the appropriate args were given
+        and that they're valid entries in the control manager."""
+
+    policy = None
+    try:
+        policy = ctrlmgr._get_policy(args.id)
+    except ValueError as e:
+        print("Error: ", e)
+        print_options(ctrlmgr.policies.keys())
+        exit(1)
+
+    try:
+        policy.get_level_with_ancestors_sequence(args.level)
+    except ValueError as e:
+        print("Error: ", e)
+        print_options(policy.levels_by_id.keys())
+        exit(1)
+
+
+def calculate_stats(ctrls):
+    total = len(ctrls)
+    ctrlstats = collections.defaultdict(int)
+
+    for ctrl in ctrls:
+        ctrlstats[str(ctrl.status)] += 1
+
+    applicable = total - ctrlstats[controls.Status.NOT_APPLICABLE]
+    assessed = ctrlstats[controls.Status.AUTOMATED] + ctrlstats[controls.Status.SUPPORTED] + \
+        ctrlstats[controls.Status.DOCUMENTATION] + ctrlstats[controls.Status.INHERENTLY_MET] + \
+        ctrlstats[controls.Status.PARTIAL]
+
+    print("Total controls = {total}".format(total=total))
+    print_specific_stat("Applicable", applicable, total)
+    print_specific_stat("Assessed", assessed, applicable)
+    print()
+    print_specific_stat("Automated", ctrlstats[controls.Status.AUTOMATED], applicable)
+    print_specific_stat("Supported", ctrlstats[controls.Status.SUPPORTED], applicable)
+    print_specific_stat("Documentation", ctrlstats[controls.Status.DOCUMENTATION], applicable)
+    print_specific_stat("Inherently Met", ctrlstats[controls.Status.INHERENTLY_MET], applicable)
+    print_specific_stat("Partial", ctrlstats[controls.Status.PARTIAL], applicable)
+
+
+def print_specific_stat(stat, current, total):
+    print("{stat} = {percent}% -- {current} / {total}".format(
+        stat=stat,
+        percent=round((current / total) * 100.00, 2),
+        current=current,
+        total=total))
+
+
+def stats(ctrlmgr, args):
+    validate_args(ctrlmgr, args)
+    ctrls = set(ctrlmgr.get_all_controls_of_level(args.id, args.level))
+    calculate_stats(ctrls)
+
+
+subcmds = dict(
+    stats=stats
+)
+
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--controls-dir",
+        help=("Directory that contains control files with policy controls. "
+              "e.g.: ~/scap-security-guide/controls"),
+        default="./controls/",
+    )
+    subparsers = parser.add_subparsers(dest="subcmd", required=True)
+    statsparser = subparsers.add_parser(
+        'stats',
+        help="outputs statistics for the given benchmark and level.")
+    statsparser.add_argument("-i", "--id", dest="id", help="id of the controls file.",
+                             required=True)
+    statsparser.add_argument("-l", "--level", dest="level", help="level to display statistics of.",
+                             required=True)
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+    controls_manager = controls.ControlsManager(args.controls_dir)
+    controls_manager.load()
+    subcmds[args.subcmd](controls_manager, args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is an initial implementation for getting stats out of a control
file. The script will take an id and a level, and output some relevant
numbers out of that. Here's a sample output

```
./utils/controleval.py stats -i cis_rhel7 -l l2_server
Total controls = 248
Applicable = 100.0% -- 248 / 248
Assessed = 68.55% -- 170 / 248

Automated = 60.48% -- 150 / 248
Supported = 0.0% -- 0 / 248
Documentation = 0.0% -- 0 / 248
Inherently Met = 0.0% -- 0 / 248
Partial = 8.06% -- 20 / 248
```

The idea is to give a notion of how far are we into finishing evaluating
a certain benchmark.

More enhancements can be done in the future, such as outputting which
controls are missing or outputting these categories in such a way that
they could be ingested by a UI.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>