### PR TITLE
Align rsyslog_remote_loghost to benchmarks

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1501,9 +1501,9 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no # rule does not cover /etc/rsyslog.d/*.conf
-#    rules:
-#    - rsyslog_remote_loghost
+    automated: yes
+    rules:
+    - rsyslog_remote_loghost
 
   - id: 4.2.1.6
     title: Ensure remote rsyslog messages are only accepted on designated log hosts. (Manual)

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1454,15 +1454,14 @@ controls:
       - l1_workstation
     automated: no
 
-  # NEEDS RULE
-  # The rsyslog_remote_loghost rule is not sufficient
-  # https://github.com/ComplianceAsCode/content/issues/7333
   - id: 4.2.1.5
     title: Ensure rsyslog is configured to send logs to a remote log host (Automated)
     levels:
       - l1_server
       - l1_workstation
-    automated: no
+    status: automated
+    rules:
+      - rsyslog_remote_loghost
 
   - id: 4.2.1.6
     title: Ensure remote rsyslog messages are only accepted on designated log hosts. (Manual)

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -39,7 +39,7 @@
 
   <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_d" version="1">
     <ind:path>/etc/rsyslog.d</ind:path>
-    <ind:filename operation="pattern match">.*</ind:filename>
+    <ind:filename operation="pattern match">*.conf</ind:filename>
     <ind:pattern operation="pattern match">^\*\.\*[\s]+(?:@|\:omrelp\:)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>


### PR DESCRIPTION
#### Description:

The `rsyslog_remote_loghost` rule now only checks `*.conf` files in `rsyslog.d` to align with the benchmarks.

#### Rationale:

- Fixes #7333 
- https://vaulted.io/library/disa-stigs-srgs/rhel_8_stig/V-230479
- https://vaulted.io/library/disa-stigs-srgs/red_hat_enterprise_linux_7_security_technical_implementation_guide/V-204574
- https://vaulted.io/library/disa-stigs-srgs/oracle_linux_7_security_technical_implementation_guide/V-221835
