### PR TITLE
Add --only-rules option to utils/compare_ds.py

### DIFF
--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -41,6 +41,10 @@ def parse_args():
         help="Do not perform detailed comparison of checks and "
         "remediations contents."
     )
+    parser.add_argument(
+        "--only-rules", action="store_true",
+        help="Print only removals from rule set."
+    )
     return parser.parse_args()
 
 
@@ -229,7 +233,7 @@ def compare_rules(
 
 def process_benchmarks(
         old_benchmark, new_benchmark, old_oval_defs, new_oval_defs,
-        rule_id, show_diffs):
+        rule_id, show_diffs, only_rules):
     missing_rules = []
     try:
         rules_in_old_benchmark = get_rules_to_compare(old_benchmark, rule_id)
@@ -243,6 +247,8 @@ def process_benchmarks(
         if new_rule is None:
             missing_rules.append(rule_id)
             print("%s is missing in new datastream." % (rule_id))
+            continue
+        if only_rules:
             continue
         compare_rules(
             old_rule, new_rule, old_oval_defs, new_oval_defs, show_diffs)
@@ -290,7 +296,7 @@ def main():
         new_benchmark = find_benchmark(new_root, old_benchmark.get("id"))
         process_benchmarks(
             old_benchmark, new_benchmark, old_oval_defs, new_oval_defs,
-            args.rule, not args.no_diffs)
+            args.rule, not args.no_diffs, args.only_rules)
     return 0
 
 


### PR DESCRIPTION
#### Description:
With option `--only-rules`, only missing rules in new datastream are shown.

```
[mlysonek@fedora content]$ python3 utils/compare_ds.py old_ds.xml missing_remediation.xml                                                                                                                                                     
Rule 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date' points to 'security-data-oval-com.redhat.rhsa-RHEL8.xml' which isn't a part of the old datastream                                                                        
New datastream is missing bash remediation for rule 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date'.                                                                                                                          
[mlysonek@fedora content]$ python3 utils/compare_ds.py --only-rules old_ds.xml missing_remediation.xml                                                                                                                                        

[mlysonek@fedora content]$ python3 utils/compare_ds.py old_ds.xml missing_rule.xml                                                                                                                                                            
xccdf_org.ssgproject.content_rule_rpm_verify_permissions is missing in new datastream.                                                                                                                                                        
Rule 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date' points to 'security-data-oval-com.redhat.rhsa-RHEL8.xml' which isn't a part of the old datastream                                                                        
[mlysonek@fedora content]$ python3 utils/compare_ds.py --only-rules old_ds.xml missing_rule.xml                                                                                                                                               
xccdf_org.ssgproject.content_rule_rpm_verify_permissions is missing in new datastream.                                                                                                                                                        

[mlysonek@fedora content]$ python3 utils/compare_ds.py missing_remediation.xml old_ds.xml                                                                                                                                                     
Rule 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date' points to 'security-data-oval-com.redhat.rhsa-RHEL8.xml' which isn't a part of the old datastream                                                                        
New datastream adds bash remediation for rule 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date'.                                                                                                                                
[mlysonek@fedora content]$ python3 utils/compare_ds.py --only-rules missing_remediation.xml old_ds.xml                                                                                                                                        

[mlysonek@fedora content]$ python3 utils/compare_ds.py missing_rule.xml old_ds.xml                                                                                                                                                            
Rule 'xccdf_org.ssgproject.content_rule_security_patches_up_to_date' points to 'security-data-oval-com.redhat.rhsa-RHEL8.xml' which isn't a part of the old datastream                                                                        
[mlysonek@fedora content]$ python3 utils/compare_ds.py --only-rules missing_rule.xml old_ds.xml                                                                                                                                                                        
```

#### Rationale:
Remediation/OVAL check can be removed from datastream, it doesn't break tailoring. However, removing a rule from datastream might breaks customers tailoring.