### PR TITLE
SSGTS: Switch message to warning when a rule has no test scenarios

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -33,7 +33,6 @@ class CombinedChecker(rule.RuleChecker):
     """
     def __init__(self, test_env):
         super(CombinedChecker, self).__init__(test_env)
-        self._matching_rule_found = False
 
         self.rules_not_tested_yet = set()
         self.results = list()

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -118,7 +118,6 @@ class RuleChecker(oscap.Checker):
     """
     def __init__(self, test_env):
         super(RuleChecker, self).__init__(test_env)
-        self._matching_rule_found = False
 
         self.results = list()
         self._current_result = None
@@ -282,10 +281,8 @@ class RuleChecker(oscap.Checker):
     def _test_target(self, target):
         rules_to_test = self._get_rules_to_test(target)
         if not rules_to_test:
-            self._matching_rule_found = False
-            logging.error("No matching rule ID found for '{0}'".format(target))
+            logging.error("No tests found matching the rule ID(s) '{0}'".format(", ".join(target)))
             return
-        self._matching_rule_found = True
 
         scenarios_by_rule = dict()
         for rule in rules_to_test:


### PR DESCRIPTION


#### Description:
- SSGTS: Switch message to warning when a rule has no test scenarios
  - When the rule has no test scenarios the SSGTS will just report a warning
that there are not test scenarios to be tested. Additionally remove
unused code.

#### Rationale:

- Fixes #7483
