### PR TITLE
Add rule prevent_direct_root_logins

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/prevent_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/prevent_direct_root_logins/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Direct root Logins Are Not Allowed'
+
+description: |-
+    Configure the operating system to prevent direct logins to the
+    <tt>root</tt> account by performing the following operations:
+    <pre>$ sudo passwd -l root</pre>
+
+rationale: |-
+    Disabling direct root logins ensures proper accountability and
+    multifactor authentication to privileged accounts.
+
+severity: medium
+
+references:
+    disa: CCI-000770
+    srg: SRG-OS-000109-GPOS-00056
+    stigid@ubuntu2004: UBTU-20-010408
+
+ocil_clause: 'the output does not contain "L" in the second field'
+
+ocil: |-
+    Verify the operating system prevents direct logins to the root account
+    with the following command:
+    <pre>$ sudo passwd -S root
+    root L 04/23/2020 0 99999 7 -1</pre>
+    If the output does not contain "L" in the second field to indicate the
+    account is locked, then run the following command:
+    <pre>$ sudo passwd -l root</pre>

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -423,6 +423,7 @@ selections:
     # UBTU-20-010407 The Ubuntu operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.
 
     # UBTU-20-010408 The Ubuntu operating system must prevent direct login into the root account.
+    - prevent_direct_root_logins
 
     # UBTU-20-010409 The Ubuntu operating system must disable account identifiers (individuals, groups, roles, and devices) after 35 days of inactivity.
     - account_disable_post_pw_expiration


### PR DESCRIPTION
#### Description:

- UBTU-20-010408:
The Ubuntu operating system must prevent direct login into the root account.
Verify the operating system prevents direct logins to the root account with the following command:
$ sudo passwd -S root
root L 04/23/2020 0 99999 7 -1
If the output does not contain "L" in the second field to indicate the account is locked, this is a finding.