### PR TITLE
OCP4/PCI-DSS: Move requirement 2.6 out of the base level

### DIFF
--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -475,11 +475,15 @@ controls:
   rules: []
 
 - id: Req-2.6
-  title: "2.6 Shared hosting providers must protect each entity\u2019s hosted environment\
-    \ and cardholder data. These providers must meet specific requirements as detailed\
-    \ in Appendix A: Additional PCI DSS Requirements for Shared Hosting Providers."
+  title: >-
+    2.6 Shared hosting providers must protect each entity's hosted environment
+    and cardholder data.
+  description: |-
+    These providers must meet specific requirements as
+    detailed in Appendix A: Additional PCI DSS Requirements for Shared Hosting
+    Providers.
   levels:
-  - base
+  - shared_hosting_provider
   notes: ''
   status: pending
   rules: []


### PR DESCRIPTION
It belongs on the shared hosting provider section instead.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>