### PR TITLE
Test if cce_identifiers is defined before using it

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1134,7 +1134,7 @@ rpm --quiet -q "{{{ pkgname }}}"
   # product this remediation is being built for, or it is empty.
   #}}
 {{%- macro set_cce_value() -%}}
-{{% if 'cce' in cce_identifiers -%}}
+{{% if cce_identifiers and 'cce' in cce_identifiers -%}}
 cce="{{{ cce_identifiers['cce'] }}}"
 {{%- endif %}}
 {{%- endmacro -%}}
@@ -1191,7 +1191,7 @@ if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
     "${sed_command[@]}" "s/{{{ key }}}\\>.*/$formatted_output/gi" "{{{ config_file }}}"
 else
     # \n is precaution for case where file ends without trailing newline
-    {{% if 'cce' in cce_identifiers -%}}
+    {{% if cce_identifiers and 'cce' in cce_identifiers -%}}
     {{{ set_cce_value() }}}
     printf '\n# Per %s: Set %s in %s\n' "$cce" "$formatted_output" "{{{ config_file }}}" >> "{{{ config_file }}}"
     {{%- endif %}}


### PR DESCRIPTION


#### Description:
- Test if cce_identifiers is defined before using it.
  - When running SSGTS, templated tests will try to load these macros but in
case of extra OVALs expansion, it won't have the CCE identifiers
defined. So it's needed to avoid using this variable otherwise it throws
Undefined variable Jinja error.

#### Rationale:

- Should fix:

```
Traceback (most recent call last):
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/test_suite.py", line 431, in <module>
    main()
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/test_suite.py", line 427, in main
    options.func(options)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/ssg_test_suite/rule.py", line 464, in perform_rule_check
    checker.test_target(options.target)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/ssg_test_suite/oscap.py", line 659, in test_target
    self._test_target(target)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/ssg_test_suite/rule.py", line 282, in _test_target
    rules_to_test = self._get_rules_to_test(target)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/ssg_test_suite/rule.py", line 263, in _get_rules_to_test
    for rule in common.iterate_over_rules(self.test_env.product):
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/ssg_test_suite/common.py", line 593, in iterate_over_rules
    all_tests[test_case] = process_file_with_macros(test_path, local_env_yaml)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/../ssg/jinja.py", line 184, in process_file_with_macros
    return process_file(filepath, substitutions_dict)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/../ssg/jinja.py", line 136, in process_file
    return template.render(substitutions_dict)
  File "/usr/local/lib64/python3.6/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/usr/local/lib64/python3.6/site-packages/jinja2/environment.py", line 925, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/tmp/tmp.Kuu0TPsu3w/content/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh", line 3, in top-level template code
    {{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '%s %s') }}}
  File "/usr/local/lib64/python3.6/site-packages/jinja2/runtime.py", line 828, in _invoke
    rv = self._func(*arguments)
  File "/tmp/tmp.Kuu0TPsu3w/content/tests/../shared/macros-bash.jinja", line 1194, in template
    {{% if 'cce' in cce_identifiers -%}}
jinja2.exceptions.UndefinedError: 'cce_identifiers' is undefined
```
