### PR TITLE
Remove unnecessary debug task

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/ansible/shared.yml
@@ -7,11 +7,6 @@
   ansible.builtin.package_facts:
     manager: auto
 
-- name: Print the package facts
-  ansible.builtin.debug:
-    var: ansible_facts.packages
-
-
 - name: Start ntpd service if ntp installed
   service:
     name: "ntpd"


### PR DESCRIPTION
#### Description:

- Remove unnecessary debug task.

#### Rationale:

- The released playbooks should not have debug tasks.
