### PR TITLE
Ground work for implementation of CPE applicability language

### DIFF
--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -137,7 +137,8 @@ def main():
             continue
         benchmark_cpe_names.add(cpe_name)
     # add CPE names used by factref elements in CPEAL platforms
-    for factref in shorthandtree.findall(".//ns1:fact-ref", {"ns1": "http://cpe.mitre.org/language/2.0"}):
+    for factref in shorthandtree.findall(
+            ".//ns1:fact-ref", {"ns1": "http://cpe.mitre.org/language/2.0"}):
         cpe_factref_name = factref.get("name")
         benchmark_cpe_names.add(cpe_factref_name)
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -138,7 +138,7 @@ def main():
         benchmark_cpe_names.add(cpe_name)
     # add CPE names used by factref elements in CPEAL platforms
     for factref in shorthandtree.findall(
-            ".//ns1:fact-ref", {"ns1": "http://cpe.mitre.org/language/2.0"}):
+            ".//ns1:fact-ref", {"ns1":ssg.constants.PREFIX_TO_NS["cpe-lang"]}):
         cpe_factref_name = factref.get("name")
         benchmark_cpe_names.add(cpe_factref_name)
 

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -133,7 +133,7 @@ def main():
         cpe_name = platform.get("idref")
         # skip CPE AL platforms (they are handled later)
         # this is temporary solution until we get rid of old type of platforms in the benchmark
-        if cpe_name.startswith("cpe_platform_"):
+        if cpe_name.startswith("#"):
             continue
         benchmark_cpe_names.add(cpe_name)
     # add CPE names used by factref elements in CPEAL platforms

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -131,15 +131,19 @@ def main():
     shorthandtree = ssg.xml.parse_file(args.shorthandfile)
     for platform in shorthandtree.findall(".//platform"):
         cpe_name = platform.get("idref")
+        # skip CPE AL platforms (they are handled later)
+        # this is temporary solution until we get rid of old type of platforms in the benchmark
+        if cpe_name.startswith("cpe_platform_"):
+            continue
         benchmark_cpe_names.add(cpe_name)
-        print (benchmark_cpe_names)
+    # add CPE names used by factref elements in CPEAL platforms
+    for factref in shorthandtree.findall(".//ns1:fact-ref", {"ns1": "http://cpe.mitre.org/language/2.0"}):
+        cpe_factref_name = factref.get("name")
+        benchmark_cpe_names.add(cpe_factref_name)
 
     product_cpes = ssg.build_cpe.ProductCPEs(product_yaml)
     cpe_list = ssg.build_cpe.CPEList()
     for cpe_name in benchmark_cpe_names:
-        # skip CPE AL platforms
-        if cpe_name.startswith("cpe_platform_"):
-            break
         cpe_list.add(product_cpes.get_cpe(cpe_name))
 
     cpedict_filename = "ssg-" + product + "-cpe-dictionary.xml"

--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -132,10 +132,14 @@ def main():
     for platform in shorthandtree.findall(".//platform"):
         cpe_name = platform.get("idref")
         benchmark_cpe_names.add(cpe_name)
+        print (benchmark_cpe_names)
 
     product_cpes = ssg.build_cpe.ProductCPEs(product_yaml)
     cpe_list = ssg.build_cpe.CPEList()
     for cpe_name in benchmark_cpe_names:
+        # skip CPE AL platforms
+        if cpe_name.startswith("cpe_platform_"):
+            break
         cpe_list.add(product_cpes.get_cpe(cpe_name))
 
     cpedict_filename = "ssg-" + product + "-cpe-dictionary.xml"

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -106,17 +106,18 @@ class ProductCPEs(object):
     def get_product_cpe_names(self):
         return [ cpe.name for cpe in self.product_cpes.values() ]
 
-    def parse_platform_definition(self, platforms):
+    def parse_platform_definition(self, platform_line):
         # let's construct the platform id
-        id_list = [self._convert_platform_to_id(platform) for platform in platforms]
-        id = "_or_".join(id_list)
-        id = "cpe_platform_" + id
+        id = "cpe_platform_" + self._convert_platform_to_id(platform_line)
         platform = CPEALPlatform(id)
-        # add initial test
-        initial_test = CPEALLogicalTest(operator="OR", negate="false")
-        platform.add_test(initial_test)
-        for platform_line in platforms:
+        # add initial test if the line does not contain AND or NEGATE operator
+        # othervise the presence of & or ! will create the test while parsing
+        if "&" not in platform_line and "!" not in platform_line:
+            initial_test = CPEALLogicalTest(operator="OR", negate="false")
+            platform.add_test(initial_test)
             initial_test.add_object(self.parse_platform_line(platform_line))
+        else:
+            platform.add_test(self.parse_platform_line(platform_line))
         return platform
 
     def parse_platform_line(self, platform_line):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -219,7 +219,11 @@ class CPEALPlatformSpecification(object):
         self.platforms = []
 
     def add_platform(self, platform):
