### PR TITLE
Fix typo in rsyslog streamdriver remediations

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/ansible/shared.yml
@@ -5,5 +5,5 @@
 # disruption = low
 
 {{{ ansible_set_config_file(file="/etc/rsyslog.d/encrypt.conf",
-             parameter="\$ActionSendStreamDriverMode", value="1", create=true, separator=" ", separator_regex=" ")
+             parameter="$ActionSendStreamDriverMode", value="1", create=true, separator=" ", separator_regex=" ")
 }}}

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/ansible/shared.yml
@@ -5,5 +5,5 @@
 # disruption = low
 
 {{{ ansible_set_config_file(file="/etc/rsyslog.d/encrypt.conf",
-                    parameter="\$DefaultNetstreamDriver", value="gtls", create=true, separator=" ", separator_regex=" ")
+                    parameter="$DefaultNetstreamDriver", value="gtls", create=true, separator=" ", separator_regex=" ")
 }}}


### PR DESCRIPTION
#### Description:

- Fix typo in rsyslog streamdriver remediations

#### Rationale:

- The remediations don't need to escape '$'.
