### PR TITLE
Fix for issue  #7655

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1478,7 +1478,7 @@ class Rule(object):
                 if isinstance(self.sce_metadata['check-export'], str):
                     self.sce_metadata['check-export'] = [self.sce_metadata['check-export']]
                 for entry in self.sce_metadata['check-export']:
-                    value, export = entry.split('=')
+                    export, value = entry.split('=')
                     check_export = ET.SubElement(check, 'check-export')
                     check_export.set('value-id', value)
                     check_export.set('export-name', export)


### PR DESCRIPTION
#### Description:

Bug fix.
Annotation for check-export take a list of "ENVVAR=value_id". This was inverted.

#### Rationale:

- Fixes #7655
