### PR TITLE
Remove CCENUM leftovers

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
@@ -2,4 +2,4 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com", '@CCENUM@', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com", '%s %s') }}}


### PR DESCRIPTION
#### Description:

- Remove CCENUM leftovers. Related to #7657
- This issue breaks execution of SSGTS

#### Rationale:

- Fixes:

```
 File "/tmp/tmp.iJGkN5AURZ/content/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh", line 3, in top-level template code
    {{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '@CCENUM@', '%s %s') }}}
TypeError: macro 'bash_replace_or_append' takes not more than 4 argument(s)
```
