### PR TITLE
Updated style guide to define test scripts header

### DIFF
--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -268,6 +268,20 @@ Value must be low, medium, or high.
 * Shall test one change
 * Shall use the `.sh` for the file extension
 * Shall use the `#!/bin/bash` shebang at the first line
+* Shall have a single empty line after the shebang line or after the last [header parameter](https://complianceascode.readthedocs.io/en/latest/tests/README.html#scenarios-format), like in the following valid examples:
+```bash
+#!/bin/bash
+
+<code here>
+```
+or
+```bash
+#!/bin/bash
+# packages = audit
+
+<code here>
+```
+
 * Must follow all the rules in the [Bash](manual/developer/04_style_guide:bash) section
 
 ## Markup Languages

--- a/tests/README.md
+++ b/tests/README.md
@@ -194,7 +194,6 @@ Using `platform` and `variables` metadata:
 
 ```bash
 #!/bin/bash
-#
 # platform = Red Hat Enterprise Linux 7,multi_platform_fedora
 # variables = auth_enabled=yes,var_example_1=value_example
 


### PR DESCRIPTION
#### Description:

This is not a real problem, but since we have a style guide, it would be good to have this defined.

#### Rationale:

Currently our test scripts are not consistent. We have at least 3 cases:
1 - Test scripts without unnecessary lines (suggestion in this PR), like in this example:
```
#!/bin/bash

<code here>
```
2 - Test scripts with an extra "#" but without any header parameter, like in this example:
```
#!/bin/bash
#

<code here>
```
3 - Test scripts with an extra "#" and header parameters, like in this example:
```
#!/bin/bash
#
# packages = audit

<code here>
```
The suggestion for the style guide is the have the simplest and shortest option, like in case 1.