### PR TITLE
Add Variable-based CPE and UFW rules for Ubuntu 20.04 STIG

### DIFF
--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -58,6 +58,8 @@ def main():
     for el in defs.findall(".//{%s}definition" % oval_ns):
         if el.get("class") != "inventory":
             continue
+        if el.get("id").startswith("var_"):
+            continue
         inventory_defs.append(el)
 
     # Keep the list of 'id' attributes from untranslated inventory def elements
@@ -145,6 +147,8 @@ def main():
     product_cpes = ssg.build_cpe.ProductCPEs(product_yaml)
     cpe_list = ssg.build_cpe.CPEList()
     for cpe_name in benchmark_cpe_names:
+        if cpe_name.startswith("var_") or cpe_name.startswith("not_var_"):
+            continue
         cpe_list.add(product_cpes.get_cpe(cpe_name))
 
     cpedict_filename = "ssg-" + product + "-cpe-dictionary.xml"

--- a/linux_os/guide/system/network/network-ufw/group.yml
+++ b/linux_os/guide/system/network/network-ufw/group.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: Uncomplicated Firewall (ufw)
+
+description: |-
+    The Linux kernel in Ubuntu provides a packet filtering system called
+    netfilter, and the traditional interface for manipulating netfilter are
+    the iptables suite of commands. iptables provide a complete firewall
+    solution that is both highly configurable and highly flexible.
+
+    Becoming proficient in iptables takes time, and getting started with
+    netfilter firewalling using only iptables can be a daunting task. As a
+    result, many frontends for iptables have been created over the years,
+    each trying to achieve a different result and targeting a different
+    audience.
+
+    The Uncomplicated Firewall (ufw) is a frontend for iptables and is
+    particularly well-suited for host-based firewalls. ufw provides a
+    framework for managing netfilter, as well as a command-line interface
+    for manipulating the firewall. ufw aims to provide an easy to use
+    interface for people unfamiliar with firewall concepts, while at the
+    same time simplifies complicated iptables commands to help an
+    administrator who knows what he or she is doing. ufw is an upstream
+    for other distributions and graphical frontends.
+
+platform: machine

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -12,6 +12,10 @@ rationale: |-
     code. <tt>ufw</tt> allows system operators to set up firewalls and IP
     masquerading, etc.
 
+platforms:
+  - var_ufw
+  - machine
+
 severity: medium
 
 references:

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -20,6 +20,9 @@ severity: medium
 
 references:
     cis@ubuntu2004: 3.5.1.1
+    disa: CCI-002314
+    srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2004: UBTU-20-010433
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Install ufw Package'
+
+description: |-
+    {{{ describe_package_install(package="ufw") }}}
+
+rationale: |-
+    <tt>ufw</tt> controls the Linux kernel network packet filtering
+    code. <tt>ufw</tt> allows system operators to set up firewalls and IP
+    masquerading, etc.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.1
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="ufw") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: ufw

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -8,6 +8,10 @@ description: |-
 rationale: |-
     The ufw service must be enabled and running in order for ufw to protect the system
 
+platforms:
+  - var_ufw
+  - machine
+
 severity: medium
 
 references:

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify ufw Enabled'
+
+description: |-
+    {{{ describe_service_enable(service="ufw") }}}
+
+rationale: |-
+    The ufw service must be enabled and running in order for ufw to protect the system
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.3
+
+ocil: |-
+    {{{ ocil_service_enabled(service="ufw") }}}
+
+template:
+    name: service_enabled
+    vars:
+        servicename: ufw
+
+platform: machine

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -16,6 +16,9 @@ severity: medium
 
 references:
     cis@ubuntu2004: 3.5.1.3
+    disa: CCI-002314
+    srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2004: UBTU-20-010434
 
 ocil: |-
     {{{ ocil_service_enabled(service="ufw") }}}