-        self.platforms.append(platform)
+        """
+        we check if semantically equal platform is not already in the list of platforms
+        """
+        if platform not in self.platforms:
+            self.platforms.append(platform)
 
     def to_xml_element(self):
         cpe_platform_spec = ET.Element(

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -108,15 +108,12 @@ class ProductCPEs(object):
 
     def parse_platform_definition(self, platforms):
         # let's construct the platform id
-        #print ("parsing platforms")
-        #print (platforms)
-        id_list = [self._convert_platform_to_id(platform) for platform in platforms ]
+        id_list = [self._convert_platform_to_id(platform) for platform in platforms]
         id = "_or_".join(id_list)
         id = "cpe_platform_" + id
-        #print (id)
         platform = CPEALPlatform(id)
         # add initial test
-        initial_test = CPEALTest(operator = "OR", negate = "false")
+        initial_test = CPEALTest(operator="OR", negate="false")
         platform.add_test(initial_test)
         for platform_line in platforms:
             initial_test.add_object(self.parse_platform_line(platform_line))
@@ -126,13 +123,13 @@ class ProductCPEs(object):
         # remove spaces
         platform_line = platform_line.replace(" ", "")
         if "&" in platform_line:
-            and_test = CPEALTest(operator = "AND", negate = "false")
+            and_test = CPEALTest(operator="AND", negate="false")
             and_members = platform_line.split("&")
             for member in and_members:
                 and_test.add_object(self.parse_platform_line(member))
             return and_test
         elif "!" in platform_line:
-            negated_test = CPEALTest(operator = "OR", negate = "true")
+            negated_test = CPEALTest(operator="OR", negate="true")
             # remove ! from the element and process it further
             platform_line.replace("!", "")
             negated_test.add_object(self.parse_platform_line(platform_line))
@@ -141,8 +138,6 @@ class ProductCPEs(object):
             # the line should contain a CPEAL ref name
             cpealfactref = CPEALFactRef(self.get_cpe_name(platform_line))
             return cpealfactref
-
-
 
     def _convert_platform_to_id(self, platform):
         id = platform
@@ -211,12 +206,14 @@ class CPEItem(object):
         cpe_item_check.set('system', oval_namespace)
         cpe_item_check.set('href', cpe_oval_filename)
         cpe_item_check.text = self.check_id
-
         return cpe_item
 
+
 class CPEALPlatformSpecification(object):
+
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
+
     def __init__(self):
         self.platforms = []
 
@@ -224,15 +221,18 @@ class CPEALPlatformSpecification(object):
         self.platforms.append(platform)
 
     def to_xml_element(self):
-        cpe_al_platform_spec = ET.Element("{%s}platform-specification" % CPEALPlatformSpecification.ns)
+        cpe_al_platform_spec = ET.Element(
+            "{%s}platform-specification" % CPEALPlatformSpecification.ns)
         for platform in self.platforms:
             cpe_al_platform_spec.append(platform.to_xml_element())
-
         return cpe_al_platform_spec
 
+
 class CPEALPlatform(object):
+
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
+
     def __init__(self, id):
         self.id = id
         self.test = None
@@ -244,7 +244,6 @@ class CPEALPlatform(object):
         cpe_al_platform = ET.Element("{%s}platform" % CPEALPlatform.ns)
         cpe_al_platform.set('id', self.id)
         cpe_al_platform.append(self.test.to_xml_element())
-
         return cpe_al_platform
 
     def __eq__(self, other):
@@ -252,8 +251,10 @@ class CPEALPlatform(object):
 
 
 class CPEALTest(object):
+
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
+
     def __init__(self, operator, negate):
         self.operator = operator
         self.negate = negate
@@ -261,7 +262,9 @@ class CPEALTest(object):
 
     def __eq__(self, other):
         if self.operator == other.operator and self.negate == other.negate:
-            diff = [i for i in self.objects + other.objects if i not in self.objects or i not in other.objects]
+            diff = [
+                i for i in self.objects + other.objects
+                if i not in self.objects or i not in other.objects]
             if not diff:
                 return True
                 return True
@@ -286,10 +289,11 @@ class CPEALTest(object):
         return self.objects
 
 
-
 class CPEALFactRef (object):
+
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
+
     def __init__(self, name):
         self.name = name
 

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -268,11 +268,13 @@ class CPEALTest(object):
         self.objects = []
 
     def __eq__(self, other):
-        if self.operator == other.operator:
-            for object in self.objects:
-                if object not in other.objects:
-                    return False
-            return True
+        if self.operator == other.operator and self.negate == other.negate:
+            diff = [i for i in self.objects + other.objects if i not in self.objects or i not in other.objects]
+            if not diff:
+                return True
+                return True
+            else:
+                return False
         else:
             return False
 

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -362,17 +362,9 @@ def parse_platform_line(platform_line, product_cpe):
     # remove spaces
     platform_line = platform_line.replace(" ", "")
     if "&" in platform_line:
-        and_test = CPEALLogicalTest(operator="AND", negate="false")
-        and_members = platform_line.split("&")
-        for member in and_members:
-            and_test.add_object(parse_platform_line(member))
-        return and_test
+        raise (NotImplementedError("not implemented yet"))
     elif "!" in platform_line:
-        negated_test = CPEALLogicalTest(operator="OR", negate="true")
-        # remove ! from the element and process it further
-        platform_line = platform_line.replace("!", "")
-        negated_test.add_object(parse_platform_line(platform_line))
-        return negated_test
+        raise (NotImplementedError("not implemented yet"))
     else:
         # the line should contain a CPEAL ref name
         cpealfactref = CPEALFactRef(product_cpe.get_cpe_name(platform_line))

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -106,19 +106,6 @@ class ProductCPEs(object):
     def get_product_cpe_names(self):
         return [ cpe.name for cpe in self.product_cpes.values() ]
 
-    def parse_platform_definition(self, platform_line):
-        # let's construct the platform id
-        id = "cpe_platform_" + convert_platform_to_id(platform_line)
-        platform = CPEALPlatform(id)
-        # add initial test if the line does not contain AND or NEGATE operator
-        # othervise the presence of & or ! will create the test while parsing
-        if "&" not in platform_line and "!" not in platform_line:
-            initial_test = CPEALLogicalTest(operator="OR", negate="false")
-            platform.add_test(initial_test)
-            initial_test.add_object(parse_platform_line(platform_line, self))
-        else:
-            platform.add_test(parse_platform_line(platform_line, self))
-        return platform
 
 
 class CPEList(object):
@@ -396,3 +383,21 @@ def convert_platform_to_id(platform):
     id = id.replace("&", "_and_")
     id = id.replace("!", "not_")
     return id
+
+def parse_platform_definition(platform_line, product_cpes):
+    """
+    This function takes one line of platform definition from yaml file and returns a
+    CPE platform with appropriate tests and factrefs.
+    """
+    # let's construct the platform id
+    id = "cpe_platform_" + convert_platform_to_id(platform_line)
+    platform = CPEALPlatform(id)
+    # add initial test if the line does not contain AND or NEGATE operator
+    # othervise the presence of & or ! will create the test while parsing
+    if "&" not in platform_line and "!" not in platform_line:
+        initial_test = CPEALLogicalTest(operator="OR", negate="false")
+        platform.add_test(initial_test)
+        initial_test.add_object(parse_platform_line(platform_line, product_cpes))
+    else:
+        platform.add_test(parse_platform_line(platform_line, product_cpes))
+    return platform

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -30,7 +30,6 @@ class ProductCPEs(object):
         self.cpes_by_id = {}
         self.cpes_by_name = {}
         self.product_cpes = {}
-        self.cpe_al_ref_checks = {}
         self.cpe_al_platforms = {}
         self.cpe_al_platform_specification = CPEALPlatformSpecification()
 
@@ -42,16 +41,10 @@ class ProductCPEs(object):
             for cpe_id in cpe.keys():
                 map_[cpe_id] = CPEItem(cpe[cpe_id])
 
-    def _load_cpes_al_ref_list(self, map_, cpes_list):
-        for cpe in cpes_list:
-            for cpe_id in cpe.keys():
-                map_[cpe_id] = CPEALCheckFactRef(cpe[cpe_id])
-
     def load_product_cpes(self):
         try:
             product_cpes_list = self.product_yaml["cpes"]
             self._load_cpes_list(self.product_cpes, product_cpes_list)
-            self._load_cpes_al_ref_list(self.cpe_al_ref_checks, product_cpes_list)
 
         except KeyError:
             print("Product %s does not define 'cpes'" % (self.product_yaml["product"]))
@@ -81,7 +74,6 @@ class ProductCPEs(object):
             # Get past "cpes" key, which was added for readability of the content
             cpes_list = open_raw(dir_item_path)["cpes"]
             self._load_cpes_list(self.cpes_by_id, cpes_list)
-            self._load_cpes_al_ref_list(self.cpe_al_ref_checks, cpes_list)
 
         # Add product_cpes to map of CPEs by ID
         self.cpes_by_id = merge_dicts(self.cpes_by_id, self.product_cpes)
@@ -294,25 +286,6 @@ class CPEALTest(object):
         return self.objects
 
 
-class CPEALCheckFactRef(object):
-    prefix = "cpe-lang"
-    ns = PREFIX_TO_NS[prefix]
-    def __init__(self, cpeitem_data):
-        self.name = cpeitem_data["name"]
-        self.title = cpeitem_data["title"]
-        self.check_id = cpeitem_data["check_id"]
-
-    def __eq__(self, other):
-        return self.check_id == other.check_id
-
-    def to_xml_element(self, cpe_oval_filename):
-        cpe_al_refcheck = ET.Element("{%s}check-fact-ref" % CPEALCheckFactRef.ns)
-        cpe_al_refcheck.set('description', self.title)
-        cpe_al_refcheck.set('system', oval_namespace)
-        cpe_al_refcheck.set('href', cpe_oval_filename)
-        cpe_al_refcheck.set('id-ref', self.check_id)
-
-        return cpe_al_refcheck
 
 class CPEALFactRef (object):
     prefix = "cpe-lang"

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -30,8 +30,8 @@ class ProductCPEs(object):
         self.cpes_by_id = {}
         self.cpes_by_name = {}
         self.product_cpes = {}
-        self.cpe_al_platforms = {}
-        self.cpe_al_platform_specification = CPEALPlatformSpecification()
+        self.cpe_platforms = {}
+        self.cpe_platform_specification = CPEALPlatformSpecification()
 
         self.load_product_cpes()
         self.load_content_cpes()
@@ -221,11 +221,11 @@ class CPEALPlatformSpecification(object):
         self.platforms.append(platform)
 
     def to_xml_element(self):
-        cpe_al_platform_spec = ET.Element(
+        cpe_platform_spec = ET.Element(
             "{%s}platform-specification" % CPEALPlatformSpecification.ns)
         for platform in self.platforms:
-            cpe_al_platform_spec.append(platform.to_xml_element())
-        return cpe_al_platform_spec
+            cpe_platform_spec.append(platform.to_xml_element())
+        return cpe_platform_spec
 
 
 class CPEALPlatform(object):
@@ -241,10 +241,10 @@ class CPEALPlatform(object):
         self.test = test
 
     def to_xml_element(self):
-        cpe_al_platform = ET.Element("{%s}platform" % CPEALPlatform.ns)
-        cpe_al_platform.set('id', self.id)
-        cpe_al_platform.append(self.test.to_xml_element())
-        return cpe_al_platform
+        cpe_platform = ET.Element("{%s}platform" % CPEALPlatform.ns)
+        cpe_platform.set('id', self.id)
+        cpe_platform.append(self.test.to_xml_element())
+        return cpe_platform
 
     def __eq__(self, other):
         return self.test == other.test
@@ -270,13 +270,13 @@ class CPEALTest(object):
             return False
 
     def to_xml_element(self):
-        cpe_al_test = ET.Element("{%s}logical-test" % CPEALTest.ns)
-        cpe_al_test.set('operator', self.operator)
-        cpe_al_test.set('negate', self.negate)
+        cpe_test = ET.Element("{%s}logical-test" % CPEALTest.ns)
+        cpe_test.set('operator', self.operator)
+        cpe_test.set('negate', self.negate)
         for obj in self.objects:
-            cpe_al_test.append(obj.to_xml_element())
+            cpe_test.append(obj.to_xml_element())
 
-        return cpe_al_test
+        return cpe_test
 
     def add_object(self, object):
         self.objects.append(object)
@@ -297,10 +297,10 @@ class CPEALFactRef (object):
         return self.name == other.name
 
     def to_xml_element(self):
-        cpe_al_factref = ET.Element("{%s}fact-ref" % CPEALFactRef.ns)
-        cpe_al_factref.set('name', self.name)
+        cpe_factref = ET.Element("{%s}fact-ref" % CPEALFactRef.ns)
+        cpe_factref.set('name', self.name)
 
-        return cpe_al_factref
+        return cpe_factref
 
 def extract_subelement(objects, sub_elem_type):
     """

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -120,6 +120,7 @@ class ProductCPEs(object):
         #print (platforms)
         id_list = [self._convert_platform_to_id(platform) for platform in platforms ]
         id = "_or_".join(id_list)
+        id = "cpe_platform_" + id
         #print (id)
         platform = CPEALPlatform(id)
         # add initial test

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -248,7 +248,10 @@ class CPEALPlatform(object):
         return cpe_platform
 
     def __eq__(self, other):
-        return self.test == other.test
+        if not isinstance(other, CPEALPlatform):
+            return False
+        else:
+            return self.test == other.test
 
 
 class CPEALLogicalTest(object):
@@ -262,19 +265,25 @@ class CPEALLogicalTest(object):
         self.objects = []
 
     def __eq__(self, other):
-        if self.operator == other.operator and self.negate == other.negate:
-            diff = [
-                i for i in self.objects + other.objects
-                if i not in self.objects or i not in other.objects]
-            return (not diff)
-        else:
+        if not isinstance(other, CPEALLogicalTest):
             return False
+        else:
+            if self.operator == other.operator and self.negate == other.negate:
+                diff = [
+                    i for i in self.objects + other.objects
+                    if i not in self.objects or i not in other.objects]
+                return (not diff)
+            else:
+                return False
 
     def to_xml_element(self):
         cpe_test = ET.Element("{%s}logical-test" % CPEALLogicalTest.ns)
         cpe_test.set('operator', self.operator)
         cpe_test.set('negate', self.negate)
-        for obj in self.objects:
+        # logical tests must go first, therefore we spearate tests and factrefs
+        tests = [t for t in self.objects if isinstance(t, CPEALLogicalTest)]
+        factrefs = [f for f in self.objects if isinstance(f, CPEALFactRef)]
+        for obj in tests + factrefs:
             cpe_test.append(obj.to_xml_element())
 
         return cpe_test
@@ -295,7 +304,10 @@ class CPEALFactRef (object):
         self.name = name
 
     def __eq__(self, other):
-        return self.name == other.name
+        if not isinstance(other, CPEALFactRef):
+            return False
+        else:
+            return self.name == other.name
 
     def to_xml_element(self):
         cpe_factref = ET.Element("{%s}fact-ref" % CPEALFactRef.ns)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -108,7 +108,7 @@ class ProductCPEs(object):
 
     def parse_platform_definition(self, platform_line):
         # let's construct the platform id
-        id = "cpe_platform_" + self._convert_platform_to_id(platform_line)
+        id = "cpe_platform_" + convert_platform_to_id(platform_line)
         platform = CPEALPlatform(id)
         # add initial test if the line does not contain AND or NEGATE operator
         # othervise the presence of & or ! will create the test while parsing
@@ -119,13 +119,6 @@ class ProductCPEs(object):
         else:
             platform.add_test(parse_platform_line(platform_line, self))
         return platform
-
-    def _convert_platform_to_id(self, platform):
-        id = platform.replace(" ", "")
-        id = id.replace("&", "_and_")
-        id = id.replace("!", "not_")
-        return id
-
 
 
 class CPEList(object):
@@ -397,3 +390,9 @@ def parse_platform_line(platform_line, product_cpe):
         # the line should contain a CPEAL ref name
         cpealfactref = CPEALFactRef(product_cpe.get_cpe_name(platform_line))
         return cpealfactref
+
+def convert_platform_to_id(platform):
+    id = platform.replace(" ", "")
+    id = id.replace("&", "_and_")
+    id = id.replace("!", "not_")
+    return id

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -30,6 +30,7 @@ class ProductCPEs(object):
         self.cpes_by_id = {}
         self.cpes_by_name = {}
         self.product_cpes = {}
+        self.cpe_al_ref_checks = {}
 
         self.load_product_cpes()
         self.load_content_cpes()
@@ -39,11 +40,17 @@ class ProductCPEs(object):
             for cpe_id in cpe.keys():
                 map_[cpe_id] = CPEItem(cpe[cpe_id])
 
+    def _load_cpes_al_ref_list(self, map_, cpes_list):
+        for cpe in cpes_list:
+            for cpe_id in cpe.keys():
+                map_[cpe_id] = CPEALFactCheck(cpe[cpe_id])
+
     def load_product_cpes(self):
 
         try:
             product_cpes_list = self.product_yaml["cpes"]
             self._load_cpes_list(self.product_cpes, product_cpes_list)
+            self._load_cpes_al_ref_list(self.cpe_al_ref_checks, product_cpes_list)
 
         except KeyError:
             print("Product %s does not define 'cpes'" % (self.product_yaml["product"]))
@@ -73,6 +80,7 @@ class ProductCPEs(object):
             # Get past "cpes" key, which was added for readability of the content
             cpes_list = open_raw(dir_item_path)["cpes"]
             self._load_cpes_list(self.cpes_by_id, cpes_list)
+            self._load_cpes_al_ref_list(self.cpe_al_ref_checks, cpes_list)
 
         # Add product_cpes to map of CPEs by ID
         self.cpes_by_id = merge_dicts(self.cpes_by_id, self.product_cpes)
@@ -166,6 +174,46 @@ class CPEItem(object):
         cpe_item_check.text = self.check_id
 
         return cpe_item
+
+class CPEALPlatformSpecification(object):
+    def __init__(self):
+        self.platforms = []
+
+    def add_platform(self, platform):
+        self.platforms.append(platform)
+
+class CPEALPlatform(object):
+    def __init__():
+        self.id = ""
+        self.test = None
+
+    def add_test(self, test):
+        self.test = test
+
+class CPEALTest(object):
+    def __init__(self):
+        self.id = None
+        self.operator = None
+        self.negated = False
+        self.objects = []
+
+    def __eq__(self, other):
+        if self.operator == other.operator:
+            for object in self.objects:
+                if object not in other.objects:
+                    return False
+            return True
+        else:
+            return False
+
+class CPEALFactCheck(object):
+    def __init__(self, cpeitem_data):
+        self.name = cpeitem_data["name"]
+        self.title = cpeitem_data["title"]
+        self.check_id = cpeitem_data["check_id"]
+
+    def __eq__(self, other):
+        return self.refid == other.refid
 
 
 def extract_subelement(objects, sub_elem_type):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -132,7 +132,7 @@ class ProductCPEs(object):
         elif "!" in platform_line:
             negated_test = CPEALLogicalTest(operator="OR", negate="true")
             # remove ! from the element and process it further
-            platform_line.replace("!", "")
+            platform_line = platform_line.replace("!", "")
             negated_test.add_object(self.parse_platform_line(platform_line))
             return negated_test
         else:
@@ -141,9 +141,9 @@ class ProductCPEs(object):
             return cpealfactref
 
     def _convert_platform_to_id(self, platform):
-        id = platform
-        id.replace(" & ", "_and_")
-        id.replace("!", "not_")
+        id = platform.replace(" ", "")
+        id = id.replace("&", "_and_")
+        id = id.replace("!", "not_")
         return id
 
 

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -372,8 +372,6 @@ def parse_platform_line(platform_line, product_cpe):
 
 def convert_platform_to_id(platform):
     id = platform.replace(" ", "")
-    id = id.replace("&", "_and_")
-    id = id.replace("!", "not_")
     return id
 
 def parse_platform_definition(platform_line, product_cpes):
@@ -384,12 +382,7 @@ def parse_platform_definition(platform_line, product_cpes):
     # let's construct the platform id
     id = "cpe_platform_" + convert_platform_to_id(platform_line)
     platform = CPEALPlatform(id)
-    # add initial test if the line does not contain AND or NEGATE operator
-    # othervise the presence of & or ! will create the test while parsing
-    if "&" not in platform_line and "!" not in platform_line:
-        initial_test = CPEALLogicalTest(operator="OR", negate="false")
-        platform.add_test(initial_test)
-        initial_test.add_object(parse_platform_line(platform_line, product_cpes))
-    else:
-        platform.add_test(parse_platform_line(platform_line, product_cpes))
+    initial_test = CPEALLogicalTest(operator="OR", negate="false")
+    platform.add_test(initial_test)
+    initial_test.add_object(parse_platform_line(platform_line, product_cpes))
     return platform

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -182,6 +182,13 @@ class CPEALPlatformSpecification(object):
     def add_platform(self, platform):
         self.platforms.append(platform)
 
+    def to_xml_element(self, cpe_oval_filename):
+        cpe_al_platform_spec = ET.Element("{%s}cpe-lang:platform-specification" % CPEItem.ns)
+        for platform in self.platforms:
+            cpe_al_platform_spec.append(platform.to_xml_element(cpe_oval_file))
+
+        return cpe_al_platform_spec
+
 class CPEALPlatform(object):
     def __init__():
         self.id = ""
@@ -190,11 +197,19 @@ class CPEALPlatform(object):
     def add_test(self, test):
         self.test = test
 
+    def to_xml_element(self, cpe_oval_filename):
+        cpe_al_platform = ET.Element("{%s}cpe-lang:platform" % CPEItem.ns)
+        cpe_al_platform.add('id', self.id)
+        cpe_al_platform.append(self.text.to_xml_element(cpe_oval_filename))
+
+        return cpe_al_platform
+
+
 class CPEALTest(object):
     def __init__(self):
         self.id = None
-        self.operator = None
-        self.negated = False
+        self.operator = ""
+        self.negate = ""
         self.objects = []
 
     def __eq__(self, other):
@@ -206,6 +221,16 @@ class CPEALTest(object):
         else:
             return False
 
+    def to_xml_element(self, cpe_oval_filename):
+        cpe_al_test = ET.Element("{%s}cpe-lang:logical-test" % CPEItem.ns)
+        cpe_al_test.set('operator', self.operator)
+        cpe_al_test.set('negate', self.negate)
+        for obj in self.objects:
+            cpe_al_test.append(obj.to_xml_element(cpe_oval_filename))
+
+        return cpe_al_test
+
+
 class CPEALFactCheck(object):
     def __init__(self, cpeitem_data):
         self.name = cpeitem_data["name"]
@@ -214,6 +239,15 @@ class CPEALFactCheck(object):
 
     def __eq__(self, other):
         return self.refid == other.refid
+
+    def to_xml_element(self, cpe_oval_filename):
+        cpe_al_refcheck = ET.Element("{%s}cpe-lang:check-fact-ref" % CPEItem.ns)
+        cpe_al_refcheck.set('description', self.title)
+        cpe_al_refcheck.set('system', oval_namespace)
+        cpe_al_refcheck.set('href', cpe_oval_filename)
+        cpe_al_refcheck.set('id-ref', self.check_id)
+
+        return cpe_al_refcheck
 
 
 def extract_subelement(objects, sub_elem_type):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -113,7 +113,7 @@ class ProductCPEs(object):
         id = "cpe_platform_" + id
         platform = CPEALPlatform(id)
         # add initial test
-        initial_test = CPEALTest(operator="OR", negate="false")
+        initial_test = CPEALLogicalTest(operator="OR", negate="false")
         platform.add_test(initial_test)
         for platform_line in platforms:
             initial_test.add_object(self.parse_platform_line(platform_line))
@@ -123,13 +123,13 @@ class ProductCPEs(object):
         # remove spaces
         platform_line = platform_line.replace(" ", "")
         if "&" in platform_line:
-            and_test = CPEALTest(operator="AND", negate="false")
+            and_test = CPEALLogicalTest(operator="AND", negate="false")
             and_members = platform_line.split("&")
             for member in and_members:
                 and_test.add_object(self.parse_platform_line(member))
             return and_test
         elif "!" in platform_line:
-            negated_test = CPEALTest(operator="OR", negate="true")
+            negated_test = CPEALLogicalTest(operator="OR", negate="true")
             # remove ! from the element and process it further
             platform_line.replace("!", "")
             negated_test.add_object(self.parse_platform_line(platform_line))
@@ -250,7 +250,7 @@ class CPEALPlatform(object):
         return self.test == other.test
 
 
-class CPEALTest(object):
+class CPEALLogicalTest(object):
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
@@ -270,7 +270,7 @@ class CPEALTest(object):
             return False
 
     def to_xml_element(self):
-        cpe_test = ET.Element("{%s}logical-test" % CPEALTest.ns)
+        cpe_test = ET.Element("{%s}logical-test" % CPEALLogicalTest.ns)
         cpe_test.set('operator', self.operator)
         cpe_test.set('negate', self.negate)
         for obj in self.objects:

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -265,11 +265,7 @@ class CPEALTest(object):
             diff = [
                 i for i in self.objects + other.objects
                 if i not in self.objects or i not in other.objects]
-            if not diff:
-                return True
-                return True
-            else:
-                return False
+            return (not diff)
         else:
             return False
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -953,6 +953,7 @@ class Group(XCCDFEntity):
         platform=lambda: "",
         platforms=lambda: set(),
         cpe_names=lambda: set(),
+        cpe_al_platform_names=lambda: set(),
         ** XCCDFEntity.KEYS
     )
 
@@ -982,6 +983,14 @@ class Group(XCCDFEntity):
 
         if data["platform"]:
             data["platforms"].add(data["platform"])
+
+        # parse platform definition and get CPEAL platform
+        if data["platforms"]:
+            cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(data["platforms"])
+            data["cpe_al_platform_names"].add(cpeal_platform.id)
+            # add platform to platform specification
+            if cpeal_platform not in env_yaml["product_cpes"].cpe_al_platform_specification.platforms:
+                env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(cpeal_platform)
         return data
 
     def load_entities(self, rules_by_id, values_by_id, groups_by_id):
@@ -1030,9 +1039,9 @@ class Group(XCCDFEntity):
         add_nondata_subelements(group, "requires", "id", self.requires)
         add_nondata_subelements(group, "conflicts", "id", self.conflicts)
 
-        for cpe_name in self.cpe_names:
+        for cpe_al_platform_name in self.cpe_al_platform_names:
             platform_el = ET.SubElement(group, "platform")
-            platform_el.set("idref", cpe_name)
+            platform_el.set("idref", cpe_al_platform_name)
 
         for _value in self.values.values():
             group.append(_value.to_xml_element())

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -992,8 +992,7 @@ class Group(XCCDFEntity):
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(platform)
                 data["cpe_platform_names"].add(cpe_platform.id)
                 # add platform to platform specification
-                if cpe_platform not in env_yaml["product_cpes"].cpe_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
+                env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
         return data
 
     def load_entities(self, rules_by_id, values_by_id, groups_by_id):
@@ -1132,10 +1131,8 @@ class Group(XCCDFEntity):
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     platform)
                 group.cpe_platform_names.add(cpe_platform.id)
-                if cpe_platform not in env_yaml[
-                        "product_cpes"].cpe_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(
-                        cpe_platform)
+                env_yaml["product_cpes"].cpe_platform_specification.add_platform(
+                    cpe_platform)
 
     def _pass_our_properties_on_to(self, obj):
         for attr in self.ATTRIBUTES_TO_PASS_ON:
@@ -1156,10 +1153,8 @@ class Group(XCCDFEntity):
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
-                if cpe_platform not in env_yaml[
-                        "product_cpes"].cpe_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(
-                        cpe_platform)
+                env_yaml["product_cpes"].cpe_platform_specification.add_platform(
+                    cpe_platform)
 
     def __str__(self):
         return self.id_
@@ -1262,10 +1257,8 @@ class Rule(XCCDFEntity):
                     platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
                 # add platform to platform specification
-                if cpe_platform not in env_yaml[
-                        "product_cpes"].cpe_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(
-                        cpe_platform)
+                env_yaml["product_cpes"].cpe_platform_specification.add_platform(
+                    cpe_platform)
 
 
         if sce_metadata and rule.id_ in sce_metadata:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1248,10 +1248,11 @@ class Rule(XCCDFEntity):
                     raise
             # parse platform definition and get CPEAL platform
             if len(rule.platforms) > 0:
-                rule.cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(rule.platforms)
+                cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(rule.platforms)
+                rule.cpe_al_platform_names.add(cpeal_platform.id)
                 # add platform to platform specification
-                if rule.cpeal_platform not in env_yaml["product_cpes"].cpe_al_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(rule.cpeal_platform)
+                if cpeal_platform not in env_yaml["product_cpes"].cpe_al_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(cpeal_platform)
 
 
         if sce_metadata and rule.id_ in sce_metadata:
@@ -1572,9 +1573,9 @@ class Rule(XCCDFEntity):
         add_nondata_subelements(rule, "requires", "id", self.requires)
         add_nondata_subelements(rule, "conflicts", "id", self.conflicts)
 
-        for cpe_name in self.cpe_names:
+        for cpe_al_platform_name in self.cpe_al_platform_names:
             platform_el = ET.SubElement(rule, "platform")
-            platform_el.set("idref", cpe_name)
+            platform_el.set("idref", cpe_al_platform_name)
 
         return rule
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -865,7 +865,9 @@ class Benchmark(XCCDFEntity):
         notice.set('id', self.notice_id)
         add_sub_element(root, "front-matter", self.front_matter)
         add_sub_element(root, "rear-matter", self.rear_matter)
-        root.append(self.cpe_al_platform_spec.to_xml_element())
+        # if there are no platforms, do not output platform-specification at all
+        if len(self.cpe_al_platform_spec.platforms) > 0:
+            root.append(self.cpe_al_platform_spec.to_xml_element())
 
         # The Benchmark applicability is determined by the CPEs
         # defined in the product.yml

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -810,6 +810,7 @@ class Benchmark(XCCDFEntity):
         benchmark = super(Benchmark, cls).from_yaml(yaml_file, env_yaml)
         if env_yaml:
             benchmark.product_cpe_names = env_yaml["product_cpes"].get_product_cpe_names()
+            benchmark.cpe_al_platform_spec = env_yaml["product_cpes"].cpe_al_platform_specification
 
         benchmark.id_ = benchmark_id
 
@@ -863,6 +864,8 @@ class Benchmark(XCCDFEntity):
         notice.set('id', self.notice_id)
         add_sub_element(root, "front-matter", self.front_matter)
         add_sub_element(root, "rear-matter", self.rear_matter)
+        # tbd: oval file hardcoded here, must be fixed
+        root.append(self.cpe_al_platform_spec.to_xml_element("ssg-oval-cpe.xml"))
 
         # The Benchmark applicability is determined by the CPEs
         # defined in the product.yml

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1259,11 +1259,14 @@ class Rule(XCCDFEntity):
                     raise
             # parse platform definition and get CPEAL platform
             if len(rule.platforms) > 0:
-                cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(rule.platforms)
+                cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(
+                    rule.platforms)
                 rule.cpe_al_platform_names.add(cpeal_platform.id)
                 # add platform to platform specification
-                if cpeal_platform not in env_yaml["product_cpes"].cpe_al_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(cpeal_platform)
+                if cpeal_platform not in env_yaml[
+                        "product_cpes"].cpe_al_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(
+                        cpeal_platform)
 
 
         if sce_metadata and rule.id_ in sce_metadata:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1043,7 +1043,7 @@ class Group(XCCDFEntity):
 
         for cpe_al_platform_name in self.cpe_al_platform_names:
             platform_el = ET.SubElement(group, "platform")
-            platform_el.set("idref", cpe_al_platform_name)
+            platform_el.set("idref", "#"+cpe_al_platform_name)
 
         for _value in self.values.values():
             group.append(_value.to_xml_element())
@@ -1589,7 +1589,7 @@ class Rule(XCCDFEntity):
 
         for cpe_al_platform_name in self.cpe_al_platform_names:
             platform_el = ET.SubElement(rule, "platform")
-            platform_el.set("idref", cpe_al_platform_name)
+            platform_el.set("idref", "#"+cpe_al_platform_name)
 
         return rule
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -938,6 +938,7 @@ class Group(XCCDFEntity):
     """
     ATTRIBUTES_TO_PASS_ON = (
         "platforms",
+        "cpe_names",
     )
 
     GENERIC_FILENAME = "group.yml"
@@ -1133,6 +1134,9 @@ class Group(XCCDFEntity):
                 except CPEDoesNotExist:
                     print("Unsupported platform '%s' in group '%s'." % (platform, group.id_))
                     raise
+            cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
+                group.platforms)
+            group.cpe_platform_names.add(cpe_platform.id)
 
     def _pass_our_properties_on_to(self, obj):
         for attr in self.ATTRIBUTES_TO_PASS_ON:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -989,11 +989,12 @@ class Group(XCCDFEntity):
 
         # parse platform definition and get CPEAL platform
         if data["platforms"]:
-            cpe_platform = env_yaml["product_cpes"].parse_platform_definition(data["platforms"])
-            data["cpe_platform_names"].add(cpe_platform.id)
-            # add platform to platform specification
-            if cpe_platform not in env_yaml["product_cpes"].cpe_platform_specification.platforms:
-                env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
+            for platform in data["platforms"]:
+                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(platform)
+                data["cpe_platform_names"].add(cpe_platform.id)
+                # add platform to platform specification
+                if cpe_platform not in env_yaml["product_cpes"].cpe_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
         return data
 
     def load_entities(self, rules_by_id, values_by_id, groups_by_id):
@@ -1134,9 +1135,9 @@ class Group(XCCDFEntity):
                 except CPEDoesNotExist:
                     print("Unsupported platform '%s' in group '%s'." % (platform, group.id_))
                     raise
-            cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
-                group.platforms)
-            group.cpe_platform_names.add(cpe_platform.id)
+                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
+                    platform)
+                group.cpe_platform_names.add(cpe_platform.id)
 
     def _pass_our_properties_on_to(self, obj):
         for attr in self.ATTRIBUTES_TO_PASS_ON:
