### PR TITLE
Fix typo in audit_perm_change_success rule

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -11,7 +11,7 @@ title: 'Configure auditing of successful permission changes'
 " %}}
 
 description: |-
-    Ensure that successful attempts to modify permissions of iles or directories are audited.
+    Ensure that successful attempts to modify permissions of files or directories are audited.
 
     The following rules configure audit as described above:
     <pre>{{{ file_contents_audit_perm_change_success|indent }}}    </pre>


### PR DESCRIPTION
Replace 'iles' with 'files'

#### Description:
- Fix a typo in current rule description text.

#### Rationale:
- There is a typo in current rule description text.