--- a/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
@@ -1,0 +1,73 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Only Allow Authorized Network Services in ufw'
+
+description: |-
+    Check the firewall configuration for any unnecessary or prohibited
+    functions, ports, protocols, and/or services by running the following
+    command:
+    <pre>$ sudo ufw show raw
+    Chain OUTPUT (policy ACCEPT)
+    target prot opt sources destination
+    Chain INPUT (policy ACCEPT 1 packets, 40 bytes)
+    pkts bytes target prot opt in out source destination
+    Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
+    pkts bytes target prot opt in out source destination
+    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+    pkts bytes target prot opt in out source destination</pre>
+
+    Ask the System Administrator for the site or program PPSM CLSA. Verify
+    the services allowed by the firewall match the PPSM CLSA.
+
+rationale: |-
+    To prevent unauthorized connection of devices, unauthorized transfer of
+    information, or unauthorized tunneling (i.e., embedding of data types
+    within data types), organizations must disable or restrict unused or
+    unnecessary physical and logical ports/protocols on information systems.
+    
+    Operating systems are capable of providing a wide variety of functions
+    and services. Some of the functions and services provided by default
+    may not be necessary to support essential organizational operations.
+    Additionally, it is sometimes convenient to provide multiple services
+    from a single component (e.g., VPN and IPS); however, doing so
+    increases risk over limiting the services provided by any one component.
+
+    To support the requirements and principles of least functionality, the
+    operating system must support the organizational requirements, providing
+    only essential capabilities and limiting the use of ports, protocols,
+    and/or services to only those required, authorized, and approved to
+    conduct official business or to address authorized quality of life
+    issues.
+
+platforms:
+    - var_ufw
+    - machine
+
+severity: medium
+
+references:
+    disa: CCI-000382
+    srg: SRG-OS-000096-GPOS-00050
+    stigid@ubuntu2004: UBTU-20-010407
+
+ocil_clause: 'unauthorized network services can be accessed from the network'
+
+ocil: |-
+    Check the firewall configuration for any unnecessary or prohibited
+    functions, ports, protocols, and/or services by running the following
+    command:
+    <pre>$ sudo ufw show raw</pre>
+
+    Ask the System Administrator for the site or program PPSM CLSA. Verify
+    the services allowed by the firewall match the PPSM CLSA.
+
+    Add all ports, protocols, or services allowed by the PPSM CLSA by using
+    the following command:
+    <pre>$ sudo ufw allow "direction" "port/protocol/service"</pre>
+    where the direction is "in" or "out" and the port is the one
+    corresponding to the protocol or service allowed.
+
+    To deny access to ports, protocols, or services, use:
+    <pre>$ sudo ufw deny "direction" "port/protocol/service"</pre>

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
@@ -1,0 +1,52 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'ufw Must rate-limit network interfaces'
+
+description: |-
+    The operating system must configure the uncomplicated firewall to
+    rate-limit impacted network interfaces.
+
+rationale: |-
+    This requirement addresses the configuration of the operating system to
+    mitigate the impact of DoS attacks that have occurred or are ongoing on
+    system availability. For each system, known and potential DoS attacks
+    must be identified and solutions for each type implemented. A variety
+    of technologies exist to limit or, in some cases, eliminate the effects
+    of DoS attacks (e.g., limiting processes or establishing memory
+    partitions). Employing increased capacity and bandwidth, combined with
+    service redundancy, may reduce the susceptibility to some DoS attacks.
+
+platforms:
+    - var_ufw
+    - machine
+
+severity: medium
+
+references:
+    disa: CCI-002385
+    srg: SRG-OS-000420-GPOS-00186
+    stigid@ubuntu2004: UBTU-20-010446
+
+ocil_clause: 'network interface not rate-limit'
+
+ocil: |-
+    Check all the services listening to the ports with the following
+    command:
+    <pre>$ sudo ss -l46ut
+    Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+    tcp LISTEN 0 128 [::]:ssh [::]:*</pre>
+
+    For each entry, verify that the ufw is configured to rate limit the
+    service ports with the following command:
+    <pre>$ sudo ufw status</pre>
+
+    If any port with a state of "LISTEN" is not marked with the "LIMIT"
+    action, run the following command, replacing "service" with the
+    service that needs to be rate limited:
+    <pre>$ sudo ufw limit "service"</pre>
+
+    Rate-limiting can also be done on an interface. An example of adding
+    a rate-limit on the eth0 interface follows:
+    <pre>$ sudo ufw limit in on eth0</pre>

