### PR TITLE
Add rule sshd_enable_pubkey_auth

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/rule.yml
@@ -1,0 +1,41 @@
+documentation_complete: true
+
+title: 'Enable Public Key Authentication'
+
+description: |-
+    Verify the sshd daemon allows public key authentication with the
+    following:
+    <pre>$ grep ^PubkeyAuthentication /etc/ssh/sshd_config
+    PubkeyAuthentication yes</pre>
+
+rationale: |-
+    Without the use of multifactor authentication, the ease of access to
+    privileged functions is greatly increased. Multifactor authentication
+    requires using two or more factors to achieve authentication.
+    A privileged account is defined as an information system account with
+    authorizations of a privileged user. 
+    The DoD CAC with DoD-approved PKI is an example of multifactor
+    authentication.
+
+severity: medium
+
+references:
+    disa: CCI-000765,CCI-000766,CCI-000767,CCI-000768
+    srg: SRG-OS-000105-GPOS-00052,SRG-OS-000106-GPOS-00053,SRG-OS-000107-GPOS-00054,SRG-OS-000108-GPOS-00055
+    stigid@ubuntu2004: UBTU-20-010033
+
+ocil_clause: 'it is not enabled'
+
+ocil: |-
+    To check if PubkeyAuthentication is enabled or set correctly, run the
+    following command:
+    <pre>$ sudo grep ^PubkeyAuthentication /etc/ssh/sshd_config</pre>
+    If configured properly, output should be <pre>yes</pre>
+
+template:
+    name: sshd_lineinfile
+    vars:
+        missing_parameter_pass: 'false'
+        parameter: PubkeyAuthentication
+        rule_id: sshd_enable_pubkey_auth
+        value: 'yes'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/commented.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/commented.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '#PubkeyAuthentication yes' > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/correct.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'PubkeyAuthentication yes' > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/disabled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/disabled.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'PubkeyAuthentication no' > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/nothing.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/nothing.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/substring.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pubkey_auth/tests/substring.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'PPubkeyAuthenticationn yes' > /etc/ssh/sshd_config

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -55,6 +55,7 @@ selections:
     - accounts_umask_etc_login_defs
 
     # UBTU-20-010033 The Ubuntu operating system must implement smart card logins for multifactor authentication for local and network access to privileged and non-privileged accounts.
+    - sshd_enable_pubkey_auth
     - smartcard_pam_enabled
 
     # UBTU-20-010035 The Ubuntu operating system must use strong authenticators in establishing nonlocal maintenance and diagnostic sessions.


### PR DESCRIPTION
#### Description:

- As part of UBTU-20-010033 (Ubuntu 20.04 STIG):

Configure the Ubuntu operating system to use multifactor authentication for network access to accounts.
1. Add or update `pam_pkcs11.so` in "/etc/pam.d/common-auth" to match the following line:
`auth [success=2 default=ignore] pam_pkcs11.so`
2. Set the sshd option `PubkeyAuthentication yes` in the "/etc/ssh/sshd_config" file.

1 is already achieved by smartcard_pam_enabled, so we added the missing second step.
