### PR TITLE
Force masking of ctrl-alt-del.target in Ansible remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -7,6 +7,7 @@
 - name: Disable Ctrl-Alt-Del Reboot Activation
   systemd:
     name: ctrl-alt-del.target
+    force: yes
     masked: yes
     state: stopped
 


### PR DESCRIPTION


#### Description:

- Without forcing the remediation the target never converges.
  - The target is stopped but not masked.

#### Rationale:

- Rule `disable_ctrlaltdel_reboot` never passes when remediating with Ansible.
