### PR TITLE
OCP4: Add assessment for section 1 for PCI-DSS

### DIFF
--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -21,7 +21,7 @@ references:
     cis@ocp4: 5.3.2
     nerc-cip: CIP-003-3 R4,CIP-003-3 R4.2,CIP-003-3 R5,CIP-003-3 R6,CIP-004-3 R2.2.4,CIP-004-3 R3,CIP-007-3 R2,CIP-007-3 R2.1,CIP-007-3 R2.2,CIP-007-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: AC-4,AC-4(21),CA-3(5),CM-6,CM-6(1),CM-7,CM-7(1),SC-7,SC-7(3),SC-7(5),SC-7(8),SC-7(12),SC-7(13),SC-7(18)
-    pcidss: Req-1.1.4,Req-1.2,Req-1.2.1
+    pcidss: Req-1.1.4,Req-1.2,Req-1.2.1,Req-1.3.1,Req-1.3.2
 
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies?limit=500' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces?limit=500' %}}

--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -1,6 +1,6 @@
 policy: PCI-DSS
 title: Configuration Recommendations of a GNU/Linux System
-id: pcidss
+id: pcidss_ocp4
 version: '3.2.1'
 source: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
 levels:
@@ -19,14 +19,16 @@ controls:
   levels:
   - base
   notes: ''
-  status: not applicable
+  status: automated
   controls:
   - id: Req-1.1.1
     title: 1.1.1 A formal process for approving and testing all network connections
       and changes to the firewall and router configurations
     levels:
     - base
-    notes: ''
+    notes: |-
+      This is an organizational control and not something that can be provided
+      by the OpenShift Container Platform.
     status: not applicable
     rules: []
 
@@ -35,7 +37,15 @@ controls:
       cardholder data environment and other networks, including any wireless networks
     levels:
     - base
-    notes: ''
+    notes: |-
+      While there are ways and tools where the OpenShift Container Platform could
+      help address this control, covering the scope of a deployment with the application
+      specific connections is out of scope.
+
+      If such functionality is needed, there are tools such as Advanced Cluster
+      Security [1] that may help fulfil this control.
+
+      [1] https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet
     status: not applicable
     rules: []
 
@@ -44,7 +54,15 @@ controls:
       and networks
     levels:
     - base
-    notes: ''
+    notes: |-
+      While there are ways and tools where the OpenShift Container Platform could
+      help address this control, covering the scope of a deployment with the application
+      specific connections is out of scope.
+
+      If such functionality is needed, there are tools such as Advanced Cluster
+      Security [1] that may help fulfil this control.
+
+      [1] https://www.redhat.com/en/resources/advanced-cluster-security-for-kubernetes-datasheet
     status: not applicable
     rules: []
 
@@ -53,7 +71,14 @@ controls:
       any demilitarized zone (DMZ) and the internal network zone
     levels:
     - base
-    notes: ''
+    notes: |-
+      While there will be a firewall protecting the cluster from outside traffic,
+      network connectivity within the cluster is handled by the SDN plugin and
+      is configurable via NetworkPolicies [1]. We can ensure that each non-control
+      plane namespace has a NetworkPolicy enabled, but it's still the responsibility
+      of the system administrator to ensure that the policy is correct.
+
+      [1] https://docs.openshift.com/container-platform/latest/networking/network_policy/about-network-policy.html
     status: automated
     rules:
       - configure_network_policies
@@ -64,7 +89,9 @@ controls:
       network components
     levels:
     - base
-    notes: ''
+    notes: |-
+      This is an organizational control related to the personnel and not something
+      that can be provided by the OpenShift Container Platform.
     status: not applicable
     rules: []
 
@@ -76,7 +103,9 @@ controls:
       not limited to FTP, Telnet, POP3, IMAP, and SNMP v1 and v2.
     levels:
     - base
-    notes: ''
+    notes: |-
+      This is an organizational control and not something that can be provided
+      by the OpenShift Container Platform.
     status: not applicable
     rules: []
 
@@ -85,7 +114,9 @@ controls:
       six months
     levels:
     - base
-    notes: ''
+    notes: |-
+      This is an organizational control and not something that can be provided
+      by the OpenShift Container Platform.
     status: not applicable
     rules: []
 
