### PR TITLE
OCP4: Simply moderate profiles

### DIFF
--- a/products/ocp4/profiles/moderate-node.profile
+++ b/products/ocp4/profiles/moderate-node.profile
@@ -34,6 +34,11 @@ description: |-
     publishing processes, this profile mirrors ComplianceAsCode
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
+
+# CM-6 CONFIGURATION SETTINGS
+# CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
+extends: cis-node
+
 selections:
 
     # AU-4
@@ -54,106 +59,3 @@ selections:
     - directory_permissions_var_log_oauth_audit
     - file_ownership_var_log_oauth_audit
     - file_permissions_var_log_oauth_audit
-
-    # CM-6 CONFIGURATION SETTINGS
-    # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
-    - etcd_unique_ca
-    - file_groupowner_cni_conf
-    - file_groupowner_controller_manager_kubeconfig
-    - file_groupowner_etcd_data_dir
-    - file_groupowner_etcd_data_files
-    - file_groupowner_etcd_member
-    - file_groupowner_etcd_pki_cert_files
-    - file_groupowner_ip_allocations
-    - file_groupowner_kube_apiserver
-    - file_groupowner_kube_controller_manager
-    - file_groupowner_kube_scheduler
-    - file_groupowner_kubelet_conf
-    - file_groupowner_master_admin_kubeconfigs
-    - file_groupowner_multus_conf
-    - file_groupowner_openshift_pki_cert_files
-    - file_groupowner_openshift_pki_key_files
-    - file_groupowner_openshift_sdn_cniserver_config
-    - file_groupowner_ovs_conf_db
-    - file_groupowner_ovs_conf_db_lock
-    - file_groupowner_ovs_pid
-    - file_groupowner_ovs_sys_id_conf
-    - file_groupowner_ovs_vswitchd_pid
-    - file_groupowner_ovsdb_server_pid
-    - file_groupowner_scheduler_kubeconfig
-    - file_groupowner_worker_ca
-    - file_groupowner_worker_kubeconfig
-    - file_groupowner_worker_service
-    - file_owner_cni_conf
-    - file_owner_controller_manager_kubeconfig
-    - file_owner_etcd_data_dir
-    - file_owner_etcd_data_files
-    - file_owner_etcd_member
-    - file_owner_etcd_pki_cert_files
-    - file_owner_ip_allocations
-    - file_owner_kube_apiserver
-    - file_owner_kube_controller_manager
-    - file_owner_kube_scheduler
-    - file_owner_kubelet_conf
-    - file_owner_master_admin_kubeconfigs
-    - file_owner_multus_conf
-    - file_owner_openshift_pki_cert_files
-    - file_owner_openshift_pki_key_files
-    - file_owner_openshift_sdn_cniserver_config
-    - file_owner_ovs_conf_db
-    - file_owner_ovs_conf_db_lock
-    - file_owner_ovs_pid
-    - file_owner_ovs_sys_id_conf
-    - file_owner_ovs_vswitchd_pid
-    - file_owner_ovsdb_server_pid
-    - file_owner_scheduler_kubeconfig
-    - file_owner_worker_ca
-    - file_owner_worker_kubeconfig
-    - file_owner_worker_service
-    - file_permissions_cni_conf
-    - file_permissions_controller_manager_kubeconfig
-    - file_permissions_etcd_data_dir
-    - file_permissions_etcd_data_files
-    - file_permissions_etcd_member
-    - file_permissions_etcd_pki_cert_files
-    - file_permissions_ip_allocations
-    - file_permissions_kube_apiserver
-    - file_permissions_kube_controller_manager
-    - file_permissions_kubelet_conf
-    - file_permissions_master_admin_kubeconfigs
-    - file_permissions_multus_conf
-    - file_permissions_openshift_pki_cert_files
-    - file_permissions_openshift_pki_key_files
-    - file_permissions_ovs_conf_db
-    - file_permissions_ovs_conf_db_lock
-    - file_permissions_ovs_pid
-    - file_permissions_ovs_sys_id_conf
-    - file_permissions_ovs_vswitchd_pid
-    - file_permissions_ovsdb_server_pid
-    - file_permissions_scheduler
-    - file_permissions_scheduler_kubeconfig
-    - file_permissions_worker_ca
-    - file_permissions_worker_kubeconfig
-    - file_permissions_worker_service
-    - file_perms_openshift_sdn_cniserver_config
-    - kubelet_anonymous_auth
-    - kubelet_authorization_mode
-    - kubelet_configure_client_ca
-    - kubelet_configure_event_creation
-    - kubelet_configure_tls_cipher_suites
-    - kubelet_enable_cert_rotation
-    - kubelet_enable_client_cert_rotation
-    - kubelet_enable_iptables_util_chains
-    - kubelet_enable_protect_kernel_defaults
-    - kubelet_enable_server_cert_rotation
-    - kubelet_enable_streaming_connections
-    - kubelet_eviction_thresholds_set_hard_imagefs_available
-    - kubelet_eviction_thresholds_set_hard_imagefs_inodesfree
-    - kubelet_eviction_thresholds_set_hard_memory_available
-    - kubelet_eviction_thresholds_set_hard_nodefs_available
-    - kubelet_eviction_thresholds_set_hard_nodefs_inodesfree
-    - kubelet_eviction_thresholds_set_soft_imagefs_available
-    - kubelet_eviction_thresholds_set_soft_imagefs_inodesfree
-    - kubelet_eviction_thresholds_set_soft_memory_available
-    - kubelet_eviction_thresholds_set_soft_nodefs_available
-    - kubelet_eviction_thresholds_set_soft_nodefs_inodesfree

