### PR TITLE
Fix test scenarios of selinux_state rule

### DIFF
--- a/linux_os/guide/system/selinux/selinux_state/tests/selinux_missing.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_state/tests/selinux_missing.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
 
 SELINUX_FILE='/etc/selinux/config'
 sed -i '/^[[:space:]]*SELINUX/d' $SELINUX_FILE

--- a/linux_os/guide/system/selinux/selinux_state/tests/selinux_permissive.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_state/tests/selinux_permissive.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
+# remediation = none
 
 SELINUX_FILE='/etc/selinux/config'
 


### PR DESCRIPTION
Fail test scenarios are running the rule remediation
which breaks test environemnt for SSGTS (`fixfiles -f`
clears `/tmp` directory). Therefore, we set `remediation`
test metadata to `none` for these scenarios to not run
remediation fix script.