### PR TITLE
Ubuntu smartcard rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -2,6 +2,8 @@
 {{% set smartcard_packages = ['pam_pkcs11', 'mozilla-nss', 'mozilla-nss-tools', 'pcsc-ccid', 'pcsc-lite', 'pcsc-tools', 'opensc', 'coolkey'] %}}
 {{% elif product in ["rhel7", "ol7"] %}}
 {{% set smartcard_packages = ['pam_pkcs11'] %}}
+{{% elif 'ubuntu' in product %}}
+{{% set smartcard_packages = ['libpam-pkcs11'] %}}
 {{% else %}}
 {{% set smartcard_packages = ['openssl-pkcs11'] %}}
 {{% endif %}}
@@ -65,4 +67,7 @@ template:
         pkgname: openssl-pkcs11
         pkgname@rhel7: pam_pkcs11
         pkgname@ol7: pam_pkcs11
+        pkgname@ubuntu1604: libpam-pkcs11
+        pkgname@ubuntu1804: libpam-pkcs11
+        pkgname@ubuntu2004: libpam-pkcs11
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/bash/ubuntu.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+if grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep ca; then
+    sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/bash/ubuntu.sh
@@ -4,6 +4,6 @@ if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
-if grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep ca; then
-    sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf
+if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "ca"; then
+    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on;/" /etc/pam_pkcs11/pam_pkcs11.conf
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/tests/commented.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+sed -i "/^\s*#/! s/cert_policy.*/# cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/tests/correct.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "ca"; then
+    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on;/" /etc/pam_pkcs11/pam_pkcs11.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/tests/missing_ca.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/tests/missing_ca.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+sed -i "/^\s*#/! s/cert_policy.*/cert_policy = signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
@@ -4,6 +4,6 @@ if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
-if grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep -qv ocsp_on; then
-    sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf
+if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "oscp_on"; then
+    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on;/" /etc/pam_pkcs11/pam_pkcs11.conf
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/ubuntu.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+if grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep -qv ocsp_on; then
+    sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/commented.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+sed -i "/^\s*#/! s/cert_policy.*/# cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/correct.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "oscp_on"; then
+    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on;/" /etc/pam_pkcs11/pam_pkcs11.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/missing_ocsp.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/missing_ocsp.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/bash/ubuntu.sh
@@ -4,6 +4,6 @@ if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
 fi
 
