### PR TITLE
remove rule disable_prelink from rhel7 cis

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -395,11 +395,9 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    status: partial
+    status: planned
     notes: >-
       The rule to remove prelink package is missing.
-    rules:
-    - disable_prelink
 
   - id: 1.6.1.1
     title: Ensure SELinux is installed (Automated)


### PR DESCRIPTION
#### Description:

- remove rule from rhel7 cis control

#### Rationale:

It was not properly aligned with the benchmark.