### PR TITLE
Add Fedora Rawhide support

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -5,7 +5,9 @@ dnf install -y gpg
 fedora_version=$(grep -oP '[[:digit:]]+' /etc/redhat-release)
 
 function get_release_fingerprint {
-    if [ "${fedora_version}" -eq "{{{ latest_version }}}" ]; then
+    if [ "${fedora_version}" -eq "{{{ rawhide_version }}}" ]; then
+        readonly FEDORA_RELEASE_FINGERPRINT="{{{ rawhide_release_fingerprint }}}"
+    elif [ "${fedora_version}" -eq "{{{ latest_version }}}" ]; then
         readonly FEDORA_RELEASE_FINGERPRINT="{{{ latest_release_fingerprint }}}"
     elif [ "${fedora_version}" -eq "{{{ previous_version }}}" ]; then
         readonly FEDORA_RELEASE_FINGERPRINT="{{{ previous_release_fingerprint }}}"

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/oval/shared.xml
@@ -24,6 +24,7 @@
     <criteria comment="Fedora Vendor keys" operator="AND">
       <extend_definition comment="Fedora installed" definition_ref="installed_OS_is_fedora" />
       <criteria comment="Supported Fedora key is installed" operator="OR">
+          {{{ fedora_gpgkey_criterion(rawhide_version, rawhide_pkg_release, rawhide_pkg_version) }}}
           {{{ fedora_gpgkey_criterion(future_version, future_pkg_release, future_pkg_version) }}}
           {{{ fedora_gpgkey_criterion(latest_version, latest_pkg_release, latest_pkg_version) }}}
           {{{ fedora_gpgkey_criterion(previous_version, previous_pkg_release, previous_pkg_version) }}}
@@ -37,6 +38,7 @@
   </linux:rpminfo_object>
 
   <!-- Perform the particular tests themselves -->
+  {{{ fedora_gpgkey_check(rawhide_version, rawhide_pkg_release, rawhide_pkg_version) }}}
   {{{ fedora_gpgkey_check(future_version, future_pkg_release, future_pkg_version) }}}
   {{{ fedora_gpgkey_check(latest_version, latest_pkg_release, latest_pkg_version) }}}
   {{{ fedora_gpgkey_check(previous_version, previous_pkg_release, previous_pkg_version) }}}

--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -18,6 +18,11 @@ dconf_gdm_dir: "distro.d"
 
 cpes_root: "../../shared/applicability"
 cpes:
+  - fedora_36:
+      name: "cpe:/o:fedoraproject:fedora:36"
+      title: "Fedora 36"
+      check_id: installed_OS_is_fedora
+
   - fedora_35:
       name: "cpe:/o:fedoraproject:fedora:35"
       title: "Fedora 35"
@@ -33,14 +38,27 @@ cpes:
       title: "Fedora 33"
       check_id: installed_OS_is_fedora
 
-# The fingerprint and pkg_version are retrieved from https://getfedora.org/keys/
+# Retrieve the fingerprint as follows:
+#   gpg --show-keys --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-primary" | grep '^fpr' | cut -d ":" -f 10
+# For current supported releases, this can be verified by comparing it to the keys published on:
+#   https://getfedora.org/keys/
+rawhide_version: 36
+rawhide_release_fingerprint: "53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4"
+# The shortened version of the key, to be used for the pkg_version variable can be derived as follows:
+#   gpg --show-keys --keyid-format short "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-primary" | grep 'rsa' | cut -d "/" -f 2 | awk '{print $1}'
+# Alternatively, you can simply take the last 8 digits of the fingerprint above.
+# For currently supported releases, this can also be verified by comparing it to the keyid values published on:
+#   https://getfedora.org/keys/
+rawhide_pkg_version: "38ab71f4"
+# The pkg_release can be derived as follows:
+#   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-x86_64
+#   rpm -q gpg-pubkey --qf '%{VERSION}-%{RELEASE}\n' | grep -i <pkg_version> | cut -f 2 -d -
+rawhide_pkg_release: "60242b08"
+
 future_version: 35
 future_release_fingerprint: "787EA6AE1147EEE56C40B30CDB4639719867C58F"
 future_pkg_version: "9867c58f"
 future_pkg_release: "601c49ca"
-# Obtain the pkg_release like this:
-# sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-x86_64
-# rpm -q gpg-pubkey --qf '%{VERSION}-%{RELEASE}\n' | grep <pkg_version> | cut -f 2 -d -
 
 latest_version: 34
 latest_release_fingerprint: "8C5BA6990BDB26E19F2A1A801161AE6945719A39"

--- a/shared/checks/oval/installed_OS_is_fedora.xml
+++ b/shared/checks/oval/installed_OS_is_fedora.xml
@@ -8,6 +8,7 @@
       <reference ref_id="cpe:/o:fedoraproject:fedora:33" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:34" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:35" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:36" source="CPE" />
       <description>The operating system installed on the system is Fedora</description>
     </metadata>
     <criteria operator="AND">


### PR DESCRIPTION
#### Description:

- As an extension to #7546, I have noticed that some tweaks are needed to our current approach to Fedora content in order to support Fedora Rawhide.

- This PR also cleans up the comments inside the Fedora product slightly, to make it more clear where to find the GPG keys for releases such as Rawhide, which aren't featured prominently on https://getfedora.org/keys/.

#### Rationale:

- This expands the current CPE range to support Fedora Rawhide, which currently reports as "Fedora 36" by CPE identifier:
```
[root@cd2352e2553b /]# grep CPE_NAME /etc/os-release
CPE_NAME="cpe:/o:fedoraproject:fedora:36"
```
- We do already have variables for referencing a `future_version`, `future_release_fingerprint` etc, and these would apply to Rawhide releases at least some of the time. But as soon as the "next" Fedora release branches off from Rawhide, the Rawhide branch updates its CPE and identifiers to track the next release after that.
- This happened most recently on 2021-08-10, when the upcoming Fedora 35 was branched off Rawhide, and Rawhide started to track Fedora 36. Using the old system of `future_version` and `latest_version`, we wouldn't introduce support for 36 into our `product.yml` until the official Fedora 35 release in late October, where 35 would graduate to `latest_version`, and 36 would move to `future_version`.
- So unless we address Rawhide specifically, then it will work some of the time, except for this awkward 2-3 month period around each mainline Fedora release when the branches don't line up with our supported versions.

- This is fairly low priority since, as I think we noted, there isn't too much demand for Fedora support in CAC, so I'm expecting there to be even less people wanting to run it against Rawhide (let's be honest... it's probably just me, isn't it?). But it would definitely be nice to have so reviews and suggestions are appreciated!