@@ -106,9 +137,17 @@ controls:
       the cardholder data environment, and specifically deny all other traffic.
     levels:
     - base
-    notes: ''
+    notes: |-
+      East-West traffic in the cluster can be managed via NetworkPolicies [1]. So,
+      we can verify that each non-control plane namespace has a relevant NetworkPolicy enabled.
+      However, Egress traffic needs to be taken into account as well, and this setup
+      will vary depending on the SDN plugin used [2][3].
+
+      [1] https://docs.openshift.com/container-platform/latest/networking/network_policy/about-network-policy.html
+      [2] https://docs.openshift.com/container-platform/latest/networking/openshift_sdn/configuring-egress-firewall.html
+      [3] https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html
     automated: yes
-    status: supported
+    status: partial
     rules:
       - configure_network_policies_namespaces
 
@@ -116,8 +155,13 @@ controls:
     title: 1.2.2 Secure and synchronize router configuration files.
     levels:
     - base
-    notes: ''
-    status: pending
+    notes: |-
+      Router configurations are out of scope from the OpenShift Container Platform.
+      While this is still relevant and something that organizations do, this is
+      dependent on where OpenShift is deployed. In cloud deployments, router configurations
+      are virtual and need to be verified depending on the implementation; e.g.
+      in OpenStack, one would need to verify Neutron's Security Groups.
+    status: not applicable
     rules: []
 
   - id: Req-1.2.3
@@ -127,8 +171,11 @@ controls:
       and the cardholder data environment.
     levels:
     - base
-    notes: ''
-    status: pending
+    notes: |-
+      Firewall configurations are out of scope from the OpenShift Container Platform.
+      While this is still relevant and something that organizations do, this is
+      dependent on where OpenShift is deployed.
+    status: not applicable
     rules: []
 
 - id: Req-1.3
@@ -137,48 +184,68 @@ controls:
   levels:
   - base
   notes: ''
-  status: pending
+  status: partial
   controls:
   - id: Req-1.3.1
     title: 1.3.1 Implement a DMZ to limit inbound traffic to only system components
       that provide authorized publicly accessible services, protocols, and ports.
     levels:
     - base
-    notes: ''
-    status: pending
-    rules: []
+    notes: |-
+      To a limited degree, OpenShift's ingress routing (enabled by default)
+      and NetworkPolicies can support restriction of inbound traffic to pods.
+      Further restricting needs to happen on the cloud where OpenShift is deployed
+      at, but that's outside of OpenShift's scope.
+    status: partial
+    # TODO(jaosorior): Add rules to check for egress policies and ingress configurations
+    rules:
+      - configure_network_policies_namespaces
 
   - id: Req-1.3.2
     title: 1.3.2 Limit inbound Internet traffic to IP addresses within the DMZ.
     levels:
     - base
-    notes: ''
-    status: pending
-    rules: []
+    notes: |-
+      To a limited degree, OpenShift's ingress routing (enabled by default)
+      and NetworkPolicies can support restriction of inbound traffic to pods.
+      Further restricting needs to happen on the cloud where OpenShift is deployed
+      at, but that's outside of OpenShift's scope.
+    status: partial
+    # TODO(jaosorior): Add rules to check for egress policies and ingress configurations
+    rules:
+      - configure_network_policies_namespaces
 
   - id: Req-1.3.3
-    title: 1.3.3 Do not allow any direct connections inbound or outbound for traffic
-      between the Internet and the cardholder data environment.
-    levels:
-    - base
-    notes: ''
-    status: pending
-    rules: []
-
-  - id: Req-1.3.4
-    title: 1.3.4 Implement anti-spoofing measures to detect and block forged source
-      IP addresses from entering the network.
+    title: >-
+      1.3.3 Implement anti-spoofing measures to detect and block forged
+      source IP addresses from entering the network.
     description: (For example, block traffic originating from the Internet with an internal
       source address.)
     levels:
     - base