@@ -1159,6 +1160,9 @@ class Group(XCCDFEntity):
                 except CPEDoesNotExist:
                     print("Unsupported platform '%s' in rule '%s'." % (platform, rule.id_))
                     raise
+                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
+                    platform)
+                rule.cpe_platform_names.add(cpe_platform.id)
 
     def __str__(self):
         return self.id_
@@ -1263,9 +1267,9 @@ class Rule(XCCDFEntity):
                     print("Unsupported platform '%s' in rule '%s'." % (platform, rule.id_))
                     raise
             # parse platform definition and get CPEAL platform
-            if len(rule.platforms) > 0:
+            for platform in rule.platforms:
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
-                    rule.platforms)
+                    platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
                 # add platform to platform specification
                 if cpe_platform not in env_yaml[

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -14,7 +14,7 @@ import glob
 
 import yaml
 
-from .build_cpe import CPEDoesNotExist
+from .build_cpe import CPEDoesNotExist, parse_platform_definition
 from .constants import XCCDF_REFINABLE_PROPERTIES, SCE_SYSTEM, ocil_cs, ocil_namespace, xhtml_namespace, xsi_namespace, timestamp
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 from .rule_yaml import parse_prodtype
@@ -989,7 +989,7 @@ class Group(XCCDFEntity):
         # parse platform definition and get CPEAL platform
         if data["platforms"]:
             for platform in data["platforms"]:
-                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(platform)
+                cpe_platform = parse_platform_definition(platform, env_yaml["product_cpes"])
                 data["cpe_platform_names"].add(cpe_platform.id)
                 # add platform to platform specification
                 env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
@@ -1128,8 +1128,8 @@ class Group(XCCDFEntity):
         # Once the group has inherited properties, update cpe_names
         if env_yaml:
             for platform in group.platforms:
-                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
-                    platform)
+                cpe_platform = parse_platform_definition(
+                    platform, env_yaml["product_cpes"])
                 group.cpe_platform_names.add(cpe_platform.id)
                 env_yaml["product_cpes"].cpe_platform_specification.add_platform(
                     cpe_platform)
