### PR TITLE
Add rules banner_etc_issue_net and sshd_enable_warning_banner_net

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+title: 'Enable SSH Warning Banner'
+
+description: |-
+    To enable the warning banner and ensure it is consistent
+    across the system, add or correct the following line in <tt>/etc/ssh/sshd_config</tt>:
+    <pre>Banner /etc/issue.net</pre>
+    Another section contains information on how to create an
+    appropriate system-wide warning banner.
+
+rationale: |-
+    The warning message reinforces policy awareness during the logon process and
+    facilitates possible legal action against attackers. Alternatively, systems
+    whose ownership should not be obvious should ensure usage of a banner that does
+    not provide easy attribution.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 5.2.18
+    cjis: 5.5.6
+    cobit5: DSS05.04,DSS05.10,DSS06.10
+    cui: 3.1.9
+    disa: CCI-000048,CCI-000050,CCI-001384,CCI-001385,CCI-001386,CCI-001387,CCI-001388
+    hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
+    isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
+    isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9'
+    iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
+    nist: AC-8(a),AC-8(c),AC-17(a),CM-6(a)
+    nist-csf: PR.AC-7
+    ospp: FTA_TAB.1
+    srg: SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088
+    vmmsrg: SRG-OS-000023-VMM-000060,SRG-OS-000024-VMM-000070
+
+{{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue.net") }}}
+
+template:
+    name: sshd_lineinfile
+    vars:
+        missing_parameter_pass: 'false'
+        parameter: Banner
+        rule_id: sshd_enable_warning_banner_net
+        value: /etc/issue.net

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/rule.yml
@@ -31,6 +31,7 @@ references:
     nist-csf: PR.AC-7
     ospp: FTA_TAB.1
     srg: SRG-OS-000023-GPOS-00006,SRG-OS-000024-GPOS-00007,SRG-OS-000228-GPOS-00088
+    stigid@ubuntu2004: UBTU-20-010038
     vmmsrg: SRG-OS-000023-VMM-000060,SRG-OS-000024-VMM-000070
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="Banner", value="/etc/issue.net") }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/comment.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+
+if grep -q "^Banner" /etc/ssh/sshd_config; then
+	sed -i "s|^Banner.*|# Banner /etc/issue.net/|" /etc/ssh/sshd_config
+else
+	echo "# Banner /etc/issue.net" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+
+if grep -q "^Banner" /etc/ssh/sshd_config; then
+	sed -i "s|^Banner.*|Banner /etc/issue.net|" /etc/ssh/sshd_config
+else
+	echo "Banner /etc/issue.net" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/line_not_there.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+#
+
+sed -i "/^Banner.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner_net/tests/wrong_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+#
+
+if grep -q "^Banner" /etc/ssh/sshd_config; then
+	sed -i "s/^Banner.*/Banner none/" /etc/ssh/sshd_config
+else
+	echo "Banner none" >> /etc/ssh/sshd_config
+fi

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/bash/shared.sh
@@ -1,0 +1,21 @@
+# platform = multi_platform_ubuntu
+. /usr/share/scap-security-guide/remediation_functions
+{{{ bash_instantiate_variables("login_banner_text") }}}
+
+# Multiple regexes transform the banner regex into a usable banner
+# 0 - Remove anchors around the banner text
+{{{ bash_deregexify_banner_anchors("login_banner_text") }}}
+# 1 - Keep only the first banners if there are multiple
+#    (dod_banners contains the long and short banner)
+{{{ bash_deregexify_multiple_banners("login_banner_text") }}}
+# 2 - Add spaces ' '. (Transforms regex for "space or newline" into a " ")
+{{{ bash_deregexify_banner_space("login_banner_text") }}}
+# 3 - Adds newlines. (Transforms "(?:\[\\n\]+|(?:\\n)+)" into "\n")
+{{{ bash_deregexify_banner_newline("login_banner_text", "\\n") }}}
+# 4 - Remove any leftover backslash. (From any parethesis in the banner, for example).
+{{{ bash_deregexify_banner_backslash("login_banner_text") }}}
+formatted=$(echo "$login_banner_text" | fold -sw 80)
+
+cat <<EOF >/etc/issue.net
+$formatted
+EOF

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="banner_etc_issue_net" version="2">
+    {{{ oval_metadata("The system login banner text should be set correctly.") }}}
+    <criteria>
+      <criterion comment="/etc/issue.net is set appropriately" test_ref="test_banner_etc_issue_net" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="at_least_one_exists" comment="correct banner in /etc/issue.net" id="test_banner_etc_issue_net" version="1">
+    <ind:object object_ref="object_banner_etc_issue_net" />
+    <ind:state state_ref="state_banner_etc_issue_net" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_banner_etc_issue_net" version="1">
+    <ind:behaviors singleline="true" multiline="false" />
+    <ind:filepath operation="pattern match">^/etc/issue.net$</ind:filepath>
+    <ind:pattern operation="pattern match">^(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_banner_etc_issue_net" version="1">
+    <ind:subexpression datatype="string" var_ref="login_banner_text" operation="pattern match" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="warning banner text variable" datatype="string" id="login_banner_text" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/rule.yml
@@ -1,0 +1,63 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Modify the System Login Banner'
+
+description: |-
+    To configure the system login banner edit <tt>/etc/issue.net</tt>. Replace the
+    default text with a message compliant with the local site policy or a legal
+    disclaimer.
+
+    The DoD required text is either:
+    <br /><br />
+    <tt>You are accessing a U.S. Government (USG) Information System (IS) that
+    is provided for USG-authorized use only. By using this IS (which includes
+    any device attached to this IS), you consent to the following conditions:
+    <br />-The USG routinely intercepts and monitors communications on this IS
+    for purposes including, but not limited to, penetration testing, COMSEC
+    monitoring, network operations and defense, personnel misconduct (PM), law
+    enforcement (LE), and counterintelligence (CI) investigations.
+    <br />-At any time, the USG may inspect and seize data stored on this IS.
+    <br />-Communications using, or data stored on, this IS are not private,
+    are subject to routine monitoring, interception, and search, and may be
+    disclosed or used for any USG-authorized purpose.
+    <br />-This IS includes security measures (e.g., authentication and access
+    controls) to protect USG interests -- not for your personal benefit or
+    privacy.
+    <br />-Notwithstanding the above, using this IS does not constitute consent
+    to PM, LE or CI investigative searching or monitoring of the content of
+    privileged communications, or work product, related to personal
+    representation or services by attorneys, psychotherapists, or clergy, and
+    their assistants. Such communications and work product are private and
+    confidential. See User Agreement for details.</tt>
+    <br /><br />
+    OR:
+    <br /><br />
+    <tt>I've read &amp; consent to terms in IS user agreem't.</tt>
+
+rationale: |-
+    Display of a standardized and approved use notification before granting
+    access to the operating system ensures privacy and security notification
+    verbiage used is consistent with applicable federal laws, Executive Orders,
+    directives, policies, regulations, standards, and guidance.
+    <br /><br />
+    System use notifications are required only for access via login interfaces
+    with human users and are not required when such human interfaces do not
+    exist.
+
+severity: medium
+
+references:
+    disa: CCI-000048,CCI-001384,CCI-001385,CCI-001386,CCI-001387,CCI-001388
+    srg: SRG-OS-000023-GPOS-00006,SRG-OS-000228-GPOS-00088
+    stigid@ubuntu2004: UBTU-20-010038
+
+ocil_clause: 'it does not display the required banner'
+
+ocil: |-
+    To check if the system login banner is compliant,
+    run the following command:
+    <pre>$ cat /etc/issue.net</pre>
+
+platform: machine

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_dod_default_banner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_dod_default_banner.pass.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is
+provided for USG-authorized use only. By using this IS (which includes any
+device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for
+purposes including, but not limited to, penetration testing, COMSEC monitoring,
+network operations and defense, personnel misconduct (PM), law enforcement
+(LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject
+to routine monitoring, interception, and search, and may be disclosed or used
+for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls)
+to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE
+or CI investigative searching or monitoring of the content of privileged
+communications, or work product, related to personal representation or services
+by attorneys, psychotherapists, or clergy, and their assistants. Such
+communications and work product are private and confidential. See User
+Agreement for details." > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_dod_default_banner_no_newline.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_dod_default_banner_no_newline.fail.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is
+provided for USG-authorized use only. By using this IS (which includes any
+device attached to this IS), you consent to the following conditions:-The USG routinely intercepts and monitors communications on this IS for
+purposes including, but not limited to, penetration testing, COMSEC monitoring,
+network operations and defense, personnel misconduct (PM), law enforcement
+(LE), and counterintelligence (CI) investigations.-At any time, the USG may inspect and seize data stored on this IS.-Communications using, or data stored on, this IS are
+not private, are subject
+to routine monitoring, interception, and search, and may be disclosed or used
+for any USG-authorized purpose.-This IS includes security measures (e.g., authentication and access controls)
+to protect USG interests--not for your personal benefit or privacy.-Notwithstanding the above, using this IS does not constitute consent to PM, LE
+or CI investigative searching or monitoring of the content of privileged
+communications, or work product, related to personal representation or services
+by attorneys, psychotherapists, or clergy, and their assistants. Such
+communications and work product are private and confidential. See User
+Agreement for details." > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_dod_short.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_dod_short.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_short banner
+echo "I've read & consent to terms in IS user agreem't." > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_double_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_double_banner.fail.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default|dod_short banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is
+provided for USG-authorized use only. By using this IS (which includes any
+device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for
+purposes including, but not limited to, penetration testing, COMSEC monitoring,
+network operations and defense, personnel misconduct (PM), law enforcement
+(LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject
+to routine monitoring, interception, and search, and may be disclosed or used
+for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls)
+to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE
+or CI investigative searching or monitoring of the content of privileged
+communications, or work product, related to personal representation or services
+by attorneys, psychotherapists, or clergy, and their assistants. Such
+communications and work product are private and confidential. See User
+Agreement for details. I've read & consent to terms in IS user agreem't." > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_usgcb_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_usgcb_banner.fail.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default|dod_short banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is
+provided for USG-authorized use only. By using this IS (which includes any
+device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for
+purposes including, but not limited to, penetration testing, COMSEC monitoring,
+network operations and defense, personnel misconduct (PM), law enforcement
+(LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject
+to routine monitoring, interception, and search, and may be disclosed or used
+for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls)
+to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE
+or CI investigative searching or monitoring of the content of privileged
+communications, or work product, related to personal representation or services
+by attorneys, psychotherapists, or clergy, and their assistants. Such
+communications and work product are private and confidential. See User
+Agreement for details. I've read & consent to terms in IS user agreem't." > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_with_extra_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_disa_with_extra_line.fail.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_default|dod_short banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is
+provided for USG-authorized use only. By using this IS (which includes any
+device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for
+purposes including, but not limited to, penetration testing, COMSEC monitoring,
+network operations and defense, personnel misconduct (PM), law enforcement
+(LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject
+to routine monitoring, interception, and search, and may be disclosed or used
+for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls)
+to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE
+or CI investigative searching or monitoring of the content of privileged
+communications, or work product, related to personal representation or services
+by attorneys, psychotherapists, or clergy, and their assistants. Such
+communications and work product are private and confidential. See User
+Agreement for details.
+Extra line at end." > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_ospp_usbcg_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_ospp_usbcg_banner.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+echo "This is not the expected banner" > /etc/issue.net

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_ospp_usbcg_banner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue_net/tests/banner_etc_issue_net_ospp_usbcg_banner.pass.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+# dod_banners banner
+echo "You are accessing a U.S. Government (USG) Information System (IS) that is
+provided for USG-authorized use only. By using this IS (which includes any
+device attached to this IS), you consent to the following conditions:
+-The USG routinely intercepts and monitors communications on this IS for
+purposes including, but not limited to, penetration testing, COMSEC monitoring,
+network operations and defense, personnel misconduct (PM), law enforcement
+(LE), and counterintelligence (CI) investigations.
+-At any time, the USG may inspect and seize data stored on this IS.
+-Communications using, or data stored on, this IS are not private, are subject
+to routine monitoring, interception, and search, and may be disclosed or used
+for any USG-authorized purpose.
+-This IS includes security measures (e.g., authentication and access controls)
+to protect USG interests--not for your personal benefit or privacy.
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE
+or CI investigative searching or monitoring of the content of privileged
+communications, or work product, related to personal representation or services
+by attorneys, psychotherapists, or clergy, and their assistants. Such
+communications and work product are private and confidential. See User
+Agreement for details." > /etc/issue.net

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -67,6 +67,8 @@ selections:
     - sshd_set_idle_timeout
 
     # UBTU-20-010038 The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting any local or remote connection to the system.
+    - banner_etc_issue_net
+    - sshd_enable_warning_banner_net
 
     # UBTU-20-010042 The Ubuntu operating system must use SSH to protect the confidentiality and integrity of transmitted information.
     - package_openssh-server_installed


### PR DESCRIPTION
#### Description:

- Ubuntu STIG profile has a banner in /etc/issue.net, because of that we created two rules to address this:
banner_etc_issue_net and sshd_enable_warning_banner_net