### PR TITLE
Add rule sshd_enable_pam

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
@@ -1,0 +1,40 @@
+documentation_complete: true
+
+title: 'Enable PAM'
+
+description: |-
+    UsePAM Enables the Pluggable Authentication Module interface. If set to “yes” this will
+    enable PAM authentication using ChallengeResponseAuthentication and
+    PasswordAuthentication in addition to PAM account and session module processing for all
+    authentication types.
+
+    To enable PAM authentication, add or correct the following line in the
+    <tt>/etc/ssh/sshd_config</tt> file:
+    <pre>UsePAM yes</pre>
+
+rationale: |-
+    When UsePAM is set to yes, PAM runs through account and session types properly. This is
+    important if you want to restrict access to services based off of IP, time or other factors of
+    the account. Additionally, you can make sure users inherit certain environment variables
+    on login or disallow access to the server.
+
+references:
+    cis@ubuntu2004: 5.2.19
+
+severity: medium
+
+ocil_clause: 'it is commented out or is not enabled'
+
+ocil: |-
+    To check if UsePAM is enabled or set correctly, run the following
+    command:
+    <pre>$ sudo grep UsePAM /etc/ssh/sshd_config</pre>
+    If configured properly, output should be <pre>yes</pre>
+
+template:
+    name: sshd_lineinfile
+    vars:
+        missing_parameter_pass: 'false'
+        parameter: UsePAM
+        rule_id: sshd_enable_pam
+        value: 'yes'

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
@@ -20,6 +20,9 @@ rationale: |-
 
 references:
     cis@ubuntu2004: 5.2.19
+    disa: CCI-000877
+    srg: SRG-OS-000125-GPOS-00065
+    stigid@ubuntu2004: UBTU-20-010035
 
 severity: medium
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/commented.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/commented.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo '#UsePAM yes' > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/correct.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/correct.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'UsePAM yes' > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/disabled.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/disabled.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'UsePAM no' > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/nothing.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/nothing.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo > /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/substring.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/tests/substring.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'UUsePAMM yes' > /etc/ssh/sshd_config

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -58,6 +58,7 @@ selections:
     - smartcard_pam_enabled
 
     # UBTU-20-010035 The Ubuntu operating system must use strong authenticators in establishing nonlocal maintenance and diagnostic sessions.
+    - sshd_enable_pam
 
     # UBTU-20-010036 The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic after a period of inactivity.
     - sshd_set_keepalive


### PR DESCRIPTION
#### Description:

- As part of the STIG Profile:
Verify the Ubuntu operating system is configured to use strong authenticators in the establishment of nonlocal maintenance and diagnostic maintenance.

Verify that "UsePAM" is set to "yes" in "/etc/ssh/sshd_config:
`$ grep ^UsePAM /etc/ssh/sshd_config
UsePAM yes`

If "UsePAM" is not set to "yes", this is a finding.