### PR TITLE
Add rule audit_sudo_log_events

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_sudo_log_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_sudo_log_events/rule.yml
@@ -1,0 +1,57 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Record Attempts to perform maintenance activities'
+
+description: |-
+    The {{{ full_name }}} operating system must generate audit records for
+    privileged activities, nonlocal maintenance, diagnostic sessions and
+    other system-level access.
+
+    Verify the operating system audits activities performed during nonlocal
+    maintenance and diagnostic sessions. Run the following command:
+    <pre>$ sudo auditctl -l | grep sudo.log
+    -w /var/log/sudo.log -p wa -k maintenance</pre>
+
+rationale: |-
+    If events associated with nonlocal administrative access or diagnostic
+    sessions are not logged, a major tool for assessing and investigating
+    attacks would not be available.
+    This requirement addresses auditing-related issues associated with
+    maintenance tools used specifically for diagnostic and repair actions
+    on organizational information systems.
+    Nonlocal maintenance and diagnostic activities are those activities
+    conducted by individuals communicating through a network, either an
+    external network (e.g., the internet) or an internal network. Local
+    maintenance and diagnostic activities are those activities carried
+    out by individuals physically present at the information system or
+    information system component and not communicating across a network
+    connection.
+    This requirement applies to hardware/software diagnostic test
+    equipment or tools. This requirement does not cover hardware/software
+    components that may support information system maintenance, yet are a
+    part of the system, for example, the software implementing "ping,"
+    "ls," "ipconfig," or the hardware and software implementing the
+    monitoring port of an Ethernet switch.
+
+severity: medium
+
+references:
+    disa: CCI-000172,CCI-002884
+    srg: SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215
+    stigid@ubuntu2004: UBTU-20-010244
+
+ocil_clause: 'Audit rule is not present'
+
+ocil: |-
+    Verify the operating system audits activities performed during nonlocal
+    maintenance and diagnostic sessions. Run the following command:
+    <pre>$ sudo auditctl -l | grep sudo.log
+    -w /var/log/sudo.log -p wa -k maintenance
+    </pre>
+
+template:
+    name: audit_rules_login_events
+    vars:
+        path: /var/log/sudo.log

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -362,6 +362,7 @@ selections:
     - ensure_rtc_utc_configuration
 
     # UBTU-20-010244 The Ubuntu operating system must generate audit records for privileged activities, nonlocal maintenance, diagnostic sessions and other system-level access.
+    - audit_sudo_log_events
 
     # UBTU-20-010267 The Ubuntu operating system must generate audit records for any successful/unsuccessful use of unlink system call.
     - audit_rules_file_deletion_events_unlink


### PR DESCRIPTION
#### Description:

- As part of Ubuntu 20.04 STIG:
Verify the Ubuntu operating system audits activities performed during nonlocal maintenance and diagnostic sessions.
Check the currently configured audit rules with the following command:
`$ sudo auditctl -l | grep sudo.log
-w /var/log/sudo.log -p wa -k maintenance`

If the command does not return lines that match the example or the lines are commented out, this is a finding.
Note: The "-k" allows for specifying an arbitrary identifier, and the string after it does not need to match the example output above.