### PR TITLE
OCP4: Add platform to rules that need it

### DIFF
--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Disable Anonymous Authentication to the Kubelet'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure authorization is set to Webhook'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Configure the Client CA Certificate'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Kubelet - Ensure Event Creation Is Configured'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers"
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Enable Certificate Rotation'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Enable Client Certificate Rotation'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Allow Automatic Firewall Configuration'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Enable Protect Kernel Defaults'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Enable Server Certificate Rotation'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'kubelet - Do Not Disable Streaming Timeouts'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionHard: imagefs.available'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_inodesfree/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionHard: imagefs.inodesFree'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionHard: memory.available'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionHard: nodefs.available'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionHard: nodefs.inodesFree'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_available/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionSoft: imagefs.available'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_imagefs_inodesfree/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionSoft: imagefs.inodesFree'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_memory_available/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionSoft: memory.available'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_available/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionSoft: nodefs.available'
 
 description: |-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_soft_nodefs_inodesfree/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Ensure Eviction threshold Settings Are Set - evictionSoft: nodefs.inodesFree'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The OpenShift Container Network Interface Files'
 
 description: '{{{ describe_file_group_owner(file="/etc/cni/net.d/*", group="root") }}}'

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 
 title: 'Verify Group Who Owns The OpenShift SDN Container Network Interface Plugin IP Address Allocations'
 

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
 description: '{{{ describe_file_group_owner(file="/var/run/multus/cni/net.d/*", group="root") }}}'

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The OpenShift SDN CNI Server Config'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Process ID File'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Persistent System ID'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_vswitchd_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Daemon PID File'
 
 description: |-

--- a/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovsdb_server_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Open vSwitch Database Server PID'
 
 description: |-

--- a/applications/openshift/master/file_owner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_owner_cni_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The OpenShift Container Network Interface Files'
 
 description: '{{{ describe_file_owner(file="/etc/cni/net.d/*", owner="root") }}}'

--- a/applications/openshift/master/file_owner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_owner_ip_allocations/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The OpenShift SDN Container Network Interface Plugin IP Address Allocations'
 
 description: '{{{ describe_file_owner(file="/var/lib/cni/networks/openshift-sdn/.*", owner="root") }}}'

--- a/applications/openshift/master/file_owner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_owner_multus_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The OpenShift Multus Container Network Interface Plugin Files'
 
 description: '{{{ describe_file_owner(file="/var/run/multus/cni/net.d/*", owner="root") }}}'

--- a/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_owner_openshift_sdn_cniserver_config/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The OpenShift SDN CNI Server Config'
 
 description: |-

--- a/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Open vSwitch Configuration Database'
 
 description: |-

--- a/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_conf_db_lock/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Open vSwitch Configuration Database Lock'
 
 description: |-

--- a/applications/openshift/master/file_owner_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Open vSwitch Process ID File'
 
 description: |-

--- a/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_sys_id_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Open vSwitch Persistent System ID'
 
 description: |-

--- a/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovs_vswitchd_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Open vSwitch Daemon PID File'
 
 description: |-

--- a/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_owner_ovsdb_server_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Open vSwitch Database Server PID'
 
 description: |-

--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_permissions_ip_allocations/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the OpenShift SDN Container Network Interface Plugin IP Address Allocations'
 
 description: |-

--- a/applications/openshift/master/file_permissions_multus_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_multus_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the OpenShift Multus Container Network Interface Plugin Files'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Configuration Database'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_conf_db_lock/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Configuration Database Lock'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ovs_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Process ID File'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_sys_id_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Persistent System ID'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovs_vswitchd_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Daemon PID File'
 
 description: |-

--- a/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
+++ b/applications/openshift/master/file_permissions_ovsdb_server_pid/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Open vSwitch Database Server PID'
 
 description: |-

--- a/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_perms_openshift_sdn_cniserver_config/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the OpenShift SDN CNI Server Config'
 
 description: |-

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Kubelet Configuration File'
 
 description: '{{{ describe_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'

--- a/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns the Worker Certificate Authority File'
 
 description: '{{{ describe_file_group_owner(file="/etc/kubernetes/kubelet-ca.crt", group="root") }}}'

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The Worker Kubeconfig File'
 
 description: '{{{ describe_file_group_owner(file="/var/lib/kubelet/kubeconfig", group="root") }}}'

--- a/applications/openshift/worker/file_groupowner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_service/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Group Who Owns The OpenShift Node Service File'
 
 description: |-

--- a/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Kubelet Configuration File'
 
 description: '{{{ describe_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'

--- a/applications/openshift/worker/file_owner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_ca/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns the Worker Certificate Authority File'
 
 description: '{{{ describe_file_owner(file="/etc/kubernetes/kubelet-ca.crt", owner="root") }}}'

--- a/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The Worker Kubeconfig File'
 
 description: '{{{ describe_file_owner(file="/var/lib/kubelet/kubeconfig", owner="root") }}}'

--- a/applications/openshift/worker/file_owner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_service/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify User Who Owns The OpenShift Node Service File'
 
 description: |-

--- a/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on The Kubelet Configuration File'
 
 description: |-

--- a/applications/openshift/worker/file_permissions_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_ca/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Worker Certificate Authority File'
 
 description: |-

--- a/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the Worker Kubeconfig File'
 
 description: |-

--- a/applications/openshift/worker/file_permissions_worker_service/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_service/rule.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 prodtype: ocp4
 
+platform: ocp4-node
+
 title: 'Verify Permissions on the OpenShift Node Service File'
 
 description: |-


### PR DESCRIPTION
In order to more easily filter rules, this explicitly adds the platform
to the rules that apply to `ocp4-node`.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>