### PR TITLE
Included CPE applicability test for audit rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/group.yml
@@ -38,3 +38,5 @@ description: |-
     After reviewing all the rules, reading the following sections, and
     editing as needed, the new rules can be activated as follows:
     <pre>$ sudo service auditd restart</pre>
+
+platform: audit

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/group.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/group.yml
@@ -35,3 +35,5 @@ description: |-
     <tt>/var/log/audit</tt> is on its own partition, and that this partition is
     larger than the maximum amount of data <tt>auditd</tt> will retain
     normally.</i>
+
+platform: audit

--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -62,6 +62,8 @@ references:
 ocil: |-
     {{{ ocil_service_enabled(service="auditd") }}}
 
+platform: audit
+
 template:
     name: service_enabled
     vars:

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -1,4 +1,9 @@
 cpes:
+  - audit:
+      name: "cpe:/a:audit"
+      title: "Package audit is installed"
+      check_id: installed_env_has_audit_package
+
   - chrony:
       name: "cpe:/a:chrony"
       title: "Package chrony is installed"

--- a/shared/checks/oval/installed_env_has_audit_package.xml
+++ b/shared/checks/oval/installed_env_has_audit_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_audit_package" version="1">
+    <metadata>
+      <title>Package audit is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package audit is installed.</description>
+      <reference ref_id="cpe:/a:audit" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package audit is installed" test_ref="test_env_has_audit_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_audit_installed" version="1"
+  comment="system has package audit installed">
+    <linux:object object_ref="obj_env_has_audit_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_audit_installed" version="1">
+    <linux:name>audit</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_audit_installed" version="1"
+  comment="system has package audit installed">
+    <linux:object object_ref="obj_env_has_audit_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_audit_installed" version="1">
+    <linux:name>auditd</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>


### PR DESCRIPTION
#### Description:

This PR includes a new CPE entry to test if audit package is installed. Then, rules which depends on this package were updated to consider this CPE.

#### Rationale:

Not all systems have audit package installed by default.
