### PR TITLE
Add a fail test for accounts_password_all_shadowed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/oval/shared.xml
@@ -13,6 +13,6 @@
     <unix:username operation="pattern match">.*</unix:username>
   </unix:password_object>
   <unix:password_state id="state_accounts_password_all_shadowed" version="1">
-    <unix:password operation="pattern match">x|\*</unix:password>
+    <unix:password operation="pattern match">^[x*]$</unix:password>
   </unix:password_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/hash.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/hash.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "testuser:0fcf3792f5fffc4fcd1801fab37e0470c66d46cb0f01:8000:8000:testuser:/home/testuser:/bin/bash" >> /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_hash.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_hash.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "testuser:x0fcf3792f5fffc4fcd1801fab37e0470c66d46cb0f01:8000:8000:testuser:/home/testuser:/bin/bash" >> /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_username.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_username.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "xtestuser:0fcf3792f5fffc4fcd1801fab37e0470c66d46cb0f01:8000:8000:testuser:/home/testuser:/bin/bash" >> /etc/passwd


### PR DESCRIPTION


#### Description:
This rule missed a fail test scenario. We will add a fake user
with a random string different than x or asterisk in the second
field in /etc/passwd.

#### Rationale:

This PR will improve the test coverage of RHEL 7 CIS profiles.