### PR TITLE
Allow specific Jinja processing for test suite

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -519,6 +519,7 @@ zypper install -y "{{{ package }}}"
     Remove a package
 
     Uses the right command based on pkg_manager property defined in product.yml.
+    When used in a test scenario, the macro will remove even protected packages.
 
     :param package: name of the package
     :type package: str
@@ -527,11 +528,11 @@ zypper install -y "{{{ package }}}"
 {{%- if pkg_manager is defined -%}}
 {{%- if pkg_manager == "yum" or pkg_manager == "dnf" -%}}
 if rpm -q --quiet "{{{ package }}}" ; then
-    if grep -q "{{{ package }}}" $(find /etc/dnf/protected.d /etc/yum/protected.d -type f); then
-        {{{ pkg_manager }}} remove -y --setopt protected_packages= "{{{ package }}}"
-    else
-        {{{ pkg_manager }}} remove -y "{{{ package }}}"
-    fi
+{{% if SSG_TEST_SUITE_ENV %}}
+    {{{ pkg_manager }}} remove -y --setopt protected_packages= "{{{ package }}}"
+{{% else %}}
+    {{{ pkg_manager }}} remove -y "{{{ package }}}"
+{{% endif %}}
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
 DEBIAN_FRONTEND=noninteractive apt-get remove -y "{{{ package }}}"

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -527,7 +527,11 @@ zypper install -y "{{{ package }}}"
 {{%- if pkg_manager is defined -%}}
 {{%- if pkg_manager == "yum" or pkg_manager == "dnf" -%}}
 if rpm -q --quiet "{{{ package }}}" ; then
-    {{{ pkg_manager }}} remove -y "{{{ package }}}"
+    if grep -q "{{{ package }}}" $(find /etc/dnf/protected.d /etc/yum/protected.d -type f); then
+        {{{ pkg_manager }}} remove -y --setopt protected_packages= "{{{ package }}}"
+    else
+        {{{ pkg_manager }}} remove -y "{{{ package }}}"
+    fi
 fi
 {{%- elif pkg_manager == "apt_get" -%}}
 DEBIAN_FRONTEND=noninteractive apt-get remove -y "{{{ package }}}"

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -277,6 +277,10 @@ def get_product_context(product=None):
     # property to bypass this error.
     product_yaml['cmake_build_type'] = 'Debug'
 
+    # Set the Jinja processing environment to Test Suite,
+    # this allows Jinja macros to behave differently in a content build time and in a test time.
+    product_yaml['SSG_TEST_SUITE_ENV'] = True
+
     return product_yaml
 
 


### PR DESCRIPTION
#### Description:

There are some specific cases where a protected package should be removed, mostly for testing purposes, but this doesn't work with traditional ways, as expected.

A good example is the `sudo` package, where more details were discussed in this PR:
https://github.com/ComplianceAsCode/content/pull/7519

For treating this situation of protected packages, it was necessary to create rule specific test scenarios to override the templated ones. Although this approach works, it is reactive and demand manual analysis.

#### Rationale:

Since we can previously know which packages are protected in a system which use YUM or DNF, the approach suggested in this PR treats this exception directly on `bash-macros.jinja`. The main advantage of this is that test scenarios don't need any change. Even if the list of protected packages in a system changes, this will be automatically and properly treated in the same standard.

This macro can be easily updated for similar exceptions in other distros.