--- a/linux_os/guide/system/network/var_firewall_package.var
+++ b/linux_os/guide/system/network/var_firewall_package.var
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'Selected firewall utility'
+
+description: 'Which firewalling utility (iptables, nftables, ufw, or firewalld) should be used.'
+
+type: string
+
+interactive: true
+
+options:
+    default: iptables
+    iptables: iptables
+    nftables: nftables
+    ufw: ufw
+    firewalld: firewalld

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -513,6 +513,7 @@ selections:
     - service_rsyslog_enabled
 
     # UBTU-20-010433 The Ubuntu operating system must have an application firewall installed in order to control remote access methods.
+    - package_ufw_installed
 
     # UBTU-20-010434 The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -516,6 +516,7 @@ selections:
     - package_ufw_installed
 
     # UBTU-20-010434 The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).
+    - service_ufw_enabled
 
     # UBTU-20-010435 The Ubuntu operating system must, for networked systems, compare internal information system clocks at least every 24 hours with a server which is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).
     - var_time_service_set_maxpoll=36_hours

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -437,6 +437,7 @@ selections:
     - package_rsh-server_removed
 
     # UBTU-20-010407 The Ubuntu operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.
+    - ufw_only_required_services
 
     # UBTU-20-010408 The Ubuntu operating system must prevent direct login into the root account.
     - prevent_direct_root_logins

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -550,6 +550,7 @@ selections:
     # UBTU-20-010445 Ubuntu operating system must implement cryptographic mechanisms to prevent unauthorized disclosure of all information at rest.
 
     # UBTU-20-010446 The Ubuntu operating system must configure the uncomplicated firewall to rate-limit impacted network interfaces.
+    - ufw_rate_limit
 
     # UBTU-20-010447 The Ubuntu operating system must implement non-executable data to protect its memory from unauthorized code execution.
     - bios_enable_execution_restrictions

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -514,6 +514,7 @@ selections:
     - service_rsyslog_enabled
 
     # UBTU-20-010433 The Ubuntu operating system must have an application firewall installed in order to control remote access methods.
+    - var_firewall_package=ufw
     - package_ufw_installed
 
     # UBTU-20-010434 The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).

--- a/shared/applicability/variables.yml
+++ b/shared/applicability/variables.yml
@@ -1,0 +1,32 @@
+cpes:
+  - var_chrony:
+      name: "cpe:/a:var_chrony"
+      title: "Chrony is selected"
+      check_id: var_time_synchronization_daemon_is_chrony
+      variable: var_time_synchronization_daemon
+      value: chrony
+      negated: false
+
+  - not_var_chrony:
+      name: "cpe:/a:not_var_chrony"
+      title: "Chrony is not selected"
+      check_id: var_time_synchronization_daemon_is_not_chrony
+      variable: var_time_synchronization_daemon
+      value: chrony
+      negated: true
+
+  - var_ntp:
+      name: "cpe:/a:var_ntp"
+      title: "ntp is selected"
+      check_id: var_time_synchronization_daemon_is_ntp
+      variable: var_time_synchronization_daemon
+      value: ntp
+      negated: false
+
+  - not_var_ntp:
+      name: "cpe:/a:not_var_ntp"
+      title: "ntp is not selected"
+      check_id: var_time_synchronization_daemon_is_not_ntp
+      variable: var_time_synchronization_daemon
+      value: ntp
+      negated: true

--- a/shared/applicability/variables.yml
+++ b/shared/applicability/variables.yml
@@ -30,3 +30,53 @@ cpes:
       variable: var_time_synchronization_daemon
       value: ntp
       negated: true
