### PR TITLE
Fix set_tests_properties for fix_rules-sort_prodtypes

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,8 +126,8 @@ add_test(
     NAME "fix_rules-sort_prodtypes"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/fix_rules.py" "--dry-run" "--root" "${CMAKE_SOURCE_DIR}" "--json" "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" "sort_prodtypes"
 )
-set_tests_properties("fix_rules-sort_subkeys" PROPERTIES LABELS quick)
-set_tests_properties("fix_rules-sort_subkeys" PROPERTIES DEPENDS "test-rule-dir-json")
+set_tests_properties("fix_rules-sort_prodtypes" PROPERTIES LABELS quick)
+set_tests_properties("fix_rules-sort_prodtypes" PROPERTIES DEPENDS "test-rule-dir-json")
 
 if (PY_YAMLPATH)
     if (PY_PYTEST)


### PR DESCRIPTION
#### Description:

Fix `set_tests_properties` on the `fix_rules-sort_prodtypes` test. In some cases this will fail due to not having `test-rule-dir-json` done first.

#### Rationale:

Fix the test suite on new builds.
