### PR TITLE
Fix CombinedChecker run_aborted traceback

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -38,6 +38,7 @@ class CombinedChecker(rule.RuleChecker):
         self.rules_not_tested_yet = set()
         self.results = list()
         self._current_result = None
+        self.run_aborted = False
 
     def _rule_should_be_tested(self, rule, rules_to_be_tested, tested_templates):
         if rule.short_id not in rules_to_be_tested:


### PR DESCRIPTION
#### Description:

- Initialize the `run_aborted` in `CombinedChecker`
  -  The property was only being set during manual user abort.

#### Rationale:

- After a combined test run finishes `run_aborted` is not set
- Fixes the following traceback.
```
Traceback (most recent call last):
  File "/tmp/tmp.dgQ5o5WsMD/rpmbuild/BUILD/scap-security-guide-0.1.58/tests/test_suite.py", line 415, in <module>
    main()
  File "/tmp/tmp.dgQ5o5WsMD/rpmbuild/BUILD/scap-security-guide-0.1.58/tests/test_suite.py", line 411, in main
    options.func(options)
  File "/tmp/tmp.dgQ5o5WsMD/rpmbuild/BUILD/scap-security-guide-0.1.58/tests/ssg_test_suite/combined.py", line 121, in perform_combined_check
    if checker.run_aborted:
AttributeError: 'CombinedChecker' object has no attribute 'run_aborted'
```