### PR TITLE
Check that OVAL ID matches rule ID

### DIFF
--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -254,6 +254,16 @@ def _check_oval_version_from_oval(oval_file_tree, oval_version):
         return True
 
 
+def _check_rule_id(oval_file_tree, rule_id, file_path):
+    for definition in oval_file_tree.findall(
+            "./{%s}def-group/{%s}definition" % (oval_ns, oval_ns)):
+        definition_id = definition.get("id")
+        if definition_id != rule_id:
+            msg = ("OVAL definition ID '%s' doesn't match "
+                "rule ID '%s' in '%s'\n" % (definition_id, rule_id, file_path))
+            sys.stderr.write(msg)
+
+
 def checks(env_yaml, yaml_path, oval_version, oval_dirs):
     """
     Concatenate all XML files in the oval directory, to create the document
@@ -307,6 +317,7 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
             if _check_is_loaded(already_loaded, filename, oval_version):
                 continue
             oval_file_tree = _create_oval_tree_from_string(xml_content)
+            _check_rule_id(oval_file_tree, rule_id, _path)
             if not _check_oval_version_from_oval(oval_file_tree, oval_version):
                 continue
 

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -224,7 +224,7 @@ def _check_is_loaded(loaded_dict, filename, version):
     return False
 
 
-def _check_oval_version_from_oval(xml_content, oval_version):
+def _create_oval_tree_from_string(xml_content):
     try:
         argument = oval_header + xml_content + oval_footer
         oval_file_tree = ElementTree.fromstring(argument)
@@ -237,6 +237,10 @@ def _check_oval_version_from_oval(xml_content, oval_version):
             "%s\n%s\nError when parsing OVAL file.\n" %
             (before, column_pointer))
         sys.exit(1)
+    return oval_file_tree
+
+
+def _check_oval_version_from_oval(oval_file_tree, oval_version):
     for defgroup in oval_file_tree.findall("./{%s}def-group" % oval_ns):
         file_oval_version = defgroup.get("oval_version")
 
@@ -302,7 +306,8 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
                 continue
             if _check_is_loaded(already_loaded, filename, oval_version):
                 continue
-            if not _check_oval_version_from_oval(xml_content, oval_version):
+            oval_file_tree = _create_oval_tree_from_string(xml_content)
+            if not _check_oval_version_from_oval(oval_file_tree, oval_version):
                 continue
 
             body.append(xml_content)
@@ -322,7 +327,8 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
                         continue
                     if _check_is_loaded(already_loaded, filename, oval_version):
                         continue
-                    if not _check_oval_version_from_oval(xml_content, oval_version):
+                    oval_file_tree = _create_oval_tree_from_string(xml_content)
+                    if not _check_oval_version_from_oval(oval_file_tree, oval_version):
                         continue
                     body.append(xml_content)
                     included_checks_count += 1


### PR DESCRIPTION
#### Description:

The build system will print a message when the OVAL definition ID doesn't match the rule ID.

#### Rationale:

Before this change,  it silently ignored the mismatch and the rule missed any OVAL check in the built data stream.

Fixes: #7118
