### PR TITLE
WIP: Add directory to add tailorings for OCP

### DIFF
--- a/ocp-resources/tailorings/rhcos4-moderate.yaml
+++ b/ocp-resources/tailorings/rhcos4-moderate.yaml
@@ -1,0 +1,15 @@
+---
+# This is a manifest that is meant to create a TailoredProfile
+# for the rhcos4-moderate profile. In our E2E tests we actually build
+# the content container itself and put it in a custom profilebundle.
+# So, we use the name we use in CI directly (e2e)
+apiVersion: compliance.openshift.io/v1alpha1
+kind: TailoredProfile
+metadata:
+  name: e2e-moderate
+spec:
+  extends: e2e-moderate
+  title: E2E rhcos4-moderate profile
+  description: |-
+    A tailoring in order to be able to set rules and values for the
+    rhcos4-moderate profile, for testing.


### PR DESCRIPTION
Now that we're introducing remediations that require values to be set,
we need to be able to pass those values somehow. Normally this is done
via a tailoring... so let's add a directory where we can do that. The
e2e framework needs to detect this directory and use the tailoring
insead when needed.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>