### PR TITLE
Created pass/fail scripts for rule sshd_use_approved_macs

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_rhel
+#
+# profiles = xccdf_org.ssgproject.content_profile_cis
+
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
@@ -1,5 +1,3 @@
 # platform = multi_platform_rhel
-#
-# profiles = xccdf_org.ssgproject.content_profile_cis
 
 {{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
@@ -1,5 +1,3 @@
 # platform = Red Hat Enterprise Linux 7
 
-{{{ bash_instantiate_variables("umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com") }}}
-
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
@@ -1,3 +1,5 @@
 # platform = Red Hat Enterprise Linux 7
+#
+# profiles = xccdf_org.ssgproject.content_profile_cis
 
 {{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
@@ -1,0 +1,5 @@
+# platform = Red Hat Enterprise Linux 7
+
+{{{ bash_instantiate_variables("umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com") }}}
+
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel, multi_platform_fedora
+# platform = multi_platform_rhel
 
 {{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel, multi_platform_fedora
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com"", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,5 +1,3 @@
 # platform = multi_platform_rhel, multi_platform_fedora
 
-{{{ bash_instantiate_variables("wrong_value_expected_to_fail.com") }}}
-
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com"", '@CCENUM@', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_rhel, multi_platform_fedora
+
+{{{ bash_instantiate_variables("wrong_value_expected_to_fail.com") }}}
+
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '@CCENUM@', '%s %s') }}}


### PR DESCRIPTION
rhel7

#### Description:

- _Created the pass/fail scripts for cis profile on rhel7 for the test sshd_use_approved_macs, fail scenario can be used for any version of rhel/fedora._