+
+  # The following variables are for var_firewall_package, choosing between
+  # iptables, nftables, and ufw.
+  - var_iptables:
+      name: "cpe:/a:var_iptables"
+      title: "iptables is selected"
+      check_id: var_firewall_package_is_iptables
+      variable: var_firewall_package
+      value: iptables
+      negated: false
+
+  - not_var_iptables:
+      name: "cpe:/a:not_var_iptables"
+      title: "iptables is not selected"
+      check_id: var_firewall_package_is_not_iptables
+      variable: var_firewall_package
+      value: iptables
+      negated: true
+
+  - var_nftables:
+      name: "cpe:/a:var_nftables"
+      title: "nftables is selected"
+      check_id: var_firewall_package_is_nftables
+      variable: var_firewall_package
+      value: nftables
+      negated: false
+
+  - not_var_nftables:
+      name: "cpe:/a:not_var_nftables"
+      title: "nftables is not selected"
+      check_id: var_firewall_package_is_not_nftables
+      variable: var_firewall_package
+      value: nftables
+      negated: true
+
+  - var_ufw:
+      name: "cpe:/a:var_ufw"
+      title: "ufw is selected"
+      check_id: var_firewall_package_is_ufw
+      variable: var_firewall_package
+      value: ufw
+      negated: false
+
+  - not_var_ufw:
+      name: "cpe:/a:not_var_ufw"
+      title: "ufw is not selected"
+      check_id: var_firewall_package_is_not_ufw
+      variable: var_firewall_package
+      value: ufw
+      negated: true

--- a/shared/checks/oval/var_firewall_package_is_iptables.xml
+++ b/shared/checks/oval/var_firewall_package_is_iptables.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_var_is_value("var_firewall_package", "iptables") }}}

--- a/shared/checks/oval/var_firewall_package_is_nftables.xml
+++ b/shared/checks/oval/var_firewall_package_is_nftables.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_var_is_value("var_firewall_package", "nftables") }}}

--- a/shared/checks/oval/var_firewall_package_is_not_iptables.xml
+++ b/shared/checks/oval/var_firewall_package_is_not_iptables.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_var_is_value("var_firewall_package", "iptables", negate=true) }}}

--- a/shared/checks/oval/var_firewall_package_is_not_nftables.xml
+++ b/shared/checks/oval/var_firewall_package_is_not_nftables.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_var_is_value("var_firewall_package", "nftables", negate=true) }}}

--- a/shared/checks/oval/var_firewall_package_is_not_ufw.xml
+++ b/shared/checks/oval/var_firewall_package_is_not_ufw.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_var_is_value("var_firewall_package", "ufw", negate=true) }}}

--- a/shared/checks/oval/var_firewall_package_is_ufw.xml
+++ b/shared/checks/oval/var_firewall_package_is_ufw.xml
@@ -1,0 +1,1 @@
+{{{ oval_check_var_is_value("var_firewall_package", "ufw") }}}

--- a/shared/macros-highlevel.jinja
+++ b/shared/macros-highlevel.jinja
@@ -25,14 +25,16 @@ substituting the correct package management software.
 
 :param package: Name of package
 :type package: str
+:param removed: Boolean condition for ocil_clause
+:type removed: bool
 
 #}}
-{{% macro complete_ocil_entry_package(package) -%}}
+{{% macro complete_ocil_entry_package(package, removed=False) -%}}
   {{% if pkg_system is defined %}}
     {{%- if pkg_system == "rpm" %}}
-        {{{ rpm_complete_ocil_entry_package(package) }}}
+        {{{ rpm_complete_ocil_entry_package(package, removed=removed) }}}
     {{%- elif pkg_system == "dpkg" %}}
-        {{{ dpkg_complete_ocil_entry_package(package) }}}
+        {{{ dpkg_complete_ocil_entry_package(package, removed=removed) }}}
     {{%- else -%}}
 ocil: |-
     JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -902,3 +902,49 @@
   {{%- endif %}}
 </def-group>
 {{%- endmacro %}}
