### PR TITLE
Remove STIG ref RHEL-07-040510 as its no longer in the STIG

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_invalid_ratelimit/rule.yml
@@ -41,7 +41,6 @@ references:
     nist: SC-5
     srg: SRG-OS-000420-GPOS-00186
     stigid@ol7: OL07-00-040510
-    stigid@rhel7: RHEL-07-040510
     vmmsrg: SRG-OS-000420-VMM-001690
 
 ocil_clause: 'rate limiting of duplicate TCP acknowledgments is not configured'


### PR DESCRIPTION
#### Description:

Remove STIG reference. IT seems rule is no longer in the RHEL7 STIG profile. 

#### Rationale:

This rule is no longer in the latest STIG.

- Fixes #6723