### PR TITLE
Enable shell remediation for aide_check_audit_tools rule on SLE platform

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_ubuntu,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

- Enable shell remediation for aide_check_audit_tools rule on SLE platform

#### Rationale:

- Add multi_platform_sle to the shell remediation
- Make sure it includes in aide config also audispd as in other  non-redhat platforms