### PR TITLE
Fix `render-policy.py` to use `products/` directory

### DIFF
--- a/utils/template_renderer.py
+++ b/utils/template_renderer.py
@@ -58,7 +58,7 @@ class Renderer(object):
         self.template_data = dict()
 
     def get_env_yaml(self, build_dir):
-        product_yaml = self.project_directory / self.product / "product.yml"
+        product_yaml = self.project_directory / "products" / self.product / "product.yml"
         build_config_yaml = pathlib.Path(build_dir) / "build_config.yml"
         if not (product_yaml.exists() and build_config_yaml.exists()):
             msg = (


### PR DESCRIPTION
When the `products/` directory was introduced, the change wasn't
reflected in some of the libraries for the utilities in the project. one
example was the `render-policy.py`, for which the underlying library
still looked for products on the top level directory of the repo. This
fixes that, thus fixing the utility.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>