### PR TITLE
RHCOS4: Mark wireless_disable_interfaces as NOT-APPLICABLE in e2e tests

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: PASS
+default_result: NOT-APPLICABLE


### PR DESCRIPTION
In our standard AWS-based E2E tests, the wireless interface is not
present, and so this rule will return NOT-APPLICABLE. The rule is still
relevant, but let's fix the test.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>