### PR TITLE
Add new audit rules privileged commands for Ubuntu STIG

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_apparmor_parser/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_apparmor_parser/rule.yml
@@ -1,0 +1,44 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Record Any Attempts to Run apparmor_parser'
+
+description: |-
+    At a minimum, the audit system should collect any execution attempt
+    of the <tt>apparmor_parser</tt> command for all users and root. If
+    the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
+    program to read audit rules during daemon startup (the default), add
+    the following lines to a file with suffix <tt>.rules</tt> in the
+    directory <tt>/etc/audit/rules.d</tt>:
+    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
+    utility to read audit rules during daemon startup, add the following
+    lines to <tt>/etc/audit/audit.rules</tt> file:
+    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+rationale: |-
+    Without generating audit records that are specific to the security and
+    mission needs of the organization, it would be difficult to establish,
+    correlate, and investigate the events relating to an incident or identify
+    those responsible for one.
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+references:
+    disa: CCI-000172
+    srg: SRG-OS-000064-GPOS-00033
+    stigid@ubuntu2004: UBTU-20-010166
+
+ocil: |-
+    To verify that execution of the command is being audited, run the following command:
+    <pre>sudo auditctl -l | grep apparmor_parser</pre>
+    The output should return something similar to:
+    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid>=1000 -F auid!=-1 -F key=privileged</pre>
+
+template:
+    name: audit_rules_privileged_commands
+    vars:
+        path: /sbin/apparmor_parser

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/bash/shared.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_ubuntu
+
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_watch_rule("auditctl", "/sbin/fdisk", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/sbin/fdisk", "x", "modules") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/oval/shared.xml
@@ -1,0 +1,39 @@
+<def-group>
+  <definition class="compliance" id="audit_rules_privileged_commands_fdisk" version="1">
+    {{{ oval_metadata("Ensure audit rule for all uses of the fdisk command is enabled.") }}}
+
+    <criteria operator="OR">
+
+      <!-- Test the augenrules case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
+        <criterion comment="audit augenrules fdisk" test_ref="test_fdisk_augenrules" />
+      </criteria>
+
+      <!-- Test the auditctl case -->
+      <criteria operator="AND">
+        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
+        <criterion comment="audit auditctl fdisk" test_ref="test_fdisk_auditctl" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit augenrules fdisk" id="test_fdisk_augenrules" version="1">
+    <ind:object object_ref="object_fdisk_augenrules" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_fdisk_augenrules" version="1">
+    <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="audit auditctl fdisk" id="test_fdisk_auditctl" version="1">
+    <ind:object object_ref="object_fdisk_auditctl" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_fdisk_auditctl" version="1">
+    <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/sbin/fdisk[\s]+-p[\s]+x[\s]+-k[\s]+modules[\s]*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
@@ -1,0 +1,36 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Ensure auditd Collects Information on the Use of Privileged Commands - fdisk'
+
+description: |-
+    Configure the operating system to audit the execution of the partition
+    management program "fdisk".
+
+rationale: |-
+    Without generating audit records that are specific to the security
+    and mission needs of the organization, it would be difficult to
+    establish, correlate, and investigate the events relating to an
+    incident or identify those responsible for one.
+    Audit records can be generated from various components within the
+    information system (e.g., module or policy filter).
+
+severity: medium
+
+references:
+    disa: CCI-000172
+    srg: SRG-OS-000477-GPOS-00222
+    stigid@ubuntu2004: UBTU-20-010298
+
+ocil_clause: 'it is not the case'
+
+ocil: |-
+    To verify that auditing of privileged command use is configured, run the
+    following command:
+
+    <pre>$ sudo auditctl -l | grep fdisk
+    -w /sbin/fdisk -p x -k fdisk </pre>
+
+    If the command does not return a line, or the line is commented out, this
+    is a finding.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/auditctl_correct.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = auditd
+
+echo "-w /sbin/fdisk -p x -k modules" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/auditctl_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/auditctl_remove_all_rules.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = auditd
+
+rm -f /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/auditctl_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/auditctl_wrong_rule.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = auditd
+
+echo "-w /sbin/something -p x -k modules" >> /etc/audit/audit.rules
+sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = auditd
+
+echo "-w /sbin/fdisk -p x -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_remove_all_rules.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = auditd
+
+mkdir -p /etc/audit/rules.d
+rm -f /etc/audit/rules.d/*
+> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_wrong_rule.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = auditd
+
+echo "-w /sbin/something -p x -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: rhel8,rhel9,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_update'
 
@@ -35,9 +35,10 @@ identifiers:
     cce@rhel9: CCE-89481-6
 
 references:
-    disa: CCI-000169
-    srg: SRG-OS-000037-GPOS-00015,SRG-OS-000042-GPOS-00020,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
+    disa: CCI-000169,CCI-000172
+    srg: SRG-OS-000037-GPOS-00015,SRG-OS-000042-GPOS-00020,SRG-OS-000062-GPOS-00031,SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
     stigid@rhel8: RHEL-08-030310
+    stigid@ubuntu2004: UBTU-20-010173
 
 ocil_clause: 'it is not the case'
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -280,6 +280,7 @@ selections:
     - audit_rules_execution_chcon
 
     # UBTU-20-010166 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the apparmor_parser command.
+    - audit_rules_privileged_commands_apparmor_parser
 
     # UBTU-20-010167 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the setfacl command.
     - audit_rules_execution_setfacl

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -393,6 +393,7 @@ selections:
     - audit_rules_privileged_commands_kmod
 
     # UBTU-20-010298 The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the fdisk command.
+    - audit_rules_privileged_commands_fdisk
 
     # UBTU-20-010300 The Ubuntu operating system must have a crontab script running weekly to offload audit events of standalone systems.
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -301,6 +301,7 @@ selections:
     - audit_rules_privileged_commands_passwd
 
     # UBTU-20-010173 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the unix_update command.
+    - audit_rules_privileged_commands_unix_update
 
     # UBTU-20-010174 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the gpasswd command.
     - audit_rules_privileged_commands_gpasswd


### PR DESCRIPTION
#### Description:

- Add rule audit_rules_privileged_commands_apparmor_parser
- Add audit_rules_privileged_commands_apparmor_parser to ubuntu stig
- Add ubuntu prodtype and references to audit_rules_privileged_commands_unix_update
- Add rule audit_rules_privileged_commands_unix_update to ubuntu stig
- Add rule audit_rules_privileged_commands_fdisk
- Add bash for audit_rules_privileged_commands_fdisk
- Add oval for audit_rules_privileged_commands_fdisk
- Add tests for audit_rules_privileged_commands_fdisk
- Add audit_rules_privileged_commands_fdisk to ubuntu stig profile 