### PR TITLE
SLE bash remediation enable for some account related rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_password_pam_unix_remember") }}}
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_account_disable_post_pw_expiration") }}}
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_max_concurrent_login_sessions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ubuntu,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_accounts_max_concurrent_login_sessions") }}}
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -28,6 +28,7 @@ selections:
     - var_password_pam_remember=5
     - var_password_pam_retry=3
     - var_password_pam_ucredit=1
+    - var_accounts_maximum_age_login_defs=60
     #
     # Note: must configure "var_accounts_authorized_local_users_regex" when
     # "accounts_authorized_local_users" rule is enabled

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -23,6 +23,7 @@ selections:
     - var_auditd_action_mail_acct=root
     - var_multiple_time_servers=suse
     - var_smartcard_drivers=cac
+    - var_password_pam_unix_remember=4
     ### Rules:
     - account_disable_post_pw_expiration
     - account_unique_name

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -20,6 +20,8 @@ selections:
     - var_accounts_tmout=15_min
     - inactivity_timeout_value=15_minutes
     - var_sudo_timestamp_timeout=always_prompt
+    - var_password_pam_unix_remember=5
+    - var_accounts_maximum_age_login_defs=60
     #
     # Note: must configure "var_accounts_authorized_local_users_regex" when
     # "accounts_authorized_local_users" rule is enabled


### PR DESCRIPTION
#### Description:

- Enable bash remediation in SLE platforms for rules
  - account_disable_post_pw_expiration
  - accounts_max_concurrent_login_sessions
  - accounts_maximum_age_login_defs



#### Rationale:

- Enable platform SLE in bash definitions
- Add needed variables in pci-dss and stig profiles