### PR TITLE
remove old rule from rhel7 stig

### DIFF
--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_hbss_software/package_MFEhiplsm_installed/rule.yml
@@ -28,7 +28,6 @@ references:
     nist-csf: DE.AE-1,DE.AE-2,DE.AE-3,DE.AE-4,DE.CM-1,DE.CM-5,DE.CM-6,DE.CM-7,DE.DP-2,DE.DP-3,DE.DP-4,DE.DP-5,ID.RA-1,PR.AC-5,PR.DS-5,PR.IP-8,PR.PT-4,RS.AN-1,RS.CO-3
     pcidss: Req-11.4
     srg: SRG-OS-000191-GPOS-00080,SRG-OS-000196,SRG-OS-000480-GPOS-00227
-    stigid@rhel7: RHEL-07-020019
 
 ocil_clause: 'the HBSS HIPS module is not installed'
 

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -316,7 +316,6 @@ selections:
     - mount_option_dev_shm_noexec
     - mount_option_dev_shm_nosuid
     - audit_rules_privileged_commands_mount
-    - package_MFEhiplsm_installed
     - file_ownership_var_log_audit
     - file_permissions_var_log_audit
     - sysctl_net_ipv4_conf_all_rp_filter


### PR DESCRIPTION
#### Description:

remove rule package_MFEhiplsm_installed from stig and remove stigid

#### Rationale:

the requirement is satisfied by a different rule now (package_mcafeetp_installed and agent_mfetpd_running)