### PR TITLE
Improvements on wireless_disable_interfaces rule

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/oval/shared.xml
@@ -2,15 +2,20 @@
   <definition class="compliance" id="wireless_disable_interfaces" version="1">
     {{{ oval_metadata("All wireless interfaces should be disabled.") }}}
     <criteria>
-      <criterion comment="query /proc/net/wireless" test_ref="test_wireless_disable_interfaces" />
+      <criterion comment="check if wifi interfaces are disabled" test_ref="test_wireless_disable_interfaces" negate="true" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="query /proc/net/wireless" id="test_wireless_disable_interfaces" version="1">
-    <ind:object object_ref="object_wireless_disable_interfaces" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_wireless_disable_interfaces" version="1">
-    <ind:filepath>/proc/net/wireless</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*[-\w]+:</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
-  </ind:textfilecontent54_object>
+
+  <unix:interface_test check="all" check_existence="at_least_one_exists" id="test_wireless_disable_interfaces" version="1" comment="check if UP flag is present on wifi interfaces">
+    <unix:object object_ref="object_active_wifi_interfaces" />
+    <unix:state state_ref="state_wifi_up" />
+  </unix:interface_test>
+
+  <unix:interface_object id="object_active_wifi_interfaces" version="1">
+    <unix:name operation="pattern match">^wl.*$</unix:name>
+  </unix:interface_object>
+
+  <unix:interface_state id="state_wifi_up" version="1">
+    <unix:flag datatype="string" entity_check="at least one" operation="equals">UP</unix:flag>
+  </unix:interface_state>
 </def-group>

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -100,4 +100,4 @@ ocil: |-
     <pre>wifi disconnected</pre>
     {{% endif %}}
 
-platform: machine
+platform: wifi-iface

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/disabled_wireless_interfaces.pass.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/disabled_wireless_interfaces.pass.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+#
+
+{{{ bash_package_install("NetworkManager") }}}
+nmcli radio wifi off

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/enabled_wireless_interface.fail.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/enabled_wireless_interface.fail.sh
@@ -1,0 +1,5 @@
+#/bin/bash
+#
+
+{{{ bash_package_install("NetworkManager") }}}
+nmcli radio wifi on

--- a/shared/applicability/hardware.yml
+++ b/shared/applicability/hardware.yml
@@ -1,0 +1,5 @@
+cpes:
+  - wifi-iface:
+      name: "cpe:/a:wifi-iface"
+      title: "WiFi interface is present"
+      check_id: installed_env_has_wifi_interface

--- a/shared/checks/oval/installed_env_has_wifi_interface.xml
+++ b/shared/checks/oval/installed_env_has_wifi_interface.xml
@@ -1,0 +1,23 @@
+<def-group>
+  <definition class="inventory" id="installed_env_has_wifi_interface" version="1">
+    <metadata>
+      <title>WiFi interface is present</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if any wifi interface is present.</description>
+      <reference ref_id="cpe:/a:wifi-iface" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="WiFi interface is present" test_ref="test_proc_net_wireless_exists" />
+    </criteria>
+  </definition>
+
+  <unix:file_test check="all" check_existence="all_exist" comment="Test if /proc/net/wireless exists" id="test_proc_net_wireless_exists" version="1">
+    <unix:object object_ref="object_proc_net_wireless_exists" />
+  </unix:file_test>
+
+  <unix:file_object comment="/proc/net/wireless file" id="object_proc_net_wireless_exists" version="1">
+    <unix:filepath>/proc/net/wireless</unix:filepath>
+  </unix:file_object>
+</def-group>


### PR DESCRIPTION
#### Description:

Included test scenarios
CPE test included to report notapplicable where there is no wifi
Greater accuracy to detect non-disabled wifi interfaces

#### Rationale:

The previous approach to validade that wifi interfaces are disabled relies on the content of /proc/net/wireless.
WiFi interfaces will only appear in this file if they are actually connected. It means that a wifi interfaces not present in this file can be disconnected but still active, ready to be connected, like in these examples:

**WiFi Interface Enabled and Connected**
```
2: wlo1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DORMANT group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff
    altname wlp0s20f3
```

**WiFi Interface Enabled and Disconnected**
```
2: wlo1: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN mode DORMANT group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff permaddr yy:yy:yy:yy:yy:yy
    altname wlp0s20f3
```

**WiFi Interface Disabled**
```
2: wlo1: <BROADCAST,MULTICAST> mtu 1500 qdisc noqueue state DOWN mode DEFAULT group default qlen 1000
    link/ether xx:xx:xx:xx:xx:xx brd ff:ff:ff:ff:ff:ff permaddr yy:yy:yy:yy:yy:yy
    altname wlp0s20f3
```

The new approach instead check for the UP FLAG of wifi interfaces to make sure they are actually disabled (not UP).


In parallel, a CPE has been included to report "not applicable" instead of "error" where there is no wireless interface.
This CPE relies on the presence of /proc/net/wireless file, which is always present when any wireless interfaces are detected by the system, even if the wireless interfaces are inactive.