### PR TITLE
SLE bash remediation accounts_passwords_pam_faildelay_delay

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle12.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle12.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+
+{{{ bash_instantiate_variables("var_password_pam_delay") }}}
+
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', 'required', 'pam_faildelay.so', 'delay', "$var_password_pam_delay", "$var_password_pam_delay") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle15.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/bash/sle15.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+
+{{{ bash_instantiate_variables("var_password_pam_delay") }}}
+
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', 'required', 'pam_faildelay.so', 'delay', "$var_password_pam_delay", "$var_password_pam_delay") }}}

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -22,6 +22,7 @@ selections:
     - var_sudo_timestamp_timeout=always_prompt
     - var_password_pam_unix_remember=5
     - var_accounts_maximum_age_login_defs=60
+    - var_password_pam_delay=4000000
     #
     # Note: must configure "var_accounts_authorized_local_users_regex" when
     # "accounts_authorized_local_users" rule is enabled


### PR DESCRIPTION
#### Description:

- Enable bash remediation support of accounts_passwords_pam_faildelay_delay rule for SLE platforms

#### Rationale:

- Add SLE15 and SLE12 specific bash remediations to avoid issue with build script and add required variable in sle15 stig profile