### PR TITLE
Add ubuntu platform to rsyslog_remote_access_monitoring bash and tests

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 declare -A REMOTE_METHODS=( ['auth.*']='^.*auth\.\*.*$' ['authpriv.*']='^.*authpriv\.\*.*$' ['daemon.*']='^.*daemon\.\*.*$' )
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/no_remote_methods.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/no_remote_methods.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 declare -A REMOTE_METHODS=( ['auth.*']='^.*auth\.\*.*$' ['authpriv.*']='^.*authpriv\.\*.*$' ['daemon.*']='^.*daemon\.\*.*$' )
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/remote_method_set_multiple_configs.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/remote_method_set_multiple_configs.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 declare -A REMOTE_METHODS=( ['auth.*']='^.*auth\.\*.*$' ['authpriv.*']='^.*authpriv\.\*.*$' ['daemon.*']='^.*daemon\.\*.*$' )
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/remote_method_set_rsyslog_conf.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/remote_method_set_rsyslog_conf.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 declare -A REMOTE_METHODS=( ['auth.*']='^.*auth\.\*.*$' ['authpriv.*']='^.*authpriv\.\*.*$' ['daemon.*']='^.*daemon\.\*.*$' )
 RSYSLOG_CONF='/etc/rsyslog.conf'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/remote_method_set_rsyslog_d.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/tests/remote_method_set_rsyslog_d.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 declare -A REMOTE_METHODS=( ['auth.*']='^.*auth\.\*.*$' ['authpriv.*']='^.*authpriv\.\*.*$' ['daemon.*']='^.*daemon\.\*.*$' )
 RSYSLOG_CONF='/etc/rsyslog.conf'


### PR DESCRIPTION
#### Description:

- Add ubuntu to shared bash script in rsyslog_remote_access_monitoring
- Add ubuntu platform to rsyslog_remote_access_monitoring tests