### PR TITLE
SLES-15-010460: install_smartcard_packages: SLE15: don't check coolkey package presence

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/ansible/shared.yml
@@ -14,7 +14,9 @@
       - pcsc-lite
       - pcsc-tools
       - opensc
+{{% if product not in ["sle15"] %}}
       - coolkey
+{{% endif %}}
 
 - name: Ensure {{ smartcard_packages }} are installed
   package:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/oval/shared.xml
@@ -1,4 +1,12 @@
+{{% if product in ["sle12"] %}}
 {{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc', 'coolkey'] %}}
+{{% elif product in ["sle15"] %}}
+{{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc'] %}}
+{{% elif product in ["rhel7", "ol7"] %}}
+{{% set smartcard_packages = ['pam_pkcs11'] %}}
+{{% else %}}
+{{% set smartcard_packages = ['openssl-pkcs11'] %}}
+{{% endif %}}
 
 <def-group>
   <definition class="compliance" id="install_smartcard_packages"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -1,5 +1,7 @@
-{{% if product in ["sle12", "sle15"] %}}
+{{% if product in ["sle12"] %}}
 {{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc', 'coolkey'] %}}
+{{% elif product in ["sle15"] %}}
+{{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc'] %}}
 {{% elif product in ["rhel7", "ol7"] %}}
 {{% set smartcard_packages = ['pam_pkcs11'] %}}
 {{% else %}}


### PR DESCRIPTION
The STIG manual is asking for coolkey to be installed but this
package has been moved to the package hub module since SLE15.

The problem are:
- it's not in the default installation media and mirroring it will eat a lot of space,
  so it's possibly not available,
- there's no support for packages in the package hub, so people won't possibly install it.
  ref: https://packagehub.suse.com/support/

Signed-off-by: Arnaud Patard <apatard@hupstream.com>