### PR TITLE
SLE bash remediation for audit,smartcard and sysctl rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/bash/shared.sh
@@ -1,0 +1,15 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+
+SMARTCARD_PACKAGES=( "pam_pkcs11"  "mozilla-nss"  "mozilla-nss-tools"  "pcsc-ccid"  "pcsc-lite"  "pcsc-tools"  "opensc")
+{{% if product not in ["sle15"] %}}
+SMARTCARD_PACKAGES+=("coolkey")
+{{% endif %}}
+
+for PKGNAME in "${SMARTCARD_PACKAGES[@]}"
+do
+    {{{ bash_package_install(package=PKGNAME) }}}
+done

--- a/shared/templates/audit_rules_login_events/bash.template
+++ b/shared/templates/audit_rules_login_events/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
 # reboot = true
 # strategy = disable
 # complexity = low


### PR DESCRIPTION
#### Description:

- Enable bash remediation support for SLE platform of templates used in audit,smartcard and sysctl rules

#### Rationale:
Rules affected:
 - sysctl_kernel_kptr_restrict
 - sysctl_kernel_randomize_va_space
 - sysctl_net_ipv4_conf_all_accept_redirects
 - sysctl_net_ipv4_conf_all_accept_source_route
 - sysctl_net_ipv4_conf_all_send_redirects
 - sysctl_net_ipv4_conf_default_accept_redirects
 - sysctl_net_ipv4_conf_default_accept_source_route
 - sysctl_net_ipv4_conf_default_send_redirects
 - sysctl_net_ipv4_ip_forward
 - sysctl_net_ipv4_tcp_syncookies
 - sysctl_net_ipv6_conf_all_forwarding
 - sysctl_net_ipv6_conf_all_accept_redirects
 - sysctl_net_ipv6_conf_all_accept_source_route
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
 - sysctl_net_ipv6_conf_default_forwarding
 - audit_rules_login_events_lastlog
 - install_smartcard_packages
 - audit_rules_login_events_tallylog
