### PR TITLE
Add bios_enable_execution_restrictions to Ubuntu 20.04 STIG profile

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
@@ -27,7 +27,11 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_object id="obj_messages_nx_active" version="1">
+        {{% if 'ubuntu' not in product %}}
         <ind:filepath>/var/log/messages</ind:filepath>
+        {{% else %}}
+        <ind:filepath>/var/log/dmesg</ind:filepath>
+        {{% endif %}}
         <ind:pattern operation="pattern match">^.+protection: disabled.+</ind:pattern>
         <ind:instance datatype="int">1</ind:instance>
     </ind:textfilecontent54_object>

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -28,6 +28,7 @@ references:
     cis@sle15: 1.6.2
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05
     cui: 3.1.7
+    disa: CCI-002824
     isa-62443-2009: 4.3.4.3.2,4.3.4.3.3
     isa-62443-2013: 'SR 7.6'
     iso27001-2013: A.12.1.2,A.12.5.1,A.12.6.2,A.14.2.2,A.14.2.3,A.14.2.4
@@ -35,5 +36,6 @@ references:
     nist-csf: PR.IP-1
     srg: SRG-OS-000433-GPOS-00192
     stigid@rhel8: RHEL-08-010420
+    stigid@ubuntu2004: UBTU-20-010447
 
 platform: machine

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004
 
 title: 'Enable NX or XD Support in the BIOS'
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -518,6 +518,7 @@ selections:
     # UBTU-20-010446 The Ubuntu operating system must configure the uncomplicated firewall to rate-limit impacted network interfaces.
 
     # UBTU-20-010447 The Ubuntu operating system must implement non-executable data to protect its memory from unauthorized code execution.
+    - bios_enable_execution_restrictions
 
     # UBTU-20-010448 The Ubuntu operating system must implement address space layout randomization to protect its memory from unauthorized code execution.
     - sysctl_kernel_randomize_va_space


### PR DESCRIPTION
#### Description:

- Add ubuntu2004 to prodtype in bios_enable_execution_restrictions
- Add disa and stigid references to bios_enable_execution_restrictions
- Make bios_enable_execution_restrictions oval check for dmesg instead of /var/log/messages
- Add bios_enable_execution_restrictions to Ubuntu 20.04 STIG profile