### PR TITLE
SLE bash of accounts_authorized_local_users rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ol
+# platform = multi_platform_ol,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_accounts_authorized_local_users_regex") }}}
 


### PR DESCRIPTION
#### Description:

- Enable bash remediation support of accounts_authorized_local_users rule for SLE platforms

#### Rationale:

- Enable SLE platform in the shared bash remediation
