### PR TITLE
Added test scenarios for root_path_no_dot rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/absolute_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/absolute_path.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:./:/root/bin"' >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/colon_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/colon_on_path.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin:"' >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doublecolon_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doublecolon_on_path.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+echo 'export PATH="/usr/local/sbin::/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doubleperiod_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/doubleperiod_on_path.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+echo 'export PATH="/usr/local/sbin:..:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/no_risky_path.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/no_risky_path.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+
+echo 'export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/period_on_path.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/tests/period_on_path.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = none
+
+echo 'export PATH=".:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/root/bin"' >> /etc/bashrc


### PR DESCRIPTION
#### Description:

Simple test scenarios to validate that no dangerous values is defined on PATH variable.

#### Rationale:

Test scenarios for this rule were missing and are required for some standards.
