### PR TITLE
Add remaining Blueprint templates

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -315,7 +315,7 @@
 
     -   **arg_value** - argument value, eg. `'1'`
 
--   Languages: Ansible, Bash, OVAL
+-   Languages: Ansible, Bash, OVAL, Blueprint
 
 #### kernel_module_disabled
 -   Checks if the given Linux kernel module is disabled.
@@ -355,7 +355,7 @@
 
     -   **min_size** - the minimum recommended partition size, in bytes
 
--   Languages: Anaconda, OVAL
+-   Languages: Anaconda, OVAL, Blueprint
 
 #### mount_option
 -   Checks if a given partition is mounted with a specific option such
@@ -433,7 +433,7 @@
         state uses operation "greater than or equal" to compare the
         collected package version with the version in the OVAL state.
 
--   Languages: Anaconda, Ansible, Bash, OVAL, Puppet
+-   Languages: Anaconda, Ansible, Bash, OVAL, Puppet, Blueprint
 
 #### package_removed
 -   Checks if the given package is not installed.
@@ -541,7 +541,7 @@
         If **daemonname** is not specified it means the name of the
         daemon is the same as the name of service.
 
--   Languages: Ansible, Bash, OVAL, Puppet, Ignition, Kubernetes
+-   Languages: Ansible, Bash, OVAL, Puppet, Ignition, Kubernetes, Blueprint
 
 #### service_enabled
 -   Checks if a system service is enabled. Uses either systemd or SysV
@@ -560,7 +560,7 @@
         If **daemonname** is not specified it means the name of the
         daemon is the same as the name of service.
 
--   Languages: Ansible, Bash, OVAL, Puppet
+-   Languages: Ansible, Bash, OVAL, Puppet, Blueprint
 
 #### shell_lineinfile
 -   Checks shell variable assignments in files. Remediations will paste

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -353,6 +353,8 @@
 
     -   **mountpoint** - path to the mount point, eg. `/var/tmp`
 
+    -   **min_size** - the minimum recommended partition size, in bytes
+
 -   Languages: Anaconda, OVAL
 
 #### mount_option

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_boot/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_boot/rule.yml
@@ -32,3 +32,4 @@ template:
     name: mount
     vars:
         mountpoint: /boot
+        min_size: 1073741824

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
@@ -54,3 +54,4 @@ template:
     name: mount
     vars:
         mountpoint: /home
+        min_size: 1073741824

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_opt/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_opt/rule.yml
@@ -31,3 +31,4 @@ template:
     name: mount
     vars:
         mountpoint: /opt
+        min_size: 1073741824

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_srv/rule.yml
@@ -33,3 +33,4 @@ template:
     name: mount
     vars:
         mountpoint: /srv
+        min_size: 1073741824

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -47,3 +47,4 @@ template:
     name: mount
     vars:
         mountpoint: /tmp
+        min_size: 1073741824

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_usr/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_usr/rule.yml
@@ -30,3 +30,4 @@ template:
     name: mount
     vars:
         mountpoint: /usr
+        min_size: 5368709120

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
@@ -54,3 +54,4 @@ template:
     name: mount
     vars:
         mountpoint: /var
+        min_size: 3221225472

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
@@ -51,4 +51,5 @@ template:
     name: mount
     vars:
         mountpoint: /var/log
+        min_size: 5368709120
 {{% endif %}}

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -63,4 +63,5 @@ template:
     name: mount
     vars:
         mountpoint: /var/log/audit
+        min_size: 10737418240
 {{% endif %}}

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -41,3 +41,4 @@ template:
     name: mount
     vars:
         mountpoint: /var/tmp
+        min_size: 1073741824

--- a/shared/templates/grub2_bootloader_argument/blueprint.template
+++ b/shared/templates/grub2_bootloader_argument/blueprint.template
@@ -1,0 +1,4 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
+
+[customizations.kernel]
+append = "{{{ ARG_NAME_VALUE }}}"

--- a/shared/templates/grub2_bootloader_argument/template.yml
+++ b/shared/templates/grub2_bootloader_argument/template.yml
@@ -2,3 +2,4 @@ supported_languages:
   - ansible
   - bash
   - oval
+  - blueprint

--- a/shared/templates/mount/blueprint.template
+++ b/shared/templates/mount/blueprint.template
@@ -1,0 +1,5 @@
+# platform = multi_platform_rhel,multi_platform_fedora
+
+[[customizations.filesystem]]
+mountpoint = "{{{ MOUNTPOINT }}}"
+size = {{{ MIN_SIZE }}}

--- a/shared/templates/mount/template.yml
+++ b/shared/templates/mount/template.yml
@@ -1,3 +1,4 @@
 supported_languages:
   - anaconda
   - oval
+  - blueprint

--- a/shared/templates/service_disabled/blueprint.template
+++ b/shared/templates/service_disabled/blueprint.template
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+[customizations.services]
+disabled = ["{{{ DAEMONNAME }}}"]

--- a/shared/templates/service_disabled/template.yml
+++ b/shared/templates/service_disabled/template.yml
@@ -5,3 +5,4 @@ supported_languages:
   - kubernetes
   - oval
   - puppet
+  - blueprint

--- a/shared/templates/service_enabled/blueprint.template
+++ b/shared/templates/service_enabled/blueprint.template
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+[customizations.services]
+enabled = ["{{{ DAEMONNAME }}}"]

--- a/shared/templates/service_enabled/template.yml
+++ b/shared/templates/service_enabled/template.yml
@@ -3,3 +3,4 @@ supported_languages:
   - bash
   - oval
   - puppet
+  - blueprint


### PR DESCRIPTION
Templates: `service_enabled`, `service_disabled`, `mount` and `grub2_bootloader_argument`.

This PR will also extend `mount` template with `min_size` argument, for the recommended minimal size of the partition.