### PR TITLE
Add sphinx missing dependency in the developer guide

### DIFF
--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -117,6 +117,14 @@ pip install json2html
 Install Sphinx packages if you want to generate HTML Documentation, from source directory run:
 
 ```bash
+# Fedora/RHEL
+yum install python3-sphinx
+
+# Ubuntu/Debian
+apt-get install python3-sphinx
+```
+
+```bash
 pip install -r docs/requirements.txt
 ```
 


### PR DESCRIPTION
#### Description:

- Add sphinx missing dependency in the developer guide

#### Rationale:

- Adds the package that contains `sphinx-build` for example.
