### PR TITLE
Moved CCE number expansion from XSLT to jinja macro 

### DIFF
--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/bash/shared.sh
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_wrlinux,multi_platform_sle
 
 
-{{{ bash_replace_or_append('/etc/vsftpd.conf', '^banner_file', '/etc/issue', '@CCENUM@', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/vsftpd.conf', '^banner_file', '/etc/issue', '%s=%s') }}}

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
@@ -2,7 +2,7 @@
 
 
 # Use LDAP for authentication
-{{{ bash_replace_or_append('/etc/sysconfig/authconfig', '^USELDAPAUTH', 'yes', '@CCENUM@', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/sysconfig/authconfig', '^USELDAPAUTH', 'yes', '%s=%s') }}}
 
 # Configure client to use TLS for all authentications
-{{{ bash_replace_or_append('/etc/nslcd.conf', '^ssl', 'start_tls', '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/nslcd.conf', '^ssl', 'start_tls', '%s %s') }}}

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
@@ -2,6 +2,6 @@
 
 {{{ bash_instantiate_variables("var_postfix_root_mail_alias") }}}
 
-{{{ bash_replace_or_append('/etc/aliases', '^root', "$var_postfix_root_mail_alias", '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append('/etc/aliases', '^root', "$var_postfix_root_mail_alias", '%s: %s') }}}
 
 newaliases

--- a/linux_os/guide/services/ntp/chronyd_client_only/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 
-{{{ bash_replace_or_append("/etc/chrony.conf", '^port', '0', '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append("/etc/chrony.conf", '^port', '0', '%s %s') }}}

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 
-{{{ bash_replace_or_append("/etc/chrony.conf", '^cmdport', '0', '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append("/etc/chrony.conf", '^cmdport', '0', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv
 
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Protocol', '2', '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Protocol', '2', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_sshd_disable_compression") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Compression', "$var_sshd_disable_compression", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Compression', "$var_sshd_disable_compression", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^RhostsRSAAuthentication', 'no', '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^RhostsRSAAuthentication', 'no', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Ciphers', "$sshd_approved_ciphers", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Ciphers', "$sshd_approved_ciphers", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 
-{{{ bash_replace_or_append('/etc/systemd/system.conf', '^CtrlAltDelBurstAction=', 'none', '@CCENUM@', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/systemd/system.conf', '^CtrlAltDelBurstAction=', 'none', '%s=%s') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_account_disable_post_pw_expiration") }}}
 
-{{{ bash_replace_or_append('/etc/default/useradd', '^INACTIVE', "$var_account_disable_post_pw_expiration", '@CCENUM@', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/default/useradd', '^INACTIVE', "$var_account_disable_post_pw_expiration", '%s=%s') }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_accounts_fail_delay") }}}
 
-{{{ bash_replace_or_append('/etc/login.defs', '^FAIL_DELAY', "$var_accounts_fail_delay", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/login.defs', '^FAIL_DELAY', "$var_accounts_fail_delay", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_accounts_user_umask") }}}
 
-{{{ bash_replace_or_append('/etc/login.defs', '^UMASK', "$var_accounts_user_umask", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/login.defs', '^UMASK', "$var_accounts_user_umask", '%s %s') }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -8,4 +8,4 @@ AUDITCONFIG=/etc/audit/audisp-remote.conf
 AUDITCONFIG=/etc/audisp/audisp-remote.conf
 {{% endif %}}
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^remote_server', "$var_audispd_remote_server", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^remote_server', "$var_audispd_remote_server") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
@@ -10,4 +10,4 @@ option="^enable_krb5"
 value="yes"
 {{% endif %}}
 
-{{{ bash_replace_or_append("$AUDISP_REMOTE_CONFIG", "$option", "$value", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDISP_REMOTE_CONFIG", "$option", "$value") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
@@ -7,4 +7,4 @@ AUDISP_SYSLOGCONFIG=/etc/audit/plugins.d/syslog.conf
 AUDISP_SYSLOGCONFIG=/etc/audisp/plugins.d/syslog.conf
 {{% endif %}}
 
-{{{ bash_replace_or_append("$AUDISP_SYSLOGCONFIG", '^active', "$var_syslog_active", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDISP_SYSLOGCONFIG", '^active', "$var_syslog_active") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_auditd_disk_full_action") }}}
 
-{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_full_action', "$var_auditd_disk_full_action", "@CCENUM@") }}}
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_full_action', "$var_auditd_disk_full_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^action_mail_acct', "$var_auditd_action_mail_acct", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^action_mail_acct', "$var_auditd_action_mail_acct") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^admin_space_left_action', "$var_auditd_admin_space_left_action", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^admin_space_left_action', "$var_auditd_admin_space_left_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^max_log_file', "$var_auditd_max_log_file", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^max_log_file', "$var_auditd_max_log_file") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^max_log_file_action', "$var_auditd_max_log_file_action", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^max_log_file_action', "$var_auditd_max_log_file_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^num_logs', "$var_auditd_num_logs", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^num_logs', "$var_auditd_num_logs") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
@@ -10,4 +10,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^space_left_action', "$var_auditd_space_left_action", "@CCENUM@") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", '^space_left_action', "$var_auditd_space_left_action") }}}

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
-{{{ bash_replace_or_append('/etc/rsyslog.conf', '^\*\.\*', "@@$rsyslog_remote_loghost_address", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/rsyslog.conf', '^\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/bash/shared.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_ports/bash/shared.sh
@@ -33,7 +33,7 @@ if [ $nic_bound = false ];then
     # Add first NIC to SSH enabled zone
 
     if ! firewall-cmd --state -q; then
-        {{{ bash_replace_or_append("/etc/sysconfig/network-scripts/ifcfg-${eth_interface_list[0]}", '^ZONE=', "$firewalld_sshd_zone", '@CCENUM@', '%s=%s') | indent(8) }}}
+        {{{ bash_replace_or_append("/etc/sysconfig/network-scripts/ifcfg-${eth_interface_list[0]}", '^ZONE=', "$firewalld_sshd_zone", '%s=%s') | indent(8) }}}
     else
         # If firewalld service is running, we need to do this step with firewall-cmd
         # Otherwise firewalld will comunicate with NetworkManage and will revert assigned zone

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -10,7 +10,7 @@ if [ "$(getconf LONG_BIT)" = "32" ] ; then
   # If kernel.exec-shield present in /etc/sysctl.conf, change value to "1"
   #	else, add "kernel.exec-shield = 1" to /etc/sysctl.conf
   #
-  {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.exec-shield', '1', '@CCENUM@') }}}
+  {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.exec-shield', '1') }}}
 fi
 
 if [ "$(getconf LONG_BIT)" = "64" ] ; then

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/bash/sle12.sh
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/bash/sle12.sh
@@ -1,3 +1,3 @@
 # platform = SUSE Linux Enterprise 12
 
-{{{ bash_replace_or_append('/etc/zypp/zypp.conf', '^solver.upgradeRemoveDroppedPackages', 'true', '@CCENUM@', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/zypp/zypp.conf', '^solver.upgradeRemoveDroppedPackages', 'true', '%s=%s') }}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
 
-{{{ bash_replace_or_append( pkg_manager_config_file , '^gpgcheck', '1', '@CCENUM@') }}}
+{{{ bash_replace_or_append( pkg_manager_config_file , '^gpgcheck', '1') }}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_all
 
-{{{ bash_replace_or_append( pkg_manager_config_file , '^localpkg_gpgcheck', '1', '@CCENUM@') }}}
+{{{ bash_replace_or_append( pkg_manager_config_file , '^localpkg_gpgcheck', '1') }}}

--- a/products/jre/guide/java/java_jre_configure_crypto_policy/bash/shared.sh
+++ b/products/jre/guide/java/java_jre_configure_crypto_policy/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 JRE_CONFIG_FILE="/usr/lib/jvm/jre/lib/security/java.security"
-{{{ bash_replace_or_append("$JRE_CONFIG_FILE", '^security.useSystemPropertiesFile', 'true', '@CCENUM@', '%s=%s') }}}
+{{{ bash_replace_or_append("$JRE_CONFIG_FILE", '^security.useSystemPropertiesFile', 'true', '%s=%s') }}}

--- a/products/vsel/guide/vsel/general_settings/virus_notification/bash/shared.sh
+++ b/products/vsel/guide/vsel/general_settings/virus_notification/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^notifications.virusDetected.active', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^notifications.virusDetected.active', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/general_settings/web_client_disabled/bash/shared.sh
+++ b/products/vsel/guide/vsel/general_settings/web_client_disabled/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.disableCltWebUI', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.disableCltWebUI', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_app_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_app_primary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.App.primary', 'Clean', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.App.primary', 'Clean', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_app_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_app_secondary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.App.secondary', 'Quarantine', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.App.secondary', 'Quarantine', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_default_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_default_primary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.Default.primary', 'Clean', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.Default.primary', 'Clean', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_default_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_default_secondary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.Default.secondary', 'Quarantine', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.Default.secondary', 'Quarantine', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_error/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_error/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.error', 'Block', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.error', 'Block', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_timeout/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_timeout/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.timeout', 'Pass', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.action.timeout', 'Pass', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_allFiles/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_allFiles/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.allFiles', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.allFiles', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_decompArchive/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_decompArchive/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.decompArchive', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.decompArchive', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_enabled/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_enabled/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.oasEnabled', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.oasEnabled', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_heuristicAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_heuristicAnalysis/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.heuristicAnalysis', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.heuristicAnalysis', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_macroAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_macroAnalysis/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.macroAnalysis', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.macroAnalysis', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_program/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_program/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.program', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.program', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanMaxTmo/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanMaxTmo/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanMaxTmo', '45', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanMaxTmo', '45', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanNWFiles/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanNWFiles/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanNWFiles', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanNWFiles', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanOnRead/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanOnRead/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanOnRead', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanOnRead', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanOnWrite/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanOnWrite/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanOnWrite', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.OAS.scanOnWrite', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_app_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_app_primary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.App.primary', 'Clean', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.App.primary', 'Clean', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_app_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_app_secondary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.App.secondary', 'Quarantine', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.App.secondary', 'Quarantine', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_default_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_default_primary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.Default.primary', 'Clean', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.Default.primary', 'Clean', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_default_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_default_secondary/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.Default.secondary', 'Quarantine', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.action.Default.secondary', 'Quarantine', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_allFiles/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_allFiles/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.allFiles', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.allFiles', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_decompArchive/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_decompArchive/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.decompArchive', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.decompArchive', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_extensions/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_extensions/bash/shared.sh
@@ -7,5 +7,5 @@ if  ! grep -q extensions.mode "$NAILS_CONFIG_FILE"; then
 	sed -i '$a nailsd.profile.ODS_default.filter.extensions.mode: all' "$NAILS_CONFIG_FILE"
 
 else
-	{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", 'extensions.mode', 'all', '@CCENUM@', '%s: %s') }}}
+	{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", 'extensions.mode', 'all', '%s: %s') }}}
 fi

--- a/products/vsel/guide/vsel/on_demand_settings/ods_heuristicAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_heuristicAnalysis/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.heuristicAnalysis', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.heuristicAnalysis', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_macroAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_macroAnalysis/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.macroAnalysis', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.macroAnalysis', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_mime/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_mime/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.mime', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.mime', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_program/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_program/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.program', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.program', 'true', '%s: %s') }}}

--- a/products/vsel/guide/vsel/on_demand_settings/ods_scanNWFiles_local/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_scanNWFiles_local/bash/shared.sh
@@ -2,4 +2,4 @@
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"
-{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.scanNWFiles', 'true', '@CCENUM@', '%s: %s') }}}
+{{{ bash_replace_or_append("$NAILS_CONFIG_FILE", '^nailsd.profile.ODS.scanNWFiles', 'true', '%s: %s') }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1150,7 +1150,6 @@ cce="CCE"
   config_file:		Configuration file that will be modified
   key:			Configuration option to change
   value:		Value of the configuration option to change
-  cce:			The CCE identifier or '@CCENUM@' if no CCE identifier exists
   format:		The printf-like format string that will be given stripped key and value as arguments,
              so e.g. '%s=%s' will result in key=value subsitution (i.e. without spaces around =)
  
@@ -1162,16 +1161,16 @@ cce="CCE"
   Example Call(s):
  
       With default format of 'key = value':
-      {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.randomize_va_space', '2', '@CCENUM@') }}}
+      {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.randomize_va_space', '2') }}}
  
       With custom key/value format:
-      {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', 'disabled', '@CCENUM@', '%s=%s') }}}
+      {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', 'disabled', '%s=%s') }}}
  
       With a variable:
-      {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', "$var_selinux_state", '@CCENUM@', '%s=%s') }}}
+      {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', "$var_selinux_state", '%s=%s') }}}
  
 #}}
-{{%- macro bash_replace_or_append(config_file, key, value, cce, format='%s = %s') -%}}
+{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s') -%}}
 
 # Test if the config_file is a symbolic link. If so, use --follow-symlinks with sed.
 # Otherwise, regular sed command will do.

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1131,13 +1131,11 @@ rpm --quiet -q "{{{ pkgname }}}"
   #
   # This macro gets the var cce_identifiers from the environment created by the build scripts.
   # The cce_identifiers is a dictionary that contains either the 'cce':'CCENUM' record for the
-  # product this remediation is being built for, or it is empty, in which case the string 'CCE' is used.
+  # product this remediation is being built for, or it is empty.
   #}}
 {{%- macro set_cce_value() -%}}
 {{% if 'cce' in cce_identifiers -%}}
 cce="{{{ cce_identifiers['cce'] }}}"
-{{%- else -%}}
-cce="CCE"
 {{%- endif %}}
 {{%- endmacro -%}}
 
@@ -1179,9 +1177,6 @@ if test -L "{{{ config_file }}}"; then
     sed_command+=('--follow-symlinks')
 fi
 
-# Set the rule CCE value; if the rule has none, it is set to 'CCE'
-{{{ set_cce_value() }}}
-
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.
 stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "{{{ key }}}")
@@ -1196,7 +1191,10 @@ if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
     "${sed_command[@]}" "s/{{{ key }}}\\>.*/$formatted_output/gi" "{{{ config_file }}}"
 else
     # \n is precaution for case where file ends without trailing newline
+    {{% if 'cce' in cce_identifiers -%}}
+    {{{ set_cce_value() }}}
     printf '\n# Per %s: Set %s in %s\n' "$cce" "$formatted_output" "{{{ config_file }}}" >> "{{{ config_file }}}"
+    {{%- endif %}}
     printf '%s\n' "$formatted_output" >> "{{{ config_file }}}"
 fi
 {{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1127,6 +1127,21 @@ rpm --quiet -q "{{{ pkgname }}}"
 {{%- endmacro -%}}
 
 {{#
+  # Set rule CCE value
+  #
+  # This macro gets the var cce_identifiers from the environment created by the build scripts.
+  # The cce_identifiers is a dictionary that contains either the 'cce':'CCENUM' record for the
+  # product this remediation is being built for, or it is empty, in which case the string 'CCE' is used.
+  #}}
+{{%- macro set_cce_value() -%}}
+{{% if 'cce' in cce_identifiers -%}}
+cce="{{{ cce_identifiers['cce'] }}}"
+{{%- else -%}}
+cce="CCE"
+{{%- endif %}}
+{{%- endmacro -%}}
+
+{{#
   Macro to replace configuration setting in config file or add the configuration setting if
   it does not exist.
  
@@ -1165,12 +1180,8 @@ if test -L "{{{ config_file }}}"; then
     sed_command+=('--follow-symlinks')
 fi
 
-# If the cce arg is empty, CCE is not assigned.
-if [ -z "{{{ cce }}}" ]; then
-    cce="CCE"
-else
-    cce="{{{ cce }}}"
-fi
+# Set the rule CCE value; if the rule has none, it is set to 'CCE'
+{{{ set_cce_value() }}}
 
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -6,4 +6,4 @@
 
 {{{ bash_instantiate_variables("var_password_pam_" + VARIABLE) }}}
 
-{{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' + VARIABLE , '$var_password_pam_' + VARIABLE , '@CCENUM@', '%s = %s') }}}
+{{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' + VARIABLE , '$var_password_pam_' + VARIABLE , '%s = %s') }}}

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -16,7 +16,7 @@
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to appropriate value
 #	else, add "{{{ SYSCTLVAR }}} = value" to /etc/sysctl.conf
 #
-{{{ bash_replace_or_append('/etc/sysctl.conf', '^' + SYSCTLVAR , '$sysctl_' + SYSCTLID + '_value', '@CCENUM@') }}}
+{{{ bash_replace_or_append('/etc/sysctl.conf', '^' + SYSCTLVAR , '$sysctl_' + SYSCTLID + '_value') }}}
 {{%- else %}}
 
 #
@@ -28,5 +28,5 @@
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to "{{{ SYSCTLVAL }}}"
 #	else, add "{{{ SYSCTLVAR }}} = {{{ SYSCTLVAL }}}" to /etc/sysctl.conf
 #
-{{{ bash_replace_or_append('/etc/sysctl.conf', '^' + SYSCTLVAR , SYSCTLVAL , '@CCENUM@') }}}
+{{{ bash_replace_or_append('/etc/sysctl.conf', '^' + SYSCTLVAR , SYSCTLVAL ) }}}
 {{%- endif %}}

--- a/shared/transforms/xccdf-addremediations.xslt
+++ b/shared/transforms/xccdf-addremediations.xslt
@@ -45,44 +45,6 @@
 <xsl:variable name="fixgroups" select="$bash_fixgroup | $ansible_fixgroup | $puppet_fixgroup | $anaconda_fixgroup | $ignition_fixgroup | $kubernetes_fixgroup| $blueprint_fixgroup" />
 <xsl:variable name="fixcommongroups" select="$bash_fixcommongroup | $ansible_fixcommongroup | $puppet_fixcommongroup | $anaconda_fixcommongroup | $ignition_fixcommongroup | $kubernetes_fixcommongroup| $blueprint_fixcommongroup" />
 
-<xsl:template name="find-and-replace">
-  <xsl:param name="text"/>
-  <xsl:param name="replace"/>
-  <xsl:param name="with"/>
-  <xsl:choose>
-    <xsl:when test="contains($text,$replace)">
-      <xsl:value-of select="substring-before($text,$replace)"/>
-      <xsl:value-of select="$with"/>
-      <xsl:call-template name="find-and-replace">
-        <xsl:with-param name="text" select="substring-after($text,$replace)"/>
-        <xsl:with-param name="replace" select="$replace"/>
-        <xsl:with-param name="with" select="$with"/>
-      </xsl:call-template>
-    </xsl:when>
-    <xsl:otherwise>
-      <xsl:value-of select="$text" />
-    </xsl:otherwise>
-  </xsl:choose>
-</xsl:template>
-
-<xsl:template match="text()" mode="fix_contents">
-  <xsl:param name="rule"/>
-  <xsl:param name="fix"/>
-  <xsl:variable name="rep0" select="."/>
-
-  <xsl:variable name="ident_cce" select="$rule/xccdf:ident[@system='https://nvd.nist.gov/cce/index.cfm']/text()"/>
-
-  <xsl:variable name="rep1">
-    <xsl:call-template name="find-and-replace">
-      <xsl:with-param name="text" select="$rep0"/>
-      <xsl:with-param name="replace" select="'@CCENUM@'"/>
-      <xsl:with-param name="with" select="$ident_cce"/>
-    </xsl:call-template>
-  </xsl:variable>
-
-  <xsl:value-of select="$rep1"/>
-</xsl:template>
-
 <xsl:template match="@* | node()" mode="fix_contents">
   <xsl:param name="rule"/>
   <xsl:param name="fix"/>

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -182,6 +182,7 @@ class Remediation(object):
 
         self.local_env_yaml["rule_title"] = self.associated_rule.title
         self.local_env_yaml["rule_id"] = self.associated_rule.id_
+        self.local_env_yaml["cce_identifiers"] = self.associated_rule.identifiers
 
     def parse_from_file_with_jinja(self, env_yaml):
         return parse_from_file_with_jinja(self.file_path, env_yaml)

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -282,7 +282,8 @@ class Builder(object):
 
         return processed
 
-    def build_rule(self, rule_id, rule_title, template, langs_to_generate, rule, platforms=None):
+    def build_rule(self, rule_id, rule_title, template, langs_to_generate, identifiers,
+                   platforms=None):
         """
         Builds templated content for a given rule for selected languages,
         writing the output to the correct build directories.
@@ -303,8 +304,8 @@ class Builder(object):
         local_env_yaml["rule_id"] = rule_id
         local_env_yaml["rule_title"] = rule_title
         local_env_yaml["products"] = self.env_yaml["product"]
-        if rule is not None:
-            local_env_yaml["cce_identifiers"] = rule.identifiers
+        if identifiers is not None:
+            local_env_yaml["cce_identifiers"] = identifiers
 
         for lang in langs_to_generate:
             try:
@@ -362,8 +363,8 @@ class Builder(object):
                 # rule is not templated, skipping
                 continue
             langs_to_generate = self.get_langs_to_generate(rule)
-            self.build_rule(rule.id_, rule.title, rule.template, langs_to_generate, rule,
-                            platforms=rule.platforms)
+            self.build_rule(rule.id_, rule.title, rule.template, langs_to_generate,
+                            rule.identifiers, platforms=rule.platforms)
 
     def build(self):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -363,7 +363,7 @@ class Builder(object):
                 continue
             langs_to_generate = self.get_langs_to_generate(rule)
             self.build_rule(
-                rule.id_, rule.title, rule.template, langs_to_generate, rule, platforms=rule.platforms)
+             rule.id_, rule.title, rule.template, langs_to_generate, rule, platforms=rule.platforms)
 
     def build(self):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -282,7 +282,7 @@ class Builder(object):
 
         return processed
 
-    def build_rule(self, rule_id, rule_title, template, langs_to_generate, platforms=None):
+    def build_rule(self, rule_id, rule_title, template, langs_to_generate, rule, platforms=None):
         """
         Builds templated content for a given rule for selected languages,
         writing the output to the correct build directories.
@@ -303,6 +303,9 @@ class Builder(object):
         local_env_yaml["rule_id"] = rule_id
         local_env_yaml["rule_title"] = rule_title
         local_env_yaml["products"] = self.env_yaml["product"]
+        if rule is not None:
+            local_env_yaml["cce_identifiers"] = rule.identifiers
+
         for lang in langs_to_generate:
             try:
                 self.build_lang(
@@ -345,7 +348,7 @@ class Builder(object):
             # as rule ID, we can use it instead of the rule ID even if no rule
             # with that ID exists
             self.build_rule(
-                oval_def_id, oval_def_id, template, langs_to_generate)
+                oval_def_id, oval_def_id, template, langs_to_generate, None)
 
     def build_all_rules(self):
         for rule_file in sorted(os.listdir(self.resolved_rules_dir)):
@@ -360,7 +363,7 @@ class Builder(object):
                 continue
             langs_to_generate = self.get_langs_to_generate(rule)
             self.build_rule(
-                rule.id_, rule.title, rule.template, langs_to_generate, platforms=rule.platforms)
+                rule.id_, rule.title, rule.template, langs_to_generate, rule, platforms=rule.platforms)
 
     def build(self):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -362,8 +362,8 @@ class Builder(object):
                 # rule is not templated, skipping
                 continue
             langs_to_generate = self.get_langs_to_generate(rule)
-            self.build_rule(
-             rule.id_, rule.title, rule.template, langs_to_generate, rule, platforms=rule.platforms)
+            self.build_rule(rule.id_, rule.title, rule.template, langs_to_generate, rule,
+                            platforms=rule.platforms)
 
     def build(self):
         """

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -38,7 +38,7 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key to empty file" {
     tmp_file="$(mktemp)"
     printf "" > "$tmp_file"
-    expected_output="\n# Per CCE: Set kernel.randomize_va_space = 2 in $tmp_file\nkernel.randomize_va_space = 2\n"
+    expected_output="kernel.randomize_va_space = 2\n"
 
     call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
 
@@ -51,7 +51,7 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key to non-empty file" {
     tmp_file="$(mktemp)"
     printf "%s\n" "kernel.randomize_va_fake = 5" > "$tmp_file"
-    expected_output="kernel.randomize_va_fake = 5\n\n# Per CCE: Set kernel.randomize_va_space = 2 in $tmp_file\nkernel.randomize_va_space = 2\n"
+    expected_output="kernel.randomize_va_fake = 5\nkernel.randomize_va_space = 2\n"
 
     call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
 
@@ -90,7 +90,7 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key with format to empty file" {
     tmp_file="$(mktemp)"
     printf "" > "$tmp_file"
-    expected_output="\n# Per CCE: Set kernel.randomize_va_space=2 in $tmp_file\nkernel.randomize_va_space=2\n"
+    expected_output="kernel.randomize_va_space=2\n"
 
     call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
 
@@ -103,7 +103,7 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key with format to non-empty file" {
     tmp_file="$(mktemp)"
     printf "%s\n" "kernel.randomize_va_fake=5" > "$tmp_file"
-    expected_output="kernel.randomize_va_fake=5\n\n# Per CCE: Set kernel.randomize_va_space=2 in $tmp_file\nkernel.randomize_va_space=2\n"
+    expected_output="kernel.randomize_va_fake=5\nkernel.randomize_va_space=2\n"
 
     call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
 

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -2,11 +2,11 @@
 
 
 function call_bash_replace_or_append {
-    {{{ bash_replace_or_append("$1", "$2", "$3", "$4") | indent(4) }}}
+    {{{ bash_replace_or_append("$1", "$2", "$3") | indent(4) }}}
 }
 
 function call_bash_replace_or_append_w_format {
-    {{{ bash_replace_or_append("$1", "$2", "$3", "$4", "$5") | indent(4) }}}
+    {{{ bash_replace_or_append("$1", "$2", "$3", "$4") | indent(4) }}}
 }
 
 @test "bash_replace_or_append - Basic value remediation" {
@@ -14,7 +14,7 @@ function call_bash_replace_or_append_w_format {
     printf "%s\n" "kernel.randomize_va_space = 5" > "$tmp_file"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@'
+    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -27,7 +27,7 @@ function call_bash_replace_or_append_w_format {
     printf "%s\n" "kernel.randomize_va_space = 2" > "$tmp_file"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@'
+    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -38,9 +38,9 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key to empty file" {
     tmp_file="$(mktemp)"
     printf "" > "$tmp_file"
-    expected_output="\n# Per @CCENUM@: Set kernel.randomize_va_space = 2 in $tmp_file\nkernel.randomize_va_space = 2\n"
+    expected_output="\n# Per CCE: Set kernel.randomize_va_space = 2 in $tmp_file\nkernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@'
+    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -51,9 +51,9 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key to non-empty file" {
     tmp_file="$(mktemp)"
     printf "%s\n" "kernel.randomize_va_fake = 5" > "$tmp_file"
-    expected_output="kernel.randomize_va_fake = 5\n\n# Per @CCENUM@: Set kernel.randomize_va_space = 2 in $tmp_file\nkernel.randomize_va_space = 2\n"
+    expected_output="kernel.randomize_va_fake = 5\n\n# Per CCE: Set kernel.randomize_va_space = 2 in $tmp_file\nkernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@'
+    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -66,7 +66,7 @@ function call_bash_replace_or_append_w_format {
     printf "%s\n" "kernel.randomize_va_space=5" > "$tmp_file"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -79,7 +79,7 @@ function call_bash_replace_or_append_w_format {
     printf "%s\n" "kernel.randomize_va_space=2" > "$tmp_file"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -90,9 +90,9 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key with format to empty file" {
     tmp_file="$(mktemp)"
     printf "" > "$tmp_file"
-    expected_output="\n# Per @CCENUM@: Set kernel.randomize_va_space=2 in $tmp_file\nkernel.randomize_va_space=2\n"
+    expected_output="\n# Per CCE: Set kernel.randomize_va_space=2 in $tmp_file\nkernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -103,61 +103,9 @@ function call_bash_replace_or_append_w_format {
 @test "bash_replace_or_append - Append key with format to non-empty file" {
     tmp_file="$(mktemp)"
     printf "%s\n" "kernel.randomize_va_fake=5" > "$tmp_file"
-    expected_output="kernel.randomize_va_fake=5\n\n# Per @CCENUM@: Set kernel.randomize_va_space=2 in $tmp_file\nkernel.randomize_va_space=2\n"
+    expected_output="kernel.randomize_va_fake=5\n\n# Per CCE: Set kernel.randomize_va_space=2 in $tmp_file\nkernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '@CCENUM@' '%s=%s'
-
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
-
-    rm "$tmp_file"
-}
-
-@test "bash_replace_or_append - Remediation with format and CCE" {
-    tmp_file="$(mktemp)"
-    printf "%s\n" "kernel.randomize_va_space 5" > "$tmp_file"
-    expected_output="kernel.randomize_va_space 2\n"
-
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '12345' '%s %s'
-
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
-
-    rm "$tmp_file"
-}
-
-@test "bash_replace_or_append - No remediation with format and CCE" {
-    tmp_file="$(mktemp)"
-    printf "%s\n" "kernel.randomize_va_space 2" > "$tmp_file"
-    expected_output="kernel.randomize_va_space 2\n"
-
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '12345' '%s %s'
-
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
-
-    rm "$tmp_file"
-}
-
-@test "bash_replace_or_append - Append key with format and CCE to empty file" {
-    tmp_file="$(mktemp)"
-    printf "" > "$tmp_file"
-    expected_output="\n# Per 12345: Set kernel.randomize_va_space 2 in $tmp_file\nkernel.randomize_va_space 2\n"
-
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '12345' '%s %s'
-
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
-
-    rm "$tmp_file"
-}
-
-@test "bash_replace_or_append - Append key with format and CCE to non-empty file" {
-    tmp_file="$(mktemp)"
-    printf "%s\n" "kernel.randomize_va_fake 5" > "$tmp_file"
-    expected_output="kernel.randomize_va_fake 5\n\n# Per 12345: Set kernel.randomize_va_space 2 in $tmp_file\nkernel.randomize_va_space 2\n"
-
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '12345' '%s %s'
+    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]


### PR DESCRIPTION
#### Description:

- Previously when we wanted to put a rule's CCE number into the changed files during remediations, we used the '@CCENUM@' string which was then searched and replaced by a XSLT template. This was not ideal, so I created the set_cce_value jinja macro which gets the CCE number from the environment provided by the build script.
- Removed the obsolete XSLT template and removed the 'cce' argument from all bash_replace_or_append macro invocations
- Fixed BATS unit tests for bash_replace_or_append

#### Rationale:

- #7446
