### PR TITLE
Add an SSGTS option to inject a product to the FIPS certified check

### DIFF
--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -118,7 +118,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
         env:
-          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates"
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -139,7 +139,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
         env:
-          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates"
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -24,6 +24,7 @@ SYSTEM_ATTRIBUTE = {
 
 
 BENCHMARK_QUERY = ".//ds:component/xccdf-1.2:Benchmark"
+OVAL_DEF_QUERY = ".//ds:component/oval-def:oval_definitions/oval-def:definitions"
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -200,6 +201,18 @@ def add_platform_to_benchmark(root, cpe_regex):
         for cpe_str in cpes_to_add:
             e = ET.Element("xccdf-1.2:platform", idref=cpe_str)
             benchmark.insert(platform_index, e)
+
+
+def add_product_to_fips_certified(root, product="fedora"):
+    query = OVAL_DEF_QUERY + "/{0}".format(
+        "oval-def:definition[@id='oval:ssg-installed_OS_is_FIPS_certified:def:1']/"
+        "oval-def:criteria")
+    criteria = root.find(query, PREFIX_TO_NS)
+    if criteria:
+        e = ET.Element("oval-def:extend_definition",
+                       comment="Installed OS is {0}".format(product),
+                       definition_ref="oval:ssg-installed_OS_is_{0}:def:1".format(product))
+        criteria.append(e)
 
 
 def _get_benchmark_node(datastream, benchmark_id, logging):

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -81,6 +81,11 @@ def parse_args():
             "as a literal CPE, and added as a platform. "
             "For example, use 'cpe:/o:fedoraproject:fedora:30' or 'enterprise_linux'.")
     common_parser.add_argument(
+            "--add-product-to-fips-certified",
+            default=None,
+            help="Add installed_OS_is_$product extend_definition to the "
+            "installed_OS_is_FIPS_certified OVAL criteria definition.")
+    common_parser.add_argument(
             "--remove-machine-only",
             default=False,
             action="store_true",
@@ -415,6 +420,9 @@ def main():
                 xml_operations.remove_ocp4_platforms(root)
             if options.add_platform:
                 xml_operations.add_platform_to_benchmark(root, options.add_platform)
+            if options.add_product_to_fips_certified:
+                xml_operations.add_product_to_fips_certified(
+                    root, options.add_product_to_fips_certified)
 
         options.func(options)
 


### PR DESCRIPTION
#### Description:

- Add an SSGTS option to inject a product to the FIPS certified check.

#### Rationale:

- SSGTS using Github Actions uses Fedora as a testing environment and installed_OS_is_FIPS_certified is dependency of many rules and to make these rules behave well we needed to inject a check there so rules can pass as expected.