--- a/products/ocp4/profiles/moderate.profile
+++ b/products/ocp4/profiles/moderate.profile
@@ -37,6 +37,10 @@ description: |-
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
 
+# CM-6 CONFIGURATION SETTINGS
+# CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
+extends: cis
+
 selections:
     # AC-2(5)
     - var_oauth_inactivity_timeout=10m0s
@@ -64,72 +68,6 @@ selections:
     # AU-9
     - audit_log_forwarding_enabled
     - audit_log_forwarding_uses_tls
-
-    # CM-6 CONFIGURATION SETTINGS
-    # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
-    - api_server_anonymous_auth
-    - api_server_basic_auth
-    - api_server_token_auth
-    - api_server_kubelet_client_cert
-    - api_server_kubelet_client_key
-    - api_server_kubelet_certificate_authority
-    - api_server_auth_mode_no_aa
-    - api_server_auth_mode_node
-    - api_server_auth_mode_rbac
-    - api_server_api_priority_gate_enabled
-    - api_server_api_priority_flowschema_catch_all
-    - api_server_api_priority_v1alpha1_flowschema_catch_all
-    - api_server_admission_control_plugin_AlwaysAdmit
-    - api_server_admission_control_plugin_AlwaysPullImages
-    - api_server_admission_control_plugin_SecurityContextDeny
-    - api_server_admission_control_plugin_ServiceAccount
-    - api_server_no_adm_ctrl_plugins_disabled
-    - api_server_admission_control_plugin_NamespaceLifecycle
-    - api_server_admission_control_plugin_Scc
-    - api_server_admission_control_plugin_NodeRestriction
-    - api_server_insecure_bind_address
-    - api_server_insecure_port
-    - api_server_bind_address
-    - api_server_profiling_protected_by_rbac
-    - api_server_audit_log_path
-    - openshift_api_server_audit_log_path
-    - api_server_audit_log_maxbackup
-    - ocp_api_server_audit_log_maxbackup
-    - api_server_audit_log_maxsize
-    - ocp_api_server_audit_log_maxsize
-    - api_server_request_timeout
-    - api_server_service_account_lookup
-    - api_server_service_account_public_key
-    - rbac_debug_role_protects_pprof
-    - controller_use_service_account
-    - file_permissions_proxy_kubeconfig
-    - file_owner_proxy_kubeconfig
-    - file_groupowner_proxy_kubeconfig
-    - kubelet_disable_readonly_port
-    - rbac_limit_cluster_admin
-    - rbac_limit_secrets_access
-    - rbac_wildcard_use
-    - rbac_pod_creation_access
-    - accounts_unique_service_account
-    - accounts_restrict_service_account_tokens
-    - scc_limit_privileged_containers
-    - scc_limit_process_id_namespace
-    - scc_limit_ipc_namespace
-    - scc_limit_network_namespace
-    - scc_limit_privilege_escalation
-    - scc_limit_root_containers
-    - scc_limit_net_raw_capability
-    - scc_limit_container_allowed_capabilities
-    - scc_drop_container_capabilities
-    - configure_network_policies
-    - configure_network_policies_namespaces
-    - secrets_no_environment_variables
-    - secrets_consider_external_storage
-    - general_configure_imagepolicywebhook
-    - general_namespaces_in_use
-    - general_default_seccomp_profile
-    - general_apply_scc
-    - general_default_namespace_use
 
     # RA-5 VULNERABILITY SCANNING
     - compliancesuite_exists


### PR DESCRIPTION
Since they effectively include the CIS rules, let's directly use the
`extends` key to ensure they're always up-to-date.

This simplifies the profile since we no longer need to add all the rules
explicitly.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>