### PR TITLE
Update test scenarios to use authselect when authconfig is not available

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/disablefaillock_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/disablefaillock_authconfig.fail.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-authconfig --disablefaillock --updateall
+if [ -f /usr/sbin/authconfig ]
+then
+    authconfig --disablefaillock --updateall
+else
+    authselect select sssd --force
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_sssd_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/remediable_sssd_authconfig.fail.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
-authconfig --enablesssdauth --updateall
+if [ -f /usr/sbin/authconfig ]
+then
+    authconfig --enablefaillock --updateall
+else
+    authselect select sssd with-faillock --force
+fi


### PR DESCRIPTION

#### Description:

- In test scenarios, use `authselect` when `authconfig` is not available

#### Rationale:

- From RHEL-8.5, `authconfig` is not available anymore, this issue causes some test scenarios to abort a Test Suite run. 
  - The test scenario was updated to check for the binary, and run equivalent `authselect` commands.
