### PR TITLE
Use --duplicate-templates in SSGTS integration with Github

### DIFF
--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -117,6 +117,8 @@ jobs:
       - name: Run tests in a container - Bash
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
+        env:
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -136,6 +138,8 @@ jobs:
       - name: Run tests in a container - Ansible
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
+        env:
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log

--- a/tests/test_rule_in_container.sh
+++ b/tests/test_rule_in_container.sh
@@ -8,6 +8,7 @@
 # ARG_OPTIONAL_SINGLE([logdir],[l],[Directory where logs will be stored])
 # ARG_OPTIONAL_BOOLEAN([dontclean],[],[Dont remove HTML reports from the log directory.])
 # ARG_OPTIONAL_BOOLEAN([dry-run],[],[Just print the test suite command-line.])
+# ARG_USE_ENV([ADDITIONAL_SSGTS_OPTIONS],[],[Whitespace-separated string of arguments to pass to SSGTS])
 # ARG_POSITIONAL_SINGLE([rule],[The short rule ID. Wildcards are supported.])
 # ARG_TYPE_GROUP_SET([remediations],[REMEDIATION],[remediate-using],[oscap,bash,ansible])
 # ARG_DEFAULTS_POS([])
@@ -74,6 +75,8 @@ print_help()
 	printf '\t%s\n' "--dontclean: Dont remove HTML reports from the log directory."
 	printf '\t%s\n' "--dry-run: Just print the test suite command-line."
 	printf '\t%s\n' "-h, --help: Prints help"
+	printf '\nEnvironment variables that are supported:\n'
+	printf '\t%s\n' "ADDITIONAL_SSGTS_OPTIONS: Whitespace-separated string of arguments to pass to SSGTS."
 }
 
 
@@ -214,7 +217,7 @@ test -n "$_arg_remediate_using" && additional_args+=(--remediate-using "$_arg_re
 
 test -n "$_arg_logdir" && additional_args+=(--logdir "$_arg_logdir")
 
-command=(python3 "${script_dir}/test_suite.py" rule --remove-machine-only "${additional_args[@]}" --add-platform "$test_image_cpe_product" --container "$_arg_name" -- "${_arg_rule}")
+command=(python3 "${script_dir}/test_suite.py" rule ${ADDITIONAL_SSGTS_OPTIONS} --remove-machine-only "${additional_args[@]}" --add-platform "$test_image_cpe_product" --container "$_arg_name" -- "${_arg_rule}")
 if test "$_arg_dry_run" = on; then
 	printf '%s\n' "${command[*]}"
 else


### PR DESCRIPTION
This option will ensure that all templated rules are properly
tested. Otherwise only one rule for such template would be tested.

Additionally its expands the test_rule_in_container.sh script to
support additional SSGTS parameters using env variable.

#### Description:

- Use --duplicate-templates in SSGTS integration with Github.
  - This option will ensure that all templated rules are properly
tested. Otherwise only one rule for such template would be tested.
  - Additionally its expands the test_rule_in_container.sh script to
support additional SSGTS parameters using env variable.
