### PR TITLE
Add metadata to chronyd or ntpd remediations

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [ 'master', '*', '!stabilization*', '!stable*' ]
   pull_request:
-    branches: [ 'master' ]
+    branches: [ 'master', 'stabilization*' ]
 jobs:
   validate-ubuntu:
     name: Build, Test on Ubuntu 20.04

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
@@ -1,5 +1,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
-
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
 - name: Gather the package facts
   ansible.builtin.package_facts:
     manager: auto

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/bash/shared.sh
@@ -1,5 +1,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle
-
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
 if {{{ bash_package_installed("chrony") }}} ; then
     if ! /usr/sbin/pidof ntpd ; then
         {{{ bash_service_command("enable", "chronyd") | indent(8) }}}


### PR DESCRIPTION
#### Description:

- Add metadata to `service_chronyd_or_ntpd_enabled` remediations
  - The added metadata is aligned with the template `service_enabled`.

#### Rationale:

- Fixes playbook schema tests:
```shell
cmake -DSSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED:BOOLEAN=ON ../ && ninja-build ../
ctest -R ansible-assert-playbooks-schema --output-on-failure
```
