### PR TITLE
ntp/chrony remove server remediations and test scenarios

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 echo "server 0.pool.ntp.org" > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct_pool.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/correct_pool.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 echo "pool 0.pool.ntp.org" > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_empty.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 echo "" > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/file_missing.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 rm -f /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/line_missing.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 echo "some line" > /etc/chrony.conf
 echo "another line" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/multiple_servers.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 echo "server 0.pool.ntp.org" > /etc/chrony.conf
 echo "server 1.pool.ntp.org" >> /etc/chrony.conf

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/server_not_specified.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/tests/server_not_specified.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
-
+# platform = multi_platform_fedora,multi_platform_rhel
 
 echo "server " > /etc/chrony.conf

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 7
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/ansible/shared.yml
@@ -1,0 +1,22 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("var_multiple_time_servers") }}}
+
+- name: "Detect if ntp is already configured with pools or servers"
+  find:
+    path: /etc
+    patterns: ntp.conf
+    contains: '^[\s]*(?:server|pool)[\s]+[\w]+'
+  register: ntp_servers
+
+- name: "Configure remote time servers"
+  lineinfile:
+    path: /etc/ntp.conf
+    line: 'server {{ item }}'
+    state: present
+    create: True
+  loop: '{{ var_multiple_time_servers.split(",") }}'
+  when: ntp_servers.matched == 0

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+
+{{{ bash_instantiate_variables("var_multiple_time_servers") }}}
+
+config_file="/etc/ntp.conf"
+
+if ! grep -q '^[\s]*(?:server|pool)[\s]+[\w]+' "$config_file" ; then
+          {{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") | indent(2) }}}
+fi

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 7
 
 {{{ bash_instantiate_variables("var_multiple_time_servers") }}}
 

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/correct.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/correct.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = ntp
+# platform = Red Hat Enterprise Linux 7
+
+echo "server 0.pool.ntp.org" > /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/file_empty.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = ntp
+# platform = Red Hat Enterprise Linux 7
+
+echo "" > /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/file_missing.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = ntp
+# platform = Red Hat Enterprise Linux 7
+
+rm -f /etc/ntp.conf

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/tests/multiple_servers.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = ntp
+# platform = Red Hat Enterprise Linux 7
+
+echo "server 0.pool.ntp.org" > /etc/ntp.conf
+echo "server 1.pool.ntp.org" >> /etc/ntp.conf


### PR DESCRIPTION
#### Description:
**chronyd_specify_remote_server**
Update platform to `multi_platform_rhel` and remove unnecessary empty lines from tests

**ntpd_specify_remote_server**
Add remediations and test scenarios that are basically same as for `chronyd_specify_remote_server`. Remediations use same remote server variable as chronyd - `var_multiple_time_servers`