### PR TITLE
SLES-15-030590: products/sle15/profiles/stig.profile: Fix variable value

### DIFF
--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -76,6 +76,7 @@ selections:
     - auditd_audispd_disk_full_action
     - auditd_audispd_encrypt_sent_records
     - auditd_audispd_network_failure_action
+    - var_auditd_disk_full_action=syslog
     - auditd_data_disk_full_action
     - auditd_data_retention_action_mail_acct
     - auditd_data_retention_space_left


### PR DESCRIPTION
SLES-15-030590 is saying that 'syslog' is a valid value but the check is looking for 'single'
which is not even the value shown in the rule (the rule is asking to check for 'syslog' and
ask to set 'halt'. Since the check is talking of 'syslog', this value has been choosen.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>