### PR TITLE
Fix RHEL8 CIS reference of mount_option_dev_shm_nodev

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -25,7 +25,7 @@ identifiers:
 references:
     cis-csc: 11,13,14,3,8,9
     cis@rhel7: 1.1.8
-    cis@rhel8: 1.1.5
+    cis@rhel8: 1.1.15
     cis@sle12: 1.1.8
     cis@sle15: 1.1.16
     cis@ubuntu1804: 1.1.14


### PR DESCRIPTION
#### Description:

- Rule `mount_option_dev_shm_nodev` should have `1.1.15` RHEL8 CIS reference.