+
+{{#
+  Macro which generates a complete check for a variable having a value.
+#}}
+{{%- macro oval_check_var_is_value(variable, value, negate=False) -%}}
+<def-group>
+  {{% if not negate %}}
+  <definition class="compliance" id="{{{ variable }}}_is_{{{ value }}}" version="1">
+  {{% else %}}
+  <definition class="compliance" id="{{{ variable }}}_is_not_{{{ value }}}" version="1">
+  {{% endif %}}
+    <metadata>
+      <title>Check {{{ variable }}} against {{{ value }}} (negated: {{{ negate }}})</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>
+        {{% if not negate %}}
+          Compare whether {{{ variable }}} is presently {{{ value }}}.
+        {{% else %}}
+          Compare whether {{{ variable }}} is not {{{ value }}}.
+        {{% endif %}}
+      </description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion test_ref="test_{{{ variable }}}_against_{{{ value }}}_negated_{{{ negate|lower }}}" negate="{{{ negate|lower }}}" />
+    </criteria>
+  </definition>
+
+  <external_variable id="{{{ variable }}}" datatype="string" version="1" comment="Value of {{{ variable }}} as a string" />
+
+  <ind:variable_object id="obj_{{{ variable }}}_against_{{{ value }}}_negated_{{{ negate|lower }}}" version="1">
+    <ind:var_ref>{{{ variable }}}</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="ste_{{{ variable }}}_against_{{{ value }}}_negated_{{{ negate|lower }}}" version="1">
+    <ind:value datatype="string" operation="equals">{{{ value }}}</ind:value>
+  </ind:variable_state>
+
+  <ind:variable_test id="test_{{{ variable }}}_against_{{{ value }}}_negated_{{{ negate|lower }}}"
+                     check="all" comment="test {{{ variable }}} against {{{ value }}} (negated {{{ negated|lower }}})" version="1">
+    <ind:object object_ref="obj_{{{ variable }}}_against_{{{ value }}}_negated_{{{ negate|lower }}}" />
+    <ind:state state_ref="ste_{{{ variable }}}_against_{{{ value }}}_negated_{{{ negate|lower }}}" />
+  </ind:variable_test>
+</def-group>
+{{%- endmacro -%}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -656,13 +656,19 @@ ocil_clause: "service and/or socket are running"
 
 :param package: The package to check
 :type package: str
+:param removed: Boolean condition for ocil_clause
+:type removed: bool
 
 #}}
-{{%- macro rpm_complete_ocil_entry_package(package) %}}
+{{%- macro rpm_complete_ocil_entry_package(package, removed=False) %}}
 ocil: |-
     {{{ rpm_ocil_package(package) }}}
 
+{{% if removed %}}
+ocil_clause: "the package is removed"
+{{% else %}}
 ocil_clause: "the package is installed"
+{{% endif %}}
 {{%- endmacro %}}
 
 
@@ -671,12 +677,18 @@ ocil_clause: "the package is installed"
 
 :param package: The package to check
 :type package: str
+:param removed: Boolean condition for ocil_clause
+:type removed: bool
 #}}
-{{%- macro dpkg_complete_ocil_entry_package(package) %}}
+{{%- macro dpkg_complete_ocil_entry_package(package, removed=False) %}}
 ocil: |-
     {{{ dpkg_ocil_package(package) }}}
 
+{{% if removed %}}
+ocil_clause: "the package is removed"
+{{% else %}}
 ocil_clause: "the package is installed"
+{{% endif %}}
 {{%- endmacro %}}
 
 

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -9,7 +9,7 @@ import sys
 
 from .constants import oval_namespace
 from .constants import PREFIX_TO_NS
-from .utils import merge_dicts, required_key
+from .utils import merge_dicts, required_key, parse_template_boolean_value
 from .xml import ElementTree as ET
 from .yaml import open_and_macro_expand
 from .boolean_expression import Algebra, Symbol, Function
@@ -102,6 +102,10 @@ class ProductCPEs(object):
         cpe = self.get_cpe(cpe_id)
         return cpe.name
 
+    def get_check_id(self, cpe_id):
+        cpe = self.get_cpe(cpe_id)
+        return cpe.check_id
+
     def get_product_cpe_names(self):
         return [ cpe.name for cpe in self.product_cpes.values() ]
 
@@ -130,6 +134,9 @@ class CPEList(object):
 
         self.cpe_items.sort(key=lambda cpe: cpe.name)
         for cpe_item in self.cpe_items:
+            if cpe_item.variable:
+                continue
+
             cpe_list.append(cpe_item.to_xml_element(cpe_oval_file))
 
         return cpe_list
@@ -155,6 +162,9 @@ class CPEItem(object):
         self.check_id = cpeitem_data["check_id"]
         self.bash_conditional = cpeitem_data.get("bash_conditional", "")
         self.ansible_conditional = cpeitem_data.get("ansible_conditional", "")
+        self.variable = cpeitem_data.get("variable", None)
+        self.value = cpeitem_data.get("value", None)
+        self.negated = parse_template_boolean_value(cpeitem_data, "negated", False)
 
     def to_xml_element(self, cpe_oval_filename):
         cpe_item = ET.Element("{%s}cpe-item" % CPEItem.ns)

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -29,7 +29,9 @@ def _check_is_applicable_for_product(oval_check_def, product):
 
     # Define general platforms
     multi_platforms = ['<platform>multi_platform_all',
-                       '<platform>multi_platform_' + product]
+                       '<platform>multi_platform_' + product,
+                       ':platform>multi_platform_all',
+                       ':platform>multi_platform_' + product]
 
     # First test if OVAL check isn't for 'multi_platform_all' or
     # 'multi_platform_' + product
@@ -41,7 +43,7 @@ def _check_is_applicable_for_product(oval_check_def, product):
     # and '<product>' to use as OVAL AffectedType metadata element,
     # e.g. Chromium content uses both of them across the various checks
     # Thus for now check both of them when checking concrete platform / product
-    affected_type_elements = ['<platform>', '<product>']
+    affected_type_elements = ['<platform>', '<product>', ':platform>', ':product>']
 
     for afftype in affected_type_elements:
         # Get official name for product (prefixed with content of afftype)

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -13,6 +13,7 @@ from .constants import oval_namespace as oval_ns
 from .constants import oval_footer
 from .constants import oval_header
 from .constants import MULTI_PLATFORM_LIST
+from .constants import PREFIX_TO_NS, OVAL_SUB_NS
 from .jinja import process_file_with_macros
 from .rule_yaml import parse_prodtype
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs_in_paths
@@ -227,7 +228,12 @@ def _check_is_loaded(loaded_dict, filename, version):
 def _create_oval_tree_from_string(xml_content):
     try:
         for prefix, uri in PREFIX_TO_NS.items():
+            if prefix == 'oval-def':
+                ElementTree.register_namespace("", uri)
+                continue
             ElementTree.register_namespace(prefix, uri)
+        for prefix, suffix in OVAL_SUB_NS.items():
+            ElementTree.register_namespace(prefix, oval_ns + "#" + suffix)
     except Exception:
         # Probably an old version of Python
         # Doesn't matter, as this is non-essential.

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -307,7 +307,7 @@ class BashRemediation(Remediation):
             assert cpe.value
 
             if cpe.negated:
-                return '[ "${0}" != "{1}" ]'.format(cpe.variable, cpe.value)
+                return '{{ [ -n "${0}" ] && [ "${0}" != "{1}" ] ; }}'.format(cpe.variable, cpe.value)
             return '[ "${0}" == "{1}" ]'.format(cpe.variable, cpe.value)
         elif platform is not None:
             # Assume any other platform is a Package CPE
@@ -572,7 +572,7 @@ class AnsibleRemediation(Remediation):
             assert cpe.value
 
             if cpe.negated:
-                return '{0} != "{1}"'.format(cpe.variable, cpe.value)
+                return '{0} and {0} != "{1}"'.format(cpe.variable, cpe.value)
             return '{0} == {1}'.format(cpe.variable, cpe.value)
         elif platform is not None:
             # Assume any other platform is a Package CPE

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -334,7 +334,9 @@ class BashRemediation(Remediation):
 
             cpe = self.local_env_yaml["product_cpes"].get_cpe(platform)
             assert cpe.variable
-            return "populate {0}".format(cpe.variable)
+            var_include = ". /usr/share/scap-security-guide/remediation_functions\n"
+            var_include += "populate {0}".format(cpe.variable)
+            return var_include
 
 
 class AnsibleRemediation(Remediation):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -335,8 +335,7 @@ class BashRemediation(Remediation):
 
             cpe = self.local_env_yaml["product_cpes"].get_cpe(platform)
             assert cpe.variable
-            var_include = ". /usr/share/scap-security-guide/remediation_functions\n"
-            var_include += "populate {0}".format(cpe.variable)
+            var_include = "{0}='(bash-populate {0})'".format(cpe.variable)
             return var_include
 
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -307,7 +307,8 @@ class BashRemediation(Remediation):
             assert cpe.value
 
             if cpe.negated:
-                return '{{ [ -n "${0}" ] && [ "${0}" != "{1}" ] ; }}'.format(cpe.variable, cpe.value)
+                return '{{ [ -n "${0}" ] && [ "${0}" != "{1}" ] ; }}'.format(cpe.variable,
+                                                                             cpe.value)
             return '[ "${0}" == "{1}" ]'.format(cpe.variable, cpe.value)
         elif platform is not None:
             # Assume any other platform is a Package CPE

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1203,6 +1203,7 @@ class Group(XCCDFEntity):
                 cpe_platform = add_platform_if_not_defined(cpe_platform, product_cpes)
                 group.cpe_platform_names.add(cpe_platform.id_)
 
+
     def _pass_our_properties_on_to(self, obj):
         for attr in self.ATTRIBUTES_TO_PASS_ON:
             if hasattr(obj, attr) and getattr(obj, attr) is None:
@@ -1222,6 +1223,7 @@ class Group(XCCDFEntity):
                 cpe_platform = Platform.from_text(platform, product_cpes)
                 cpe_platform = add_platform_if_not_defined(cpe_platform, product_cpes)
                 rule.cpe_platform_names.add(cpe_platform.id_)
+
 
     def __str__(self):
         return self.id_
@@ -1314,6 +1316,12 @@ class Rule(XCCDFEntity):
         # ensure that content of rule.platform is in rule.platforms as
         # well
         if rule.platform is not None:
+            if not isinstance(rule.platform, str):
+                msg = "Unknown platform content; did you mean platforms for "
+                msg += "list content on rule {0}, value: {1}"
+                msg.format(rule.id_, rule.platform)
+                raise ValueError(msg)
+
             rule.platforms.add(rule.platform)
 
         # Convert the platform names to CPE names

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -6,6 +6,7 @@ import sys
 import imp
 import glob
 
+import ssg.build_ovals
 import ssg.build_yaml
 import ssg.utils
 import ssg.yaml

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -209,6 +209,11 @@ class Builder(object):
                                                template_vars, lang,
                                                local_env_yaml)
 
+        if lang == "oval" and platforms:
+            filled_template = ssg.build_ovals.update_with_var_platforms(filled_template,
+                                                                        local_env_yaml,
+                                                                        platforms)
+
         ext = lang_to_ext_map[lang]
         output_file_name = rule_id + ext
         output_filepath = os.path.join(


### PR DESCRIPTION
#### Description:

- This is a long PR as it adds support for variable-based CPEs and as an example I've included the UFW rules which make use of it.
- The variable-based CPEs commits were mainly developed by @cipherboy. I will let him talk about it, if possible.
- Let me know if you think I should break this into multiple PRs instead. I also have a few commits that adds the platform bits to iptables rules and others, that I didn't include here but I can certainly add in a separate PR.