### PR TITLE
Create rule verify_use_mappers

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/rule.yml
@@ -1,0 +1,46 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: "Verify that 'use_mappers' is set to 'pwent' in PAM"
+
+description: |-
+    The operating system must map the authenticated identity to the user or
+    group account for PKI-based authentication.
+
+    Verify that <tt>use_mappers</tt> is set to <tt>pwent</tt> in
+    <tt>/etc/pam_pkcs11/pam_pkcs11.conf</tt> file with the following command:
+
+    <pre>$ grep ^use_mappers /etc/pam_pkcs11/pam_pkcs11.conf
+
+    use_mappers = pwent</pre>
+
+rationale: |-
+    Without mapping the certificate used to authenticate to the user account,
+    the ability to determine the identity of the individual user or group will
+    not be available for forensic analysis.
+
+severity: low
+
+references:
+    disa: CCI-000187
+    srg: SRG-OS-000068-GPOS-00036
+    stigid@ubuntu2004: UBTU-20-010006
+
+ocil_clause: 'use_mappers is not uncommented or configured correctly'
+
+ocil: |-
+    Verify that <tt>use_mappers</tt> is set to <tt>pwent</tt> in
+    <tt>/etc/pam_pkcs11/pam_pkcs11.conf</tt> file with the following command:
+
+    <pre>$ grep ^use_mappers /etc/pam_pkcs11/pam_pkcs11.conf
+
+    use_mappers = pwent</pre>
+
+template:
+    name: lineinfile
+    vars:
+        text: "use_mappers = pwent"
+        path: /etc/pam_pkcs11/pam_pkcs11.conf
+        oval_extended_definitions:
+            smartcard_configure_cert_checking

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/commented.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '# use_mappers = pwent' > /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# packages = libpam-pkcs11
+
+echo 'use_mappers = pwent' > /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/nothing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/nothing.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/substring.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/tests/substring.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'uuse_mapperss = pwent' > /etc/pam_pkcs11/pam_pkcs11.conf

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -26,6 +26,7 @@ selections:
     - vlock_installed
 
     # UBTU-20-010006 The Ubuntu operating system must map the authenticated identity to the user or group account for PKI-based authentication.
+    - verify_use_mappers
 
     # UBTU-20-010007 The Ubuntu operating system must enforce 24 hours/1 day as the minimum password lifetime. Passwords for new users must have a 24 hours/1 day minimum password lifetime restriction.
     - var_accounts_minimum_age_login_defs=1


### PR DESCRIPTION
#### Description:

- UBTU-20-010006 needs a rule to:

Verify that "use_mappers" is set to "pwent" in "/etc/pam_pkcs11/pam_pkcs11.conf" file:
$ grep ^use_mappers /etc/pam_pkcs11/pam_pkcs11.conf
use_mappers = pwent
If "use_mappers" is not found or the list does not contain "pwent" this is a finding.