### PR TITLE
Add rule only_allow_dod_certs

### DIFF
--- a/linux_os/guide/system/network/network_ssl/only_allow_dod_certs/rule.yml
+++ b/linux_os/guide/system/network/network_ssl/only_allow_dod_certs/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Only Allow DoD PKI-established CAs'
+
+description: |-
+    The operating system must only allow the use of DoD PKI-established
+    certificate authorities for verification of the establishment of
+    protected sessions.
+
+rationale: |-
+    Untrusted Certificate Authorities (CA) can issue certificates, but they
+    may be issued by organizations or individuals that seek to compromise
+    DoD systems or by organizations with insufficient security controls. If
+    the CA used for verifying the certificate is not a DoD-approved CA,
+    trust of this CA has not been established.
+    The DoD will only accept PKI-certificates obtained from a DoD-approved
+    internal or external certificate authority. Reliance on CAs for the
+    establishment of secure sessions includes, for example, the use of
+    SSL/TLS certificates.
+
+severity: medium
+
+references:
+    disa: CCI-002470
+    srg: SRG-OS-000403-GPOS-00182
+    stigid@ubuntu2004: UBTU-20-010443

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -520,6 +520,7 @@ selections:
     - is_fips_mode_enabled
 
     # UBTU-20-010443 The Ubuntu operating system must only allow the use of DoD PKI-established certificate authorities for verification of the establishment of protected sessions.
+    - only_allow_dod_certs
 
     # UBTU-20-010444 Ubuntu operating system must implement cryptographic mechanisms to prevent unauthorized modification of all information at rest.
 


### PR DESCRIPTION
#### Description:

- UBTU-20-010443:
The Ubuntu operating system must only allow the use of DoD PKI-established certificate authorities for verification of the establishment of protected sessions.