@@ -1150,8 +1150,8 @@ class Group(XCCDFEntity):
         # Once the rule has inherited properties, update cpe_platform_names
         if env_yaml:
             for platform in rule.platforms:
-                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
-                    platform)
+                cpe_platform = parse_platform_definition(
+                    platform, env_yaml["product_cpes"])
                 rule.cpe_platform_names.add(cpe_platform.id)
                 env_yaml["product_cpes"].cpe_platform_specification.add_platform(
                     cpe_platform)
@@ -1253,8 +1253,8 @@ class Rule(XCCDFEntity):
                 or env_yaml and rule.prodtype == "all"):
             # parse platform definition and get CPEAL platform
             for platform in rule.platforms:
-                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
-                    platform)
+                cpe_platform = parse_platform_definition(
+                    platform, env_yaml["product_cpes"])
                 rule.cpe_platform_names.add(cpe_platform.id)
                 # add platform to platform specification
                 env_yaml["product_cpes"].cpe_platform_specification.add_platform(

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1132,6 +1132,10 @@ class Group(XCCDFEntity):
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     platform)
                 group.cpe_platform_names.add(cpe_platform.id)
+                if cpe_platform not in env_yaml[
+                        "product_cpes"].cpe_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(
+                        cpe_platform)
 
     def _pass_our_properties_on_to(self, obj):
         for attr in self.ATTRIBUTES_TO_PASS_ON:
