### PR TITLE
profile_tool.py: Update fields displayed in HTML

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -240,7 +240,11 @@ def main():
             'missing_puppet_fixes',
             'missing_anaconda_fixes',
             'missing_cces',
-            'ansible_parity'
+            'ansible_parity',
+            'implemented_checks',
+            'implemented_fixes',
+            'missing_checks',
+            'missing_fixes'
             ]
         link = """<a href="{}"><div style="height:100%;width:100%">{}</div></a>"""
 

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -728,6 +728,8 @@ class XCCDFBenchmark(object):
             del profile_stats['assigned_cces_pct']
             del profile_stats['ssg_version']
             del profile_stats['ansible_parity_pct']
+            del profile_stats['implemented_checks_pct']
+            del profile_stats['implemented_fixes_pct']
 
             return profile_stats
         else:


### PR DESCRIPTION


#### Description:
- profile_tool.py: Update fields displayed in HTML
  - New fields were introduced in the profile statistics but weren't updated
in the HTML page generation, which cause to fields being rendered its
whole list of rules to the HTML instead of having it written to a file
so it can be nice displayed.

#### Rationale:

- Makes page like this to be nicely displayed again: https://jenkins.complianceascode.io/job/scap-security-guide-stats/Statistics/rhel8/product-statistics/statistics.html
