### PR TITLE
Update config path in auditd_overflow_action

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/rule.yml
@@ -50,10 +50,9 @@ ocil_clause: 'it is not activated'
 
 ocil: |-
     To verify the audispd's syslog plugin is active, run the following command:
-{{% if product in ["rhel8", "fedora", "rhv4"] %}}
+{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
     <pre>$ sudo grep active /etc/audit/plugins.d/syslog.conf</pre>
 {{% else %}}
     <pre>$ sudo grep active /etc/audisp/plugins.d/syslog.conf</pre>
 {{% endif %}}
     If the plugin is active, the output will show <tt>yes</tt>.
-

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/ansible/shared.yml
@@ -4,7 +4,13 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_set_config_file(file="/etc/audit/auditd.conf",
+{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
+{{% set audisp_conf_file = "/etc/audit/auditd.conf" %}}
+{{% else %}}
+{{% set audisp_conf_file = "/etc/audisp/audispd.conf" %}}
+{{% endif %}}
+
+{{{ ansible_set_config_file(file=audisp_conf_file,
                   parameter="overflow_action",
                   value="syslog",
                   separator=" = ",

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/bash/shared.sh
@@ -4,7 +4,13 @@
 # complexity = low
 # disruption = low
 
-{{{set_config_file(path="/etc/audit/auditd.conf",
+{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
+{{% set audisp_conf_file = "/etc/audit/auditd.conf" %}}
+{{% else %}}
+{{% set audisp_conf_file = "/etc/audisp/audispd.conf" %}}
+{{% endif %}}
+
+{{{set_config_file(path=audisp_conf_file,
                   parameter="overflow_action",
                   value="syslog",
                   insensitive=true,

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/oval/shared.xml
@@ -1,5 +1,11 @@
+{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
+{{% set audisp_conf_file = "/etc/audit/auditd.conf" %}}
+{{% else %}}
+{{% set audisp_conf_file = "/etc/audisp/audispd.conf" %}}
+{{% endif %}}
+
 {{{ oval_check_config_file(
-    path="/etc/audit/auditd.conf",
+    path=audisp_conf_file,
     prefix_regex="^[ \\t]*(?i)",
     parameter="overflow_action",
     value="(?i)(syslog|single|halt)(?-i)",

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/rule.yml
@@ -4,7 +4,13 @@ title: Appropriate Action Must be Setup When the Internal Audit Event Queue is F
 
 description: |-
     The audit system should have an action setup in the event the internal event queue becomes full.
-    To setup an overflow action edit <tt>/etc/audit/auditd.conf</tt>. Set <tt>overflow_action</tt>
+    To setup an overflow action edit 
+    {{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
+        <tt>/etc/audit/auditd.conf</tt>.
+    {{% else %}}
+        <tt>/etc/audisp/audispd.conf</tt>.
+    {{% endif %}}
+    Set <tt>overflow_action</tt>
     to one of the following values: <tt>syslog</tt>, <tt>single</tt>, <tt>halt</tt>.
 
 


### PR DESCRIPTION
#### Description:

- Updated rule text, oval check, ansible and bash remediations to use the correct path to configure audisp plugin.
- Also updated auditd_audispd_syslog_plugin_activated rule text to mention correct path for OL8

#### Rationale:

- Config options for audisp plugin are placed in /etc/audisp/auditd.conf for audit package previous to v3
- Placing the config option `overflow_action` in /etc/audit/auditd.conf prevents the auditd service from starting on reboot
- This is the issue I mentioned in #7292 
