### PR TITLE
Add package_apparmor_installed rule and make apparmor_configured work on Ubuntu STIG

### DIFF
--- a/linux_os/guide/system/apparmor/apparmor_configured/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/apparmor_configured/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 
 # Enable apparmor
 {{{ bash_service_command("enable", "apparmor") }}}

--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -59,5 +59,8 @@ template:
     vars:
         servicename: apparmor
         packagename: apparmor-parser
+        packagename@ubuntu1604: apparmor
+        packagename@ubuntu1804: apparmor
+        packagename@ubuntu2004: apparmor
 
 platform: machine

--- a/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_disabled.fail.sh
+++ b/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_disabled.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor
 
 

--- a/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/apparmor/apparmor_configured/tests/installed_enabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = apparmor
 
 

--- a/linux_os/guide/system/apparmor/package_apparmor_installed/rule.yml
+++ b/linux_os/guide/system/apparmor/package_apparmor_installed/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Ensure AppArmor is installed'
+
+description: |-
+    AppArmor provide Mandatory Access Controls.
+
+rationale: |-
+    Without a Mandatory Access Control system installed only the default
+    Discretionary Access Control system will be available.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 1.7.1.1
+
+template:
+    name: package_installed
+    vars:
+        pkgname: apparmor

--- a/linux_os/guide/system/apparmor/package_apparmor_installed/rule.yml
+++ b/linux_os/guide/system/apparmor/package_apparmor_installed/rule.yml
@@ -15,6 +15,9 @@ severity: medium
 
 references:
     cis@ubuntu2004: 1.7.1.1
+    disa: CCI-001764,CCI-001774,CCI-002165,CCI-002235
+    srg: SRG-OS-000368-GPOS-00154,SRG-OS-000312-GPOS-00122,SRG-OS-000312-GPOS-00123,SRG-OS-000312-GPOS-00124,SRG-OS-000324-GPOS-00125,SRG-OS-000370-GPOS-00155
+    stigid@ubuntu2004: UBTU-20-010439
 
 template:
     name: package_installed

--- a/linux_os/guide/system/apparmor/package_apparmor_installed/tests/installed.pass.sh
+++ b/linux_os/guide/system/apparmor/package_apparmor_installed/tests/installed.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if command -v yum; then
+    yum install -y apparmor
+elif command -v apt-get; then
+    DEBIAN_FRONTEND=noninteractive apt-get install -y apparmor
+fi

--- a/linux_os/guide/system/apparmor/package_apparmor_installed/tests/removed.fail.sh
+++ b/linux_os/guide/system/apparmor/package_apparmor_installed/tests/removed.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if command -v rpm; then
+    rpm -e --nodeps apparmor
+elif command -v apt-get; then
+    DEBIAN_FRONTEND=noninteractive apt-get remove -y apparmor
+fi

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -493,6 +493,7 @@ selections:
     - apt_conf_disallow_unauthenticated
 
     # UBTU-20-010439 The Ubuntu operating system must be configured to use AppArmor.
+    - package_apparmor_installed
     - apparmor_configured
 
     # UBTU-20-010440 The Ubuntu operating system must allow the use of a temporary password for system logons with an immediate change to a permanent password.


### PR DESCRIPTION
#### Description:

- Add packagename@ubuntu to apparmor_configured
- Add ubuntu platform to apparmor_configured bash
- Add ubuntu platform to apparmor_configured tests
- Add package_apparmor_installed for CIS 1.7.1.
- Add tests for package_apparmor_installed
- Add package_apparmor_installed to ubuntu stig profile
- Add STIG references to package_apparmor_installed 