### PR TITLE
products/sle15/product.yml: Fix grub.cfg path

### DIFF
--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -17,7 +17,7 @@ release_key_fingerprint: "FEAB502539D846DB2C0961CA70AF9E8139DB7C82"
 oval_feed_url: "https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml"
 
 grub2_boot_path: "/boot/grub2"
-grub2_uefi_boot_path: "/boot/efi/EFI/sles"
+grub2_uefi_boot_path: "/boot/grub2"
 aide_bin_path: "/usr/bin/aide"
 
 cpes_root: "../../shared/applicability"


### PR DESCRIPTION
All tools are still using /boot/grub2, even in the UEFI case,
so change the value to match reality.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>