@@ -1152,6 +1156,10 @@ class Group(XCCDFEntity):
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
+                if cpe_platform not in env_yaml[
+                        "product_cpes"].cpe_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(
+                        cpe_platform)
 
     def __str__(self):
         return self.id_

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -938,7 +938,7 @@ class Group(XCCDFEntity):
     """
     ATTRIBUTES_TO_PASS_ON = (
         "platforms",
-        "cpe_names",
+        "cpe_platform_names",
     )
 
     GENERIC_FILENAME = "group.yml"
@@ -955,7 +955,6 @@ class Group(XCCDFEntity):
         rules=lambda: dict(),
         platform=lambda: "",
         platforms=lambda: set(),
-        cpe_names=lambda: set(),
         cpe_platform_names=lambda: set(),
         ** XCCDFEntity.KEYS
     )
@@ -1130,11 +1129,6 @@ class Group(XCCDFEntity):
         # Once the group has inherited properties, update cpe_names
         if env_yaml:
             for platform in group.platforms:
-                try:
-                    group.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))
-                except CPEDoesNotExist:
-                    print("Unsupported platform '%s' in group '%s'." % (platform, group.id_))
-                    raise
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     platform)
                 group.cpe_platform_names.add(cpe_platform.id)
@@ -1152,14 +1146,9 @@ class Group(XCCDFEntity):
         self.rules[rule.id_] = rule
         self._pass_our_properties_on_to(rule)
 
-        # Once the rule has inherited properties, update cpe_names
+        # Once the rule has inherited properties, update cpe_platform_names
         if env_yaml:
             for platform in rule.platforms:
-                try:
-                    rule.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))
-                except CPEDoesNotExist:
-                    print("Unsupported platform '%s' in rule '%s'." % (platform, rule.id_))
-                    raise
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
@@ -1203,7 +1192,6 @@ class Rule(XCCDFEntity):
         platforms=lambda: set(),
         inherited_platforms=lambda: list(),
         template=lambda: None,
-        cpe_names=lambda: set(),
         cpe_platform_names=lambda: set(),
         ** XCCDFEntity.KEYS
     )
@@ -1260,12 +1248,6 @@ class Rule(XCCDFEntity):
         if (
                 env_yaml and env_yaml["product"] in parse_prodtype(rule.prodtype)
                 or env_yaml and rule.prodtype == "all"):
-            for platform in rule.platforms:
-                try:
-                    rule.cpe_names.add(env_yaml["product_cpes"].get_cpe_name(platform))
-                except CPEDoesNotExist:
-                    print("Unsupported platform '%s' in rule '%s'." % (platform, rule.id_))
-                    raise
             # parse platform definition and get CPEAL platform
             for platform in rule.platforms:
                 cpe_platform = env_yaml["product_cpes"].parse_platform_definition(

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -810,7 +810,7 @@ class Benchmark(XCCDFEntity):
         benchmark = super(Benchmark, cls).from_yaml(yaml_file, env_yaml)
         if env_yaml:
             benchmark.product_cpe_names = env_yaml["product_cpes"].get_product_cpe_names()
-            benchmark.cpe_al_platform_spec = env_yaml["product_cpes"].cpe_al_platform_specification
+            benchmark.cpe_platform_spec = env_yaml["product_cpes"].cpe_platform_specification
 
         benchmark.id_ = benchmark_id
 
@@ -866,8 +866,8 @@ class Benchmark(XCCDFEntity):
         add_sub_element(root, "front-matter", self.front_matter)
         add_sub_element(root, "rear-matter", self.rear_matter)
         # if there are no platforms, do not output platform-specification at all
-        if len(self.cpe_al_platform_spec.platforms) > 0:
-            root.append(self.cpe_al_platform_spec.to_xml_element())
+        if len(self.cpe_platform_spec.platforms) > 0:
+            root.append(self.cpe_platform_spec.to_xml_element())
 
         # The Benchmark applicability is determined by the CPEs
         # defined in the product.yml
@@ -955,7 +955,7 @@ class Group(XCCDFEntity):
         platform=lambda: "",
         platforms=lambda: set(),
         cpe_names=lambda: set(),
-        cpe_al_platform_names=lambda: set(),
+        cpe_platform_names=lambda: set(),
         ** XCCDFEntity.KEYS
     )
 
@@ -988,11 +988,11 @@ class Group(XCCDFEntity):
 
         # parse platform definition and get CPEAL platform
         if data["platforms"]:
-            cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(data["platforms"])
-            data["cpe_al_platform_names"].add(cpeal_platform.id)
+            cpe_platform = env_yaml["product_cpes"].parse_platform_definition(data["platforms"])
+            data["cpe_platform_names"].add(cpe_platform.id)
             # add platform to platform specification
-            if cpeal_platform not in env_yaml["product_cpes"].cpe_al_platform_specification.platforms:
-                env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(cpeal_platform)
+            if cpe_platform not in env_yaml["product_cpes"].cpe_platform_specification.platforms:
+                env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
         return data
 
     def load_entities(self, rules_by_id, values_by_id, groups_by_id):
@@ -1041,9 +1041,9 @@ class Group(XCCDFEntity):
         add_nondata_subelements(group, "requires", "id", self.requires)
         add_nondata_subelements(group, "conflicts", "id", self.conflicts)
 
-        for cpe_al_platform_name in self.cpe_al_platform_names:
+        for cpe_platform_name in self.cpe_platform_names:
             platform_el = ET.SubElement(group, "platform")
-            platform_el.set("idref", "#"+cpe_al_platform_name)
+            platform_el.set("idref", "#"+cpe_platform_name)
 
         for _value in self.values.values():
             group.append(_value.to_xml_element())
@@ -1196,6 +1196,7 @@ class Rule(XCCDFEntity):
         inherited_platforms=lambda: list(),
         template=lambda: None,
         cpe_names=lambda: set(),
+        cpe_platform_names=lambda: set(),
         ** XCCDFEntity.KEYS
     )
 
@@ -1259,14 +1260,14 @@ class Rule(XCCDFEntity):
                     raise
             # parse platform definition and get CPEAL platform
             if len(rule.platforms) > 0:
-                cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(
+                cpe_platform = env_yaml["product_cpes"].parse_platform_definition(
                     rule.platforms)
-                rule.cpe_al_platform_names.add(cpeal_platform.id)
+                rule.cpe_platform_names.add(cpe_platform.id)
                 # add platform to platform specification
-                if cpeal_platform not in env_yaml[
-                        "product_cpes"].cpe_al_platform_specification.platforms:
-                    env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(
-                        cpeal_platform)
+                if cpe_platform not in env_yaml[
+                        "product_cpes"].cpe_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_platform_specification.add_platform(
+                        cpe_platform)
 
 
         if sce_metadata and rule.id_ in sce_metadata:
@@ -1587,9 +1588,9 @@ class Rule(XCCDFEntity):
         add_nondata_subelements(rule, "requires", "id", self.requires)
         add_nondata_subelements(rule, "conflicts", "id", self.conflicts)
 
-        for cpe_al_platform_name in self.cpe_al_platform_names:
+        for cpe_platform_name in self.cpe_platform_names:
             platform_el = ET.SubElement(rule, "platform")
-            platform_el.set("idref", "#"+cpe_al_platform_name)
+            platform_el.set("idref", "#"+cpe_platform_name)
 
         return rule
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -849,6 +849,7 @@ class Benchmark(XCCDFEntity):
         root.set('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
         root.set('xmlns:xhtml', 'http://www.w3.org/1999/xhtml')
         root.set('xmlns:dc', 'http://purl.org/dc/elements/1.1/')
+        root.set('xmlns:cpe-lang', 'http://cpe.mitre.org/language/2.0')
         root.set('id', 'product-name')
         root.set('xsi:schemaLocation',
                  'http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd')
@@ -864,8 +865,7 @@ class Benchmark(XCCDFEntity):
         notice.set('id', self.notice_id)
         add_sub_element(root, "front-matter", self.front_matter)
         add_sub_element(root, "rear-matter", self.rear_matter)
-        # tbd: oval file hardcoded here, must be fixed
-        root.append(self.cpe_al_platform_spec.to_xml_element("ssg-oval-cpe.xml"))
+        root.append(self.cpe_al_platform_spec.to_xml_element())
 
         # The Benchmark applicability is determined by the CPEs
         # defined in the product.yml
@@ -1246,6 +1246,13 @@ class Rule(XCCDFEntity):
                 except CPEDoesNotExist:
                     print("Unsupported platform '%s' in rule '%s'." % (platform, rule.id_))
                     raise
+            # parse platform definition and get CPEAL platform
+            if len(rule.platforms) > 0:
+                rule.cpeal_platform = env_yaml["product_cpes"].parse_platform_definition(rule.platforms)
+                # add platform to platform specification
+                if rule.cpeal_platform not in env_yaml["product_cpes"].cpe_al_platform_specification.platforms:
+                    env_yaml["product_cpes"].cpe_al_platform_specification.add_platform(rule.cpeal_platform)
+
 
         if sce_metadata and rule.id_ in sce_metadata:
             rule.sce_metadata = sce_metadata[rule.id_]

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -112,6 +112,7 @@ PREFIX_TO_NS = {
     "xlink": xlink_namespace,
     "cpe-dict": "http://cpe.mitre.org/dictionary/2.0",
     "cat": cat_namespace,
+    "cpe-lang": "http://cpe.mitre.org/language/2.0",
 }
 
 

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -99,6 +99,8 @@ def instance_in_platforms(inst, platforms):
 def remove_machine_platform(root):
     remove_platforms_from_element(root, "xccdf-1.2:Rule", "cpe:/a:machine")
     remove_platforms_from_element(root, "xccdf-1.2:Group", "cpe:/a:machine")
+    remove_platforms_from_element(root, "xccdf-1.2:Rule", "#cpe_platform_machine")
+    remove_platforms_from_element(root, "xccdf-1.2:Group", "#cpe_platform_machine")
 
 
 def remove_ocp4_platforms(root):

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -8,7 +8,7 @@ import ssg.constants
 import ssg.yaml
 import io
 
-machine_cpe = "cpe:/a:machine"
+machine_cpe = "#cpe_platform_machine"
 
 
 def main():


### PR DESCRIPTION
#### Description:

- create new classes for CPEAL platform-specification, platform, logical-test fact-ref
- implement parsing mechanism for more complex platform specification (it will probably change in follow-up PR):
  - OR is done by using separate lines
  - and is done by using & in a line
  - negation is done with ! preceding the platform name
- the new functionality is added into CPEProduct class
- the XCCDF document now contains cpe-lang:platform-specification with all the platforms
- platforms are currently using fact-ref, which points to the good old cpe name we used before. This is done partially to prevent big breakage, but mainly because xccdf 1.1 does not support high enough version of CPE applicability language to use check-fact-ref directly
- groups and rules already use these new platforms, profiles and benchmarks not yet
- the goal is to just move from cpe-names to CPE platforms, no changes to applicability