### PR TITLE
SLES-15-030360: add missing umount2 checks

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/rule.yml
@@ -34,6 +34,7 @@ references:
     nist@sle12: AU-3,AU-3.1,AU-12.1(ii),AU-12(a),AU-12.1(iv),AU-12(c),MA-4(1)(a)
     srg: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
     stigid@sle12: SLES-12-020300
+    stigid@sle15: SLES-15-030360
 
 {{{ complete_ocil_entry_audit_syscall(syscall="umount2") }}}
 

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -93,6 +93,7 @@ selections:
     - audit_rules_dac_modification_removexattr
     - audit_rules_dac_modification_setxattr
     - audit_rules_dac_modification_umount
+    - audit_rules_dac_modification_umount2
     - audit_rules_enable_syscall_auditing
     - audit_rules_execution_chacl
     - audit_rules_execution_chmod


### PR DESCRIPTION
The pull request #7500 (https://github.com/ComplianceAsCode/content/pull/7500)
has fixed the issue with umount syscall being 32bits only but now the umount2
syscall is not checked any more, so update the profile and add the STIG id
to the check.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>