### PR TITLE
SLES-15-010100: Fix check

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/bash/shared.sh
@@ -1,5 +1,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
-
+{{% if product in ['sle12','sle15'] %}}
+gsettings set org.gnome.desktop.lockdown disable-lock-screen false
+{{% else %}}
 {{{ bash_dconf_settings("org/gnome/desktop/screensaver", "lock-enabled", "true", "local.d", "00-security-settings") }}}
 {{{ bash_dconf_lock("org/gnome/desktop/screensaver", "lock-enabled", "local.d", "00-security-settings-lock") }}}
+{{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/oval/shared.xml
@@ -20,7 +20,11 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
+{{% if product in ['sle12','sle15'] %}}
+    <ind:pattern operation="pattern match">^\[org\/gnome\/desktop\/lockdown\]([^\n]*\n+)+?disable-lock-screen=false$</ind:pattern>
+{{% else %}}
     <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver]([^\n]*\n+)+?lock-enabled=true$</ind:pattern>
+{{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -33,7 +37,11 @@
   version="1">
     <ind:path>/etc/dconf/db/local.d/locks/</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
+{{% if product in ['sle12','sle15'] %}}
+    <ind:pattern operation="pattern match">^\/org\/gnome\/desktop\/lockdown\/disable-lock-screen$</ind:pattern>
+{{% else %}}
     <ind:pattern operation="pattern match">^/org/gnome/desktop/screensaver/lock-enabled$</ind:pattern>
+{{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
While the rule correctly states that the dconf key to use on SLES is
/org/gnome/desktop/lockdown, the check is using a different key:
/org/gnome/desktop/screensaver/lock-enabled.
Correct the oval test and bash remediation script to use the proper
commands / dconf path.

Signed-off-by: Arnaud Patard <apatard@hupstream.com>