### PR TITLE
Add rule no_duplicate_uids

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/oval/ubuntu.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/oval/ubuntu.xml
@@ -1,0 +1,47 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Although the useradd program will not let you create a duplicate User ID (UID), it is possible for an administrator to manually edit the /etc/passwd file and change the UID field.") }}}
+    <criteria>
+      <criterion test_ref="tst_no_duplicate_uids_exist" comment="no duplicate UIDs exist" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_object id="obj_uids_in_etc_passwd" version="1">
+    <ind:filepath datatype="string">/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">^.*?:[^:]*:([^:]*):.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:variable_object id="obj_num_duplicate_uids" version="1">
+    <ind:var_ref>var_num_duplicate_uids_in_etc_passwd</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="ste_no_duplicate_uids" version="1">
+    <ind:value datatype="int" operation="equals">0</ind:value>
+  </ind:variable_state>
+  <ind:variable_test check="all" id="tst_no_duplicate_uids_exist" version="1" comment="no duplicate UIDs exist">
+    <ind:object object_ref="obj_num_duplicate_uids" />
+    <ind:state state_ref="ste_no_duplicate_uids" />
+  </ind:variable_test>
+  <local_variable datatype="int" id="var_uids_in_etc_passwd" version="1" comment="all UIDs in /etc/passwd">
+    <object_component item_field="subexpression" object_ref="obj_uids_in_etc_passwd" />
+  </local_variable>
+  <local_variable datatype="int" id="var_num_unique_uids_in_etc_passwd" version="1" comment="number of unique UIDs in /etc/passwd">
+    <count>
+      <unique>
+        <variable_component var_ref="var_uids_in_etc_passwd" />
+      </unique>
+    </count>
+  </local_variable>
+  <local_variable datatype="int" id="var_num_total_uids_in_etc_passwd" version="1" comment="total number of UIDs in /etc/passwd">
+    <count>
+        <variable_component var_ref="var_uids_in_etc_passwd" />
+    </count>
+  </local_variable>
+  <local_variable datatype="int" id="var_num_duplicate_uids_in_etc_passwd" version="1" comment="number of duplicate UIDs">
+    <arithmetic arithmetic_operation="add">
+      <arithmetic arithmetic_operation="multiply">
+        <literal_component datatype="int">-1</literal_component>
+        <variable_component var_ref="var_num_unique_uids_in_etc_passwd" />
+      </arithmetic>
+      <variable_component var_ref="var_num_total_uids_in_etc_passwd" />
+    </arithmetic>
+  </local_variable>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/rule.yml
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Ensure no duplicate UIDs exist'
+
+description: |-
+    Although the useradd program will not let you create a duplicate User ID (UID),
+    it is possible for an administrator to manually edit the /etc/passwd file
+    and change the UID field. Users must be assigned unique UIDs for
+    accountability and to ensure appropriate access protections.
+
+rationale: |-
+    Users must be assigned unique UIDs for accountability and to ensure
+    appropriate access protections.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 6.2.13

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/rule.yml
@@ -18,3 +18,6 @@ severity: medium
 
 references:
     cis@ubuntu2004: 6.2.13
+    disa: CCI-000764,CCI-000804
+    srg: SRG-OS-000104-GPOS-00051,SRG-OS-000121-GPOS-00062
+    stigid@ubuntu2004: UBTU-20-010010

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/rule.yml
@@ -21,3 +21,8 @@ references:
     disa: CCI-000764,CCI-000804
     srg: SRG-OS-000104-GPOS-00051,SRG-OS-000121-GPOS-00062
     stigid@ubuntu2004: UBTU-20-010010
+
+warnings:
+    - general: |-
+        Due to the risk of removing user accounts or changing user's UIDS,
+        automated remediation is not available for this configuration check.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/tests/duplicate_user_uid.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/tests/duplicate_user_uid.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+useradd -ou 123456 user1
+useradd -ou 123456 user2

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/tests/unique_user_uid.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_duplicate_uids/tests/unique_user_uid.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+useradd -u 123456 user1

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -40,6 +40,7 @@ selections:
     - '!grub2_password'
 
     # UBTU-20-010010 The Ubuntu operating system must uniquely identify interactive users.
+    - no_duplicate_uids
 
     # UBTU-20-010012 The Ubuntu operating system must ensure only users who need access to security functions are part of sudo group.
 


### PR DESCRIPTION
#### Description:

- The Ubuntu operating system must uniquely identify interactive users.
- This rule doesn't have a remediation, as this requires manual interaction.