### PR TITLE
Fix Ubuntu 20.04 SCAP 1.2 validation

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/ubuntu.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/oval/ubuntu.xml
@@ -1,3 +1,4 @@
+{{%- if target_oval_version == [5, 11] -%}}
 <def-group>
   <definition class="compliance" id="aide_periodic_cron_checking" version="3">
     {{{ oval_metadata("By default, AIDE does not install itself for periodic
@@ -74,3 +75,4 @@
     <linux:state state_ref="ste_aide_is_active" />
   </linux:systemdunitproperty_test>
 </def-group>
+{{% endif %}}


### PR DESCRIPTION


#### Description:

- Restrict check of `aide_periodic_cron_checking` to OVAL 5.11 builds.

#### Rationale:
- Fixes https://jenkins.complianceascode.io/job/scap-security-guide-scapval-scap-1.2/567/console
- `systemdunitproterty_test` was added in OVAL 5.11
- SCAP 1.2 uses OVAL 5.10

