### PR TITLE
Add ubuntu platform to approved fips ciphers and macs bash

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers_ordered_stig/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
 if grep -q -P '^\s*[Cc]iphers\s+' /etc/ssh/sshd_config; then
   sed -i 's/^\s*[Cc]iphers.*/Ciphers aes256-ctr,aes192-ctr,aes128-ctr/' /etc/ssh/sshd_config
 else

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = multi_platform_wrlinux,Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
 if grep -q -P '^\s*MACs\s+' /etc/ssh/sshd_config; then
   sed -i 's/^\s*MACs.*/MACs hmac-sha2-512,hmac-sha2-256/' /etc/ssh/sshd_config
 else


### PR DESCRIPTION
#### Description:

- Add ubuntu platform to sshd_use_approved_ciphers_ordered_stig and sshd_use_approved_macs_ordered_stig