-if grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep -Eqv 'crl_auto|crl_offline'; then
-    sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on,crl_auto;/g" /etc/pam_pkcs11/pam_pkcs11.conf
+if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -Eqv 'crl_auto|crl_offline'; then
+    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on,crl_auto;/" /etc/pam_pkcs11/pam_pkcs11.conf
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/bash/ubuntu.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ubuntu
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+if grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep -Eqv 'crl_auto|crl_offline'; then
+    sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on,crl_auto;/g" /etc/pam_pkcs11/pam_pkcs11.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="smartcard_configure_crl" version="1">
+    {{{ oval_metadata("Enable local cache of revocation data for PKI-based authentication") }}}
+    <criteria comment="smart card local cache of revocation date is configured" operator="AND">
+      <extend_definition comment="smartcard package is installed" definition_ref="install_smartcard_packages" />
+      <criterion comment="cert_policy directive contains crl_auto or crl_offline" test_ref="test_pam_pkcs11_cert_policy_crl" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_pam_pkcs11_cert_policy_crl" check="all" check_existence="all_exist"
+  comment="Test crl in /etc/pam_pkcs11/pkcs11.conf" version="1">
+    <ind:object object_ref="object_pam_pkcs11_cert_policy_crl" />
+    <ind:state state_ref="state_pam_pkcs11_cert_policy_crl" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_pam_pkcs11_cert_policy_crl" version="1">
+    <ind:filepath>/etc/pam_pkcs11/pam_pkcs11.conf</ind:filepath>
+    <!-- PKCS #11 module can be either CoolKey or OpenSC. Check cert_policy for all of them. -->
+    <ind:pattern operation="pattern match">^[\s]*cert_policy[ ]=\s*(.*);$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_pam_pkcs11_cert_policy_crl" version="1">
+    <ind:subexpression operation="pattern match">(^|,\s*)(crl_auto|crl_offline)(\s*,|$)</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Configure Smart Card Local Cache of Revocation Data'
+
+description: |-
+    Configure the operating system for PKI-based authentication to use
+    local revocation data when unable to access the network to obtain it
+    remotely. Modify all of the <tt>cert_policy</tt> lines in
+    <tt>/etc/pam_pkcs11/pam_pkcs11.conf</tt> to include <tt>crl_auto</tt>
+    or <tt>crl_offline</tt> like so:
+    <pre>cert_policy = ca,signature,ocsp_on,crl_auto;</pre>
+
+rationale: |-
+     Without configuring a local cache of revocation data, there is the
+     potential to allow access to users who are no longer authorized
+     (users with revoked certificates).
+
+severity: medium
+
+references:
+    disa: CCI-001991
+    srg: SRG-OS-000384-GPOS-00167
+    stigid@ubuntu2004: UBTU-20-010066
+
+ocil_clause: 'crl_auto or crl_offline is not configured'
+
+ocil: |-
+    To verify the operating system implements local cache of revocation
+    data for PKI authentication, run the following command:
+    <pre>sudo grep cert_policy /etc/pam_pkcs11/pam_pkcs11.conf | grep -E -- 'crl_auto|crl_offline'</pre>
+    The output should return multiple lines similar to the following:
+    <pre>cert_policy = ca,signature,ocsp_on,crl_auto;</pre>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/tests/commented.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+sed -i "/^\s*#/! s/cert_policy.*/# cert_policy = ca,signature,ocsp_on,crl_auto;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/tests/correct.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+if grep -v "^\s*\#+cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -Eqv "crl_auto|crl_offline" ; then
+    sed -i "s/\(^[[:blank:]]*\)\(\(\#*[[:blank:]]*cert_policy[[:blank:]]*=[[:blank:]]*.*;\)[^ $]*\)/\1cert_policy = ca,signature,ocsp_on,crl_auto;/" /etc/pam_pkcs11/pam_pkcs11.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/tests/missing_crl.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/tests/missing_crl.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platfrom = multi_platfrom_ubuntu
+# packages = libpam-pkcs11
+
+if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
+    cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf
+fi
+
+sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca,signature,ocsp_on;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/ubuntu.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/oval/ubuntu.xml
@@ -1,0 +1,23 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="smartcard_pam_enabled" version="3">
+   {{{ oval_metadata("Enable Smart Card logins using PAM") }}}
+
+    <criteria operator="AND" comment="smart card authentication is configured">
+      <extend_definition comment="packages needed for smartcard support are installed" definition_ref="install_smartcard_packages" />
+      <criterion comment="smart card is configured in /etc/pam.d/common-auth" test_ref="test_smart_card_common_auth" />
+    </criteria>
+  </definition>
+
+  <!-- Test the smart card authentication required case (login is allowed only by smartcard) -->
+  <ind:textfilecontent54_test id="test_smart_card_common_auth" check="all" check_existence="all_exist"
+  comment="Test smartcard authentication is required in /etc/pam.d/common-auth file" version="1">
+    <ind:object object_ref="object_smart_card_common_auth" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_smart_card_common_auth" version="1">
+    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">^\s*auth\s+\[.*\]\s+pam_pkcs11.so(?:\s|$)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -19,9 +19,15 @@ description: |-
 
     For general information about enabling smart card authentication, consult
     the documentation at:
+    {{% if 'ubuntu' in product %}}
+    <ul>
+    <li><b>{{{ weblink(link="https://pages.ubuntu.com/rs/066-EOV-335/images/SmartCardLogin_WhitePapaer_04.03.20.pdf") }}}</b></li>
+    </ul>
+    {{% else %}}
     <ul>
     <li><b>{{{ weblink(link="https://www.suse.com/c/configuring-smart-card-authentication-suse-linux-enterprise/") }}}</b></li>
     </ul>
+    {{% endif %}}
 
 rationale: |-
     Smart card login provides two-factor authentication stronger than

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+echo '# auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+echo 'auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/nothing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/nothing.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+echo > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = libpam-pkcs11
+
+echo 'aauth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -135,6 +135,7 @@ selections:
     - smartcard_configure_cert_checking
 
     # UBTU-20-010066 The Ubuntu operating system for PKI-based authentication, must implement a local cache of revocation data in case of the inability to access revocation information via the network.
+    - smartcard_configure_crl
 
     # UBTU-20-010070 The Ubuntu operating system must prohibit password reuse for a minimum of five generations.
     - var_password_pam_unix_remember=5


### PR DESCRIPTION
#### Description:

- This is a long PR that deals with all smartcard related rules in STIG for Ubuntu 20.04
- Fix ubuntu2004 smartcard package
- Add Ubuntu specific bash to smartcard_configure_ca
- Improve ubuntu bash for smartcard_configure_ca
- Add tests to smartcard_configure_ca
- Add ubuntu specific bash for smartcard_configure_cert_checking
- Improve ubuntu bash for smartcard_configure_cert_checking
- Add tests for smartcard_configure_cert_checking
- Add new rule smartcard_configure_crl
- Assign smartcard_configure_crl to UBTU-20-010066
- Add ubuntu bash to smartcard_configure_crl
- Add oval to smartcard_configure_crl
- Improve ubuntu bash for smartcard_configure_crl
- Add tests for smartcard_configure_crl
- Add ubuntu specific oval for smartcard_pam_enabled
- Add ubuntu specific bash for smartcard_pam_enabled
- Add more information for Ubuntu smartcard login setup
- Add tests to smartcard_pam_enabled