### PR TITLE
Make a few test scenarios pass

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value.pass.sh
@@ -4,5 +4,6 @@ SSHD_CONFIG="/etc/ssh/sshd_config"
 
 . "$SHARED/utilities.sh"
 
-assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 10"
+# OSPP profile selects a time out of 14_minutes
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 840"
 assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "ClientAliveCountMax 0"

--- a/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_openssl_crypto_policy/ansible/shared.yml
@@ -4,12 +4,19 @@
 # complexity = low
 # disruption = low
 
-- name: "Ensure that the correct crypto policy configuration exists in /etc/crypto-policies/local.d/opensslcnf-ospp.config"
+- name: "Remove configuration from backend file /etc/crypto-policies/back-ends/opensslcnf.config"
   lineinfile:
-    path: "/etc/crypto-policies/local.d/opensslcnf-ospp.config"
-    line: "Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
-    create: yes
-    insertafter: EOF
+    path: "/etc/crypto-policies/back-ends/opensslcnf.config"
+    regexp: "Ciphersuites\\s*=\\s*.*"
+    state: absent
+
+- name: "Ensure that the correct crypto policy configuration exists in /etc/crypto-policies/local.d/opensslcnf-ospp.config"
+  copy:
+    dest: "/etc/crypto-policies/local.d/opensslcnf-ospp.config"
+    # The newline at the beginning of the content is important
+    content: |
+      
+      Ciphersuites = TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256
 
 - name: "Update system crypto policy for changes to take effect"
   command:


### PR DESCRIPTION
#### Description:

- Align test scenario `sshd_set_idle_timeout/correct_value.pass.sh` to OSPP profile
- Fix Ansible remediation for `harden_openssl_crypto_policy`
  - Similar changes as done in inhttps://github.com/ComplianceAsCode/content/pull/7178
#### Rationale:

-  Failing test scenarios:
```
INFO - Script comment.fail.sh using profile (all) OK
ERROR - Script correct_value.pass.sh using profile xccdf_org.ssgproject.content_profile_ospp found issue:
ERROR - Rule xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout has not been evaluated! Wrong profile selected in test scenario?
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_sshd_set_idle_timeout'.
```

```
INFO - xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy
INFO - Script correct.pass.sh using profile (all) OK 
INFO - Script correct_commented.fail.sh using profile (all) OK
ERROR - Rule evaluation resulted in fail, instead of expected pass during final stage
ERROR - The check after remediation failed for rule 'xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy'.
INFO - Script correct_followed_by_incorrect.fail.sh using profile (all) OK
ERROR - Rule evaluation resulted in fail, instead of expected pass during final stage
ERROR - The check after remediation failed for rule 'xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy'.
INFO - Script empty_policy.fail.sh using profile (all) OK
ERROR - Rule evaluation resulted in fail, instead of expected pass during final stage
ERROR - The check after remediation failed for rule 'xccdf_org.ssgproject.content_rule_harden_openssl_crypto_policy'.
```