-    notes: ''
-    status: pending
+    notes: |-
+      Anti-spoofing and blocking forged IP addresses is outside the scope
+      of the OpenShift Container Platform.
+    status: not applicable
+    rules: []
+
+  - id: Req-1.3.4
+    title: >-
+      1.3.4 Do not allow unauthorized outbound traffic from the cardholder
+      data environment to the Internet.
+    levels:
+    - base
+    notes: |-
+      OpenShift can support authorization of outbound traffic via
+      egress  policy  objects[1][2].
+
+      [1] https://docs.openshift.com/container-platform/latest/networking/openshift_sdn/configuring-egress-firewall.html
+      [2] https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html
+    status: supported
     rules: []
 
   - id: Req-1.3.5
-    title: 1.3.5 Do not allow unauthorized outbound traffic from the cardholder data
-      environment to the Internet.
+    title: 1.3.5 Permit only "established" connections into the network.
     levels:
     - base
     notes: ''
@@ -186,26 +253,35 @@ controls:
     rules: []
 
   - id: Req-1.3.6
-    title: "1.3.6 Implement stateful inspection, also known as dynamic packet filtering.\
-      \ (That is, only \u201Cestablished\u201D connections are allowed into the network.)"
+    title: >-
+      1.3.6 Place system components that store cardholder data (such as a
+      database) in an internal network zone, segregated from the DMZ and other
+      untrusted networks
     levels:
     - base
-    notes: ''
-    status: pending
-    rules: []
+    notes: |-
+      Segregation of such system components can take place using the same
+      network segregation mechanisms that OpenShift already supports [1][2][3]:
+
+      * Ingress
+      * NetworkPolicies
+      * Egress Policies
+
+      Special attention needs to be taken to audit that these components
+      are appropriately segregated by the aforementioned mechanisms
+
+      [1] https://docs.openshift.com/container-platform/latest/networking/network_policy/about-network-policy.html
+      [2] https://docs.openshift.com/container-platform/latest/networking/openshift_sdn/configuring-egress-firewall.html
+      [3] https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html
+    status: partial
+    # TODO(jaosorior): Add rules to check for egress policies and ingress configurations
+    rules:
+      - configure_network_policies_namespaces
 
   - id: Req-1.3.7
-    title: 1.3.7 Place system components that store cardholder data (such as a database)
-      in an internal network zone, segregated from the DMZ and other untrusted networks.
-    levels:
-    - base
-    notes: ''
-    status: pending
-    rules: []
-
-  - id: Req-1.3.8
-    title: 1.3.8 Do not disclose private IP addresses and routing information to unauthorized
-      parties.
+    title: >-
+      1.3.7 Do not disclose private IP addresses and routing information to
+      unauthorized parties.
     description: |-
       Note: Methods to obscure IP addressing may include, but are not limited to:
       * Network Address Translation (NAT)
@@ -215,7 +291,9 @@ controls:
       * Internal use of RFC1918 address space instead of registered addresses.
     levels:
     - base
-    notes: ''
+    notes: |-
+      Protection from IP address disclosure can be handled by solutions
+      outside of OpenShift.
     status: not applicable
     rules: []
 
@@ -231,8 +309,10 @@ controls:
       employee-owned devices.
   levels:
   - base
-  notes: ''
-  status: pending
+  notes: |-
+    Personal firewall software is outside the scope of the OpenShift
+    Container Platform.
+  status: not applicable
   rules: []
 
 - id: Req-1.5
@@ -240,8 +320,12 @@ controls:
     firewalls are documented, in use, and known to all affected parties.
   levels:
   - base
-  notes: ''
-  status: pending
+  notes: |-
+    The organization will want to ensure that they include in security
+    policies and operational procedures for managing the OpenShift
+    SDN and OpenShift NetworkPolicy objects within the OpenShift
+    environment.
+  status: not applicable
   rules: []
 
 - id: Req-2.1

--- a/products/ocp4/profiles/pci-dss.profile
+++ b/products/ocp4/profiles/pci-dss.profile
@@ -16,4 +16,4 @@ description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
 selections:
-    - pcidss:all:base
+    - pcidss_ocp4:all:base


### PR DESCRIPTION
This adds the assessment for PCI-DSS's section 1 and fills in the rules
tthat are applicable that are already written.

Rules that are yet to be written will be added in subsequent pull
requests.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>