### PR TITLE
Expand Fedora CPE range to cover currently supported Fedora releases

### DIFF
--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -17,11 +17,20 @@ grub2_uefi_boot_path: "/boot/grub2"
 dconf_gdm_dir: "distro.d"
 
 cpes_root: "../../shared/applicability"
-
 cpes:
-  - fedora:
-      name: "cpe:/o:fedoraproject:fedora:32"
-      title: "Fedora 32"
+  - fedora_35:
+      name: "cpe:/o:fedoraproject:fedora:35"
+      title: "Fedora 35"
+      check_id: installed_OS_is_fedora
+
+  - fedora_34:
+      name: "cpe:/o:fedoraproject:fedora:34"
+      title: "Fedora 34"
+      check_id: installed_OS_is_fedora
+
+  - fedora_33:
+      name: "cpe:/o:fedoraproject:fedora:33"
+      title: "Fedora 33"
       check_id: installed_OS_is_fedora
 
 # The fingerprint and pkg_version are retrieved from https://getfedora.org/keys/

--- a/shared/checks/oval/installed_OS_is_fedora.xml
+++ b/shared/checks/oval/installed_OS_is_fedora.xml
@@ -5,7 +5,9 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:fedoraproject:fedora:28" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:33" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:34" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:35" source="CPE" />
       <description>The operating system installed on the system is Fedora</description>
     </metadata>
     <criteria operator="AND">


### PR DESCRIPTION
#### Description:

This PR expands the range of supported CPEs for Fedora to cover the currently supported Fedora releases (33, 34) and the upcoming release (35) to be released in October.

#### Rationale:

- As discussed in #7490, the content maintained for Fedora should be applicable to all current supported versions of Fedora. Currently the CPE range only targets Fedora 32, which is no longer supported.

- I have checked the `installed_OS_is_fedora.xml` OVAL, and it seems like it should still apply to current versions of Fedora.
Though I'm not sure if this line will have any impact or will need updating:
https://github.com/ComplianceAsCode/content/blob/45848e17ed1503af47204433bec9e0781abeeed5/shared/checks/oval/installed_OS_is_fedora.xml#L8

#### Questions:
- Hopefully I have understood the function of the `check_id` key, as I notice the RHEL content handles this differently (by having a different `check_id` OVAL referenced by each CPE:
**Fedora:**
https://github.com/ComplianceAsCode/content/blob/45848e17ed1503af47204433bec9e0781abeeed5/products/fedora/product.yml#L25
**RHEL:**
https://github.com/ComplianceAsCode/content/blob/9db750d88a1ce626f5a50a6a1b2be8d08ad48c50/products/rhel8/product.yml#L56
Seems like the RHEL one is much more specific for each sub-version of the OS, but I'm not sure if we need that for Fedora.

- Have I missed editing anything elsewhere to bring the Fedora content support up to date? I notice that some of the Fedora Dockerfiles are pretty outdated currently, but I think those are more to do with the CI/CD pipelines than anything to do with the actual Fedora content?
https://github.com/ComplianceAsCode/content/blob/45848e17ed1503af47204433bec9e0781abeeed5/Dockerfiles/fedora_linkchecker#L1
https://github.com/ComplianceAsCode/content/blob/45848e17ed1503af47204433bec9e0781abeeed5/Dockerfiles/fedora_python3#L1