### PR TITLE
Add RHEL8 FIPS STIG ID to a few rules

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -29,6 +29,7 @@ references:
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1,CIP-007-3 R7.1
     nist: AC-17(a),AC-17(2),CM-6(a),MA-4(6),SC-13
     srg: SRG-OS-000250-GPOS-00093
+    stigid@rhel8: RHEL-08-010020
 
 ocil_clause: 'the CRYPTO_POLICY variable is not set or is commented in the /etc/sysconfig/sshd'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
@@ -30,6 +30,7 @@ references:
     disa: CCI-001453
     nist: AC-17(2)
     srg: SRG-OS-000250-GPOS-00093
+    stigid@rhel8: RHEL-08-010020
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -28,6 +28,7 @@ references:
     disa: CCI-001453
     nist: AC-17(2)
     srg: SRG-OS-000250-GPOS-00093
+    stigid@rhel8: RHEL-08-010020
 
 ocil_clause: 'Crypto Policy for OpenSSH client is not configured correctly'
 


### PR DESCRIPTION
#### Description:

This adds the STIG ID `RHEL-08-010020` to the following rules:

-    configure_ssh_crypto_policy                  
-    harden_sshd_ciphers_openssh_conf_crypto_policy
-    harden_sshd_macs_openssh_conf_crypto_polic

#### Rationale:

Ensure that all rules in the RHEL8 STIG profile have STIG ids.

Resolves #6844