### PR TITLE
Implement `filter_rules` for Profiles

### DIFF
--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -452,7 +452,8 @@ controls:
   - base
   notes: ''
   status: pending
-  rules: []
+  rules:
+  - file_owner_worker_ca
 
 - id: Req-2.4
   title: 2.4 Maintain an inventory of system components that are in scope for PCI

--- a/products/ocp4/profiles/pci-dss-node.profile
+++ b/products/ocp4/profiles/pci-dss-node.profile
@@ -15,7 +15,7 @@ title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
-filter_rules: 'platform != "ocp4-node"'
+filter_rules: 'platform == "ocp4-node"'
 
 selections:
     - pcidss_ocp4:all:base

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1049,7 +1049,7 @@ def rule_filter_from_def(filterdef):
     def filterfunc(rule):
         # Remove globals for security and only expose
         # variables relevant to the rule
-        return eval(filterdef, {}, rule.__dict__)
+        return eval(filterdef, {"__builtins__": None}, rule.__dict__)
     return filterfunc
 
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -376,13 +376,23 @@ class ResolvableProfile(Profile):
         super(ResolvableProfile, self).__init__(* args, ** kwargs)
         self.resolved = False
         self.resolved_selections = set()
+        self.rule_filter = None
+
+    def read_yaml_contents(self, yaml_contents):
+        super(ResolvableProfile, self).read_yaml_contents(yaml_contents)
+        self.rule_filter = rule_filter_from_def(
+            yaml_contents.pop("filter_rules", None))
 
     def _controls_ids_to_controls(self, controls_manager, policy_id, control_id_list):
         items = [controls_manager.get_control(policy_id, cid) for cid in control_id_list]
         return items
 
     def _merge_control(self, control):
-        self.selected.extend(control.rules)
+        if self.rule_filter is not None:
+            filteredrules = (str(rule) for rule in control.rules if self.rule_filter(rule))
+            self.selected.extend(filteredrules)
+        else:
+            self.selected.extend(str(rule) for rule in control.rules)
         for varname, value in control.variables.items():
             if varname not in self.variables:
                 self.variables[varname] = value
@@ -1032,6 +1042,17 @@ class Group(object):
         return self.id_
 
 
+def rule_filter_from_def(filterdef):
+    if filterdef is None or filterdef == "":
+        return None
+
+    def filterfunc(rule):
+        # Remove globals for security and only expose
+        # variables relevant to the rule
+        return eval(filterdef, {}, rule.__dict__)
+    return filterfunc
+
+
 class Rule(object):
     """Represents XCCDF Rule
     """
@@ -1086,6 +1107,18 @@ class Rule(object):
         self.template = None
         self.local_env_yaml = None
         self.current_product = None
+
+    def __deepcopy__(self, memo):
+        cls = self.__class__
+        result = cls.__new__(cls)
+        memo[id(self)] = result
+        for k, v in self.__dict__.items():
+            # These are difficult to deep copy, so let's just re-use them.
+            if k != "template" and k != "local_env_yaml":
+                setattr(result, k, deepcopy(v, memo))
+            else:
+                setattr(result, k, v)
+        return result
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, sce_metadata=None):
@@ -1497,6 +1530,9 @@ class Rule(object):
         root = self.to_xml_element()
         tree = ET.ElementTree(root)
         tree.write(file_name)
+
+    def __str__(self):
+        return self.id_
 
 
 class DirectoryLoader(object):

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -114,18 +114,19 @@ class Control():
                 varname, value = item.split("=", 1)
                 control.variables[varname] = value
             else:
+                rule_yaml = get_rule_path_by_id(content_dir, item)
+                if rule_yaml is None:
+                    # item not found in benchmark_root
+                    continue
+                rule = ssg.build_yaml.Rule.from_yaml(rule_yaml, env_yaml)
+
                 # Check if rule is applicable to product, i.e.: prodtype has product id
                 if product is None:
                     # The product was not specified, simply add the rule
-                    control.rules.append(item)
+                    control.rules.append(rule)
                 else:
-                    rule_yaml = get_rule_path_by_id(content_dir, item)
-                    if rule_yaml is None:
-                        # item not found in benchmark_root
-                        continue
-                    rule = ssg.build_yaml.Rule.from_yaml(rule_yaml, env_yaml)
                     if rule.prodtype == "all" or product in rule.prodtype:
-                        control.rules.append(item)
+                        control.rules.append(rule)
                     else:
                         logging.info("Rule {item} doesn't apply to {product}".format(
                             item=item,

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -13,7 +13,10 @@ profiles_dir = os.path.join(data_dir, "profiles_dir")
 
 
 def test_controls_load():
-    controls_manager = ssg.controls.ControlsManager(controls_dir)
+    product_yaml = os.path.join(ssg_root, "products", "rhel8", "product.yml")
+    build_config_yaml = os.path.join(ssg_root, "build", "build_config.yml")
+    env_yaml = open_environment(build_config_yaml, product_yaml)
+    controls_manager = ssg.controls.ControlsManager(controls_dir, env_yaml)
     controls_manager.load()
 
     c_r1 = controls_manager.get_control("abcd", "R1")
@@ -50,7 +53,10 @@ def test_controls_load():
 
 
 def test_controls_levels():
-    controls_manager = ssg.controls.ControlsManager(controls_dir)
+    product_yaml = os.path.join(ssg_root, "products", "rhel8", "product.yml")
+    build_config_yaml = os.path.join(ssg_root, "build", "build_config.yml")
+    env_yaml = open_environment(build_config_yaml, product_yaml)
+    controls_manager = ssg.controls.ControlsManager(controls_dir, env_yaml)
     controls_manager.load()
 
     # Default level is the lowest level

--- a/utils/controls-template.html
+++ b/utils/controls-template.html
@@ -22,7 +22,8 @@ based on <a href="{{{ policy.source }}}">{{{ policy.source }}}</a>
   {{% if control.rules -%}}
   Selections:
   <ul>
-    {{%- for rule_id in control.rules -%}}
+    {{%- for ruleobj in control.rules -%}}
+    {{%- set rule_id = ruleobj|string %}}
     {{%- if rule_id in rules %}}
     <li><a href="https://github.com/ComplianceAsCode/content/tree/master/{{{ rules[rule_id].relative_definition_location }}}">{{{ rule_id }}}</a>: {{{ rules[rule_id].title }}}</li>
     {{%- else %}}


### PR DESCRIPTION
This implements a mechanism to filter rules for a profile based on
attributes of the rule object.

This allows us to do stuff like this:

```
filter_rules: 'platform == "ocp4-node"'
```

... Since the filter takes the Python syntax, more complex rules can be
created. e.g. one is able to use all boolean operators from the
language.

The variables available are exactly the ones available in the `Rule`
object from *build_yaml.py*.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>