### PR TITLE
Create test scenarios for rule gid_passwd_group_same

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
@@ -6,7 +6,7 @@ description: 'Add a group to the system for each GID referenced without a corres
 
 rationale: |-
     If a user is assigned the Group Identifier (GID) of a group not existing on the system, and a group
-    with the Gruop Identifier (GID) is subsequently created, the user may have unintended rights to
+    with the Group Identifier (GID) is subsequently created, the user may have unintended rights to
     any files associated with the group.
 
 severity: low
@@ -36,7 +36,7 @@ references:
     stigid@ol7: OL07-00-020300
     stigid@rhel7: RHEL-07-020300
 
-ocil_clause: 'GIFs referenced in /etc/passwd are returned as not defined in /etc/group'
+ocil_clause: 'GIDs referenced in /etc/passwd are returned as not defined in /etc/group'
 
 ocil: |-
     To ensure all GIDs referenced in <tt>/etc/passwd</tt> are defined in <tt>/etc/group</tt>,

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/tests/all_groups_exist.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/tests/all_groups_exist.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# remove offending users who don't have existing GIDs
+while read -r line ; do
+    login=$(echo $line | cut -f1 -d':')
+    gid=$(echo $line | cut -f4 -d':')
+    if ! cut -f3 -d':' /etc/group | grep -q "$gid" ; then
+        userdel -f $login
+    fi
+done < "/etc/passwd"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/tests/user_with_nonexistent_group.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/tests/user_with_nonexistent_group.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+groupdel 888888 || true
+echo "testuser:x:8000:888888:testuser:/home/testuser:/bin/bash" >> /etc/passwd


### PR DESCRIPTION
#### Description:

Create test scenarios for rule gid_passwd_group_same and also fix some typos.

#### Rationale:
Increase test coverage of CIS profile.
