### PR TITLE
 Add file_permissions_etc_audit_* rules to Ubuntu 20.04 STIG profile

### DIFF
--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8
+prodtype: fedora,rhel8,ubuntu2004
 
 title: 'Verify Permissions on /etc/audit/auditd.conf'
 

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AU-12(b)
     srg: SRG-OS-000063-GPOS-00032
     stigid@rhel8: RHEL-08-030610
+    stigid@ubuntu2004: UBTU-20-010133
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_rulesd/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_rulesd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8
+prodtype: fedora,rhel8,ubuntu2004
 
 title: 'Verify Permissions on /etc/audit/rules.d/*.rules'
 

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_rulesd/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_rulesd/rule.yml
@@ -26,6 +26,7 @@ references:
     nist: AU-12(b)
     srg: SRG-OS-000063-GPOS-00032
     stigid@rhel8: RHEL-08-030610
+    stigid@ubuntu2004: UBTU-20-010133
 
 template:
     name: file_permissions

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -186,6 +186,8 @@ selections:
     # UBTU-20-010128 The Ubuntu operating system must be configured so that the audit log directory is not write-accessible by unauthorized users.
 
     # UBTU-20-010133 The Ubuntu operating system must be configured so that audit configuration files are not write-accessible by unauthorized users.
+    - file_permissions_etc_audit_rulesd
+    - file_permissions_etc_audit_auditd
 
     # UBTU-20-010134 The Ubuntu operating system must permit only authorized accounts to own the audit configuration files.
 


### PR DESCRIPTION
#### Description:

-  Add ubuntu2004 to prodtype
- Add stigid@ubunt2004
- Add file_permissions_etc_audit_* rules to Ubuntu 20.04 STIG profile 
