### PR TITLE
service_rsyncd_disabled: remove test scenarios

### DIFF
--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/service_disabled.pass.sh
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/service_disabled.pass.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 8,Oracle Linux 8,multi_platform_fedora,multi_platform_rhv
-# packages = rsync-daemon
-
-systemctl stop rsyncd
-systemctl disable rsyncd
-systemctl mask rsyncd

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/service_enabled.pass.sh
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/tests/service_enabled.pass.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 8,Oracle Linux 8,multi_platform_fedora,multi_platform_rhv
-# packages = rsync-daemon
-
-systemctl start rsyncd
-systemctl enable rsyncd


### PR DESCRIPTION
These test scenarios are no longer needed as we have
templated ones (also the `service_enabled` test scenario
had wrong expected result).