### PR TITLE
Migrate RHACM NIST evaluation from OpenControl to controls structure

### DIFF
--- a/controls/nist_rhacm.yml
+++ b/controls/nist_rhacm.yml
@@ -1,0 +1,15291 @@
+policy: NIST
+title: Configuration Recommendations for Red Hat Advanced Cluster Manager
+id: nist_rhacm
+version: Revision 4
+source: https://www.fedramp.gov/assets/resources/documents/FedRAMP_Security_Controls_Baseline.xlsx
+levels:
+- id: low
+- id: moderate
+- id: high
+controls:
+- id: AC-1
+  status: not applicable
+  notes: |-
+    Section a: The development, documentation, and dissemination of organization-defined personnel
+    or roles is an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section a.1: An access control policy that addresses purpose, scope, roles, responsibilities,
+    management commitment, coordination among organizational entities, and compliance is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section a.2: Procedures to facilitate the implementation of the access control policy and
+    associated access controls is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Reviewing and updating current access control policies and procedures is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section b.1: Reviewing and updating the current access control policies is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b.2: Reviewing and updating the current access control procedures is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An access control policy that\
+    \ addresses purpose, scope, roles, responsibilities, management commitment, coordination\
+    \ among organizational entities, and compliance; and\n   2. Procedures to facilitate\
+    \ the implementation of the access control policy and associated access controls;\
+    \ and\n b. Reviews and updates the current:\n   1. Access control policy [Assignment:\
+    \ organization-defined frequency]; and\n   2. Access control procedures [Assignment:\
+    \ organization-defined frequency].\n\nSupplemental Guidance: This control addresses\
+    \ the establishment of policy and procedures for the effective implementation\
+    \ of selected security controls and control enhancements in the AC family. Policy\
+    \ and procedures reflect applicable federal laws, Executive Orders, directives,\
+    \ regulations, policies, standards, and guidance. Security program policies and\
+    \ procedures at the organization level may make the need for system-specific policies\
+    \ and procedures unnecessary. The policy can be included as part of the general\
+    \ information security policy for organizations or conversely, can be represented\
+    \ by multiple policies reflecting the complex nature of certain organizations.\
+    \ The procedures can be established for the security program in general and for\
+    \ particular information systems, if needed. \n\nThe organizational risk management\
+    \ strategy is a key factor in establishing policy and procedures. Related control:\
+    \ PM-9.\nControl Enhancements: None.\nReferences: NIST Special Publications 800-12,\
+    \ 800-100.\n\nAC-1 (b) (1) [at least annually] \nAC-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    AC-1 - ACCESS CONTROL POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-2
+  status: not applicable
+  notes: |-
+    Section a: Identifying and selecting the following types of information system accounts to
+    support organizational missions/business functions is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Assigning account managers for information systems is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Establishing conditions for group and role memberships is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section d: Specifying authorized users of the information system, group and role membership,
+    and access authorizations (i.e., privileges) and other attributes (as required) for each
+    account is an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section e: Requiring approvals by the organization-defined personnel or roles for requests to
+    create information system accounts is an organizational control outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+    Section f: Creating, enabling, modifying, disabling, and removing information system accounts
+    in accordance with the organization-defined procedures or conditions is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section g: Monitoring the use of information system accounts is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section h: Notifying account managers based on organization policies is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section h.1: Notifying account managers when accounts are no longer required is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section h.2: Notifying account managers when users are terminated or transferred is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section h.3: Notifying account managers when individual information system usage or
+    need-to-know changes is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+    Section i: Authorizing access to the information system based on organizational policies is
+    an organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section i.1: Authorizing access to the information system based on a valid access
+    authorization is an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section i.2: Authorizing access to the information system based on intended system usage is
+    an organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section i.3: Authorizing access to the information system based on other attributes as
+    required by the organization or associated missions/business functions is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section j: Reviewing accounts for compliance with account management requirements is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section k: Establishing a process for reissuing shared/group account credentials (if deployed)
+    when individuals are removed from the group is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Identifies and selects the following types of information system accounts to support organizational missions/business functions: [Assignment: organization-defined information system account types];
+     b. Assigns account managers for information system accounts;
+     c. Establishes conditions for group and role membership;
+     d. Specifies authorized users of the information system, group and role membership, and access authorizations (i.e., privileges) and other attributes (as required) for each account;
+     e. Requires approvals by [Assignment: organization-defined personnel or roles] for requests to create information system accounts;
+     f. Creates, enables, modifies, disables, and removes information system accounts in accordance with [Assignment: organization-defined procedures or conditions];
+     g. Monitors the use of, information system accounts;
+     h. Notifies account managers:
+       1. When accounts are no longer required;
+       2. When users are terminated or transferred; and
+       3. When individual information system usage or need-to-know changes;
+     i. Authorizes access to the information system based on:
+       1. A valid access authorization;
+       2. Intended system usage; and
+       3. Other attributes as required by the organization or associated missions/business functions;
+     j. Reviews accounts for compliance with account management requirements [Assignment: organization-defined frequency]; and
+     k. Establishes a process for reissuing shared/group account credentials (if deployed) when individuals are removed from the group.
+    Supplemental Guidance: Information system account types include individual, shared, group, system, guest/anonymous, emergency, developer/manufacturer/vendor, temporary, and service. Some of the account management requirements listed above can be implemented by organizational information systems. The identification of authorized users of the information system and the specification of access privileges reflects the requirements in other security controls in the security plan. Users requiring administrative privileges on information system accounts receive additional scrutiny by appropriate organizational personnel (e.g., system owner, mission/business owner, or chief information security officer) responsible for approving such accounts and privileged access. Organizations may choose to define access privileges or other attributes by account, by type of account, or a combination of both. Other attributes required for authorizing access include, for example, restrictions on time-of-day, day-of-week, and point-of-origin. In defining other account attributes, organizations consider system-related requirements (e.g., scheduled maintenance, system upgrades) and mission/business requirements, (e.g., time zone differences, customer requirements, remote access to support travel requirements). Failure to consider these factors could affect information system availability. Temporary and emergency accounts are accounts intended for short-term use. Organizations establish temporary accounts as a part of normal account activation procedures when there is a need for short-term accounts without the demand for immediacy in account activation. Organizations establish emergency accounts in response to crisis situations and with the need for rapid account activation. Therefore, emergency account activation may bypass normal account authorization processes. Emergency and temporary accounts are not to be confused with infrequently used accounts (e.g., local logon accounts used for special tasks defined by organizations or when network resources are unavailable). Such accounts remain available and are not subject to automatic disabling or removal dates. Conditions for disabling or deactivating accounts include, for example: (i) when shared/group, emergency, or temporary accounts are no longer required; or (ii) when individuals are transferred or terminated. Some types of information system accounts may require specialized training. Related controls: AC-3, AC-4, AC-5, AC-6, AC-10, AC-17, AC-19, AC-20, AU-9, IA-2, IA-4, IA-5, IA-8, CM-5, CM-6, CM-11, MA-3, MA-4, MA-5, PL-4, SC-13.
+
+    References: None.
+
+
+    AC-2 (j) [monthly for privileged accessed, every six (6) months for non-privileged access]
+  title: >-
+    AC-2 - ACCOUNT MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-2(1)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to support the management of information
+    system accounts is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    components that support automated management through monitoring of
+    accounts and system activity by logging of related information.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to support the management of information system accounts.
+
+    Supplemental Guidance: The use of automated mechanisms can include, for example: using email or text messaging to automatically notify account managers when users are terminated or transferred; using the information system to monitor account usage; and using telephonic notification to report atypical system account usage.
+  title: >-
+    AC-2(1) - ACCOUNT MANAGEMENT | AUTOMATED SYSTEM ACCOUNT MANAGEMENT
+  levels:
+  - high
+  - moderate
+- id: AC-2(2)
+  status: not applicable
+  notes: |-
+    Automatically removing or disabling temporary and emergency accounts after a defined
+    time period is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for account management.
+
+    This control is applicable to the OpenShift identity service provider
+    which is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: "The information system automatically [Selection: removes; disables]\
+    \ temporary and emergency accounts after [Assignment: organization-defined time\
+    \ period for each type of account].\n\nSupplemental Guidance: This control enhancement\
+    \ requires the removal of both temporary and emergency accounts automatically\
+    \ after a predefined period of time has elapsed, rather than at the convenience\
+    \ of the systems administrator.\n\nAC-2 (2) [Selection: disables] \n[Assignment:\
+    \ 24 hours from last use]"
+  title: >-
+    AC-2(2) - ACCOUNT MANAGEMENT | REMOVAL OF TEMPORARY / EMERGENCY ACCOUNTS
+  levels:
+  - high
+  - moderate
+- id: AC-2(3)
+  status: not applicable
+  notes: |-
+    Automatically disabling inactive accounts after an organization-defined time period is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+
+    This control is applicable to the OpenShift identity service provider
+    which is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system automatically disables inactive accounts after [Assignment: organization-defined time period].
+
+    AC-2 (3) [35 days for user accounts]
+    AC-2 (3) Requirement: The service provider defines the time period for non-user accounts (e.g., accounts associated with devices).  The time periods are approved and accepted by the JAB/AO. Where user management is a function of the service, reports of activity of consumer users shall be made available.
+  title: >-
+    AC-2(3) - ACCOUNT MANAGEMENT | DISABLE INACTIVE ACCOUNTS
+  levels:
+  - high
+  - moderate
+- id: AC-2(4)
+  status: not applicable
+  notes: |-
+    Automatically auditing account creation, modification, enabling, disabling, and removal
+    actions, and notifying appropriate individuals is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+  rules: []
+  description: |-
+    The information system automatically audits account creation, modification, enabling, disabling, and removal actions, and notifies [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance: Related controls: AU-2, AU-12.
+
+    AC-2 (4) [organization and/or service provider system owner]
+  title: >-
+    AC-2(4) - ACCOUNT MANAGEMENT | AUTOMATED AUDIT ACTIONS
+  levels:
+  - high
+  - moderate
+- id: AC-2(5)
+  status: not applicable
+  notes: |-
+    Requiring that users log out after an organization-defined time period of
+    inactivity is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+  rules: []
+  description: |-
+    The organization requires that users log out when [Assignment: organization-defined time-period of expected inactivity or description of when to log out].
+
+    Supplemental Guidance: Related control: SC-23.
+
+    AC-2 (5) [inactivity is anticipated to exceed Fifteen (15) minutes]
+    AC-2 (5) Guidance: Should use a shorter timeframe than AC-12.
+  title: >-
+    AC-2(5) - ACCOUNT MANAGEMENT | INACTIVITY LOGOUT
+  levels:
+  - high
+  - moderate
+- id: AC-2(6)
+  status: not applicable
+  notes: |-
+    Implementing dynamic privilege management capabilities is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+
+    This control is applicable to the OpenShift identity service provider
+    which is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: AC-2(7)
+  status: not applicable
+  notes: |-
+    Section a: Establishing and administering privileged user accounts in accordance with a
+    role-based access scheme that organizes allowed information system access and
+    privileges into roles is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+    Section b: The organization monitoring privileged role assignments is an organizational
+    control outside the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section c: The organization taking defined actions when privileged role assignments are no
+    longer appropriate is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+    (a) Establishes and administers privileged user accounts in accordance with a role-based access scheme that organizes allowed information system access and privileges into roles;
+    (b) Monitors privileged role assignments; and
+    (c) Takes [Assignment: organization-defined actions] when privileged role assignments are no longer appropriate.
+
+    Supplemental Guidance: Privileged roles are organization-defined roles assigned to individuals that allow those individuals to perform certain security-relevant functions that ordinary users are not authorized to perform. These privileged roles include, for example, key management, account management, network and system administration, database administration, and web administration.
+
+    AC-2 (7) (c) [disables/revokes access within a organization-specified timeframe]
+  title: >-
+    AC-2(7) - ACCOUNT MANAGEMENT | ROLE-BASED SCHEMES
+  levels:
+  - high
+  - moderate
+- id: AC-2(8)
+  status: not applicable
+  notes: |-
+    Creating organization-defined information system accounts dynamically is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+
+    This control is applicable to the OpenShift identity service provider
+    which is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: AC-2(9)
+  status: not applicable
+  notes: |-
+    Permitting the use of shared/group accounts that meet organization-defined conditions
+    for establishing shared/group accounts is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization only permits the use of shared/group accounts that meet [Assignment: organization-defined conditions for establishing shared/group accounts].
+
+    AC-2 (9) [organization-defined need with justification statement that explains why such accounts are necessary]
+    AC-2 (9) Required if shared/group accounts are deployed
+  title: >-
+    AC-2(9) - ACCOUNT MANAGEMENT | RESTRICTIONS ON USE OF SHARED GROUPS / ACCOUNTS
+  levels:
+  - high
+  - moderate
+- id: AC-2(10)
+  status: not applicable
+  notes: |-
+    Terminating shared/group account credentials when members leave the group is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The information system terminates shared/group account credentials\
+    \ when members leave the group.\n\n \nAC-2 (10) Required if shared/group accounts\
+    \ are deployed"
+  title: >-
+    AC-2(10) - ACCOUNT MANAGEMENT | SHARED / GROUP ACCOUNT CREDENTIAL TERMINATION
+  levels:
+  - high
+  - moderate
+- id: AC-2(11)
+  status: not applicable
+  notes: |-
+    Enforcement of organization-defined circumstances and/or usage conditions for
+    organization-defined information system accounts is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system enforces [Assignment: organization-defined circumstances and/or usage conditions] for [Assignment: organization-defined information system accounts].
+
+    Supplemental Guidance: Organizations can describe the specific conditions or circumstances under which information system accounts can be used, for example, by restricting usage to certain days of the week, time of day, or specific durations of time.
+  title: >-
+    AC-2(11) - ACCOUNT MANAGEMENT | USAGE CONDITIONS
+  levels:
+  - high
+- id: AC-2(12)
+  status: not applicable
+  notes: |-
+    Section a: Monitoring information system accounts for organization-defined atypical usage is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+    Section b: Reporting atypical usage of information system accounts to organization-defined personnel
+    or roles is outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+  rules: []
+  description: |-
+    The organization:
+     (a) Monitors information system accounts for [Assignment: organization-defined atypical use]; and
+     (b) Reports atypical usage of information system accounts to [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance: Atypical usage includes, for example, accessing information systems at certain times of the day and from locations that are not consistent with the normal usage patterns of individuals working in organizations. Related control: CA-7.
+
+    AC-2 (12) (b)[at a minimum, the ISSO and/or similar role within the organization]
+    AC-2 (12)(a) Guidance: Required for privileged accounts.
+    AC-2 (12)(b) Guidance: Required for privileged accounts.
+  title: >-
+    AC-2(12) - ACCOUNT MANAGEMENT | ACCOUNT MONITORING / ATYPICAL USAGE
+  levels:
+  - high
+  - moderate
+- id: AC-2(13)
+  status: not applicable
+  notes: |-
+    Disabling the accounts of users posing a significant risk within an
+    organization-defined time period of discovery of the risk is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for account management.
+  rules: []
+  description: |-
+    The organization disables accounts of users posing a significant risk within [Assignment: organization-defined time period] of discovery of the risk.
+
+    Supplemental Guidance: Users posing a significant risk to organizations include individuals for whom reliable evidence or intelligence indicates either the intention to use authorized access to information systems to cause harm or through whom adversaries will cause harm. Harm includes potential adverse impacts to organizational operations and assets, individuals, other organizations, or the Nation. Close coordination between authorizing officials, information system administrators, and human resource managers is essential in order for timely execution of this control enhancement. Related control: PS-4.
+
+
+    AC-2 (13) [one (1) hour]
+  title: >-
+    AC-2(13) - ACCOUNT MANAGEMENT | DISABLE ACCOUNTS FOR HIGH-RISK INDIVIDUALS
+  levels:
+  - high
+- id: AC-3
+  status: not applicable
+  notes: |-
+    Enforcing approved authorizations for logical access to information and system resources
+    in accordance with applicable access control policies is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for access enforcement.
+  rules: []
+  description: |-
+    The information system enforces approved authorizations for logical access to information and system resources in accordance with applicable access control policies.
+
+    Supplemental Guidance: Access control policies (e.g., identity-based policies, role-based policies, attribute-based policies) and access enforcement mechanisms (e.g., access control lists, access control matrices, cryptography) control access between active entities or subjects (i.e., users or processes acting on behalf of users) and passive entities or objects (e.g., devices, files, records, domains) in information systems. In addition to enforcing authorized access at the information system level and recognizing that information systems can host many applications and services in support of organizational missions and business operations, access enforcement mechanisms can also be employed at the application and service level to provide increased information security. Related controls: AC-2, AC-4, AC-5, AC-6, AC-16, AC-17, AC-18, AC-19, AC-20, AC-21, AC-22, AU-9, CM-5, CM-6, CM-11, MA-3, MA-4, MA-5, PE-3.
+
+    References: None.
+  title: >-
+    AC-3 - ACCESS ENFORCEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-3(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into
+    AC-6.
+  rules: []
+- id: AC-3(2)
+  status: pending
+  notes: |-
+    A control response for AC-3 (2) is planned.
+  rules: []
+- id: AC-3(3)
+  status: not applicable
+  notes: |-
+    Section a: Enforcement of organization-defined mandatory access control policy over all subjects
+    and objects where the policy is uniformly enforced across all subjects and objects
+    within the boundary of the information system is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section b: Enforcement of organization-defined mandatory access control policy over all subjects
+    and objects where the policy specifies that a subject that has been granted access to
+    information is constrained is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section b.1: Specifying that a subject that has been granted access to information is constrained
+    from passing the information to unauthorized subjects or objects is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section b.2: Specifying that a subject that has been granted access to information is constrained
+    from granting its privileges to other subjects is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section b.3: Specifying that a subject that has been granted access to information is constrained
+    from changing one or more security attributes on subjects, obnjects, the information
+    system, or information system components is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section b.4: Specifying that a subject that has been granted access to information is constrained
+    from choosing the security attributes and attribute values to be associated with newly
+    created or modified objects is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section b.5: Specifying that a subject that has been granted access to information is constrained
+    from changing the rules governing access control is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+    Section c: Enforcement of organization-defined mandatory access control policy over all subjects
+    and objects where the policy specifies that organization-defined subjects may explicitly
+    be granted organization-defined privileges such that they are not limited by some or all
+    of the above constraints is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for mandatory access control enforcement.
+  rules: []
+- id: AC-3(4)
+  status: not applicable
+  notes: |-
+    Section a: Enforcement of organization-defined discretionary access control policies over defined
+    subjects and objects where the policy specifies that a subject has been granted access
+    to information can pass the information to any other subjects or objects is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for discretionary access control enforcement.
+    Section b: Enforcement of organization-defined discretionary access control policies over defined
+    subjects and objects where the policy specifies that a subject has been granted access
+    to information can grant its privileges to other subjects is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for discretionary access control enforcement.
+    Section c: Enforcement of organization-defined discretionary access control policies over defined
+    subjects and objects where the policy specifies that a subject has been granted access
+    to information can change security attributes on subjects, objects, the information
+    system, or the information system's components is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for discretionary access control enforcement.
+    Section d: Enforcement of organization-defined discretionary access control policies over defined
+    subjects and objects where the policy specifies that a subject has been granted access
+    to information can choose the security attributes to be associated with newly created
+    or revised objects is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for discretionary access control enforcement.
+    Section e: Enforcement of organization-defined discretionary access control policies over defined
+    subjects and objects where the policy specifies that a subject has been granted access
+    to information can change the rules governing access control is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for discretionary access control enforcement.
+  rules: []
+- id: AC-3(5)
+  status: not applicable
+  notes: |-
+    Preventing access to organization-defined security-relevant information except during
+    secure, non-operable system states is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for preventing access to security-relavent information.
+  rules: []
+- id: AC-3(6)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into
+    MP-4 and SC-28.
+  rules: []
+- id: AC-3(7)
+  status: not applicable
+  notes: |-
+    Enforcing a role-based access control policy over defined subjects and
+    objects and controlling access based upon organization-defined roles and
+    users authorized to assume such roles is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for enforcing role-based access controls.
+  rules: []
+- id: AC-3(8)
+  status: not applicable
+  notes: |-
+    Enforcing the revocation of access authorizations resulting from
+    changes to the security attributes of subjects and objects based on
+    organization-defined fules governing the timing of revocations of access
+    authorizations is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for enforcing access authorization revocations.
+  rules: []
+- id: AC-3(9)
+  status: not applicable
+  notes: |-
+    Section a: Not releasing information outside of the established system boundaries
+    unless the receiving organization-defined information system or system
+    component provides organization-defined security safeguards is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for enforcing controlled release information.
+    Section b: Not releasing information outside of the established system boundaries
+    unless the organization-defined security safeguards are used to validate
+    the appropriateness of the information designated for release is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for enforcing controlled release information.
+  rules: []
+- id: AC-3(10)
+  status: not applicable
+  notes: |-
+    Employing an audited override of automated access control mechanisms
+    under organization-defined conditions is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for enforcing the audited override of access control mechanisms.
+  rules: []
+- id: AC-4
+  status: not applicable
+  notes: |-
+    Enforcing approved authorizations for controlling the flow of
+    information within the system and between interconnected systems based
+    on organization-defined information flow control policies is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for information flow enforcement.
+  rules: []
+  description: |-
+    The information system enforces approved authorizations for controlling the flow of information within the system and between interconnected systems based on [Assignment: organization-defined information flow control policies].
+
+    Supplemental Guidance: Information flow control regulates where information is allowed to travel within an information system and between information systems (as opposed to who is allowed to access the information) and without explicit regard to subsequent accesses to that information. Flow control restrictions include, for example, keeping export-controlled information from being transmitted in the clear to the Internet, blocking outside traffic that claims to be from within the organization, restricting web requests to the Internet that are not from the internal web proxy server, and limiting information transfers between organizations based on data structures and content. Transferring information between information systems representing different security domains with different security policies introduces risk that such transfers violate one or more domain security policies. In such situations, information owners/stewards provide guidance at designated policy enforcement points between interconnected systems. Organizations consider mandating specific architectural solutions when required to enforce specific security policies. Enforcement includes, for example: (i) prohibiting information transfers between interconnected systems (i.e., allowing access only); (ii) employing hardware mechanisms to enforce one-way information flows; and (iii) implementing trustworthy regarding mechanisms to reassign security attributes and security labels.
+
+    Organizations commonly employ information flow control policies and enforcement mechanisms to control the flow of information between designated sources and destinations (e.g., networks, individuals, and devices) within information systems and between interconnected systems. Flow control is based on the characteristics of the information and/or the information path. Enforcement occurs, for example, in boundary protection devices (e.g., gateways, routers, guards, encrypted tunnels, firewalls) that employ rule sets or establish configuration settings that restrict information system services, provide a packet-filtering capability based on header information, or message- filtering capability based on message content (e.g., implementing key word searches or using document characteristics). Organizations also consider the trustworthiness of filtering/inspection mechanisms (i.e., hardware, firmware, and software components) that are critical to information flow enforcement. Control enhancements 3 through 22 primarily address cross-domain solution needs which focus on more advanced filtering techniques, in-depth analysis, and stronger flow enforcement mechanisms implemented in cross-domain products, for example, high-assurance guards. Such capabilities are generally not available in commercial off-the-shelf information technology products. Related controls: AC-3, AC-17, AC-19, AC-21, CM-6, CM-7, SA-8, SC-2, SC-5, SC-7, SC-18.
+
+    References: None.
+  title: >-
+    AC-4 - INFORMATION FLOW ENFORCEMENT
+  levels:
+  - high
+  - moderate
+- id: AC-4(1)
+  status: not applicable
+  notes: |-
+    Using security attributes with information, source, and desstination
+    objects to enforce information flow control policies as a basis for flow
+    control decisions is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for information flow enforcement.
+  rules: []
+- id: AC-4(2)
+  status: not applicable
+  notes: |-
+    Using protected processing domains to enforce organization-defined
+    information flow control policiesas a basis for flow control decisions
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for information flow enforcement.
+  rules: []
+- id: AC-4(3)
+  status: not applicable
+  notes: |-
+    Enforcing dynamic information flow control based on organization-defined
+    policies is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-4(4)
+  status: not applicable
+  notes: |-
+    Preventing encrypted information from bypassing content-checking
+    mechanisms by either: decrypting the information; blocking the flow of
+    the encrypted information; terminating communications sessions
+    attempting to pass encrypted information; or organization-defined
+    procedures or methods is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+  rules: []
+- id: AC-4(5)
+  status: not applicable
+  notes: |-
+    Enforcing organization-defined limitations on embedding data types
+    withing other data types is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(6)
+  status: not applicable
+  notes: |-
+    Enforcing information flow control based on organization-defined
+    metadata is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-4(7)
+  status: not applicable
+  notes: |-
+    Enforcing organization-defined one-way information flows using hardware
+    mechanisms is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: AC-4(8)
+  status: not applicable
+  notes: |-
+    Enforcing information flow control using organization-defined security
+    policy filters as a basis for flow control decisions for
+    organization-defined information flows is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system enforces information flow control using [Assignment: organization-defined security policy filters] as a basis for flow control decisions for [Assignment: organization-defined information flows].
+
+    Supplemental Guidance:  Organization-defined security policy filters can address data structures and content. For example, security policy filters for data structures can check for maximum file lengths, maximum field sizes, and data/file types (for structured and unstructured data). Security policy filters for data content can check for specific words (e.g., dirty/clean word filters), enumerated values or data value ranges, and hidden content. Structured data permits the interpretation of data content by applications. Unstructured data typically refers to digital information without a particular data structure or with a data structure that does not facilitate the development of rule sets to address the particular sensitivity of the information conveyed by the data or the associated flow enforcement decisions. Unstructured data consists of: (i) bitmap objects that are inherently non language-based (i.e., image, video, or audio files); and (ii) textual objects that are based on written or printed languages (e.g., commercial off-the- shelf word processing documents, spreadsheets, or emails). Organizations can implement more than one security policy filter to meet information flow control objectives (e.g., employing clean word lists in conjunction with dirty word lists may help to reduce false positives).
+  title: >-
+    AC-4(8) - INFORMATION FLOW ENFORCEMENT | SECURITY POLICY FILTERS
+  levels:
+  - high
+- id: AC-4(9)
+  status: not applicable
+  notes: |-
+    Enforcing the use of human reviews for organization-defined information
+    flows under the organization-defined conditions is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(10)
+  status: not applicable
+  notes: |-
+    Providing the capability for privileged administrators to enable/disable
+    organization-defined security policy filters under organization-defined
+    conditions is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: AC-4(11)
+  status: not applicable
+  notes: |-
+    Providing the capability for privileged administrators to configure
+    organization-defined security policy filters to suppor different
+    security policies is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+  rules: []
+- id: AC-4(12)
+  status: not applicable
+  notes: |-
+    Using organization-defined data type identifiers to validate data
+    essential for information flow decisions when transferring information
+    between different security domains is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(13)
+  status: not applicable
+  notes: |-
+    Decomposing information into organization-defined policy-relevant
+    subcomponents for submission to policy enforcement mechanisms when
+    transferring information between different security domains is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(14)
+  status: not applicable
+  notes: |-
+    Implementing organization-defined security policy filters requiring
+    fully enumerated formats that restrict data structure and content is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(15)
+  status: not applicable
+  notes: |-
+    Examining the information for the presence of organization-defined
+    unsanctioned information and prohibits the transfer of sucnh information
+    in accordance with the organization-defined security policy is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(16)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-4.
+  rules: []
+- id: AC-4(17)
+  status: not applicable
+  notes: |-
+    Uniquely identifying and authenticating source and destination points by
+    either an organization, system, application, or individual for
+    information transfer is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+  rules: []
+- id: AC-4(18)
+  status: not applicable
+  notes: |-
+    Binding security attributes to information using organization-defined
+    binding techniques to facilitate information flow policy enforcement is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-4(19)
+  status: not applicable
+  notes: |-
+    Applying the same security policy filtering to metadata as it applies to
+    data payloads when transferring information between different security
+    domains is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-4(20)
+  status: not applicable
+  notes: |-
+    Employing organization-defined solutions in approved configurations to
+    control the flow of organization-defined information across security
+    domains is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-4(21)
+  status: not applicable
+  notes: |-
+    Separating information flows logically or physically using
+    organization-defined mechanisms and/or techniques to accomplish
+    organization-defined required separations by types of information is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system separates information flows logically or physically using [Assignment: organization-defined mechanisms and/or techniques] to accomplish [Assignment: organization- defined required separations by types of information].
+
+    Supplemental Guidance:  Enforcing the separation of information flows by type can enhance protection by ensuring that information is not commingled while in transit and by enabling flow control by transmission paths perhaps not otherwise achievable. Types of separable information include, for example, inbound and outbound communications traffic, service requests and responses, and information of differing security categories.
+  title: >-
+    AC-4(21) - INFORMATION FLOW ENFORCEMENT | PHYSICAL / LOGICAL SEPARATION OF INFORMATION
+    FLOWS
+  levels:
+  - high
+  - moderate
+- id: AC-4(22)
+  status: not applicable
+  notes: |-
+    Providing access from a single device to computing platforms,
+    applications, or data residing on multiple different security domains,
+    while preventing any information flow between the different security
+    domains is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-5
+  status: not applicable
+  notes: |-
+    Section a: Separation of duties is an organizational process outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    However, to aide in such processes, note that Red Hat Advanced Cluster
+    Management for Kubernetes provides the capability to implement
+    Role-based Access Control (RBAC) which determine whether a user is
+    allowed to perform a given action. Documentation on the Red Hat Advanced
+    Cluster Management for Kubernetes RBAC capabilities can be found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+    Section b: Documentation of the separation of duties of individuals is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes
+
+    However, to aide in such processes, note that Red Hat Advanced Cluster
+    Management for Kubernetes provides the capability to implement
+    Role-based access control (RBAC) objects which determine whether a user
+    is allowed to perform a given action. Documentation on the Red Hat
+    Advanced Cluster Management for Kubernetes RBAC capabilities can be
+    found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+    Section c: Organizational processes which define information system access
+    authorizations to support separation of duties is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    However, to aide in such processes, note that Red Hat Advanced Cluster
+    Management for Kubernetes provides the capability to implement
+    Role-based access control (RBAC) objects which determine whether a user
+    is allowed to perform a given action. Documentation on the Red Hat
+    Advanced Cluster Management for Kubernetes RBAC capabilities can be
+    found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+  rules: []
+  description: "The organization:\n a. Separates [Assignment: organization-defined\
+    \ duties of individuals];\n b. Documents separation of duties of individuals;\
+    \ and\n c. Defines information system access authorizations to support separation\
+    \ of duties.\n\nSupplemental Guidance:  Separation of duties addresses the potential\
+    \ for abuse of authorized privileges and helps to reduce the risk of malevolent\
+    \ activity without collusion. Separation of duties includes, for example: (i)\
+    \ dividing mission functions and information system support functions among different\
+    \ individuals and/or roles; (ii) conducting information system support functions\
+    \ with different individuals (e.g., system management, programming, configuration\
+    \ management, quality assurance and testing, and network security); and (iii)\
+    \ ensuring security personnel administering access control functions do not also\
+    \ administer audit functions. Related controls: AC-3, AC-6, PE-3, PE-4, PS-2.\n\
+    \nControl Enhancements:  None.\n\nReferences: None.\n\n \nAC-5 Guidance: CSPs\
+    \ have the option to provide a separation of duties matrix as an attachment to\
+    \ the SSP."
+  title: >-
+    AC-5 - SEPARATION OF DUTIES
+  levels:
+  - high
+  - moderate
+- id: AC-6
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-187
+  rules: []
+  description: |-
+    The organization employs the principle of least privilege, allowing only authorized accesses for users (or processes acting on behalf of users) which are necessary to accomplish assigned tasks in accordance with organizational missions and business functions.
+
+    Supplemental Guidance:  Organizations employ least privilege for specific duties and information systems. The principle of least privilege is also applied to information system processes, ensuring that the processes operate at privilege levels no higher than necessary to accomplish required organizational missions/business functions. Organizations consider the creation of additional processes, roles, and information system accounts as necessary, to achieve least privilege. Organizations also apply least privilege to the development, implementation, and operation of organizational information systems. Related controls: AC-2, AC-3, AC-5, CM-6, CM-7, PL-2.
+
+    References: None.
+  title: >-
+    AC-6 - LEAST PRIVILEGE
+  levels:
+  - high
+  - moderate
+- id: AC-6(1)
+  status: not applicable
+  notes: |-
+    Explicitly authorizing access to organization-defined security
+    funcitions and security-relevant information is outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes.
+
+    However, to aide in such processes, note that Red Hat Advanced Cluster
+    Management for Kubernetes provides the capability to implement
+    Role-based access control (RBAC) objects which determine whether a user
+    is allowed to perform a given action. Documentation on the Red Hat
+    Advanced Cluster Management for Kubernetes RBAC capabilities can be
+    found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+  rules: []
+  description: |-
+    The organization explicitly authorizes access to [Assignment: organization-defined security functions (deployed in hardware, software, and firmware) and security-relevant information].
+
+    Supplemental Guidance:  Security functions include, for example, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters. Security-relevant information includes, for example, filtering rules for routers/firewalls, cryptographic key management information, configuration parameters for security services, and access control lists. Explicitly authorized personnel include, for example, security administrators, system and network administrators, system security officers, system maintenance personnel, system programmers, and other privileged users. Related controls: AC-17, AC-18, AC-19.
+
+    AC-6 (1) [all functions not publicly accessible and all security-relevant information not publicly available]
+  title: >-
+    AC-6(1) - LEAST PRIVILEGE | AUTHORIZE ACCESS TO SECURITY FUNCTIONS
+  levels:
+  - high
+  - moderate
+- id: AC-6(2)
+  status: not applicable
+  notes: |-
+    Requiring that users of information system accounts, or roles, with
+    access to organization-defined security functions or security-relevant
+    information, use non-privileged accounts or roles, when accessing
+    nonsecurity functions is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    However, to aide in such processes, note that Red Hat Advanced Cluster
+    Management for Kubernetes provides the capability to implement
+    Role-based access control (RBAC) objects which determine whether a user
+    is allowed to perform a given action. Documentation on the Red Hat
+    Advanced Cluster Management for Kubernetes RBAC capabilities can be
+    found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+  rules: []
+  description: |-
+    The organization requires that users of information system accounts, or roles, with access to [Assignment: organization-defined security functions or security-relevant information], use non- privileged accounts or roles, when accessing nonsecurity functions.
+
+    Supplemental Guidance:  This control enhancement limits exposure when operating from within privileged accounts or roles. The inclusion of roles addresses situations where organizations implement access control policies such as role-based access control and where a change of role provides the same degree of assurance in the change of access authorizations for both the user and all processes acting on behalf of the user as would be provided by a change between a privileged and non-privileged account. Related control: PL-4.
+
+    AC-6 (2) [all security functions]
+    AC-6 (2) Guidance:  Examples of security functions include but are not limited to: establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters, system programming, system and security administration, other privileged functions.
+  title: >-
+    AC-6(2) - LEAST PRIVILEGE | NON-PRIVILEGED ACCESS FOR NONSECURITY FUNCTIONS
+  levels:
+  - high
+  - moderate
+- id: AC-6(3)
+  status: not applicable
+  notes: |-
+    Authorizing network access to organization-defined privileged commands
+    only for organization-defined compelling operational needs and
+    documenting the rationale for such access in the security plan for the
+    information system is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for authorizing network access to privileged commands.
+  rules: []
+  description: |-
+    The organization authorizes network access to [Assignment: organization-defined privileged commands] only for [Assignment: organization-defined compelling operational needs] and documents the rationale for such access in the security plan for the information system.
+
+    Supplemental Guidance:  Network access is any access across a network connection in lieu of local access (i.e., user being physically present at the device). Related control: AC-17.
+
+    AC-6 (3)-1 [all privileged commands]
+  title: >-
+    AC-6(3) - LEAST PRIVILEGE | NETWORK ACCESS TO PRIVILEGED COMMANDS
+  levels:
+  - high
+- id: AC-6(4)
+  status: not applicable
+  notes: |-
+    Providing separate processing domains to enable finer-grained allocation
+    of user privileges is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for providing separate processing domains.
+  rules: []
+- id: AC-6(5)
+  status: not applicable
+  notes: |-
+    Restricting privilege accounts on the information system to
+    organization-defined personnel or roles is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization restricts privileged accounts on the information system to [Assignment:
+    organization-defined personnel or roles].
+
+    Supplemental Guidance:  Privileged accounts, including super user accounts, are typically described as system administrator for various types of commercial off-the-shelf operating systems. Restricting privileged accounts to specific personnel or roles prevents day-to-day users from having access to privileged information/functions. Organizations may differentiate in the application of this control enhancement between allowed privileges for local accounts and for domain accounts provided organizations retain the ability to control information system configurations for key security parameters and as otherwise necessary to sufficiently mitigate risk. Related control: CM-6.
+  title: >-
+    AC-6(5) - LEAST PRIVILEGE | PRIVILEGED ACCOUNTS
+  levels:
+  - high
+  - moderate
+- id: AC-6(6)
+  status: not applicable
+  notes: |-
+    Prohibiting privileged access to the information system by
+    non-organizational users is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-6(7)
+  status: not applicable
+  notes: |-
+    Section a: Reviewing the privileges assigned to organization-defined roles or
+    classes of users to validate the need for such privileges is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+    Section b: Reassigning or removing privileges, if necessary, to correctly reflect
+    organizational mission/business needs is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Reviews [Assignment: organization-defined frequency] the privileges assigned to [Assignment: organization-defined roles or classes of users] to validate the need for such privileges; and
+     (b)   Reassigns or removes privileges, if necessary, to correctly reflect organizational mission/business needs.
+
+    Supplemental Guidance:  The need for certain assigned user privileges may change over time reflecting changes in organizational missions/business function, environments of operation, technologies, or threat. Periodic review of assigned user privileges is necessary to determine if the rationale for assigning such privileges remains valid. If the need cannot be revalidated, organizations take appropriate corrective actions. Related control: CA-7.
+
+    AC-6 (7)(a)-1  at a minimum, annually
+    AC-6 (7)(a)-2  all users with privileges
+  title: >-
+    AC-6(7) - LEAST PRIVILEGE | REVIEW OF USER PRIVILEGES
+  levels:
+  - high
+- id: AC-6(8)
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-187
+  rules: []
+  description: |-
+    The information system prevents [Assignment: organization-defined software] from executing at higher privilege levels than users executing the software.
+
+    Supplemental Guidance:  In certain situations, software applications/programs need to execute with elevated privileges to perform required functions. However, if the privileges required for execution are at a higher level than the privileges assigned to organizational users invoking such applications/programs, those users are indirectly provided with greater privileges than assigned by organizations.
+
+    AC-6 (8) [any software except software explicitly documented]
+  title: >-
+    AC-6(8) - LEAST PRIVILEGE | PRIVILEGE LEVELS FOR CODE EXECUTION
+  levels:
+  - high
+- id: AC-6(9)
+  status: pending
+  notes: |-
+    The customer will be responsible for auditing the execution of
+    privileged functions. A successful control response will need
+    to relate this requirement to the general auditing requirements
+    of the AU control family.
+
+    A control response is planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-355
+  rules: []
+  description: |-
+    The information system audits the execution of privileged functions.
+
+    Supplemental Guidance:  Misuse of privileged functions, either intentionally or unintentionally by authorized users, or by unauthorized external entities that have compromised information system accounts, is a serious and ongoing concern and can have significant adverse impacts on organizations. Auditing the use of privileged functions is one way to detect such misuse, and in doing so, help mitigate the risk from insider threats and the advanced persistent threat (APT). Related control: AU-2.
+  title: >-
+    AC-6(9) - LEAST PRIVILEGE | AUDITING USE OF PRIVILEGED FUNCTIONS
+  levels:
+  - high
+  - moderate
+- id: AC-6(10)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes prevents
+    non-privileged users from executing privileged funcitions to include
+    disabling, circumventing, or altering implemented security safeguards or
+    countermeasures by utilizing Role Based Access Controls (RBAC).
+
+    Documentation on the Red Hat
+    Advanced Cluster Management for Kubernetes RBAC capabilities can be
+    found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+  rules: []
+  description: |-
+    The information system prevents non-privileged users from executing privileged functions to include disabling, circumventing, or altering implemented security safeguards/countermeasures.
+
+    Supplemental Guidance:  Privileged functions include, for example, establishing information system accounts, performing system integrity checks, or administering cryptographic key management activities. Non-privileged users are individuals that do not possess appropriate authorizations. Circumventing intrusion detection and prevention mechanisms or malicious code protection mechanisms are examples of privileged functions that require protection from non-privileged users.
+  title: >-
+    AC-6(10) - LEAST PRIVILEGE | PROHIBIT NON-PRIVILEGED USERS FROM EXECUTING PRIVILEGED
+    FUNCTIONS
+  levels:
+  - high
+  - moderate
+- id: AC-7
+  status: not applicable
+  notes: |-
+    Section a: Enforcing a limit of an organization-defined number of consecutive
+    invalid login attempts by a user during an organization-defined time
+    period is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling unsuccessful logon attempts.
+    Section b: Automatically locking the account/node for a defined time period, or
+    locking the account/node until released by an administrator, or delaying
+    next logon prompts according to a TBD delay algorithm when the maximum
+    number of unsuccessful attempts is exceeded is outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling unsuccessful logon attempts.
+  rules: []
+  description: "The information system:\n a. Enforces a limit of [Assignment: organization-defined\
+    \ number] consecutive invalid logon attempts by a user during a [Assignment: organization-defined\
+    \ time period]; and\n b. Automatically [Selection: locks the account/node for\
+    \ an [Assignment: organization-defined time period]; locks the account/node until\
+    \ released by an administrator; delays next logon prompt according to [Assignment:\
+    \ organization-defined delay algorithm]] when the maximum number of unsuccessful\
+    \ attempts is exceeded.\n\nSupplemental Guidance:  This control applies regardless\
+    \ of whether the logon occurs via a local or network connection. Due to the potential\
+    \ for denial of service, automatic lockouts initiated by information systems are\
+    \ usually temporary and automatically release after a predetermined time period\
+    \ established by organizations. If a delay algorithm is selected, organizations\
+    \ may choose to employ different algorithms for different information system components\
+    \ based on the capabilities of those components. Responses to unsuccessful logon\
+    \ attempts may be implemented at both the operating system and the application\
+    \ levels. Related controls: AC-2, AC-9, AC-14, IA-5.\n\nReferences: None.\n\n\
+    AC-7(a)-1 [not more than three (3)]\n \nAC-7(a)-2 [fifteen (15) minutes] \n\n\
+    AC-7(b) [locks the account/node for a minimum of three (3) hours or until unlocked\
+    \ by an administrator]"
+  title: >-
+    AC-7 - UNSUCCESSFUL LOGON ATTEMPTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-7(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-7
+  rules: []
+- id: AC-7(2)
+  status: not applicable
+  notes: |-
+    Management of mobile devices is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes relies.
+  rules: []
+  description: |-
+    The information system purges/wipes information from [Assignment: organization-defined mobile devices] based on [Assignment: organization-defined purging/wiping requirements/techniques] after [Assignment: organization-defined number] consecutive, unsuccessful device logon attempts.
+
+    Supplemental Guidance: This control enhancement applies only to mobile devices for which a logon occurs (e.g., personal digital assistants, smart phones, tablets). The logon is to the mobile device, not to any one account on the device. Therefore, successful logons to any accounts on mobile devices reset the unsuccessful logon count to zero. Organizations define information to be purged/wiped carefully in order to avoid over purging/wiping which may result in devices becoming unusable. Purging/wiping may be unnecessary if the information on the device is protected with sufficiently strong encryption mechanisms. Related controls: AC-19, MP-5, MP-6, SC-13.
+
+    AC-7 (2)-1 [mobile devices as defined by organization policy]
+    AC-7 (2)-3 [three (3)]
+  title: >-
+    AC-7(2) - UNSUCCESSFUL LOGON ATTEMPTS | PURGE / WIPE MOBILE DEVICE
+  levels:
+  - high
+- id: AC-8
+  status: pending
+  notes: |-
+    Section a: The customer will be responsible for displaying a system use
+    notification banner to users. A successful control response will need
+    to address the conditions under which the banner will be displayed
+    (if a non-government user accesses the system, the system use
+    notification banner may not be appropriate), as well as the contents
+    of the notification message.
+
+    A control response to AC-8 is planned. Progress can be tracked
+    via:
+
+    https://issues.redhat.com/browse/ACM-356
+    Section b: The customer will be responsible for displaying the use notification
+    banner until the user acknowledges the usage condition and takes
+    explicit actions to further access the system. A successful control
+    response will need to address the means by which the user will indicate
+    acknowledgement and move forward.
+
+    A control response to AC-8 is planned. Progress can be tracked
+    via:
+
+    https://issues.redhat.com/browse/ACM-356
+    Section c: The customer will be responsible for displaying a system use
+    information message to users. A successful control response will need
+    to address the conditions under which the message will be
+    displayed (if a non-government user accesses the system, the system
+    use information message may not be appropriate), as well as the
+    contents of the notification message, including references to
+    applicable monitoring, recording, or auditing, and authorized usage
+    of the system.
+
+    A control response to AC-8 is planned. Progress can be tracked
+    via:
+
+    https://issues.redhat.com/browse/ACM-356
+    Section c.1: The customer will be responsible for determining the conditions
+    under which the system use notification will be displayed. These
+    conditions must be reviewed and accepted by the FedRAMP JAB.
+
+    A control response to AC-8 is planned. Progress can be tracked
+    via:
+
+    https://issues.redhat.com/browse/ACM-356
+    Section c.2: The customer will be responsible for how the system use notification
+    will be verified and how often it should be re-displayed and
+    re-verified. These conditions must be reviewed an accepted by the
+    FedRAMP JAB.
+
+    A control response to AC-8 is planned. Progress can be tracked
+    via:
+
+    https://issues.redhat.com/browse/ACM-356
+    Section c.3: The customer will be responsible for verifying that the system use
+    notification is being displayed as required, either through a
+    configuration baseline check or via other means. If this verification
+    does not happen through a configuration baseline check, the JAB must
+    review and accept the process used to perform the verification.
+
+    A control response to AC-8 is planned. Progress can be tracked
+    via:
+
+    https://issues.redhat.com/browse/ACM-356
+  rules: []
+  description: "The information system:\n a. Displays to users [Assignment: organization-defined\
+    \ system use notification message or banner] before granting access to the system\
+    \ that provides privacy and security notices consistent with applicable federal\
+    \ laws, Executive Orders, directives, policies, regulations, standards, and guidance\
+    \ and states that:\n   1. Users are accessing a U.S. Government information system;\n\
+    \   2. Information system usage may be monitored, recorded, and subject to audit;\n\
+    \   3. Unauthorized use of the information system is prohibited and subject to\
+    \ criminal and civil penalties; and\n   4. Use of the information system indicates\
+    \ consent to monitoring and recording;\n b. Retains the notification message or\
+    \ banner on the screen until users acknowledge the usage conditions and take explicit\
+    \ actions to log on to or further access the information system; and \n c. For\
+    \ publicly accessible systems:\n   1. Displays system use information [Assignment:\
+    \ organization-defined conditions], before granting further access;\n   2. Displays\
+    \ references, if any, to monitoring, recording, or auditing that are consistent\
+    \ with privacy accommodations for such systems that generally prohibit those activities;\
+    \ and\n   3. Includes a description of the authorized uses of the system.\n\n\
+    Supplemental Guidance:  System use notifications can be implemented using messages\
+    \ or warning banners displayed before individuals log in to information systems.\
+    \ System use notifications are used only for access via logon interfaces with\
+    \ human users and are not required when such human interfaces do not exist. Organizations\
+    \ consider system use notification messages/banners displayed in multiple languages\
+    \ based on specific organizational needs and the demographics of information system\
+    \ users. Organizations also consult with the Office of the General Counsel for\
+    \ legal review and approval of warning banner content.\n\nControl Enhancements:\
+    \  None.\n\nReferences: None.\n\n\nAC-8 (a) [see additional Requirements and Guidance]\n\
+    AC-8 (c) [see additional Requirements and Guidance]\nAC-8 Requirement: The service\
+    \ provider shall determine elements of the cloud environment that require the\
+    \ System Use Notification control. The elements of the cloud environment that\
+    \ require System Use Notification are approved and accepted by the JAB/AO. \n\
+    Requirement: The service provider shall determine how System Use Notification\
+    \ is going to be verified and provide appropriate periodicity of the check. The\
+    \ System Use Notification verification and periodicity are approved and accepted\
+    \ by the JAB/AO.\nGuidance: If performed as part of a Configuration Baseline check,\
+    \ then the % of items requiring setting that are checked and that pass (or fail)\
+    \ check can be provided. \nRequirement: If not performed as part of a Configuration\
+    \ Baseline check, then there must be documented agreement on how to provide results\
+    \ of verification and the necessary periodicity of the verification by the service\
+    \ provider. The documented agreement on how to provide verification of the results\
+    \ are approved and accepted by the JAB/AO."
+  title: >-
+    AC-8 - SYSTEM USE NOTIFICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-9
+  status: not applicable
+  notes: |-
+    Notifying the user, upon successful logon (access) to the system, of the
+    date and time of the last logon (access) is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+  rules: []
+- id: AC-9(1)
+  status: not applicable
+  notes: |-
+    Notifying the user, upon successful logon/access, of the number of
+    unsuccessful logon/access attempts since the last successful
+    logon/access is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+  rules: []
+- id: AC-9(2)
+  status: not applicable
+  notes: |-
+    Notifying the user of the number of successful logons/accesses and/or
+    unsuccessful logon/access attempts during an organization-defined time
+    period is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+  rules: []
+- id: AC-9(3)
+  status: not applicable
+  notes: |-
+    Notifying the user of changes to the organization-defined
+    security-related characteristics/parameters of the user's account during
+    an organization-defined time period is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+     for handling notifications of previous logons.
+  rules: []
+- id: AC-9(4)
+  status: not applicable
+  notes: |-
+    Notifying the user with organization-defined information to be included
+    in addition to the date and time of the last logon (access), upon a
+    successful logon (access) is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+  rules: []
+- id: AC-10
+  status: not applicable
+  notes: |-
+    Limiting the number of concurrent sessions for each account and/or
+    account type to a TBD number is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+  rules: []
+  description: |-
+    The information system limits the number of concurrent sessions for each [Assignment: organization-defined account and/or account type] to [Assignment: organization-defined number].
+
+    Supplemental Guidance:  Organizations may define the maximum number of concurrent sessions for information system accounts globally, by account type (e.g., privileged user, non-privileged user, domain, specific application), by account, or a combination. For example, organizations may limit the number of concurrent sessions for system administrators or individuals working in particularly sensitive domains or mission-critical applications. This control addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts.
+
+    Control Enhancements:  None.
+
+    References: None.
+
+
+    AC-10-2 [three (3) sessions for privileged access and two (2) sessions for non-privileged access]
+  title: >-
+    AC-10 - CONCURRENT SESSION CONTROL
+  levels:
+  - high
+  - moderate
+- id: AC-11
+  status: not applicable
+  notes: |-
+    Section a: Preventing further access to the system by initiating a session lock
+    after TBD time period of inactivity or upon receiving a request from a
+    user is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+    Section b: Retaining the session lock until the user reestablishes access using
+    established identification and authentication procedures is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for handling notifications of previous logons.
+  rules: []
+  description: |-
+    The information system:
+     a. Prevents further access to the system by initiating a session lock after [Assignment: organization-defined time period] of inactivity or upon receiving a request from a user; and
+     b. Retains the session lock until the user reestablishes access using established identification and authentication procedures.
+
+    Supplemental Guidance:  Session locks are temporary actions taken when users stop work and move away from the immediate vicinity of information systems but do not want to log out because of the temporary nature of their absences. Session locks are implemented where session activities can be determined. This is typically at the operating system level, but can also be at the application level. Session locks are not an acceptable substitute for logging out of information systems, for example, if organizations require users to log out at the end of workdays. Related control: AC-7.
+
+    References: OMB Memorandum 06-16.
+
+    AC-11(a) [fifteen (15) minutes]
+  title: >-
+    AC-11 - SESSION LOCK
+  levels:
+  - high
+  - moderate
+- id: AC-11(1)
+  status: not applicable
+  notes: |-
+    Concealing, via the session lock, information previously visible on the
+    display with a publicly viewable image is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system conceals, via the session lock, information previously visible on the display with a publicly viewable image.
+
+    Supplemental Guidance:  Publicly viewable images can include static or dynamic images, for example, patterns used with screen savers, photographic images, solid colors, clock, battery life indicator, or a blank screen, with the additional caveat that none of the images convey sensitive information.
+
+    References:  OMB Memorandum 06-16.
+  title: >-
+    AC-11(1) - SESSION LOCK | PATTERN-HIDING DISPLAYS
+  levels:
+  - high
+  - moderate
+- id: AC-12
+  status: not applicable
+  notes: |-
+    The customer will be responsible for defining events or conditions
+    requiring disconnection (for example, user requesting logout), and for
+    terminating the session when those events or conditions arise. This
+    control is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+  description: "The information system automatically terminates a user session after\
+    \ [Assignment: organization-defined conditions or trigger events requiring session\
+    \ disconnect].\n\nSupplemental Guidance:  This control addresses the termination\
+    \ of user-initiated logical sessions in contrast to SC-10 which addresses the\
+    \ termination of network connections that are associated with communications sessions\
+    \ (i.e., network disconnect). A logical session (for local, network, and remote\
+    \ access) is initiated whenever a user (or process acting on behalf of a user)\
+    \ accesses an organizational information system. Such user sessions can be terminated\
+    \ (and thus terminate user access) without terminating network sessions. Session\
+    \ termination terminates all processes associated with a user\u2019s logical session\
+    \ except those processes that are specifically created by the user (i.e., session\
+    \ owner) to continue after the session is terminated. Conditions or trigger events\
+    \ requiring automatic session termination can include, for example, organization-defined\
+    \ periods of user inactivity, targeted responses to certain types of incidents,\
+    \ time-of-day restrictions on information system use. Related controls: SC-10,\
+    \ SC-23.\n\nReferences: None."
+  title: >-
+    AC-12 - SESSION TERMINATION
+  levels:
+  - high
+  - moderate
+- id: AC-12(1)
+  status: not applicable
+  notes: |-
+    Section a: Providing a logout capability for user-initiated communications sessions
+    whenever authentication is used to gain access to resources is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: Displaying an explicit logout message to users indicating the reliable
+    termination of authenticated communications sessions is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system:
+     (a)   Provides a logout capability for user-initiated communications sessions whenever authentication is used to gain access to [Assignment: organization-defined information resources]; and
+     (b)   Displays an explicit logout message to users indicating the reliable termination of authenticated communications sessions.
+
+    Supplemental Guidance:  Information resources to which users gain access via authentication include, for example, local workstations, databases, and password-protected websites/web- based services. Logout messages for web page access, for example, can be displayed after authenticated sessions have been terminated. However, for some types of interactive sessions including, for example, file transfer protocol (FTP) sessions, information systems typically send logout messages as final messages prior to terminating sessions.
+
+    AC-12 (1) Guidance: https://www.owasp.org/index.php/Testing_for_logout_functionality_%28OTG-SESS-006%29
+  title: >-
+    AC-12(1) - SESSION TERMINATION | USER-INITIATED LOGOUTS / MESSAGE DISPLAYS
+  levels:
+  - high
+- id: AC-13
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-2 and AU-6.
+  rules: []
+- id: AC-14
+  status: not applicable
+  notes: |-
+    Section a: Identifying organization-defined user actions that can be performed on
+    the information system without identification or authentication
+    consistent with organizational missions/business functions is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+    Section b: Documenting and providing supporting raionale in the security plan for
+    the information system, user actions not requiring identification or
+    authentication is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The organization:\n a. Identifies [Assignment: organization-defined\
+    \ user actions] that can be performed on the information system without identification\
+    \ or authentication consistent with organizational missions/business functions;\
+    \ and\n b. Documents and provides supporting rationale in the security plan for\
+    \ the information system, user actions not requiring identification or authentication.\n\
+    \nSupplemental Guidance:  This control addresses situations in which organizations\
+    \ determine that no identification or authentication is required in organizational\
+    \ information systems. Organizations may allow a limited number of user actions\
+    \ without identification or authentication including, for example, when individuals\
+    \ access public websites or other publicly accessible federal information systems,\
+    \ when individuals use mobile phones to receive calls, or when facsimiles are\
+    \ received. Organizations also identify actions that normally require identification\
+    \ or authentication but may under certain circumstances (e.g., emergencies), allow\
+    \ identification or authentication mechanisms to be bypassed. Such bypasses may\
+    \ occur, for example, via a software-readable physical switch that commands bypass\
+    \ of the logon functionality and is protected from accidental or unmonitored use.\
+    \ This control does not apply to situations where identification and authentication\
+    \ have already occurred and are not repeated, but rather to situations where identification\
+    \ and authentication have not yet occurred. Organizations may decide that there\
+    \ are no user actions that can be performed on organizational information systems\
+    \ without identification and authentication and thus, the values for assignment\
+    \ statements can be none. Related controls: CP-2, IA-2.\n\nControl Enhancements:\
+    \  None.\n\n(1)   PERMITTED ACTIONS WITHOUT IDENTIFICATION OR AUTHENTICATION |\
+    \ NECESSARY USES\n[Withdrawn: Incorporated into AC-14]. \n\nReferences:  None."
+  title: >-
+    AC-14 - PERMITTED ACTIONS WITHOUT IDENTIFICATION OR
+
+    AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-14(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-14.
+  rules: []
+- id: AC-15
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into MP-3.
+  rules: []
+- id: AC-16
+  status: not applicable
+  notes: |-
+    Section a: Data release markings, such as NATO or NOFORN, are the responsibility of
+    application and data owners running workload on the OpenShift platform.
+    This control is not applicable to the configuration of Red Hat Advanced
+    Cluster Management for Kubernetes.
+    Section b: Data release markings, such as NATO or NOFORN, are the responsibility of
+    application and data owners running workload on the OpenShift platform.
+    This control is not applicable to the configuration of Red Hat Advanced
+    Cluster Management for Kubernetes.
+    Section c: Data release markings, such as NATO or NOFORN, are the responsibility of
+    application and data owners running workload on the OpenShift platform.
+    This control is not applicable to the configuration of Red Hat Advanced
+    Cluster Management for Kubernetes.
+    Section d: Data release markings, such as NATO or NOFORN, are the responsibility of
+    application and data owners running workload on the OpenShift platform.
+    This control is not applicable to the configuration of Red Hat Advanced
+    Cluster Management for Kubernetes.
+  rules: []
+- id: AC-16(1)
+  status: not applicable
+  notes: |-
+    Dynamically associating security attributes with defined subjects and
+    objects in accordance with security policies as information is created
+    and combined is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-16(2)
+  status: not applicable
+  notes: |-
+    Providing authorized individuals (or processes acting on behalf of
+    individuals) the capability to define or change the value of associated
+    security attributes is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-16(3)
+  status: not applicable
+  notes: |-
+    Maintaining the association and integrity of organization-defined
+    security attributes to organization-defined subjects and objects is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+  rules: []
+- id: AC-16(4)
+  status: not applicable
+  notes: |-
+    Supporting the association of organization-defined security attributes
+    with organization-defined subjects and objects by authorized individuals
+    (or processes acting on behalf of individuals) is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-16(5)
+  status: not applicable
+  notes: |-
+    Displaying security attributes in human-readable form on each object
+    that the system transmits to output devices to identify
+    organization-identified special dissemination, handling, or distribution
+    instructions using organization-identified human-readable, standard
+    naming conventions is an organizational control outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-16(6)
+  status: not applicable
+  notes: |-
+    Allowing personnel to associate, and maintain the association of
+    organization-defined security attributes with organization-defined
+    subjects and objects in accordance with organization-defined security
+    policies is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-16(7)
+  status: not applicable
+  notes: |-
+    Providing a consistent interpretation of security attributes transmitted
+    between distributed information system components is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-16(8)
+  status: not applicable
+  notes: |-
+    Implementing organization-defined techniques or technologies with
+    organization-defined level of assurance in associating security
+    attributes to information is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-16(9)
+  status: not applicable
+  notes: |-
+    Ensuring that security attributes associated with information are
+    reassigned only via re-grading mechanisms validated using
+    organization-defined techniques or procedures is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: AC-16(10)
+  status: not applicable
+  notes: |-
+    Providing authorized individuals the capability to define or change the
+    type and value of security attributes available for association with
+    subjects and objects is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: AC-17
+  status: not applicable
+  notes: |-
+    Section a: Establishing nd documenting usage restrictions, configuration/connection
+    requirements, and implementation guidance for each type of remote access
+    allowed is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+    Section b: Authorizing remote access to the information system prior to allowing
+    such connections is an organizational control outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes and documents usage restrictions, configuration/connection requirements, and implementation guidance for each type of remote access allowed; and
+     b. Authorizes remote access to the information system prior to allowing such connections.
+
+    Supplemental Guidance:  Remote access is access to organizational information systems by users (or processes acting on behalf of users) communicating through external networks (e.g., the Internet). Remote access methods include, for example, dial-up, broadband, and wireless. Organizations often employ encrypted virtual private networks (VPNs) to enhance confidentiality and integrity over remote connections. The use of encrypted VPNs does not make the access non-remote; however, the use of VPNs, when adequately provisioned with appropriate security controls (e.g., employing appropriate encryption techniques for confidentiality and integrity protection) may provide sufficient assurance to the organization that it can effectively treat such connections as internal networks. Still, VPN connections traverse external networks, and the encrypted VPN does not enhance the availability of remote connections. Also, VPNs with encrypted tunnels can affect the organizational capability to adequately monitor network communications traffic for malicious code. Remote access controls apply to information systems other than public web servers or systems designed for public access. This control addresses authorization prior to allowing remote access without specifying the formats for such authorization. While organizations may use interconnection security agreements to authorize remote access connections, such agreements are not required by this control. Enforcing access restrictions for remote connections is addressed in AC-3. Related controls: AC-2, AC-3, AC-18, AC-19, AC-20, CA-3, CA-7, CM-8, IA-2, IA-3, IA-8, MA-4, PE-17, PL-4, SC-10, SI-4.
+
+    References: NIST Special Publications 800-46, 800-77, 800-113, 800-114, 800-121.
+  title: >-
+    AC-17 - REMOTE ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-17(1)
+  status: not applicable
+  notes: |-
+    Monitoring and controlling remote access methods is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+  description: |-
+    The information system monitors and controls remote access methods.
+
+    Supplemental Guidance:  Automated monitoring and control of remote access sessions allows organizations to detect cyber attacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote users on a variety of information system components (e.g., servers, workstations, notebook computers, smart phones, and tablets). Related controls: AU-2, AU-12.
+  title: >-
+    AC-17(1) - REMOTE ACCESS | AUTOMATED MONITORING / CONTROL
+  levels:
+  - high
+  - moderate
+- id: AC-17(2)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes implements
+    cryptographic mechanisms to protect the confidentiality and integrity of
+    remote access sessions by utilizing the OpenShift client and HTTPS
+    protocol, which all use TLS.
+  rules: []
+  description: |-
+    The information system implements cryptographic mechanisms to protect the confidentiality and integrity of remote access sessions.
+
+    Supplemental Guidance:  The encryption strength of mechanism is selected based on the security categorization of the information. Related controls: SC-8, SC-12, SC-13.
+  title: >-
+    AC-17(2) - REMOTE ACCESS | PROTECTION OF CONFIDENTIALITY / INTEGRITY USING ENCRYPTION
+  levels:
+  - high
+  - moderate
+- id: AC-17(3)
+  status: not applicable
+  notes: |-
+    Routing all remote accesses through organization-defined number managed
+    network access control points is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for managed access control points.
+  rules: []
+  description: |-
+    The information system routes all remote accesses through [Assignment: organization-defined number] managed network access control points.
+
+    Supplemental Guidance:  Limiting the number of access control points for remote accesses reduces the attack surface for organizations. Organizations consider the Trusted Internet Connections (TIC) initiative requirements for external network connections. Related control: SC-7.
+  title: >-
+    AC-17(3) - REMOTE ACCESS | MANAGED ACCESS CONTROL POINTS
+  levels:
+  - high
+  - moderate
+- id: AC-17(4)
+  status: not applicable
+  notes: |-
+    Section a: Authorizing the execution of privileged commands and access to
+    security-relevant information via remote access only for organizational
+    defined needs is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Documenting the rationale for the execution of privileged commands and
+    access to security-relevant information via remote access in the
+    security plan for the information system is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Authorizes the execution of privileged commands and access to security-relevant information via remote access only for [Assignment: organization-defined needs]; and
+     (b)   Documents the rationale for such access in the security plan for the information system.
+
+    Supplemental Guidance:  Related control: AC-6.
+  title: >-
+    AC-17(4) - REMOTE ACCESS | PRIVILEGED COMMANDS / ACCESS
+  levels:
+  - high
+  - moderate
+- id: AC-17(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SI-4.
+  rules: []
+- id: AC-17(6)
+  status: not applicable
+  notes: |-
+    Ensuring that users protect information about remote access mechanisms
+    from unauthorized use and disclosure is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: AC-17(7)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-3(10).
+  rules: []
+- id: AC-17(8)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into CM-7.
+  rules: []
+- id: AC-17(9)
+  status: not applicable
+  notes: |-
+    Providing the capability to expeditiously disconnect or disable remote
+    access to the information system within an organization-defined time period
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for disconnect/disable access.
+  rules: []
+  description: |-
+    The organization provides the capability to expeditiously disconnect or disable remote access to the information system within [Assignment: organization-defined time period].
+
+    Supplemental Guidance:  This control enhancement requires organizations to have the capability to rapidly disconnect current users remotely accessing the information system and/or disable further remote access. The speed of disconnect or disablement varies based on the criticality of missions/business functions and the need to eliminate immediate or future remote access to organizational information systems.
+
+    AC-17 (9) [fifteen (15) minutes]
+  title: >-
+    AC-17(9) - REMOTE ACCESS | DISCONNECT / DISABLE ACCESS
+  levels:
+  - high
+  - moderate
+- id: AC-18
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes regarding the establishment of wireless access
+    usage restrictions are outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: Organizational processes regarding wireless access to the information
+    system are outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes usage restrictions, configuration/connection requirements, and implementation guidance for wireless access; and
+     b. Authorizes wireless access to the information system prior to allowing such connections.
+
+    Supplemental Guidance:  Wireless technologies include, for example, microwave, packet radio (UHF/VHF), 802.11x, and Bluetooth. Wireless networks use authentication protocols (e.g., EAP/TLS, PEAP), which provide credential protection and mutual authentication. Related controls: AC-2, AC-3, AC-17, AC-19, CA-3, CA-7, CM-8, IA-2, IA-3, IA-8, PL-4, SI-4.
+
+    References: NIST Special Publications 800-48, 800-94, 800-97.
+  title: >-
+    AC-18 - WIRELESS ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-18(1)
+  status: not applicable
+  notes: |-
+    Configuration of wireless networking is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system protects wireless access to the system using authentication of [Selection
+    (one or more): users; devices] and encryption.
+
+    Supplemental Guidance:  Related controls: SC-8, SC-13.
+  title: >-
+    AC-18(1) - WIRELESS ACCESS | AUTHENTICATION AND ENCRYPTION
+  levels:
+  - high
+  - moderate
+- id: AC-18(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SI-4.
+  rules: []
+- id: AC-18(3)
+  status: not applicable
+  notes: |-
+    Configuration of wireless networking is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization disables, when not intended for use, wireless networking capabilities internally embedded within information system components prior to issuance and deployment.
+
+    Supplemental Guidance:  Related control: AC-19.
+  title: >-
+    AC-18(3) - WIRELESS ACCESS | DISABLE WIRELESS NETWORKING
+  levels:
+  - high
+- id: AC-18(4)
+  status: not applicable
+  notes: |-
+    Configuration of wireless networking is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization identifies and explicitly authorizes users allowed to independently configure wireless networking capabilities.
+
+    Supplemental Guidance:  Organizational authorizations to allow selected users to configure wireless networking capability are enforced in part, by the access enforcement mechanisms employed within organizational information systems. Related controls: AC-3, SC-15.
+  title: >-
+    AC-18(4) - WIRELESS ACCESS | RESTRICT CONFIGURATIONS BY USERS
+  levels:
+  - high
+- id: AC-18(5)
+  status: not applicable
+  notes: |-
+    Configuration of wireless networking is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization selects radio antennas and calibrates transmission power levels to reduce the probability that usable signals can be received outside of organization-controlled boundaries.
+
+    Supplemental Guidance:  Actions that may be taken by organizations to limit unauthorized use of wireless communications outside of organization-controlled boundaries include, for example: (i) reducing the power of wireless transmissions so that the transmissions are less likely to emit a signal that can be used by adversaries outside of the physical perimeters of organizations; (ii) employing measures such as TEMPEST to control wireless emanations; and (iii) using directional/beam forming antennas that reduce the likelihood that unintended receivers will be able to intercept signals. Prior to taking such actions, organizations can conduct periodic wireless surveys to understand the radio frequency profile of organizational information systems as well as other systems that may be operating in the area. Related control: PE-19.
+  title: >-
+    AC-18(5) - WIRELESS ACCESS | ANTENNAS / TRANSMISSION POWER LEVELS
+  levels:
+  - high
+- id: AC-19
+  status: not applicable
+  notes: |-
+    Section a: Establishing organizational usage restrictions for mobile devices is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Authorization of mobile devices is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes usage restrictions, configuration requirements, connection requirements, and implementation guidance for organization-controlled mobile devices; and
+     b. Authorizes the connection of mobile devices to organizational information systems.
+
+    Supplemental Guidance:  A mobile device is a computing device that: (i) has a small form factor such that it can easily be carried by a single individual; (ii) is designed to operate without a physical connection (e.g., wirelessly transmit or receive information); (iii) possesses local, non- removable or removable data storage; and (iv) includes a self-contained power source. Mobile devices may also include voice communication capabilities, on-board sensors that allow the device to capture information, and/or built-in features for synchronizing local data with remote locations. Examples include smart phones, E-readers, and tablets. Mobile devices are typically associated with a single individual and the device is usually in close proximity to the individual; however, the degree of proximity can vary depending upon on the form factor and size of the device. The processing, storage, and transmission capability of the mobile device may be comparable to or merely a subset of desktop systems, depending upon the nature and intended purpose of the device. Due to the large variety of mobile devices with different technical characteristics and capabilities, organizational restrictions may vary for the different classes/types of such devices. Usage restrictions and specific implementation guidance for mobile devices include, for example, configuration management, device identification and authentication, implementation of mandatory protective software (e.g., malicious code detection, firewall), scanning devices for malicious code, updating virus protection software, scanning for critical software updates and patches, conducting primary operating system (and possibly other resident software) integrity checks, and disabling unnecessary hardware (e.g., wireless, infrared). Organizations are cautioned that the need to provide adequate security for mobile devices goes beyond the requirements in this control. Many safeguards and countermeasures for mobile devices are reflected in other security controls in the catalog allocated in the initial control baselines as starting points for the development of security plans and overlays using the tailoring process. There may also be some degree of overlap in the requirements articulated by the security controls within the different families of controls. AC-20 addresses mobile devices that are not organization-controlled. Related controls: AC-3, AC-7, AC-18, AC-20, CA-9, CM-2, IA-2, IA-3, MP-2, MP-4, MP-5, PL-4, SC-7, SC-43, SI-3, SI-4.
+
+    References: OMB Memorandum 06-16; NIST Special Publications 800-114, 800-124, 800-164.
+  title: >-
+    AC-19 - ACCESS CONTROL FOR MOBILE DEVICES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-19(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into MP-7.
+  rules: []
+- id: AC-19(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into MP-7.
+  rules: []
+- id: AC-19(3)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into MP-7.
+  rules: []
+- id: AC-19(4)
+  status: not applicable
+  notes: |-
+    Section a: Organizational restrictions on the use of mobile devices is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Enforcement of organizational restrictions of mobile devices is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: Restricting the connection of classified mobile devices to classified
+    information systems is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: AC-19(5)
+  status: not applicable
+  notes: |-
+    Encryption strategies for mobile devices is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs [Selection: full-device encryption; container encryption] to protect the confidentiality and integrity of information on [Assignment: organization-defined mobile devices].
+
+    Supplemental Guidance:  Container-based encryption provides a more fine-grained approach to the encryption of data/information on mobile devices, including for example, encrypting selected data structures such as files, records, or fields. Related controls: MP-5, SC-13, SC-28.
+
+    References:  OMB Memorandum 06-16; NIST Special Publications 800-114, 800-124, 800-164.
+  title: >-
+    AC-19(5) - ACCESS CONTROL FOR MOBILE DEVICES | FULL DEVICE / CONTAINER-BASED ENCRYPTION
+  levels:
+  - high
+  - moderate
+- id: AC-20
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes for establishing terms and conditions for
+    accessing the information system from external information systems is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Organizational processes for establishing terms and conditions for the
+    processing, storage, or transmission of organization-controlled
+    information using external information systems is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization establishes terms and conditions, consistent with any trust relationships established with other organizations owning, operating, and/or maintaining external information systems, allowing authorized individuals to:
+     a. Access the information system from external information systems; and
+     b. Process, store, or transmit organization-controlled information using external information systems.
+
+    Supplemental Guidance:  External information systems are information systems or components of information systems that are outside of the authorization boundary established by organizations and for which organizations typically have no direct supervision and authority over the application of required security controls or the assessment of control effectiveness. External information systems include, for example: (i) personally owned information systems/devices (e.g., notebook computers, smart phones, tablets, personal digital assistants); (ii) privately owned computing and communications devices resident in commercial or public facilities (e.g., hotels, train stations, convention centers, shopping malls, or airports); (iii) information systems owned or controlled by nonfederal governmental organizations; and (iv) federal information systems that are not owned by, operated by, or under the direct supervision and authority of organizations. This control also addresses the use of external information systems for the processing, storage, or transmission of
+    organizational information, including, for example, accessing cloud services (e.g., infrastructure as a service, platform as a service, or software as a service) from organizational information systems.
+
+    For some external information systems (i.e., information systems operated by other federal agencies, including organizations subordinate to those agencies), the trust relationships that have been established between those organizations and the originating organization may be such, that no explicit terms and conditions are required. Information systems within these organizations
+    would not be considered external. These situations occur when, for example, there are pre-existing sharing/trust agreements (either implicit or explicit) established between federal agencies or organizations subordinate to those agencies, or when such trust agreements are specified by applicable laws, Executive Orders, directives, or policies. Authorized individuals include, for example, organizational personnel, contractors, or other individuals with authorized access to organizational information systems and over which organizations have the authority to impose rules of behavior with regard to system access. Restrictions that organizations impose on authorized individuals need not be uniform, as those restrictions may vary depending upon the
+    trust relationships between organizations. Therefore, organizations may choose to impose different security restrictions on contractors than on state, local, or tribal governments.
+
+    This control does not apply to the use of external information systems to access public interfaces to organizational information systems (e.g., individuals accessing federal information through www.usa.gov). Organizations establish terms and conditions for the use of external information systems in accordance with organizational security policies and procedures. Terms and conditions address as a minimum: types of applications that can be accessed on organizational information systems from external information systems; and the highest security category of information that can be processed, stored, or transmitted on external information systems. If terms and conditions with the owners of external information systems cannot be established, organizations may impose restrictions on organizational personnel using those external systems. Related controls: AC-3, AC-17, AC-19, CA-3, PL-4, SA-9.
+
+    References: FIPS Publication 199.
+  title: >-
+    AC-20 - USE OF EXTERNAL INFORMATION SYSTEMS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-20(1)
+  status: not applicable
+  notes: |-
+    Section a: Verification of security control implementation on external systems is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Retention of approved information system connection or processing
+    agreements with organizational entities hosting the external information
+    system is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: "The organization permits authorized individuals to use an external\
+    \ information system to access the information system or to process, store, or\
+    \ transmit organization-controlled information only when the organization:\n (a)\
+    \   Verifies the implementation of required security controls on the external\
+    \ system as specified in the organization\u2019s information security policy and\
+    \ security plan; or\n (b)   Retains approved information system connection or\
+    \ processing agreements with the organizational entity hosting the external information\
+    \ system.\n\nSupplemental Guidance:  This control enhancement recognizes that\
+    \ there are circumstances where individuals using external information systems\
+    \ (e.g., contractors, coalition partners) need to access organizational information\
+    \ systems. In those situations, organizations need confidence that the external\
+    \ information systems contain the necessary security safeguards (i.e., security\
+    \ controls), so as not to compromise, damage, or otherwise harm organizational\
+    \ information systems. Verification that the required security controls have been\
+    \ implemented can be achieved, for example, by third-party, independent assessments,\
+    \ attestations, or other means, depending on the confidence level required by\
+    \ organizations. Related control: CA-2."
+  title: >-
+    AC-20(1) - USE OF EXTERNAL INFORMATION SYSTEMS | LIMITS ON AUTHORIZED USE
+  levels:
+  - high
+  - moderate
+- id: AC-20(2)
+  status: not applicable
+  notes: |-
+    Organizational processes regarding the restriction or prohibiting of the
+    use of organization-controlled portable storage devices by authorized
+    individuals on external information systems is outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization [Selection: restricts; prohibits] the use of organization-controlled portable storage devices by authorized individuals on external information systems.
+
+    Supplemental Guidance:  Limits on the use of organization-controlled portable storage devices in external information systems include, for example, complete prohibition of the use of such devices or restrictions on how the devices may be used and under what conditions the devices may be used.
+  title: >-
+    AC-20(2) - USE OF EXTERNAL INFORMATION SYSTEMS | PORTABLE STORAGE DEVICES
+  levels:
+  - high
+  - moderate
+- id: AC-20(3)
+  status: not applicable
+  notes: |-
+    Organizational processes regarding the restriction or prohibiting of the
+    use of non-organizationally owned information systems, system
+    components, or devices to process, store, or transmit organizational
+    information, is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: AC-20(4)
+  status: not applicable
+  notes: |-
+    Organizational processes regarding prohibiting the use of
+    organization-defined network accessible storage devices in external
+    information systems is beyond the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: AC-21
+  status: not applicable
+  notes: |-
+    Section a: Facilitation of information sharing is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Employment of technology or processes to assist users in making
+    information sharing/collaboration decisions is outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\na. Facilitates information sharing by enabling\
+    \ authorized users to determine whether access authorizations assigned to the\
+    \ sharing partner match the access restrictions on the information for [Assignment:\
+    \ organization-defined information sharing circumstances where user discretion\
+    \ is required]; and\nb. Employs [Assignment: organization-defined automated mechanisms\
+    \ or manual processes] to assist users in making information sharing/collaboration\
+    \ decisions.\n\_\nSupplemental Guidance:\_This control applies to information\
+    \ that may be restricted in some manner (e.g., privileged medical information,\
+    \ contract-sensitive information, proprietary information, personally identifiable\
+    \ information, classified information related to special access programs or compartments)\
+    \ based on some formal or administrative determination. Depending on the particular\
+    \ information-sharing circumstances, sharing partners may be defined at the individual,\
+    \ group, or organizational level. Information may be defined by content, type,\
+    \ security category, or special access program/compartment. Related control: AC-3.\n\
+    \nReferences: None."
+  title: >-
+    AC-21 - INFORMATION SHARING
+  levels:
+  - high
+  - moderate
+- id: AC-21(1)
+  status: not applicable
+  notes: |-
+    Enforcement of information-sharing decisions is outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AC-21(2)
+  status: not applicable
+  notes: |-
+    Implementation of information search and retrieval services that enforce
+    organization-defined information sharing restrictions is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: AC-22
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes regarding the designation of individuals
+    authorized to post information onto a publicly accessible information
+    system is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section b: Training authorized individuals to ensure that publicly accessible
+    information does not contain nonpublic information is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Reviewing the proposed content of information prior to posting onto the
+    publicly accessible information system to ensure that nonpublic
+    information is not included is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+    Section d: Reviewing content on the publicly accessible information system for
+    nonpublic information at an organization-defined frequency and removal
+    of such information, if discovered, is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Designates individuals authorized to post information onto a publicly accessible information system;
+     b. Trains authorized individuals to ensure that publicly accessible information does not contain nonpublic information;
+     c. Reviews the proposed content of information prior to posting onto the publicly accessible information system to ensure that nonpublic information is not included; and
+     d. Reviews the content on the publicly accessible information system for nonpublic information [Assignment: organization-defined frequency] and removes such information, if discovered.
+
+    Supplemental Guidance:  In accordance with federal laws, Executive Orders, directives, policies, regulations, standards, and/or guidance, the general public is not authorized access to nonpublic information (e.g., information protected under the Privacy Act and proprietary information). This control addresses information systems that are controlled by the organization and accessible to the general public, typically without identification or authentication. The posting of information on
+    non-organization information systems is covered by organizational policy. Related controls: AC-3, AC-4, AT-2, AT-3, AU-13.
+
+    Control Enhancements: None.
+
+    References: None.
+
+    AC-22 (d) [at least quarterly]
+  title: >-
+    AC-22 - PUBLICLY ACCESSIBLE CONTENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-23
+  status: not applicable
+  notes: |-
+    Organizational employment of organization-defined data mining prevention
+    and detection techniques for organization-defined data storage objects
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+- id: AC-24
+  status: not applicable
+  notes: |-
+    Establishing procedures to ensure organization-defined access control
+    decisions are applied to each access request prior to access enforcement
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    to enforce RBAC and auditing tasks needed to meet this control.
+  rules: []
+- id: AC-24(1)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes transmits
+    organization-defined access authorization information using
+    organization-defined security safeguards to organization-defined
+    information systems that enforce access control decisions by using TLS
+    and IPsec.
+  rules: []
+- id: AC-24(2)
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-435
+  rules: []
+- id: AC-25
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-436
+  rules: []
+- id: AT-1
+  status: not applicable
+  notes: |-
+    Section a: The development, documentation, and dissemination to organization-defined personnel
+    or roles is an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+
+    Section a.1: The development, documentation, and dissemination to
+    organization-defined personnel or roles a security awareness and
+    training policy that addresses purpose, scope, roles, responsibilities,
+    management commitment, coordination among organizational entities, and
+    compliance is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+
+    Section a.2: The development, documentation, and dissemination to
+    organization-defined personnel or roles procedures to facilitate the
+    implementation of the security awareness and training policy and
+    associated security awareness and training controls is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+
+    Section b: Reviewing and updating the current security awareness training policies
+    and procedures is an organizational control outside the scope of Red Hat
+    Advanced Cluster
+    Management for Kubernetes configuration.
+
+    Section b.1: Reviewing and updating the current security awareness and training
+    policy on an organization-defined frequency is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section b.2: Reviewing and updating the current security awareness and training
+    procedures on an organization-defined frequency is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A security awareness and training\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2.  Procedures\
+    \ to facilitate the implementation of the security awareness and training policy\
+    \ and associated security awareness and training controls; and\n b. Reviews and\
+    \ updates the current:\n   1. Security awareness and training policy [Assignment:\
+    \ organization-defined frequency]; and\n   2.  Security awareness and training\
+    \ procedures [Assignment: organization-defined frequency].\n\nSupplemental Guidance:\
+    \  This control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ AT family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-16, 800-50, 800-100.\n\nAT-1 (b) (1) [at least\
+    \ annually or whenever a significant change occurs] \nAT-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    AT-1 - SECURITY AWARENESS AND TRAINING POLICY ANDPROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-2
+  status: not applicable
+  notes: |-
+    Section a: Providing basic security awareness training to information system users
+    (including managers, senior executives, and contractors) as part of
+    initial training for new users is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section b: Providing basic security awareness training to information system users
+    (including managers, senior executives, and contractors) when required
+    by information system changes is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section c: Providing basic security awareness training to information system users
+    (including managers, senior executives, and contractors) on an
+    organizational-defined frequency is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization provides basic security awareness training to information system users (including managers, senior executives, and contractors):
+     a. As part of initial training for new users;
+     b. When required by information system changes; and
+     c. [Assignment: organization-defined frequency] thereafter.
+
+    Supplemental Guidance:  Organizations determine the appropriate content of security awareness training and security awareness techniques based on the specific organizational requirements and the information systems to which personnel have authorized access. The content includes a basic understanding of the need for information security and user actions to maintain security and to respond to suspected security incidents. The content also addresses awareness of the need for operations security. Security awareness techniques can include, for example, displaying posters, offering supplies inscribed with security reminders, generating email advisories/notices from senior organizational officials, displaying logon screen messages, and conducting information security awareness events. Related controls: AT-3, AT-4, PL-4.
+
+    References: C.F.R. Part 5 Subpart C (5 C.F.R. 930.301); Executive Order 13587; NIST Special Publication 800-50.
+
+    AT-2 (c) [at least annually]
+  title: >-
+    AT-2 - SECURITY AWARENESS TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-2(1)
+  status: not applicable
+  notes: |-
+    Including practical exercises in security awareness training that
+    simulate actual cyber attacks is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: AT-2(2)
+  status: not applicable
+  notes: |-
+    Including ecurity awareness training on recognizing and reporting
+    potential indicators of insider threat is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization includes security awareness training on recognizing and reporting potential indicators of insider threat.
+
+    Supplemental Guidance:  Potential indicators and possible precursors of insider threat can include behaviors such as inordinate, long-term job dissatisfaction, attempts to gain access to information not required for job performance, unexplained access to financial resources, bullying or sexual harassment of fellow employees, workplace violence, and other serious violations of organizational policies, procedures, directives, rules, or practices. Security awareness training includes how to communicate employee and management concerns regarding potential indicators of insider threat through appropriate organizational channels in accordance with established organizational policies and procedures. Related controls: PL-4, PM-12, PS-3, PS-6.
+
+    References:  C.F.R. Part 5 Subpart C (5 C.F.R 930.301); Executive Order 13587; NIST Special Publication 800-50.
+  title: >-
+    AT-2(2) - SECURITY AWARENESS | INSIDER THREAT
+  levels:
+  - high
+  - moderate
+- id: AT-3
+  status: not applicable
+  notes: |-
+    Section a: Providing  role-based security training to personnel with assigned
+    security roles and responsibilities before authorizing access to the
+    information system or performing assigned duties is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+
+    Section b: Providing  role-based security training to personnel with assigned
+    security roles and responsibilities when required by information system
+    changes is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Providing  role-based security training to personnel with assigned
+    security roles and responsibilities on an organizational-defined
+    frequency is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization provides role-based security training to personnel with assigned security roles and responsibilities:
+    a. Before authorizing access to the information system or performing assigned duties;
+    b. When required by information system changes; and
+    c. [Assignment: organization-defined frequency] thereafter.
+
+    Supplemental Guidance:  Organizations determine the appropriate content of security training based on the assigned roles and responsibilities of individuals and the specific security requirements of organizations and the information systems to which personnel have authorized access. In addition, organizations provide enterprise architects, information system developers, software developers, acquisition/procurement officials, information system managers, system/network administrators, personnel conducting configuration management and auditing activities, personnel performing independent verification and validation activities, security control assessors, and other personnel having access to system-level software, adequate security-related technical training specifically tailored for their assigned duties. Comprehensive role-based training addresses management, operational, and technical roles and responsibilities covering physical, personnel, and technical safeguards and countermeasures. Such training can include for example, policies, procedures, tools, and artifacts for the organizational security roles defined. Organizations also provide the training necessary for individuals to carry out their responsibilities related to operations and
+    supply chain security within the context of organizational information security programs. Role-based security training also applies to contractors providing services to federal agencies. Related controls: AT-2, AT-4, PL-4, PS-7, SA-3, SA-12, SA-16.
+
+    References: C.F.R. Part 5 Subpart C (5 C.F.R. 930.301); NIST Special Publications 800-16, 800-50.
+
+    AT-3 (c) [at least annually]
+  title: >-
+    AT-3 - ROLE-BASED SECURITY TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-3(1)
+  status: not applicable
+  notes: |-
+    Providing organization-defined personnel or roles with initial and an
+    organization-defined frequency training in the employment and operation
+    of environmental controls is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AT-3(2)
+  status: not applicable
+  notes: |-
+    Providing organization-defined personnel or roles with initial and an
+    organization-defined frequency training in the employment and operation
+    of physical security controls is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: AT-3(3)
+  status: not applicable
+  notes: |-
+    Including practical exercises in security training that reinforce
+    training objectives is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization includes practical exercises in security training that reinforce training objectives.
+
+    Supplemental Guidance:  Practical exercises may include, for example, security training for software developers that includes simulated cyber attacks exploiting common software vulnerabilities (e.g., buffer overflows), or spear/whale phishing attacks targeted at senior leaders/executives. These types of practical exercises help developers better understand the effects of such vulnerabilities and appreciate the need for security coding standards and processes.
+  title: >-
+    AT-3(3) - SECURITY TRAINING | PRACTICAL EXERCISES
+  levels:
+  - high
+- id: AT-3(4)
+  status: not applicable
+  notes: |-
+    Providing training to its personnel on organization-defined indicators
+    of malicious code to recognize suspicious communications and anomalous
+    behavior in organizational information systems is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization provides training to its personnel on [Assignment: organization-defined indicators of malicious code] to recognize suspicious communications and anomalous behavior in organizational information systems.
+
+    Supplemental Guidance:  A well-trained workforce provides another organizational safeguard that can be employed as part of a defense-in-depth strategy to protect organizations against malicious code coming in to organizations via email or the web applications. Personnel are trained to look for indications of potentially suspicious email (e.g., receiving an unexpected email, receiving an email containing strange or poor grammar, or receiving an email from an unfamiliar sender but who appears to be from a known sponsor or contractor). Personnel are also trained on how to respond to such suspicious email or web communications (e.g., not opening attachments, not clicking on embedded web links, and checking the source of email addresses). For this process to work effectively, all organizational personnel are trained and made aware of what constitutes suspicious communications. Training personnel on how to recognize anomalous behaviors in organizational information systems can potentially provide early warning for the presence of malicious code. Recognition of such anomalous behavior by organizational personnel can supplement automated malicious code detection and protection tools and systems employed by organizations.
+    AT-3 (4) [malicious code indicators as defined by organization  incident policy/capability]
+  title: >-
+    AT-3(4) - SECURITY TRAINING | SUSPICIOUS COMMUNICATIONS AND ANOMALOUS SYSTEM BEHAVIOR
+  levels:
+  - high
+- id: AT-4
+  status: not applicable
+  notes: |-
+    Section a: Documenting and monitoring individual information system security
+    training activities including basic security awareness training and
+    specific information system security training is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+
+    Section b: Retaining individual training records for an organization-defined time
+    period is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Documents and monitors individual information system security training activities including basic security awareness training and specific information system security training; and
+     b. Retains individual training records for [Assignment: organization-defined time period].
+
+    Supplemental Guidance:  Documentation for specialized training may be maintained by individual supervisors at the option of the organization. Related controls: AT-2, AT-3, PM-14.
+
+    Control Enhancements:  None.
+
+    References:  None.
+
+    AT-4 (b) [five (5) years or 5 years after completion of a specific training program]
+  title: >-
+    AT-4 - SECURITY TRAINING RECORDS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-5
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into PM-15.
+  rules: []
+- id: AU-1
+  status: not applicable
+  notes: |-
+    Section a: Developing an organization-level audit and accountability
+    policy is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+
+    Section a.1: Developing an organization-level audit and accountability
+    policy that addresses purpose, scope, roles, responsibilities,
+    management commitment, coordination among organizational entities,
+    and compliance is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+
+    Section a.2: Developing organization-level procedures to facilitate the
+    implementation of the audit and accountability policy and
+    associated audit and accountability controls
+    is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Section b: Review and updating an organizational-level audit and
+    accountability policy is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section b.1: Review and updating an organizational-level audit and
+    accountability policy per a defined frequency is outside
+    the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+
+    Section b.2: Reviewing and updating an organizational-level audit and
+    accountability procedures per a defined frequency is outside
+    the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. An audit and accountability policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2.  Procedures to facilitate the implementation of the audit and accountability policy and associated audit and accountability controls; and
+     b. Reviews and updates the current:
+       1. Audit and accountability policy [Assignment: organization-defined frequency]; and
+       2. Audit and accountability procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the AU family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    AU-1 (b) (1) [at least annually]
+    AU-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    AU-1 - AUDIT AND ACCOUNTABILITY POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-2
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Coordinating the security audit function with other
+    organizational entities is outside the scope of
+    system configuration.
+
+    Section c: For rationale regarding why the auditable events are deemed to be
+    adequate to support after-the-fact investigations of security incidents,
+    please contact your countries Common Criteria representative:
+    https://www.commoncriteriaportal.org/ccra/members/
+
+    Section d: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Determines that the information system is capable of auditing the following events: [Assignment: organization-defined auditable events];
+     b. Coordinates the security audit function with other organizational entities requiring audit- related information to enhance mutual support and to help guide the selection of auditable events;
+     c. Provides a rationale for why the auditable events are deemed to be adequate to support after- the-fact investigations of security incidents; and
+     d. Determines that the following events are to be audited within the information system: [Assignment: organization-defined audited events (the subset of the auditable events defined in AU-2 a.) along with the frequency of (or situation requiring) auditing for each identified event].
+
+    Supplemental Guidance:  An event is any observable occurrence in an organizational information system. Organizations identify audit events as those events which are significant and relevant to the security of information systems and the environments in which those systems operate in order to meet specific and ongoing audit needs. Audit events can include, for example, password changes, failed logons, or failed accesses related to information systems, administrative privilege usage, PIV credential usage, or third-party credential usage. In determining the set of auditable events, organizations consider the auditing appropriate for each of the security controls to be implemented. To balance auditing requirements with other information system needs, this control also requires identifying that subset of auditable events that are audited at a given point in time. For example, organizations may determine that information systems must have the capability to log every file access both successful and unsuccessful, but not activate that capability except for specific circumstances due to the potential burden on system performance. Auditing requirements, including the need for auditable events, may be referenced in other security controls and control enhancements. Organizations also include auditable events that are required by applicable federal laws, Executive Orders, directives, policies, regulations, and standards. Audit records can be generated at various levels of abstraction, including at the packet level as information traverses the network. Selecting the appropriate level of abstraction is a critical aspect of an audit capability and can facilitate the identification of root causes to problems. Organizations consider in the definition of auditable events, the auditing necessary to cover related events such as the steps in distributed, transaction-based processes (e.g., processes that are distributed across multiple organizations) and actions that occur in service-oriented architectures. Related controls: AC-6, AC-17, AU-3, AU-12, MA-4, MP-2, MP-4, SI-4.
+
+    References: NIST Special Publication 800-92; Web: http://idmanagement.gov.
+
+    AU-2 (a) [successful and unsuccessful account logon events, account management events, object access, policy change, privilege functions, process tracking, and system events. For Web applications: all administrator activity, authentication checks, authorization checks, data deletions, data access, data changes, and permission changes]
+    AU-2 (d) [organization-defined subset of the auditable events defined in AU-2a to be audited continually for each identified event].
+    AU-2 Requirement: Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.
+  title: >-
+    AU-2 - AUDIT EVENTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-2(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: AU-2(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: AU-2(3)
+  status: not applicable
+  notes: |-
+    Organizational review and updates to the audited events are
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization reviews and updates the audited events [Assignment:\
+    \ organization-defined frequency].\n\nSupplemental Guidance:  Over time, the events\
+    \ that organizations believe should be audited may change. Reviewing and updating\
+    \ the set of audited events periodically is necessary to ensure that the current\
+    \ set is still necessary and sufficient.\n\nAU-2 (3) [annually or whenever there\
+    \ is a change in the threat environment] \nAU-2 (3) Guidance: Annually or whenever\
+    \ changes in the threat environment are communicated to the service provider by\
+    \ the JAB/AO."
+  title: >-
+    AU-2(3) - AUDIT EVENTS | REVIEWS AND UPDATES
+  levels:
+  - high
+  - moderate
+- id: AU-2(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: AU-3
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system generates audit records containing information that establishes what type of event occurred, when the event occurred, where the event occurred, the source of the event, the outcome of the event, and the identity of any individuals or subjects associated with the event.
+
+    Supplemental Guidance:  Audit record content that may be necessary to satisfy the requirement of this control, includes, for example, time stamps, source and destination addresses, user/process identifiers, event descriptions, success/fail indications, filenames involved, and access control or flow control rules invoked. Event outcomes can include indicators of event success or failure and event-specific results (e.g., the security state of the information system after the event occurred). Related controls: AU-2, AU-8, AU-12, SI-11.
+
+    References: None.
+  title: >-
+    AU-3 - CONTENT OF AUDIT RECORDS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-3(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system generates audit records containing the following additional information: [Assignment: organization-defined additional, more detailed information].
+
+    Supplemental Guidance:  Detailed information that organizations may consider in audit records includes, for example, full text recording of privileged commands or the individual identities of group account users. Organizations consider limiting the additional audit information to only that information explicitly needed for specific audit requirements. This facilitates the use of audit trails and audit logs by not including information that could potentially be misleading or could make it more difficult to locate information of interest.
+
+    AU-3 (1) [session, connection, transaction, or activity duration; for client-server transactions, the number of bytes received and bytes sent; additional informational messages to diagnose or identify the event; characteristics that describe or identify the object or resource being acted upon; individual identities of group account users; full-text of privileged commands]
+    AU-3 (1) Guidance: For client-server transactions, the number of bytes sent and received gives bidirectional transfer information that can be helpful during an investigation or inquiry.
+  title: >-
+    AU-3(1) - CONTENT OF AUDIT RECORDS | ADDITIONAL AUDIT INFORMATION
+  levels:
+  - high
+  - moderate
+- id: AU-3(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system provides centralized management and configuration of the content to be captured in audit records generated by [Assignment: organization-defined information system components].
+
+    Supplemental Guidance: This control enhancement requires that the content to be captured in audit records be configured from a central location (necessitating automation). Organizations coordinate the selection of required audit content to support the centralized management and configuration capability provided by the information system. Related controls: AU-6, AU-7.
+
+    AU-3 (2) [all network, data storage, and computing devices]
+  title: >-
+    AU-3(2) - CONTENT OF AUDIT RECORDS | CENTRALIZED MANAGEMENT OF PLANNED AUDIT RECORD
+    CONTENT
+  levels:
+  - high
+- id: AU-4
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization allocates audit record storage capacity in accordance with [Assignment:
+    organization-defined audit record storage requirements].
+
+    Supplemental Guidance:  Organizations consider the types of auditing to be performed and the audit processing requirements when allocating audit storage capacity. Allocating sufficient audit storage capacity reduces the likelihood of such capacity being exceeded and resulting in the potential loss or reduction of auditing capability. Related controls: AU-2, AU-5, AU-6, AU-7, AU-11, SI-4.
+
+    References: None.
+  title: >-
+    AU-4 - AUDIT STORAGE CAPACITY
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-4(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-5
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system:
+     a. Alerts [Assignment: organization-defined personnel or roles] in the event of an audit processing failure; and
+     b. Takes the following additional actions: [Assignment: organization-defined actions to be taken (e.g., shut down information system, overwrite oldest audit records, stop generating audit records)].
+
+    Supplemental Guidance:  Audit processing failures include, for example, software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded. Organizations may choose to define additional actions for different audit processing failures (e.g., by type, by location, by severity, or a combination of such factors). This control applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the total audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both. Related controls: AU-4, SI-12.
+
+    References: None.
+
+    AU-5 (b) [organization-defined actions to be taken (overwrite oldest record)
+  title: >-
+    AU-5 - RESPONSE TO AUDIT PROCESSING FAILURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-5(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system provides a warning to [Assignment: organization-defined personnel, roles, and/or locations] within [Assignment: organization-defined time period] when allocated audit record storage volume reaches [Assignment: organization-defined percentage] of repository maximum audit record storage capacity.
+
+    Supplemental Guidance:  Organizations may have multiple audit data storage repositories distributed across multiple information system components, with each repository having different storage volume capacities.
+  title: >-
+    AU-5(1) - RESPONSE TO AUDIT PROCESSING FAILURES | AUDIT STORAGE CAPACITY
+  levels:
+  - high
+- id: AU-5(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The information system provides an alert in [Assignment: organization-defined\
+    \ real-time period] to [Assignment: organization-defined personnel, roles, and/or\
+    \ locations] when the following audit failure events occur: [Assignment: organization-defined\
+    \ audit failure events requiring real-time alerts].\n\nSupplemental Guidance:\
+    \  Alerts provide organizations with urgent messages. Real-time alerts provide\
+    \ these messages at information technology speed (i.e., the time from event detection\
+    \ to alert occurs in seconds or less).\n\nAU-5 (2)-1 [real-time] \nAU-5 (1)-2\
+    \ [service provider personnel with authority to address failed audit events] \n\
+    AU-5 (1)-3 [audit failure events requiring real-time alerts, as defined by organization\
+    \  audit policy]."
+  title: >-
+    AU-5(2) - RESPONSE TO AUDIT PROCESSING FAILURES | REAL-TIME ALERTS
+  levels:
+  - high
+- id: AU-5(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-5(4)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-6
+  status: not applicable
+  notes: |-
+    Section a: Organizational review and analysis of information system
+    audit records for indications of organization-defined
+    inappropriate or unusual activity is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Reporting findings of organization-defined inappropriate or
+    unusual activity to organization-defined personnel or roles is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Reviews and analyzes information system audit\
+    \ records [Assignment: organization-defined frequency] for indications of [Assignment:\
+    \ organization-defined inappropriate or unusual activity]; and\n b. Reports findings\
+    \ to [Assignment: organization-defined personnel or roles].\n\nSupplemental Guidance:\
+    \  Audit review, analysis, and reporting covers information security-related auditing\
+    \ performed by organizations including, for example, auditing that results from\
+    \ monitoring of account usage, remote access, wireless connectivity, mobile device\
+    \ connection, configuration settings, system component inventory, use of maintenance\
+    \ tools and nonlocal maintenance, physical access, temperature and humidity, equipment\
+    \ delivery and removal, communications at the information system boundaries, use\
+    \ of mobile code, and use of VoIP. Findings can be reported to organizational\
+    \ entities that include, for example, incident response team, help desk, information\
+    \ security group/department. If organizations are prohibited from reviewing and\
+    \ analyzing audit information or unable to conduct such activities (e.g., in certain\
+    \ national security applications or systems), the review/analysis may be carried\
+    \ out by other organizations granted such authority. Related controls: AC-2, AC-3,\
+    \ AC-6, AC-17, AT-3, AU-7, AU-16, CA-7, CM-5, CM-10, CM-11, IA-3, IA-5, IR-5,\
+    \ IR-6, MA-4, MP-4, PE-3, PE-6, PE-14, PE-16, RA-5, SC-7, SC-18, SC-19, SI-3,\
+    \ SI-4, SI-7.\n\nReferences: None.\n\nAU-6 (a)-1 [at least weekly] \nAU-6 Requirement:\
+    \ Coordination between service provider and consumer shall be documented and accepted\
+    \ by the JAB/AO. In multi-tennant environments, capability and means for providing\
+    \ review, analysis, and reporting to consumer for data pertaining to consumer\
+    \ shall be documented."
+  title: >-
+    AU-6 - AUDIT REVIEW, ANALYSIS, AND REPORTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-6(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to integrate audit review, analysis, and reporting processes to support organizational processes for investigation and response to suspicious activities.
+
+    Supplemental Guidance:  Organizational processes benefiting from integrated audit review, analysis, and reporting include, for example, incident response, continuous monitoring, contingency planning, and Inspector General audits. Related controls: AU-12, PM-7.
+  title: >-
+    AU-6(1) - AUDIT REVIEW, ANALYSIS, AND REPORTING | PROCESS INTEGRATION
+  levels:
+  - high
+  - moderate
+- id: AU-6(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: AU-6(3)
+  status: not applicable
+  notes: |-
+    Organizational analysis and correlation of audit records across
+    different repositories to gain organization-wide
+    situational awareness is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization analyzes and correlates audit records across different repositories to gain organization-wide situational awareness.
+
+    Supplemental Guidance:  Organization-wide situational awareness includes awareness across all three tiers of risk management (i.e., organizational, mission/business process, and information system) and supports cross-organization awareness. Related controls: AU-12, IR-4.
+  title: >-
+    AU-6(3) - AUDIT REVIEW, ANALYSIS, AND REPORTING | CORRELATE AUDIT REPOSITORIES
+  levels:
+  - high
+  - moderate
+- id: AU-6(4)
+  status: not applicable
+  notes: |-
+    Organizational capability to centrally review and analyze
+    audit records from multiple components within the system
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system provides the capability to centrally review and analyze audit records from multiple components within the system.
+
+    Supplemental Guidance:  Automated mechanisms for centralized reviews and analyses include, for example, Security Information Management products. Related controls: AU-2, AU-12.
+  title: >-
+    AU-6(4) - AUDIT REVIEW, ANALYSIS, AND REPORTING | CENTRAL REVIEW AND ANALYSIS
+  levels:
+  - high
+- id: AU-6(5)
+  status: not applicable
+  notes: |-
+    Organizational capability to integrate analysis or audit
+    records with analysis of additional organization-defined
+    data/information collected from other sources to further
+    enhance the ability to identify inappropriate or unusual
+    activity is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization integrates analysis of audit records with analysis of [Selection (one or more): vulnerability scanning information; performance data; information system monitoring information; [Assignment: organization-defined data/information collected from other sources]] to further enhance the ability to identify inappropriate or unusual activity.
+
+    Supplemental Guidance:  This control enhancement does not require vulnerability scanning, the generation of performance data, or information system monitoring. Rather, the enhancement requires that the analysis of information being otherwise produced in these areas is integrated with the analysis of audit information. Security Event and Information Management System tools can facilitate audit record aggregation/consolidation from multiple information system components as well as audit record correlation and analysis. The use of standardized audit record analysis scripts developed by organizations (with localized script adjustments, as necessary) provides more cost-effective approaches for analyzing audit record information collected. The correlation of audit record information with vulnerability scanning information is important in determining the veracity of vulnerability scans and correlating attack detection events with scanning results. Correlation with performance data can help uncover denial of service attacks or cyber attacks resulting in unauthorized use of resources. Correlation with system monitoring information can assist in uncovering attacks and in better relating audit information to operational situations. Related controls: AU-12, IR-4, RA-5.
+
+    AU-6 (5) [Selection (one or more): vulnerability scanning information; performance data; information system monitoring information; penetration test data; [Organization -defined data/information collected from other sources]]
+  title: >-
+    AU-6(5) - AUDIT REVIEW, ANALYSIS, AND REPORTING | INTEGRATION / SCANNING AND MONITORING
+    CAPABILITIES
+  levels:
+  - high
+- id: AU-6(6)
+  status: not applicable
+  notes: |-
+    Organizational capability to correlate information from
+    Red Hat Advanced Cluster Management for Kubernetes audit records with information obtained from monitoring
+    physical access to further enhanced the ability to identify
+    suspicious, inappropriate, unusual, or malevolent activity
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization correlates information from audit records with information\
+    \ obtained from monitoring physical access to further enhance the ability to identify\
+    \ suspicious, inappropriate, unusual, or malevolent activity.\n\nSupplemental\
+    \ Guidance:  The correlation of physical audit information and audit logs from\
+    \ information systems may assist organizations in identifying examples of suspicious\
+    \ behavior or supporting evidence of such behavior. For example, the correlation\
+    \ of an individual\u2019s identify for logical access to certain information systems\
+    \ with the additional physical security information that the individual was actually\
+    \ present at the facility when the logical access occurred, may prove to be useful\
+    \ in investigations.\n\n \nAU-6 (6) Requirement: Coordination between service\
+    \ provider and consumer shall be documented and accepted by the JAB/AO."
+  title: >-
+    AU-6(6) - AUDIT REVIEW, ANALYSIS, AND REPORTING | CORRELATION WITH PHYSICAL MONITORING
+  levels:
+  - high
+- id: AU-6(7)
+  status: not applicable
+  notes: |-
+    Organizational specification of permitted actions for
+    information system processes, roles, and/or users, associated
+    with the review, analysis, and reporting of audit
+    information is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization specifies the permitted actions for each [Selection (one or more): information system process; role; user] associated with the review, analysis, and reporting of audit information.
+
+    Supplemental Guidance:  Organizations specify permitted actions for information system processes, roles, and/or users associated with the review, analysis, and reporting of audit records through account management techniques. Specifying permitted actions on audit information is a way to enforce the principle of least privilege. Permitted actions are enforced by the information system and include, for example, read, write, execute, append, and delete.
+
+    AU-6 (7) [information system process; role; user]
+  title: >-
+    AU-6(7) - AUDIT REVIEW, ANALYSIS, AND REPORTING | PERMITTED ACTIONS
+  levels:
+  - high
+- id: AU-6(8)
+  status: not applicable
+  notes: |-
+    Organizational processes to perform full text analysis or audited
+    privileged commands in a physically distinct component or subsystem
+    of the information system, or other information system that is
+    dedicated to that analysis, is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: AU-6(9)
+  status: not applicable
+  notes: |-
+    Organizational processes to correlate information
+    from nontechnical sources with audit information to enhance
+    organization-wide situational awareness is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-6(10)
+  status: not applicable
+  notes: |-
+    Organizational adjustment of the level of audit review, analysis, and
+    reporting within the information system when there is a change in risk
+    based on law enforcement information, intelligence information, or other
+    credible sources of information, is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization adjusts the level of audit review, analysis, and reporting within the information system when there is a change in risk based on law enforcement information, intelligence information, or other credible sources of information.
+
+    Supplemental Guidance:  The frequency, scope, and/or depth of the audit review, analysis, and reporting may be adjusted to meet organizational needs based on new information received.
+  title: >-
+    AU-6(10) - AUDIT REVIEW, ANALYSIS, AND REPORTING | AUDIT LEVEL ADJUSTMENT
+  levels:
+  - high
+- id: AU-7
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system provides an audit reduction and report generation capability that:
+     a. Supports on-demand audit review, analysis, and reporting requirements and after-the-fact investigations of security incidents; and
+     b. Does not alter the original content or time ordering of audit records.
+
+    Supplemental Guidance:  Audit reduction is a process that manipulates collected audit information and organizes such information in a summary format that is more meaningful to analysts. Audit reduction and report generation capabilities do not always emanate from the same information system or from the same organizational entities conducting auditing activities. Audit reduction capability can include, for example, modern data mining techniques with advanced data filters to identify anomalous behavior in audit records. The report generation capability provided by the information system can generate customizable reports. Time ordering of audit records can be a significant issue if the granularity of the timestamp in the record is insufficient. Related control: AU-6.
+
+    References: None.
+  title: >-
+    AU-7 - AUDIT REDUCTION AND REPORT GENERATION
+  levels:
+  - high
+  - moderate
+- id: AU-7(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system provides the capability to process audit records for events of interest based on [Assignment: organization-defined audit fields within audit records].
+
+    Supplemental Guidance:  Events of interest can be identified by the content of specific audit record fields including, for example, identities of individuals, event types, event locations, event times, event dates, system resources involved, IP addresses involved, or information objects accessed. Organizations may define audit event criteria to any degree of granularity required, for example, locations selectable by general networking location (e.g., by network or subnetwork) or selectable by specific information system component. Related controls: AU-2, AU-12.
+  title: >-
+    AU-7(1) - AUDIT REDUCTION AND REPORT GENERATION | AUTOMATIC PROCESSING
+  levels:
+  - high
+  - moderate
+- id: AU-7(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-8
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system:
+     a. Uses internal system clocks to generate time stamps for audit records; and
+     b. Records time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT) and meets [Assignment: organization-defined granularity of time measurement].
+
+    Supplemental Guidance:  Time stamps generated by the information system include date and time. Time is commonly expressed in Coordinated Universal Time (UTC), a modern continuation of Greenwich Mean Time (GMT), or local time with an offset from UTC. Granularity of time measurements refers to the degree of synchronization between information system clocks and reference clocks, for example, clocks synchronizing within hundreds of milliseconds or within tens of milliseconds. Organizations may define different time granularities for different system components. Time service can also be critical to other security capabilities such as access control and identification and authentication, depending on the nature of the mechanisms used to support those capabilities. Related controls: AU-3, AU-12.
+
+    References: None.
+
+    AU-8 (b) [one second granularity of time measurement]
+  title: >-
+    AU-8 - TIME STAMPS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-8(1)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing and time synchronization capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing and time synchronization capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system:
+     (a)   Compares the internal information system clocks [Assignment: organization-defined frequency] with [Assignment: organization-defined authoritative time source]; and
+     (b)   Synchronizes the internal system clocks to the authoritative time source when the time difference is greater than [Assignment: organization-defined time period].
+
+    Supplemental Guidance:  This control enhancement provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
+
+    AU-8 (1) [http://tf.nist.gov/tf-cgi/servers.cgi] [At least hourly]
+    AU-8 (1) Requirement: The service provider selects primary and secondary time servers used by the NIST Internet time service. The secondary server is selected from a different geographic region than the primary server.
+    AU-8 (1) Requirement: The service provider synchronizes the system clocks of network computers that run operating systems other than Windows to the Windows Server Domain Controller emulator or to the same time source for that server.
+    AU-8 (1) Guidance: Synchronization of system clocks improves the accuracy of log analysis.
+  title: >-
+    AU-8(1) - TIME STAMPS | SYNCHRONIZATION WITH AUTHORITATIVE TIME SOURCE
+  levels:
+  - high
+  - moderate
+- id: AU-8(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-9
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system protects audit information and audit tools from unauthorized access, modification, and deletion.
+
+    Supplemental Guidance:  Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity. This control focuses on technical protection of audit information. Physical protection of audit information is addressed by media protection controls and physical and environmental protection controls. Related controls: AC-3, AC-6, MP-2, MP-4, PE-2, PE-3, PE-6.
+
+    References: None.
+  title: >-
+    AU-9 - PROTECTION OF AUDIT INFORMATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-9(1)
+  status: not applicable
+  notes: |-
+    Writing audit trails to hardware enforced, write-once media,
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-9(2)
+  status: not applicable
+  notes: |-
+    Backup of audit records onto a physically different system or
+    system component than the component being audited is the
+    responsibility of the centralized audit facility defined in
+    AU-4 (1), "Transfer to Alternate Storage," and outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system backs up audit records [Assignment: organization-defined frequency] onto a physically different system or system component than the system or component being audited.
+
+    Supplemental Guidance: This control enhancement helps to ensure that a compromise of the information system being audited does not also result in a compromise of the audit records. Related controls: AU-4, AU-5, AU-11.
+
+    AU-9 (2) [at least weekly]
+  title: >-
+    AU-9(2) - PROTECTION OF AUDIT INFORMATION | AUDIT BACKUP ON SEPARATE PHYSICAL
+    SYSTEMS / COMPONENTS
+  levels:
+  - high
+  - moderate
+- id: AU-9(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements cryptographic mechanisms to protect the integrity of audit information and audit tools.
+
+    Supplemental Guidance:  Cryptographic mechanisms used for protecting the integrity of audit information include, for example, signed hash functions using asymmetric cryptography enabling distribution of the public key to verify the hash information while maintaining the confidentiality of the secret key used to generate the hash. Related controls: AU-10, SC-12, SC-13.
+  title: >-
+    AU-9(3) - PROTECTION OF AUDIT INFORMATION | CRYPTOGRAPHIC PROTECTION
+  levels:
+  - high
+- id: AU-9(4)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization authorizes access to management of audit functionality to only [Assignment: organization-defined subset of privileged users].
+
+    Supplemental Guidance:  Individuals with privileged access to an information system and who are also the subject of an audit by that system, may affect the reliability of audit information by inhibiting audit activities or modifying audit records. This control enhancement requires that privileged access be further defined between audit-related privileges and other privileges, thus limiting the users with audit-related privileges. Related control: AC-5.
+  title: >-
+    AU-9(4) - PROTECTION OF AUDIT INFORMATION | ACCESS BY SUBSET OF PRIVILEGED USERS
+  levels:
+  - high
+  - moderate
+- id: AU-9(5)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-9(6)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-10
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system protects against an individual (or process acting on behalf of an individual) falsely denying having performed [Assignment: organization-defined actions to be covered by non-repudiation].
+
+    Supplemental Guidance:  Types of individual actions covered by non-repudiation include, for example, creating information, sending and receiving messages, approving information (e.g., indicating concurrence or signing a contract). Non-repudiation protects individuals against later claims by: (i) authors of not having authored particular documents; (ii) senders of not having transmitted messages; (iii) receivers of not having received messages; or (iv) signatories of not having signed documents. Non-repudiation services can be used to determine if information originated from a particular individual, or if an individual took specific actions (e.g., sending an email, signing a contract, approving a procurement request) or received specific information. Organizations obtain non-repudiation services by employing various techniques or mechanisms (e.g., digital signatures, digital message receipts). Related controls: SC-12, SC-8, SC-13, SC-16, SC-17, SC-23.
+
+    References: None.
+
+    AU-10 [minimum actions including the addition, modification, deletion, approval, sending, or receiving of data]
+  title: >-
+    AU-10 - NON-REPUDIATION
+  levels:
+  - high
+- id: AU-10(1)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-10(2)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-10(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-10(4)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-10(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: AU-11
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization retains audit records for [Assignment: organization-defined\
+    \ time period consistent with records retention policy] to provide support for\
+    \ after-the-fact investigations of security incidents and to meet regulatory and\
+    \ organizational information retention requirements.\n\nSupplemental Guidance:\
+    \  Organizations retain audit records until it is determined that they are no\
+    \ longer needed for administrative, legal, audit, or other operational purposes.\
+    \ This includes, for example, retention and availability of audit records relative\
+    \ to Freedom of Information Act (FOIA) requests, subpoenas, and law enforcement\
+    \ actions. Organizations develop standard categories of audit records relative\
+    \ to such types of actions and standard response processes for each type of action.\
+    \ The National Archives and Records Administration (NARA) General Records Schedules\
+    \ provide federal policy on record retention. Related controls: AU-4, AU-5, AU-9,\
+    \ MP-6.\n\nReferences: None.\n\nAU-11 [at least one (1) year] \nAU-11 Requirement:\
+    \ The service provider retains audit records on-line for at least ninety days\
+    \ and further preserves audit records off-line for a period that is in accordance\
+    \ with NARA requirements."
+  title: >-
+    AU-11 - AUDIT RECORD RETENTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-11(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-12
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The information system:\n a. Provides audit record generation capability\
+    \ for the auditable events defined in AU-2 a. at [Assignment: organization-defined\
+    \ information system components];\n b. Allows [Assignment: organization-defined\
+    \ personnel or roles] to select which auditable events are to be audited by specific\
+    \ components of the information system; and\n c.    Generates audit records for\
+    \ the events defined in AU-2 d. with the content defined in AU-3. \n\nSupplemental\
+    \ Guidance:  Audit records can be generated from many different information system\
+    \ components. The list of audited events is the set of events for which audits\
+    \ are to be generated. These events are typically a subset of all events for which\
+    \ the information system is capable of generating audit records. Related controls:\
+    \ AC-3, AU-2, AU-3, AU-6, AU-7.\n\nReferences: None.\n\nAU-12 (a) [all information\
+    \ system and network components where audit capability is deployed/available]"
+  title: >-
+    AU-12 - AUDIT GENERATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-12(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system compiles audit records from [Assignment: organization-defined information system components] into a system-wide (logical or physical) audit trail that is time- correlated to within [Assignment: organization-defined level of tolerance for relationship between time stamps of individual records in the audit trail].
+
+    Supplemental Guidance:  Audit trails are time-correlated if the time stamps in the individual audit records can be reliably related to the time stamps in other audit records to achieve a time ordering of the records within organizational tolerances. Related controls: AU-8, AU-12.
+
+    AU-12 (1) [all network, data storage, and computing devices]
+  title: >-
+    AU-12(1) - AUDIT GENERATION | SYSTEM-WIDE / TIME-CORRELATED AUDIT TRAIL
+  levels:
+  - high
+- id: AU-12(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-12(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The information system provides the capability for [Assignment: organization-defined\
+    \ individuals or roles] to change the auditing to be performed on [Assignment:\
+    \ organization-defined information system components] based on [Assignment: organization-defined\
+    \ selectable event criteria] within [Assignment: organization-defined time thresholds].\n\
+    \nSupplemental Guidance:  This control enhancement enables organizations to extend\
+    \ or limit auditing as necessary to meet organizational requirements. Auditing\
+    \ that is limited to conserve information system resources may be extended to\
+    \ address certain threat situations. In addition, auditing may be limited to a\
+    \ specific set of events to facilitate audit reduction, analysis, and reporting.\
+    \ Organizations can establish time thresholds in which audit actions are changed,\
+    \ for example, near real-time, within minutes, or within hours. Related control:\
+    \ AU-7.\n\nAU-12 (3) (1) [service provider-defined individuals or roles with audit\
+    \ configuration responsibilities]  \nAU-12 (3) (2) [all network, data storage,\
+    \ and computing devices]"
+  title: >-
+    AU-12(3) - AUDIT GENERATION | CHANGES BY AUTHORIZED INDIVIDUALS
+  levels:
+  - high
+- id: AU-13
+  status: not applicable
+  notes: |-
+    Monitoring of organization-defined open source information
+    and/or information sites at an organization-defined frequency for
+    evidence of unauthorized disclosure of organizational information
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-13(1)
+  status: not applicable
+  notes: |-
+    Employment of automated mechanisms to determine if
+    organizational information has been disclosed in an
+    unauthorized manner is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-13(2)
+  status: not applicable
+  notes: |-
+    Reviews of the open source information sites being monitored
+    at an organization-defined frequency is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-14
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-14(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-14(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-14(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-15
+  status: not applicable
+  notes: |-
+    The organization provides an alternate audit capability in the
+    event of a failure in primary audit capability that provides
+    organization-defined alternate audit functionality is an organizational
+    control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-16
+  status: not applicable
+  notes: |-
+    Employment of organization-defined methods for coordinating
+    organization-defined audit information among external
+    organizations when audit information is transmitted
+    across organizational boundaries is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-16(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes relies on
+    OpenShift for auditing capabilities.
+
+    This control is applicable to the OpenShift Cluster Logging
+    Operator and to the OpenShift cluster and is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: AU-16(2)
+  status: not applicable
+  notes: |-
+    Providing cross-organizational audit information to
+    organization-defined organizations based on
+    organization-defined cross-organizational sharing
+    agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: CA-1
+  status: not applicable
+  notes: |-
+    Section a: Establishing organizational security assessment and
+    authorization policy and procedures is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section b: Establishing organizational security assessment and
+    authorization policy and procedures is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A security assessment and authorization\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the security assessment and authorization\
+    \ policy and associated security assessment and authorization controls; and\n\
+    \ b. Reviews and updates the current:\n   1. Security assessment and authorization\
+    \ policy [Assignment: organization-defined frequency]; and\n   2. Security assessment\
+    \ and authorization procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance: This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the CA family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-37, 800-53A, 800-100.\n\n\
+    CA-1 (b) (1) [at least annually] \nCA-1 (b) (2) [at least annually or whenever\
+    \ a significant change occurs]"
+  title: >-
+    CA-1 - SECURITY ASSESSMENT AND AUTHORIZATION
+
+    POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-2
+  status: not applicable
+  notes: |-
+    Section a: Development of an organizational security assessment plan
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+    Section b: Development of an organizational security assessment plan
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+    Section c: Development of an organizational security assessment plan
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+    Section d: Development of an organizational security assessment plan
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+  rules: []
+  description: "The organization:\n a. Develops a security assessment plan that describes\
+    \ the scope of the assessment including:\n   1. Security controls and control\
+    \ enhancements under assessment;\n   2. Assessment procedures to be used to determine\
+    \ security control effectiveness; and\n   3. Assessment environment, assessment\
+    \ team, and assessment roles and responsibilities;\n b. Assesses the security\
+    \ controls in the information system and its environment of operation [Assignment:\
+    \ organization-defined frequency] to determine the extent to which the controls\
+    \ are implemented correctly, operating as intended, and producing the desired\
+    \ outcome with respect to meeting established security requirements;\n c. Produces\
+    \ a security assessment report that documents the results of the assessment; and\n\
+    \ d. Provides the results of the security control assessment to [Assignment: organization-defined\
+    \ individuals or roles].\n\nSupplemental Guidance:  Organizations assess security\
+    \ controls in organizational information systems and the environments in which\
+    \ those systems operate as part of: (i) initial and ongoing security authorizations;\
+    \ (ii) FISMA annual assessments; (iii) continuous monitoring; and (iv) system\
+    \ development life cycle activities. Security assessments: (i) ensure that information\
+    \ security is built into organizational information systems; (ii) identify weaknesses\
+    \ and deficiencies early in the development process; (iii) provide essential information\
+    \ needed to make risk-based decisions as part of security authorization processes;\
+    \ and (iv) ensure compliance to vulnerability mitigation procedures. Assessments\
+    \ are conducted on the implemented security controls from Appendix F (main catalog)\
+    \ and Appendix G (Program Management controls) as documented in System Security\
+    \ Plans and Information Security Program Plans. Organizations can use other types\
+    \ of assessment activities such as vulnerability scanning and system monitoring\
+    \ to maintain the security posture of information systems during the entire life\
+    \ cycle. Security assessment reports document assessment results in sufficient\
+    \ detail as deemed necessary by organizations, to determine the accuracy and completeness\
+    \ of the reports and whether the security controls are implemented correctly,\
+    \ operating as intended, and producing the desired outcome with respect to meeting\
+    \ security requirements. The FISMA requirement for assessing security controls\
+    \ at least annually does not require additional assessment activities to those\
+    \ activities already in place in organizational security authorization processes.\
+    \ Security assessment results are provided to the individuals or roles appropriate\
+    \ for the types of assessments being conducted. For example, assessments conducted\
+    \ in support of security authorization decisions are provided to authorizing officials\
+    \ or authorizing official designated representatives.\n\nTo satisfy annual assessment\
+    \ requirements, organizations can use assessment results from the following sources:\
+    \ (i) initial or ongoing information system authorizations; (ii) continuous monitoring;\
+    \ or (iii)  system development life cycle activities. Organizations ensure that\
+    \ security assessment results are current, relevant to the determination of security\
+    \ control effectiveness, and obtained with the appropriate level of assessor independence.\
+    \ Existing security control assessment results can be reused to the extent that\
+    \ the results are still valid and can also be supplemented with additional assessments\
+    \ as needed. Subsequent to initial authorizations and in accordance with OMB policy,\
+    \ organizations assess security controls during continuous monitoring. Organizations\
+    \ establish the frequency for ongoing security control assessments in accordance\
+    \ with organizational continuous monitoring strategies. Information Assurance\
+    \ Vulnerability Alerts provide useful examples of vulnerability mitigation procedures.\
+    \ External audits (e.g., audits by external entities such as regulatory agencies)\
+    \ are outside the scope of this control. Related controls: CA-5, CA-6, CA-7, PM-9,\
+    \ RA-5, SA-11, SA-12, SI-4.\n\nReferences: Executive Order 13587; FIPS Publication\
+    \ 199; NIST Special Publications 800-37, 800-39, 800-53A, 800-115, 800-137.\n\n\
+    CA-2 (b) [at least annually] \nCA-2 (d) [individuals or roles to include FedRAMP\
+    \ PMO]\nCA-2 Guidance: See the FedRAMP Documents page under Key Cloud Service\n\
+    Provider (CSP) Documents> Annual Assessment Guidance\nhttps://www.FedRAMP.gov/documents/"
+  title: >-
+    CA-2 - SECURITY ASSESSMENTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-2(1)
+  status: not applicable
+  notes: |-
+    Employment of independent assessors or assessment teams
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+  rules: []
+  description: "The organization employs assessors or assessment teams with [Assignment:\
+    \ organization-defined level of independence] to conduct security control assessments.\n\
+    \nSupplemental Guidance:  Independent assessors or assessment teams are individuals\
+    \ or groups who conduct impartial assessments of organizational information systems.\
+    \ Impartiality implies that assessors are free from any perceived or actual conflicts\
+    \ of interest with regard to the development, operation, or management of the\
+    \ organizational information systems under assessment or to the determination\
+    \ of security control effectiveness. To achieve impartiality, assessors should\
+    \ not: (i) create a mutual or conflicting interest with the organizations where\
+    \ the assessments are being conducted; (ii) assess their own work; (iii) act as\
+    \ management or employees of the organizations they are serving; or (iv) place\
+    \ themselves in positions of advocacy for the organizations acquiring their services.\
+    \ Independent assessments can be obtained from elements within organizations or\
+    \ can be contracted to public or private sector entities outside of organizations.\
+    \ Authorizing officials determine the required level of independence based on\
+    \ the security categories of information systems and/or the ultimate risk to organizational\
+    \ operations, organizational assets, or individuals. Authorizing officials also\
+    \ determine if the level of assessor independence provides sufficient assurance\
+    \ that the results are sound and can be used to make credible, risk-based decisions.\
+    \ This includes determining whether contracted security assessment services have\
+    \ sufficient independence, for example, when information system owners are not\
+    \ directly involved in contracting processes or cannot unduly influence the impartiality\
+    \ of assessors conducting assessments. In special situations,\nfor example, when\
+    \ organizations that own the information systems are small or organizational structures\
+    \ require that assessments are conducted by individuals that are in the developmental,\
+    \ operational, or management chain of system owners, independence in assessment\
+    \ processes can be achieved by ensuring that assessment results are carefully\
+    \ reviewed and analyzed by independent teams of experts to validate the completeness,\
+    \ accuracy, integrity, and reliability of the results. Organizations recognize\
+    \ that assessments performed for purposes other than direct support to authorization\
+    \ decisions are, when performed by assessors with sufficient independence, more\
+    \ likely to be useable for such decisions, thereby reducing the need to\nrepeat\
+    \ assessments.\n \nCA-2 (1) Requirement: For JAB Authorization, must use an accredited\
+    \ 3PAO."
+  title: >-
+    CA-2(1) - SECURITY ASSESSMENTS | INDEPENDENT ASSESSORS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-2(2)
+  status: not applicable
+  notes: |-
+    Specialized security assessments are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: |-
+    The organization includes as part of security control assessments, [Assignment: organization- defined frequency], [Selection: announced; unannounced], [Selection (one or more): in-depth monitoring; vulnerability scanning; malicious user testing; insider threat assessment; performance/load testing; [Assignment: organization-defined other forms of security assessment]].
+
+    Supplemental Guidance:  Organizations can employ information system monitoring, insider threat assessments, malicious user testing, and other forms of testing (e.g., verification and validation) to improve readiness by exercising organizational capabilities and indicating current performance levels as a means of focusing actions to improve security. Organizations conduct assessment activities in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards. Authorizing officials approve the assessment methods in coordination with the organizational risk executive function. Organizations can incorporate vulnerabilities uncovered during assessments into vulnerability remediation processes. Related controls: PE-3, SI-2.
+
+    CA-2 (2) [at least annually]
+    CA-2 (2) Requirement: To include 'announced', 'vulnerability scanning'
+  title: >-
+    CA-2(2) - SECURITY ASSESSMENTS | SPECIALIZED ASSESSMENTS
+  levels:
+  - high
+  - moderate
+- id: CA-2(3)
+  status: not applicable
+  notes: |-
+    Organizational acceptance of the results of an assessment
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization accepts the results of an assessment of [Assignment: organization-defined information system] performed by [Assignment: organization-defined external organization] when the assessment meets [Assignment: organization-defined requirements].
+
+    Supplemental Guidance:  Organizations may often rely on assessments of specific information systems by other (external) organizations. Utilizing such existing assessments (i.e., reusing existing assessment evidence) can significantly decrease the time and resources required for organizational assessments by limiting the amount of independent assessment activities that organizations need to perform. The factors that organizations may consider in determining whether to accept assessment results from external organizations can vary. Determinations for accepting assessment results can be based on, for example, past assessment experiences one organization has had with another organization, the reputation that organizations have with regard to assessments, the level of detail of supporting assessment documentation provided, or mandates imposed upon organizations by federal legislation, policies, or directives.
+
+    CA-2 (3)-1 [any FedRAMP Accredited 3PAO]
+    CA-2 (3)-1-2 [any FedRAMP Accredited 3PAO]
+    CA-2 (3)-1-3 [the conditions of the JAB/AO in the FedRAMP Repository]
+  title: >-
+    CA-2(3) - SECURITY ASSESSMENTS | EXTERNAL ORGANIZATIONS
+  levels:
+  - high
+  - moderate
+- id: CA-3
+  status: not applicable
+  notes: |-
+    Section a: Establishment of organizational system interconnection
+    agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration guidance.
+    Section b: Establishment of organizational system interconnection
+    agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration guidance.
+    Section c: Establishment of organizational system interconnection
+    agreements is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration guidance.
+  rules: []
+  description: |-
+    The organization:
+     a. Authorizes connections from the information system to other information systems through the use of Interconnection Security Agreements;
+     b. Documents, for each interconnection, the interface characteristics, security requirements, and the nature of the information communicated; and
+     c. Reviews and updates Interconnection Security Agreements [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control applies to dedicated connections between information systems (i.e., system interconnections) and does not apply to transitory, user-controlled connections such as email and website browsing. Organizations carefully consider the risks that may be introduced when information systems are connected to other systems with different security requirements and security controls, both within organizations and external to organizations. Authorizing officials determine the risk associated with information system connections and the appropriate controls employed. If interconnecting systems have the same authorizing official, organizations do not need to develop Interconnection Security Agreements. Instead, organizations can describe the interface characteristics between those interconnecting systems in their respective security plans. If interconnecting systems have different authorizing officials within the same organization, organizations can either develop Interconnection Security Agreements or describe the interface characteristics between systems in the security plans for the respective systems. Organizations may also incorporate Interconnection Security Agreement information into formal contracts, especially for interconnections established between federal agencies and nonfederal (i.e., private sector) organizations. Risk considerations also include information systems sharing the same networks. For certain technologies (e.g., space, unmanned aerial vehicles, and medical devices), there may be specialized connections in place during preoperational testing. Such connections may require Interconnection Security Agreements and be subject to additional security controls.
+    Related controls: AC-3, AC-4, AC-20, AU-2, AU-12, AU-16, CA-7, IA-3, SA-9, SC-7, SI-4.
+
+    References: FIPS Publication 199; NIST Special Publication 800-47.
+
+    CA-3 (c) [at least annually and on input from FedRAMP]
+  title: >-
+    CA-3 - SYSTEM INTERCONNECTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-3(1)
+  status: not applicable
+  notes: |-
+    This is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+- id: CA-3(2)
+  status: not applicable
+  notes: |-
+    This is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+- id: CA-3(3)
+  status: not applicable
+  notes: |-
+    This is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: "The organization prohibits the direct connection of an [Assignment:\
+    \ organization-defined unclassified, non-national security system] to an external\
+    \ network without the use of [Assignment; organization-defined boundary protection\
+    \ device].\n\nSupplemental Guidance:  Organizations typically do not have control\
+    \ over external networks (e.g., the Internet). Approved boundary protection devices\
+    \ (e.g., routers, firewalls) mediate communications (i.e., information flows)\
+    \ between unclassified non-national security systems and external networks. This\
+    \ control enhancement is required for organizations processing, storing, or transmitting\
+    \ Controlled Unclassified Information (CUI).\n\nCA-3 (3)-2 [Boundary Protections\
+    \ which meet the Trusted Internet Connection (TIC) requirements]\nCA-3 (3) Guidance:\
+    \ Refer to Appendix H \u2013 Cloud Considerations of the TIC 2.0 Reference Architecture\
+    \ document."
+  title: >-
+    CA-3(3) - SYSTEM INTERCONNECTIONS | UNCLASSIFIED NON-NATIONAL SECURITY SYSTEM
+    CONNECTIONS
+  levels:
+  - high
+  - moderate
+- id: CA-3(4)
+  status: not applicable
+  notes: |-
+    This is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+- id: CA-3(5)
+  status: not applicable
+  notes: |-
+    The organization employing an allow-all, deny-by-exception; deny-all, permit-by-exception
+    policy for allowing organization-defined information systems to connect to external
+    information systems is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on Red Hat Advanced Cluster
+    Management for Kubernetes components that support the capability to manage connections to
+    and from external information systems. As such, this control is applicable to the
+    organization and to the underlying OpenShift layer.
+  rules: []
+  description: |-
+    The organization employs [Selection: allow-all, deny-by-exception; deny-all, permit-by-exception] policy for allowing [Assignment: organization-defined information systems] to connect to external information systems.
+
+    Supplemental Guidance:  Organizations can constrain information system connectivity to external domains (e.g., websites) by employing one of two policies with regard to such connectivity: (i) allow-all, deny by exception, also known as blacklisting (the weaker of the two policies); or (ii) deny-all, allow by exception, also known as whitelisting (the stronger of the two policies). For either policy, organizations determine what exceptions, if any, are acceptable. Related control: CM-7.
+
+    CA-3 (5) [deny-all, permit by exception]
+
+    [any systems]
+    CA-3 (5) Guidance: For JAB Authorization, CSPs shall include details of this control in their Architecture Briefing
+  title: >-
+    CA-3(5) - SYSTEM INTERCONNECTIONS | RESTRICTIONS ON EXTERNAL SYSTEM CONNECTIONS
+  levels:
+  - high
+  - moderate
+- id: CA-4
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CA-5
+  status: not applicable
+  notes: |-
+    Section a: Creating an information system-level Plan of Action
+    and Milestones (POA&M) is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration processes.
+
+    However, to aid in remediating or
+    mitigating any known weaknesses or deficiencies in
+    Red Hat Advanced Cluster Management for Kubernetes, Red Hat is planning to make public a
+    POA&M specific to Red Hat Advanced Cluster Management for Kubernetes. This is currently in
+    progress. If you would like to monitor or collaborate on the Red Hat Advanced Cluster
+    Management for Kubernetes POA&M, Engineering progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-348
+    Section b: Organizational processes relating to updating and the maintenance
+    of an information system-level Plan of Action and Milestones (POA&M)
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    processes.
+
+    However, Red Hat will be evaluating the self-assessment POA&M items specific
+    to Red Hat Advanced Cluster Management for Kubernetes. Engineering progress can be tracked
+    at:
+
+    https://issues.redhat.com/browse/ACM-348
+  rules: []
+  description: "The organization:\n a. Develops a plan of action and milestones for\
+    \ the information system to document the organization\u2019s planned remedial\
+    \ actions to correct weaknesses or deficiencies noted during\nthe assessment of\
+    \ the security controls and to reduce or eliminate known vulnerabilities in the\
+    \ system; and\n b. Updates existing plan of action and milestones [Assignment:\
+    \ organization-defined frequency] based on the findings from security controls\
+    \ assessments, security impact analyses, and continuous monitoring activities.\n\
+    \nSupplemental Guidance:  Plans of action and milestones are key documents in\
+    \ security authorization packages and are subject to federal reporting requirements\
+    \ established by OMB. Related controls: CA-2, CA-7, CM-4, PM-4.\n\nReferences:\
+    \  OMB Memorandum 02-01; NIST Special Publication 800-37.\n\nCA-5 (b) [at least\
+    \ monthly]\nCA-5 Requirement: POA&Ms must be provided at least monthly.\nCA-5\
+    \ Guidance: See the FedRAMP Documents page under Key Cloud Service\nProvider (CSP)\
+    \ Documents> Plan of Action and Milestones (POA&M) Template Completion Guide\n\
+    https://www.FedRAMP.gov/documents/"
+  title: >-
+    CA-5 - PLAN OF ACTION AND MILESTONES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-5(1)
+  status: not applicable
+  notes: |-
+    Updates and maintenance of an information system-level
+    Plan of Action and Milestones (POA&M) document outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CA-6
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section b: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section c: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: "The organization:\n a. Assigns a senior-level executive or manager\
+    \ as the authorizing official for the information system;\n b. Ensures that the\
+    \ authorizing official authorizes the information system for processing before\
+    \ commencing operations; and\n c. Updates the security authorization [Assignment:\
+    \ organization-defined frequency].\n\nSupplemental Guidance:  Security authorizations\
+    \ are official management decisions, conveyed through authorization decision documents,\
+    \ by senior organizational officials or executives (i.e., authorizing officials)\
+    \ to authorize operation of information systems and to explicitly accept the risk\
+    \ to organizational operations and assets, individuals, other organizations, and\
+    \ the Nation based on the implementation of agreed-upon security controls. Authorizing\
+    \ officials provide budgetary\noversight for organizational information systems\
+    \ or assume responsibility for the mission/business operations supported by those\
+    \ systems. The security authorization process is an inherently federal responsibility\
+    \ and therefore, authorizing officials must be federal employees. Through the\
+    \ security authorization process, authorizing officials assume responsibility\
+    \ and are accountable for security risks associated with the operation and use\
+    \ of organizational information systems. Accordingly, authorizing officials are\
+    \ in positions with levels of authority commensurate with understanding and accepting\
+    \ such information security-related risks. OMB policy requires that organizations\
+    \ conduct ongoing authorizations of information systems by implementing continuous\
+    \ monitoring programs. Continuous monitoring programs can satisfy three-year reauthorization\
+    \ requirements, so separate reauthorization processes are not necessary. Through\
+    \ the employment of comprehensive continuous monitoring processes, critical information\
+    \ contained in authorization packages (i.e., security plans, security assessment\
+    \ reports, and plans of action and milestones) is updated on an ongoing basis,\
+    \ providing authorizing officials and information system owners with an up-to-date\
+    \ status of the security state of organizational information systems and environments\
+    \ of operation. To reduce the administrative cost of security reauthorization,\
+    \ authorizing officials use the results of continuous monitoring processes to\
+    \ the maximum extent possible as the basis for rendering reauthorization decisions.\
+    \ Related controls: CA-2, CA-7, PM-9, PM-10.\n\nControl Enhancements:  None. \n\
+    \nReferences:  OMB Circular A-130; OMB Memorandum 11-33; NIST Special Publications\
+    \ 800-37, 800-137.\n\nCA-6 (c) [at least every three (3) years or when a significant\
+    \ change occurs] \nCA-6 (c) Guidance: Significant change is defined in NIST Special\
+    \ Publication 800-37 Revision 1, Appendix F. The service provider describes the\
+    \ types of changes to the information system or the environment of operations\
+    \ that would impact the risk posture. The types of changes are approved and accepted\
+    \ by the JAB/AO."
+  title: >-
+    CA-6 - SECURITY AUTHORIZATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-7
+  status: not applicable
+  notes: |-
+    Section a: The development and implementation of a continuous monitoring program
+    that includes the establishment of organization-defined metrics to be
+    monitored is an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: The development and implementation of a continuous monitoring program
+    that includes the establishment of organization-defined frequencies for
+    monitoring and assessment of such monitoring is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Engineering progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-364
+    Section d: Engineering progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-364
+    Section e: Engineering progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-364
+    Section f: Response actions to address results of the analysis of security-related
+    information is an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section g: Reporting the security status of organization and the information system
+    to organization-defined personnel or roles at a specified organization-defined
+    frequency is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization develops a continuous monitoring strategy and implements a continuous monitoring program that includes:
+     a. Establishment of [Assignment: organization-defined metrics] to be monitored;
+     b. Establishment of [Assignment: organization-defined frequencies] for monitoring and [Assignment: organization-defined frequencies] for assessments supporting such monitoring;
+     c. Ongoing security control assessments in accordance with the organizational continuous monitoring strategy;
+     d. Ongoing security status monitoring of organization-defined metrics in accordance with the organizational continuous monitoring strategy;
+     e. Correlation and analysis of security-related information generated by assessments and monitoring;
+     f. Response actions to address results of the analysis of security-related information; and
+     g. Reporting the security status of organization and the information system to [Assignment: organization-defined personnel or roles] [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Continuous monitoring programs facilitate ongoing awareness of threats, vulnerabilities, and information security to support organizational risk management decisions. The terms continuous and ongoing imply that organizations assess/analyze security controls and information security-related risks at a frequency sufficient to support organizational risk-based decisions. The results of continuous monitoring programs generate appropriate risk response actions by organizations. Continuous monitoring programs also allow organizations to maintain the security authorizations of information systems and common controls over time in highly dynamic environments of operation with changing mission/business needs, threats, vulnerabilities, and technologies. Having access to security-related information on a continuing basis through reports/dashboards gives organizational officials the capability to make more effective and timely risk management decisions, including ongoing security authorization decisions. Automation supports more frequent updates to security authorization packages, hardware/software/firmware inventories, and other system information. Effectiveness is further enhanced when continuous monitoring outputs are formatted to provide information that is specific, measurable, actionable, relevant, and timely. Continuous monitoring activities are scaled in accordance with the security categories of information systems. Related controls: CA-2, CA-5, CA-6, CM-3, CM-4, PM-6, PM-9, RA-5, SA-11, SA-12, SI-2, SI-4.
+
+    References: OMB Memorandum 11-33; NIST Special Publications 800-37, 800-39, 800-53A, 800-115, 800-137; US-CERT Technical Cyber Security Alerts; DoD Information Assurance Vulnerability Alerts.
+
+    CA-7 (g) [to meet Federal and FedRAMP requirements]
+    CA-7 Requirement: Operating System Scans: at least monthly. Database and Web Application Scans: at least monthly. All scans performed by Independent Assessor: at least annually
+    CA-7 Guidance: CSPs must provide evidence of closure and remediation of high vulnerabilities within the timeframe for standard POA&M updates.
+    CA-7 Guidance: See the FedRAMP Documents page under Key Cloud Service
+    Provider (CSP) Documents> Continuous Monitoring Strategy Guide
+    https://www.FedRAMP.gov/documents/
+  title: >-
+    CA-7 - CONTINUOUS MONITORING
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-7(1)
+  status: not applicable
+  notes: |-
+    Employment of assessors or assessment teams is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: |-
+    The organization employs assessors or assessment teams with [Assignment: organization-defined level of independence] to monitor the security controls in the information system on an ongoing basis.
+
+    Supplemental Guidance:  Organizations can maximize the value of assessments of security controls during the continuous monitoring process by requiring that such assessments be conducted by assessors or assessment teams with appropriate levels of independence based on continuous monitoring strategies. Assessor independence provides a degree of impartiality to the monitoring process. To achieve such impartiality, assessors should not: (i) create a mutual or conflicting interest with the organizations where the assessments are being conducted; (ii) assess their own work; (iii) act as management or employees of the organizations they are serving; or (iv) place themselves in advocacy positions for the organizations acquiring their services.
+  title: >-
+    CA-7(1) - CONTINUOUS MONITORING | INDEPENDENT ASSESSMENT
+  levels:
+  - high
+  - moderate
+- id: CA-7(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CA-7(3)
+  status: not applicable
+  notes: |-
+    Organizational trend analyses processes are
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+  rules: []
+  description: |-
+    The organization employs trend analyses to determine if security control implementations, the frequency of continuous monitoring activities, and/or the types of activities used in the continuous monitoring process need to be modified based on empirical data.
+
+    Supplemental Guidance:  Trend analyses can include, for example, examining recent threat information regarding the types of threat events that have occurred within the organization or across the federal government, success rates of certain types of cyber attacks, emerging vulnerabilities in information technologies, evolving social engineering techniques, results from multiple security control assessments, the effectiveness of configuration settings, and findings from Inspectors General or auditors.
+  title: >-
+    CA-7(3) - CONTINUOUS MONITORING | TREND ANALYSES
+  levels:
+  - high
+- id: CA-8
+  status: not applicable
+  notes: |-
+    Penetration testing is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: "The organization conducts penetration testing [Assignment: organization-defined\
+    \ frequency] on [Assignment: organization-defined information systems or system\
+    \ components].\n\nSupplemental Guidance:  Penetration testing is a specialized\
+    \ type of assessment conducted on information systems or individual system components\
+    \ to identify vulnerabilities that could be exploited by adversaries. Such testing\
+    \ can be used to either validate vulnerabilities or determine the degree of resistance\
+    \ organizational information systems have to adversaries within a set of specified\
+    \ constraints (e.g., time, resources, and/or skills). Penetration testing attempts\
+    \ to duplicate\nthe actions of adversaries in carrying out hostile cyber attacks\
+    \ against organizations and provides a more in-depth analysis of security-related\
+    \ weaknesses/deficiencies. Organizations can also use the results of vulnerability\
+    \ analyses to support penetration testing activities. Penetration testing can\
+    \ be conducted on the hardware, software, or firmware components of an information\
+    \ system and can exercise both physical and technical security controls. A standard\
+    \ method for penetration testing includes, for example: (i) pretest analysis based\
+    \ on full knowledge of the target system; (ii) pretest identification of potential\
+    \ vulnerabilities based on pretest analysis; and (iii) testing designed to determine\
+    \ exploitability of identified vulnerabilities. All parties agree to the rules\
+    \ of engagement before the commencement of penetration testing scenarios. Organizations\
+    \ correlate the penetration testing rules of engagement with the tools, techniques,\
+    \ and procedures that are anticipated to be employed by adversaries carrying out\
+    \ attacks. Organizational risk assessments guide decisions on the level of independence\
+    \ required for personnel conducting penetration testing. Related control: SA-12.\n\
+    \nReferences: None.\n\nCA-8-1 [at least annually]\nGuidance: See the FedRAMP Documents\
+    \ page under Key Cloud Service Provider (CSP) Documents> Penetration Test Guidance\
+    \ \nhttps://www.FedRAMP.gov/documents/"
+  title: >-
+    CA-8 - PENETRATION TESTING
+  levels:
+  - high
+  - moderate
+- id: CA-8(1)
+  status: not applicable
+  notes: |-
+    Employment of independent penetration testers
+    is out of scope for Red Hat Advanced Cluster Management for Kubernetes configuration
+    guidance.
+  rules: []
+  description: |-
+    The organization employs an independent penetration agent or penetration team to perform penetration testing on the information system or system components.
+
+    Supplemental Guidance:  Independent penetration agents or teams are individuals or groups who conduct impartial penetration testing of organizational information systems. Impartiality implies that penetration agents or teams are free from any perceived or actual conflicts of interest with regard to the development, operation, or management of the information systems that are the targets of the penetration testing. Supplemental guidance for CA-2 (1) provides additional information regarding independent assessments that can be applied to penetration testing. Related control: CA-2.
+  title: >-
+    CA-8(1) - PENETRATION TESTING | INDEPENDENT PENETRATION AGENT OR TEAM
+  levels:
+  - high
+  - moderate
+- id: CA-8(2)
+  status: not applicable
+  notes: |-
+    Red Team Exercises are out of scope for
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+- id: CA-9
+  status: pending
+  notes: |-
+    Section a: Authorizing internal connections of organization-defined information system components
+    or classes of components] to the information system is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Documenting, for each internal connection, the interface characteristics, security
+    requirements, and the nature of the information communicated is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Authorizes internal connections of [Assignment: organization-defined information system components or classes of components] to the information system; and
+     b. Documents, for each internal connection, the interface characteristics, security requirements, and the nature of the information communicated.
+
+    Supplemental Guidance:  This control applies to connections between organizational information systems and (separate) constituent system components (i.e., intra-system connections) including, for example, system connections with mobile devices, notebook/desktop computers, printers, copiers, facsimile machines, scanners, sensors, and servers. Instead of authorizing each individual internal connection, organizations can authorize internal connections for a class of components with common characteristics and/or configurations, for example, all digital printers, scanners, and copiers with a specified processing, storage, and transmission capability or all smart phones with a specific baseline configuration. Related controls: AC-3, AC-4, AC-18, AC-19, AU-2, AU-12, CA-7, CM-2, IA-3, SC-7, SI-4.
+
+    References: None.
+  title: >-
+    CA-9 - INTERNAL SYSTEM CONNECTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-9(1)
+  status: not applicable
+  notes: |-
+    The information system performing security compliance checks on constituent system
+    components prior to the establishment of the internal connection is not applicable to
+    Red Hat Advanced Cluster Management for Kubernetes since it relies on OpenShift to
+    manage internal system connections.
+  rules: []
+- id: CM-1
+  status: not applicable
+  notes: |-
+    Section a: Developing, documenting, and disseminating an organizational configuration
+    management policy is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section b: Review and update procedures to the organizational configuration
+    management policy is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A configuration management policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the configuration management policy and associated configuration management controls; and
+     b. Reviews and updates the current:
+       1. Configuration management policy [Assignment: organization-defined frequency]; and
+       2. Configuration management procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the CM family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    CM-1 (b) (1) [at least annually]
+    CM-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    CM-1 - CONFIGURATION MANAGEMENT POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-2
+  status: not applicable
+  notes: |-
+    The recommended approach for configuration management for Red Hat Advanced Cluster
+    Management for Kubernetes (RHACM) is to implement the principles and patterns of GitOps
+
+    GitOps uses Git pull requests to manage infrastructure and application configurations.
+    The Git repository is considered the only source of truth and contains the
+    entire state of the system so that the trail of changes to the system state are
+    visible and auditable.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) contains capabilities and
+    functionality to manage GitOps for OpenShift clusters and applications including
+    Red Hat Advanced Cluster Management for Kubernetes. For more information on creating and
+    managing channels for GitOps approaches using RHACM, see:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels
+  rules: []
+  description: |-
+    The organization develops, documents, and maintains under configuration control, a current baseline configuration of the information system.
+
+    Supplemental Guidance:  This control establishes baseline configurations for information systems and system components including communications and connectivity-related aspects of systems. Baseline configurations are documented, formally reviewed and agreed-upon sets of specifications for information systems or configuration items within those systems. Baseline configurations serve as a basis for future builds, releases, and/or changes to information systems. Baseline configurations include information about information system components (e.g., standard software packages installed on workstations, notebook computers, servers, network components, or mobile devices; current version numbers and patch information on operating systems and applications; and configuration settings/parameters), network topology, and the logical placement of those components within the system architecture. Maintaining baseline configurations requires creating new baselines as organizational information systems change over time. Baseline configurations of information systems reflect the current enterprise architecture. Related controls: CM-3, CM-6, CM-8, CM-9, SA-10, PM-5, PM-7.
+
+    References: NIST Special Publication 800-128.
+  title: >-
+    CM-2 - BASELINE CONFIGURATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-2(1)
+  status: not applicable
+  notes: |-
+    Section a: The organization reviewing and updating the baseline configuration of
+    Red Hat Advanced Cluster Management for Kubernetes per an organization-defined frequency is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    However to assist in formulating a control response,
+    GitOps uses Git pull requests to manage infrastructure and application configurations.
+    The Git repository is considered the only source of truth and contains the
+    entire state of the system so that the trail of changes to the system state are
+    visible and auditable.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) contains capabilities and
+    functionality to manage GitOps for OpenShift clusters and applications including
+    Red Hat Advanced Cluster Management for Kubernetes. For more information on creating and
+    managing channels for GitOps approaches using RHACM, see:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels
+    Section b: The organization reviewing and updating the baseline configuration of Red Hat Advanced
+    Cluster Management for Kubernetes when required due to organization-defined circumstances
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    However to assist in formulating a control response,
+    GitOps uses Git pull requests to manage infrastructure and application configurations.
+    The Git repository is considered the only source of truth and contains the
+    entire state of the system so that the trail of changes to the system state are
+    visible and auditable.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) contains capabilities and
+    functionality to manage GitOps for OpenShift clusters and applications including
+    Red Hat Advanced Cluster Management for Kubernetes. For more information on creating and
+    managing channels for GitOps approaches using RHACM, see:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels
+    Section c: The organization reviewing and updating the baseline configuration of Red Hat Advanced
+    Cluster Management as an integral part of Red Hat Advanced Cluster Management for
+    Kubernetes component installations and upgrades is outside the scope of Red Hat Advanced
+    Cluster Management configuration.
+
+    However to assist in formulating a control response,
+    GitOps uses Git pull requests to manage infrastructure and application configurations.
+    The Git repository is considered the only source of truth and contains the
+    entire state of the system so that the trail of changes to the system state are
+    visible and auditable.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) contains capabilities and
+    functionality to manage GitOps for OpenShift clusters and applications including
+    Red Hat Advanced Cluster Management for Kubernetes. For more information on creating and
+    managing channels for GitOps approaches using RHACM, see:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels
+  rules: []
+  description: "The organization reviews and updates the baseline configuration of\
+    \ the information system: \n (a)   [Assignment: organization-defined frequency];\n\
+    \ (b)   When required due to [Assignment organization-defined circumstances];\
+    \ and\n (c)   As an integral part of information system component installations\
+    \ and upgrades.\n\nSupplemental Guidance:  Related control: CM-5.\n\nCM-2 (1)\
+    \ (a) [at least annually or when a significant change occurs]\nCM-2 (1) (b) [to\
+    \ include when  directed by the JAB]\n CM-2 (1) (a) Guidance: Significant change\
+    \ is defined in NIST Special Publication 800-37 Revision 1, Appendix F, page F-7."
+  title: >-
+    CM-2(1) - BASELINE CONFIGURATION | REVIEWS AND UPDATES
+  levels:
+  - high
+  - moderate
+- id: CM-2(2)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-357
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to maintain an up-to-date, complete, accurate, and readily available baseline configuration of the information system.
+
+    Supplemental Guidance:  Automated mechanisms that help organizations maintain consistent baseline configurations for information systems include, for example, hardware and software inventory tools, configuration management tools, and network management tools. Such tools can be deployed and/or allocated as common controls, at the information system level, or at the operating system or component level (e.g., on workstations, servers, notebook computers, network components, or mobile devices). Tools can be used, for example, to track version numbers on operating system applications, types of software installed, and current patch levels. This control enhancement can be satisfied by the implementation of CM-8 (2) for organizations that choose to combine information system component inventory and baseline configuration activities. Related controls: CM-7, RA-5.
+  title: >-
+    CM-2(2) - BASELINE CONFIGURATION | AUTOMATION SUPPORT FOR ACCURACY / CURRENCY
+  levels:
+  - high
+  - moderate
+- id: CM-2(3)
+  status: not applicable
+  notes: |-
+    The organization retaining an organization-defined number of previous versions of baseline
+    configurations of the information system to support rollback is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management configuration.
+
+    However to assist in formulating a control response,
+    GitOps uses Git pull requests to manage infrastructure and application configurations.
+    The Git repository is considered the only source of truth and contains the
+    entire state of the system so that the trail of changes to the system state are
+    visible and auditable.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) contains capabilities and
+    functionality to manage GitOps for OpenShift clusters and applications including
+    Red Hat Advanced Cluster Management for Kubernetes. For more information on creating and
+    managing channels for GitOps approaches using RHACM, see:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/manage_applications/index#creating-and-managing-channels
+  rules: []
+  description: |-
+    The organization retains [Assignment: organization-defined previous versions of baseline configurations of the information system] to support rollback.
+
+    Supplemental Guidance:  Retaining previous versions of baseline configurations to support rollback may include, for example, hardware, software, firmware, configuration files, and configuration records.
+
+    CM-2 (3) [organization-defined previous versions of baseline configurations of the previously approved baseline configuration of IS components]
+  title: >-
+    CM-2(3) - BASELINE CONFIGURATION | RETENTION OF PREVIOUS CONFIGURATIONS
+  levels:
+  - high
+  - moderate
+- id: CM-2(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CM-2(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CM-2(6)
+  status: pending
+  notes: |-
+    The organization maintainings a baseline configuration for information system development
+    and test environments that is managed separately from the operational baseline
+    configuration are organizational processes/procedures outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CM-2(7)
+  status: not applicable
+  notes: |-
+    Section a: Organizational issuance of organization-defined information
+    systems, system components, or devices with organizational-defined
+    configurations to individuals traveling to locations that the
+    organization deems to be of significant risk is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational processes to apply organization-defined security
+    safeguards to the devices when the individuals return is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Issues [Assignment: organization-defined information systems, system components, or devices] with [Assignment: organization-defined configurations] to individuals traveling to locations that the organization deems to be of significant risk; and
+     (b)   Applies [Assignment: organization-defined security safeguards] to the devices when the individuals return.
+
+    Supplemental Guidance:  When it is known that information systems, system components, or devices (e.g., notebook computers, mobile devices) will be located in high-risk areas, additional security controls may be implemented to counter the greater threat in such areas coupled with the lack of physical security relative to organizational-controlled areas. For example, organizational policies and procedures for notebook computers used by individuals departing on and returning from travel include, for example, determining which locations are of concern, defining required configurations for the devices, ensuring that the devices are configured as intended before travel is initiated, and applying specific safeguards to the device after travel is completed. Specially configured notebook computers include, for
+    example, computers with sanitized hard drives, limited applications, and additional hardening (e.g., more stringent configuration settings). Specified safeguards applied to mobile devices upon return from travel include, for example, examining the device for signs of physical tampering and purging/reimaging the hard disk drive. Protecting information residing on mobile devices is covered in the media protection family..\
+  title: >-
+    CM-2(7) - BASELINE CONFIGURATION | CONFIGURE SYSTEMS, COMPONENTS, OR DEVICES FOR
+    HIGH-RISK AREAS
+  levels:
+  - high
+  - moderate
+- id: CM-3
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-265
+    Section b: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-265
+    Section c: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-265
+    Section d: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-265
+    Section e: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-265
+    Section f: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-265
+    Section g: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+  rules: []
+  description: |-
+    The organization:
+     a. Determines the types of changes to the information system that are configuration-controlled;
+     b. Reviews proposed configuration-controlled changes to the information system and approves or disapproves such changes with explicit consideration for security impact analyses;
+     c. Documents configuration change decisions associated with the information system;
+     d. Implements approved configuration-controlled changes to the information system;
+     e. Retains records of configuration-controlled changes to the information system for [Assignment: organization-defined time period];
+     f. Audits and reviews activities associated with configuration-controlled changes to the information system; and
+     g. Coordinates and provides oversight for configuration change control activities through [Assignment: organization-defined configuration change control element (e.g., committee, board] that convenes [Selection (one or more): [Assignment: organization-defined frequency]; [Assignment: organization-defined configuration change conditions]].
+
+    Supplemental Guidance:  Configuration change controls for organizational information systems involve the systematic proposal, justification, implementation, testing, review, and disposition of changes to the systems, including system upgrades and modifications. Configuration change control includes changes to baseline configurations for components and configuration items of information systems, changes to configuration settings for information technology products (e.g., operating systems, applications, firewalls, routers, and mobile devices), unscheduled/unauthorized changes, and changes to remediate vulnerabilities. Typical processes for managing configuration changes to information systems include, for example, Configuration Control Boards that approve proposed changes to systems. For new development information systems or systems undergoing major upgrades, organizations consider including representatives from development organizations on the Configuration Control Boards. Auditing of changes includes activities before and after changes are made to organizational information systems and the auditing activities required to implement such changes. Related controls: CM-2, CM-4, CM-5, CM-6, CM-9, SA-10, SI-2, SI-12.
+
+    References: NIST Special Publication 800-128.
+
+    CM-3 Requirement: The service provider establishes a central means of communicating major changes to or developments in the information system or environment of operations that may affect its services to the federal government and associated service consumers (e.g., electronic bulletin board, web status page). The means of communication are approved and accepted by the JAB/AO.
+    CM-3 (e) Guidance: In accordance with record retention policies and procedures.
+  title: >-
+    CM-3 - CONFIGURATION CHANGE CONTROL
+  levels:
+  - high
+  - moderate
+- id: CM-3(1)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section b: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section c: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section d: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section e: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+    Section f: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: "The organization employs automated mechanisms to:\n (a)   Document\
+    \ proposed changes to the information system;\n (b)   Notify [Assignment: organized-defined\
+    \ approval authorities] of proposed changes to the information system and request\
+    \ change approval;\n (c)   Highlight proposed changes to the information system\
+    \ that have not been approved or disapproved by [Assignment: organization-defined\
+    \ time period];\n (d)   Prohibit changes to the information system until designated\
+    \ approvals are received; \n (e)   Document all changes to the information system;\
+    \ and\n (f) Notify [Assignment: organization-defined personnel] when approved\
+    \ changes to the information system are completed.\n\nCM-3 (1) (c)  [organization\
+    \ agreed upon time period] \nCM-3 (1) (f) [organization defined configuration\
+    \ management approval authorities]"
+  title: >-
+    CM-3(1) - CONFIGURATION CHANGE CONTROL | AUTOMATED DOCUMENT / NOTIFICATION / PROHIBITION
+    OF CHANGES
+  levels:
+  - high
+- id: CM-3(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: |-
+    The organization tests, validates, and documents changes to the information system before implementing the changes on the operational system.
+
+    Supplemental Guidance:  Changes to information systems include modifications to hardware, software, or firmware components and configuration settings defined in CM-6. Organizations ensure that testing does not interfere with information system operations. Individuals/groups conducting tests understand organizational security policies and procedures, information system security policies and procedures, and the specific health, safety, and environmental risks associated with particular facilities/processes. Operational systems may need to be taken off-line, or replicated to the extent feasible, before testing can be conducted. If information systems must be taken off-line for testing, the tests are scheduled to occur during planned system outages whenever possible. If testing cannot be conducted on operational systems, organizations employ compensating controls (e.g., testing on replicated systems).
+  title: >-
+    CM-3(2) - CONFIGURATION CHANGE CONTROL | TEST / VALIDATE / DOCUMENT CHANGES
+  levels:
+  - high
+- id: CM-3(3)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/CMP-266
+  rules: []
+- id: CM-3(4)
+  status: not applicable
+  notes: |-
+    The requirement for an information security representative to be
+    a member of the organization-defined configuration change
+    control element is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization requires an information security representative to be a member of the [Assignment: organization-defined configuration change control element].
+
+    Supplemental Guidance:  Information security representatives can include, for example, senior agency information security officers, information system security officers, or information system security managers. Representation by personnel with information security expertise is important because changes to information system configurations can have unintended side effects, some of which may be security-relevant. Detecting such changes early in the process can help avoid unintended, negative consequences that could ultimately affect the security state of organizational information systems. The configuration change control element in this control enhancement reflects the change control elements defined by organizations in CM-3.
+
+    CM-3 (4) Configuration control board (CCB) or similar (as defined in CM-3)
+  title: >-
+    CM-3(4) - CONFIGURATION CHANGE CONTROL | SECURITY REPRESENTATIVE
+  levels:
+  - high
+- id: CM-3(5)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes implementing organization-defined
+    security responses automatically if baseline configurations are changed in an unauthorized
+    manner is outside the scope of the Red Hat Advanced Cluster Management for Kubernetes
+    application, and a third-party product should be used to satisfy this control.
+  rules: []
+- id: CM-3(6)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+  rules: []
+  description: |-
+    The organization ensures that cryptographic mechanisms used to provide [Assignment: organization-defined security safeguards] are under configuration management.
+
+    Supplemental Guidance:  Regardless of the cryptographic means employed (e.g., public key, private key, shared secrets), organizations ensure that there are processes and procedures in place to effectively manage those means. For example, if devices use certificates as a basis for identification and authentication, there needs to be a process in place to address the expiration of those certificates. Related control: SC-13.
+
+    CM-3 (6) All security safeguards that rely on cryptography
+  title: >-
+    CM-3(6) - CONFIGURATION CHANGE CONTROL | CRYPTOGRAPHY MANAGEMENT
+  levels:
+  - high
+- id: CM-4
+  status: not applicable
+  notes: |-
+    Organizational analysis of changes to the information system to
+    determine potential security impacts prior to change implementation
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization analyzes changes to the information system to determine potential security impacts prior to change implementation.
+
+    Supplemental Guidance:  Organizational personnel with information security responsibilities (e.g., Information System Administrators, Information System Security Officers, Information System Security Managers, and Information System Security Engineers) conduct security impact analyses. Individuals conducting security impact analyses possess the necessary skills/technical expertise to analyze the changes to information systems and the associated security ramifications. Security impact analysis may include, for example, reviewing security plans to understand security control requirements and reviewing system design documentation to understand control implementation and how specific changes might affect the controls. Security impact analyses may also include assessments of risk to better understand the impact of the changes and to determine if additional security controls are required. Security impact analyses are scaled in accordance with the security categories of the information systems. Related controls: CA-2, CA-7, CM-3, CM-9, SA-4, SA-5, SA-10, SI-2.
+
+    References: NIST Special Publication 800-128.
+  title: >-
+    CM-4 - SECURITY IMPACT ANALYSIS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-4(1)
+  status: not applicable
+  notes: |-
+    The organization analyzing changes to the information system in a separate test environment
+    before implementation in an operational environment, looking for security impacts due to
+    flaws, weaknesses, incompatibility, or intentional malice is an organizational
+    policy/procedure outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization analyzes changes to the information system in a separate test environment before implementation in an operational environment, looking for security impacts due to flaws, weaknesses, incompatibility, or intentional malice.
+
+    Supplemental Guidance:  Separate test environment in this context means an environment that is physically or logically isolated and distinct from the operational environment. The separation is sufficient to ensure that activities in the test environment do not impact activities in the operational environment, and information in the operational environment is not inadvertently transmitted to the test environment. Separate environments can be achieved by physical or logical means. If physically separate test environments are not used, organizations determine the strength of mechanism required when implementing logical separation (e.g., separation achieved through virtual machines). Related controls: SA-11, SC-3, SC-7.
+  title: >-
+    CM-4(1) - SECURITY IMPACT ANALYSIS | SEPARATE TEST ENVIRONMENTS
+  levels:
+  - high
+- id: CM-4(2)
+  status: not applicable
+  notes: |-
+    Verification of security function implementation and status is an organizational
+    policy and procedure control. This functionality is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CM-5
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-358
+  rules: []
+  description: |-
+    The organization defines, documents, approves, and enforces physical and logical access restrictions associated with changes to the information system.
+
+    Supplemental Guidance:  Any changes to the hardware, software, and/or firmware components of information systems can potentially have significant effects on the overall security of the systems. Therefore, organizations permit only qualified and authorized individuals to access information systems for purposes of initiating changes, including upgrades and modifications. Organizations maintain records of access to ensure that configuration change control is implemented and to support after-the-fact actions should organizations discover any unauthorized changes. Access restrictions for change also include software libraries. Access restrictions include, for example, physical and logical access controls (see AC-3 and PE-3), workflow automation, media libraries, abstract layers (e.g., changes implemented into third-party interfaces rather than directly into information systems), and change windows (e.g., changes occur only during specified times, making unauthorized changes easy to discover). Related controls: AC-3, AC-6, PE-3.
+
+    References: None.
+  title: >-
+    CM-5 - ACCESS RESTRICTIONS FOR CHANGE
+  levels:
+  - high
+  - moderate
+- id: CM-5(1)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-359
+  rules: []
+  description: |-
+    The information system enforces access restrictions and supports auditing of the enforcement actions.
+
+    Supplemental Guidance:  Related controls: AU-2, AU-12, AU-6, CM-3, CM-6.
+  title: >-
+    CM-5(1) - ACCESS RESTRICTIONS FOR CHANGE | AUTOMATED ACCESS ENFORCEMENT / AUDITING
+  levels:
+  - high
+  - moderate
+- id: CM-5(2)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-360
+  rules: []
+  description: |-
+    The organization reviews information system changes [Assignment: organization-defined frequency] and [Assignment: organization-defined circumstances] to determine whether unauthorized changes have occurred.
+
+    Supplemental Guidance:  Indications that warrant review of information system changes and the specific circumstances justifying such reviews may be obtained from activities carried out by organizations during the configuration change process. Related controls: AU-6, AU-7, CM-3, CM-5, PE-6, PE-8.
+
+    CM-5 (2) [at least every thirty (30) days]
+  title: >-
+    CM-5(2) - ACCESS RESTRICTIONS FOR CHANGE | REVIEW SYSTEM CHANGES
+  levels:
+  - high
+- id: CM-5(3)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-361
+  rules: []
+  description: |-
+    The information system prevents the installation of [Assignment: organization-defined software and firmware components] without verification that the component has been digitally signed using a certificate that is recognized and approved by the organization.
+
+    Supplemental Guidance:  Software and firmware components prevented from installation unless signed with recognized and approved certificates include, for example, software and firmware version updates, patches, service packs, device drivers, and basic input output system (BIOS) updates. Organizations can identify applicable software and firmware components by type, by specific items, or a combination of both. Digital signatures and organizational verification of such signatures, is a method of code authentication. Related controls: CM-7, SC-13, SI-7.
+
+    CM-5 (3) Guidance: If digital signatures/certificates are unavailable, alternative cryptographic integrity checks (hashes, self-signed certs, etc.) can be utilized.
+  title: >-
+    CM-5(3) - ACCESS RESTRICTIONS FOR CHANGE | SIGNED COMPONENTS
+  levels:
+  - high
+  - moderate
+- id: CM-5(4)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: CM-5(5)
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+    Section b: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Limits privileges to change information system components and system-related information within a production or operational environment; and
+     (b)   Reviews and reevaluates privileges [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  In many organizations, information systems support multiple core missions/business functions. Limiting privileges to change information system components with respect to operational systems is necessary because changes to a particular information system component may have far-reaching effects on mission/business processes supported by the system where the component resides. The complex, many-to-many relationships between systems and mission/business processes are in some cases, unknown to developers. Related control: AC-2.
+
+    CM-5 (5) (b) [at least quarterly]
+  title: >-
+    CM-5(5) - ACCESS RESTRICTIONS FOR CHANGE | LIMIT PRODUCTION /
+
+    OPERATIONAL PRIVILEGES
+  levels:
+  - high
+  - moderate
+- id: CM-5(6)
+  status: pending
+  notes: |-
+    This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+- id: CM-5(7)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CM-6
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-365
+    Section b: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-365
+    Section c: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-365
+    Section d: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-365
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes and documents configuration settings for information technology products employed within the information system using [Assignment: organization-defined security configuration checklists] that reflect the most restrictive mode consistent with operational requirements;
+     b. Implements the configuration settings;
+     c. Identifies, documents, and approves any deviations from established configuration settings for [Assignment: organization-defined information system components] based on [Assignment: organization-defined operational requirements]; and
+     d. Monitors and controls changes to the configuration settings in accordance with organizational policies and procedures.
+
+    Supplemental Guidance:  Configuration settings are the set of parameters that can be changed in hardware, software, or firmware components of the information system that affect the security posture and/or functionality of the system. Information technology products for which security- related configuration settings can be defined include, for example, mainframe computers, servers (e.g., database, electronic mail, authentication, web, proxy, file, domain name), workstations, input/output devices (e.g., scanners, copiers, and printers), network components (e.g., firewalls, routers, gateways, voice and data switches, wireless access points, network appliances, sensors), operating systems, middleware, and applications. Security-related parameters are those parameters impacting the security state of information systems including the parameters required to satisfy other security control requirements. Security-related parameters include, for example: (i) registry settings; (ii) account, file, directory permission settings; and (iii) settings for functions, ports, protocols, services, and remote connections. Organizations establish organization-wide configuration settings and subsequently derive specific settings for information systems. The established settings become part of the systems configuration baseline.
+
+    Common secure configurations (also referred to as security configuration checklists, lockdown
+    and hardening guides, security reference guides, security technical implementation guides) provide recognized, standardized, and established benchmarks that stipulate secure configuration settings for specific information technology platforms/products and instructions for configuring those information system components to meet operational requirements. Common secure configurations can be developed by a variety of organizations including, for example, information technology product developers, manufacturers, vendors, consortia, academia, industry, federal agencies, and other organizations in the public and private sectors. Common secure configurations include the United States Government Configuration Baseline (USGCB) which affects the implementation of CM-6 and other controls such as AC-19 and CM-7. The Security Content Automation Protocol (SCAP) and the defined standards within the protocol (e.g., Common Configuration Enumeration) provide an effective method to uniquely identify, track, and control configuration settings. OMB establishes federal policy on configuration requirements for federal information systems. Related controls: AC-19, CM-2, CM-3, CM-7, SI-4.
+
+    References: OMB Memoranda 07-11, 07-18, 08-22; NIST Special Publications 800-70, 800-128; Web: http://nvd.nist.gov, http://checklists.nist.gov, http://www.nsa.gov.
+
+    CM-6 (a) [United States Government Configuration Baseline (USGCB)]
+    CM-6 (a) Requirement 1: The service provider shall use the Center for Internet Security guidelines (Level 1) to establish configuration settings or establishes its own configuration settings if USGCB is not available.
+    CM-6 (a) Requirement 2: The service provider shall ensure that checklists for configuration settings are Security Content Automation Protocol (SCAP) validated or SCAP compatible (if validated checklists are not available).
+    CM-6 (a) Guidance: Information on the USGCB checklists can be found at: http://usgcb.nist.gov/usgcb_faq.html#usgcbfaq_usgcbfdcc
+  title: >-
+    CM-6 - CONFIGURATION SETTINGS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-6(1)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-366
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to centrally manage, apply, and verify configuration settings for [Assignment: organization-defined information system components].
+
+    Supplemental Guidance:  Related controls: CA-7, CM-4.
+  title: >-
+    CM-6(1) - CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION
+    / VERIFICATION
+  levels:
+  - high
+  - moderate
+- id: CM-6(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+  description: |-
+    The organization employs [Assignment: organization-defined security safeguards] to respond to unauthorized changes to [Assignment: organization-defined configuration settings].
+
+    Supplemental Guidance:  Responses to unauthorized changes to configuration settings can include, for example, alerting designated organizational personnel, restoring established configuration settings, or in extreme cases, halting affected information system processing. Related controls: IR-4, SI-7.
+  title: >-
+    CM-6(2) - CONFIGURATION SETTINGS | RESPOND TO UNAUTHORIZED CHANGES
+  levels:
+  - high
+- id: CM-6(3)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CM-6(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CM-7
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-367
+    Section b: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-367
+  rules: []
+  description: "The organization:\n a. Configures the information system to provide\
+    \ only essential capabilities; and\n b. Prohibits or restricts the use of the\
+    \ following functions, ports, protocols, and/or services: [Assignment: organization-defined\
+    \ prohibited or restricted functions, ports, protocols, and/or services].\n\n\
+    Supplemental Guidance:  Information systems can provide a wide variety of functions\
+    \ and services. Some of the functions and services, provided by default, may not\
+    \ be necessary to support essential organizational operations (e.g., key missions,\
+    \ functions). Additionally, it is sometimes convenient to provide multiple services\
+    \ from single information system components, but doing so increases risk over\
+    \ limiting the services provided by any one component. Where feasible, organizations\
+    \ limit component functionality to a single function per device (e.g., email servers\
+    \ or web servers, but not both). Organizations review functions and services provided\
+    \ by information systems or individual components of information systems, to determine\
+    \ which functions and services are candidates for elimination (e.g., Voice Over\
+    \ Internet Protocol, Instant Messaging, auto-execute, and file sharing). Organizations\
+    \ consider disabling unused or unnecessary physical and logical ports/protocols\
+    \ (e.g., Universal Serial Bus, File Transfer Protocol, and Hyper Text Transfer\
+    \ Protocol) on information systems to prevent unauthorized connection of devices,\
+    \ unauthorized transfer of information, or unauthorized tunneling. Organizations\
+    \ can utilize network scanning tools, intrusion detection and prevention systems,\
+    \ and end-point protections such as firewalls and host-based intrusion detection\
+    \ systems to identify and prevent the use of prohibited functions, ports, protocols,\
+    \ and services. Related controls: AC-6, CM-2, RA-5, SA-5, SC-7.\n\nReferences:\
+    \ DoD Instruction 8551.01.\n\nCM-7 (b) [United States Government Configuration\
+    \ Baseline (USGCB)] \nCM-7 (b) Requirement: The service provider shall use the\
+    \ Center for Internet Security guidelines (Level 1) to establish list of prohibited\
+    \ or restricted functions, ports, protocols, and/or services or establishes its\
+    \ own list of prohibited or restricted functions, ports, protocols, and/or services\
+    \ if USGCB is not available.\nCM-7 Guidance: Information on the USGCB checklists\
+    \ can be found at: http://usgcb.nist.gov/usgcb_faq.html#usgcbfaq_usgcbfdcc.\n\
+    (Partially derived from AC-17(8).)"
+  title: >-
+    CM-7 - LEAST FUNCTIONALITY
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-7(1)
+  status: not applicable
+  notes: |-
+    Section a: The organization reviewing the information system per organization-defined frequency to
+    identify unnecessary and/or nonsecure functions, ports, protocols, and services is
+    an organizational process/procedure outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: The organization disabling organization-defined functions, ports, protocols, and services
+    within the information system deemed to be unnecessary and/or nonsecure is
+    an organizational process/procedure outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Reviews the information system [Assignment: organization-defined frequency] to identify unnecessary and/or nonsecure functions, ports, protocols, and services; and
+     (b)   Disables [Assignment: organization-defined functions, ports, protocols, and services within the information system deemed to be unnecessary and/or nonsecure].
+
+    Supplemental Guidance:  The organization can either make a determination of the relative security of the function, port, protocol, and/or service or base the security decision on the assessment of other entities. Bluetooth, FTP, and peer-to-peer networking are examples of less than secure protocols. Related controls: AC-18, CM-7, IA-2.
+
+    CM-7 (1) (a) [at least monthly]
+  title: >-
+    CM-7(1) - LEAST FUNCTIONALITY | PERIODIC REVIEW
+  levels:
+  - high
+  - moderate
+- id: CM-7(2)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-368
+  rules: []
+  description: "The information system prevents program execution in accordance with\
+    \ [Selection (one or more): [Assignment: organization-defined policies regarding\
+    \ software program usage and restrictions]; rules authorizing the terms and conditions\
+    \ of software program usage].\n\nSupplemental Guidance:  Related controls: CM-8,\
+    \ PM-5.\n\n \nCM-7 (2) Guidance: This control shall be implemented in a technical\
+    \ manner on the information system to only allow programs to run that adhere to\
+    \ the policy (i.e. white listing). This control is not to be based off of strictly\
+    \ written policy on what is allowed or not allowed to run."
+  title: >-
+    CM-7(2) - LEAST FUNCTIONALITY | PREVENT PROGRAM EXECUTION
+  levels:
+  - high
+  - moderate
+- id: CM-7(3)
+  status: not applicable
+  notes: |-
+    The customer is responsible for ensuring compliance with organization-defined registration
+    requirements for functions, ports, protocols, and services.
+  rules: []
+- id: CM-7(4)
+  status: not applicable
+  notes: |-
+    Section a: The customer is responsible for identifying organization-defined software programs not
+    authorized to execute on the information system.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the OpenShift operating layer
+    to provide unauthorized software support in preventing unauthorized applications from
+    running on the cluster and in a container through deny listing methods.
+    Section b: The customer is responsible for employing an allow-all, deny-by-exception policy to
+    prohibit the execution of unauthorized software programs on the information system.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the OpenShift operating layer
+    to provide unauthorized software support in preventing unauthorized applications from
+    running on the cluster and in a container through deny listing methods.
+    Section c: The customer is responsible for reviewing and updating the list of unauthorized software
+    programs per an organization-defined frequency.
+  rules: []
+- id: CM-7(5)
+  status: not applicable
+  notes: |-
+    Section a: The customer is responsible for identifying organization-defined software programs
+    authorized to execute on the information system.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the OpenShift operating layer
+    to provide authorized software support in allowing authorized applications from
+    running on the cluster and in a container through allow listing methods.
+    Section b: The customer is responsible for employing an allow-all, deny-by-exception policy to allow
+    the execution of unauthorized software programs on the information system.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the OpenShift operating layer
+    to provide authorized software support in allowing authorized applications from
+    running on the cluster and in a container through allow listing methods.
+    Section c: The customer is responsible for reviewing and updating the list of authorized software
+    programs per an organization-defined frequency.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Identifies [Assignment: organization-defined software programs authorized to execute on the information system];
+     (b)   Employs a deny-all, permit-by-exception policy to allow the execution of authorized software programs on the information system; and
+     (c)   Reviews and updates the list of authorized software programs [Assignment: organization- defined frequency].
+
+    Supplemental Guidance:  The process used to identify software programs that are authorized to execute on organizational information systems is commonly referred to as whitelisting. In addition to whitelisting, organizations consider verifying the integrity of white-listed software programs using, for example, cryptographic checksums, digital signatures, or hash functions. Verification of white-listed software can occur either prior to execution or at system startup. Related controls: CM-2, CM-6, CM-8, PM-5, SA-10, SC-34, SI-7.
+
+    CM-7(5) (c) [at least quarterly or when there is a change]
+  title: >-
+    CM-7(5) - LEAST FUNCTIONALITY | AUTHORIZED SOFTWARE / WHITELISTING
+  levels:
+  - high
+  - moderate
+- id: CM-8
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-369
+    Section b: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-369
+  rules: []
+  description: |-
+    The organization:
+     a. Develops and documents an inventory of information system components that:
+       1. Accurately reflects the current information system;
+       2. Includes all components within the authorization boundary of the information system;
+       3. Is at the level of granularity deemed necessary for tracking and reporting; and
+       4. Includes [Assignment: organization-defined information deemed necessary to achieve effective information system component accountability]; and
+     b. Reviews and updates the information system component inventory [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Organizations may choose to implement centralized information system component inventories that include components from all organizational information systems. In such situations, organizations ensure that the resulting inventories include system-specific information required for proper component accountability (e.g., information system association, information system owner). Information deemed necessary for effective accountability of information system components includes, for example, hardware inventory specifications, software license information, software version numbers, component owners, and for networked components or devices, machine names and network addresses. Inventory specifications include, for example, manufacturer, device type, model, serial number, and physical location. Related controls: CM-2, CM-6, PM-5.
+
+    References: NIST Special Publication 800-128.
+
+    CM-8 (b) [at least monthly]
+    CM-8 Requirement: must be provided at least monthly or when there is a change.
+  title: >-
+    CM-8 - INFORMATION SYSTEM COMPONENT INVENTORY
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-8(1)
+  status: not applicable
+  notes: |-
+    The organization is responsible for updating the inventory of information
+    system components as an integral part of component installations, removals,
+    and information system updates.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) relies on the OpenShift
+    operating layer to provide installation, updates, or removal of RHACM versions through
+    the Operator Lifecycle Manager (OLM) operator.
+  rules: []
+  description: |-
+    The organization updates the inventory of information system components as an integral part of component installations, removals, and information system updates.
+  title: >-
+    CM-8(1) - INFORMATION SYSTEM COMPONENT INVENTORY | UPDATES DURING INSTALLATIONS
+    / REMOVALS
+  levels:
+  - high
+  - moderate
+- id: CM-8(2)
+  status: not applicable
+  notes: |-
+    The organization is responsible for employing automated mechanisms to help maintain an
+    up-to-date, complete, accurate, and readily available inventory of information system
+    components.
+
+    Red Hat Advanced Cluster Management for Kubernetes (RHACM) relies on the OpenShift
+    operating layer to provide installation, updates, or removal of RHACM versions through
+    the Operator Lifecycle Manager (OLM) operator.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to help maintain an up-to-date, complete, accurate, and readily available inventory of information system components.
+
+    Supplemental Guidance:  Organizations maintain information system inventories to the extent feasible. Virtual machines, for example, can be difficult to monitor because such machines are not visible to the network when not in use. In such cases, organizations maintain as up-to-date, complete, and accurate an inventory as is deemed reasonable. This control enhancement can be satisfied by the implementation of CM-2 (2) for organizations that choose to combine information system component inventory and baseline configuration activities. Related control: SI-7.
+  title: >-
+    CM-8(2) - INFORMATION SYSTEM COMPONENT INVENTORY | AUTOMATED MAINTENANCE
+  levels:
+  - high
+- id: CM-8(3)
+  status: not applicable
+  notes: |-
+    Section a: The organization is responsible for employing automated mechanisms per organization-defined
+    frequency to detect the presence of unauthorized hardware, software, and firmware
+    components within the information system.
+    Section b: The organization is responsible for taking the following actions when unauthorized
+    components are detected:
+      - disabling network access by such components
+      - isolating the components
+      - notifying organization-defined personnel or roles
+  rules: []
+  description: |-
+    The organization:
+     (a)   Employs automated mechanisms [Assignment: organization-defined frequency] to detect the presence of unauthorized hardware, software, and firmware components within the information system; and
+     (b)   Takes the following actions when unauthorized components are detected: [Selection (one or more): disables network access by such components; isolates the components; notifies [Assignment: organization-defined personnel or roles]].
+
+    Supplemental Guidance:  This control enhancement is applied in addition to the monitoring for unauthorized remote connections and mobile devices. Monitoring for unauthorized system components may be accomplished on an ongoing basis or by the periodic scanning of systems for that purpose. Automated mechanisms can be implemented within information systems or in other separate devices. Isolation can be achieved, for example, by placing unauthorized information system components in separate domains or subnets or otherwise quarantining such components. This type of component isolation is commonly referred to as sandboxing. Related controls: AC-17, AC-18, AC-19, CA-7, SI-3, SI-4, SI-7, RA-5.
+
+    CM-8 (3) (a) [Continuously, using automated mechanisms with a maximum five-minute delay in detection.]
+  title: >-
+    CM-8(3) - INFORMATION SYSTEM COMPONENT INVENTORY | AUTOMATED UNAUTHORIZED COMPONENT
+    DETECTION
+  levels:
+  - high
+  - moderate
+- id: CM-8(4)
+  status: not applicable
+  notes: |-
+    Organizational processes to include in the information system
+    component inventory information, a means for identifying
+    by name, position, and/or role, individuals responsible/accountable
+    for administering those components, is outside the scope
+    of Red Hat Advanced Cluster Management configuration.
+  rules: []
+  description: |-
+    The organization includes in the information system component inventory information, a means for identifying by [Selection (one or more): name; position; role], individuals responsible/accountable for administering those components.
+
+    Supplemental Guidance:  Identifying individuals who are both responsible and accountable for administering information system components helps to ensure that the assigned components are properly administered and organizations can contact those individuals if some action is required (e.g., component is determined to be the source of a breach/compromise, component needs to be recalled/replaced, or component needs to be relocated).
+
+    CM-8 (4) [position and role]
+  title: >-
+    CM-8(4) - INFORMATION SYSTEM COMPONENT INVENTORY | ACCOUNTABILITY INFORMATION
+  levels:
+  - high
+- id: CM-8(5)
+  status: not applicable
+  notes: |-
+    Organizational verification that all components within the
+    authorization boundary of the information system are not
+    duplicated in other information system component
+    inventories is outside the scope of Red Hat Advanced Cluster Management configuration.
+  rules: []
+  description: |-
+    The organization verifies that all components within the authorization boundary of the information system are not duplicated in other information system inventories.
+
+    Supplemental Guidance:  This control enhancement addresses the potential problem of duplicate accounting of information system components in large or complex interconnected systems.
+  title: >-
+    CM-8(5) - INFORMATION SYSTEM COMPONENT INVENTORY | NO DUPLICATE ACCOUNTING OF
+    COMPONENTS
+  levels:
+  - high
+  - moderate
+- id: CM-8(6)
+  status: not applicable
+  notes: |-
+    The organization is responsible for including assessing component configurations and any
+    approved deviations to current deployed configurations in the information system component
+    inventory.
+  rules: []
+- id: CM-8(7)
+  status: not applicable
+  notes: |-
+    The organization is responsible for providing a centralized repository for the inventory of
+    information system components.
+  rules: []
+- id: CM-8(8)
+  status: not applicable
+  notes: |-
+    This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+  rules: []
+- id: CM-8(9)
+  status: not applicable
+  notes: |-
+    Section a: Organizational assignment of organization-defined acquired information
+    system components to an information system is outside the scope
+    of Red Hat Advanced Cluster Management configuration.
+    Section b: Organizational processes to receive an acknowledgement from the
+    information system owner of the assignment in CM-8(8)(a) is outside
+    the scope of Red Hat Advanced Cluster Management configuration.
+  rules: []
+- id: CM-9
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+    Section b: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+    Section c: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+    Section d: This control reflects organizational processes outside the scope
+    of Red Hat Advanced Cluster Management configuration guidance.
+  rules: []
+  description: |-
+    The organization develops, documents, and implements a configuration management plan for the information system that:
+     a. Addresses roles, responsibilities, and configuration management processes and procedures;
+     b. Establishes a process for identifying configuration items throughout the system development life cycle and for managing the configuration of the configuration items;
+     c. Defines the configuration items for the information system and places the configuration items under configuration management; and
+     d. Protects the configuration management plan from unauthorized disclosure and modification.
+
+    Supplemental Guidance:  Configuration management plans satisfy the requirements in configuration management policies while being tailored to individual information systems. Such plans define detailed processes and procedures for how configuration management is used to support system development life cycle activities at the information system level. Configuration management plans are typically developed during the development/acquisition phase of the system development life cycle. The plans describe how to move changes through change management processes, how to update configuration settings and baselines, how to maintain information system component inventories, how to control development, test, and operational environments, and how to develop, release, and update key documents. Organizations can employ templates to help ensure consistent and timely development and implementation of configuration management plans. Such templates can represent a master configuration management plan for the organization at large with subsets of the plan implemented on a system by system basis. Configuration management approval processes include designation of key management stakeholders responsible for reviewing and approving proposed changes to information systems, and personnel that conduct security impact analyses prior to the implementation of changes to the systems. Configuration items are the information system items (hardware, software, firmware, and documentation) to be configuration-managed. As information systems continue through the system development life cycle, new configuration items may be identified and some existing configuration items may no longer need to be under configuration control. Related controls: CM-2, CM-3, CM-4, CM-5, CM-8, SA-10.
+
+    References: NIST Special Publication 800-128.
+  title: >-
+    CM-9 - CONFIGURATION MANAGEMENT PLAN
+  levels:
+  - high
+  - moderate
+- id: CM-9(1)
+  status: not applicable
+  notes: |-
+    Organizational processes to assign responsibility for developing the
+    configuration management process to organizational personnel that are
+    not directly involved in information system development are outside
+    the scope of Red Hat Advanced Cluster Management configuration.
+  rules: []
+- id: CM-10
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-370
+    Section b: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-370
+    Section c: Controlling and documenting the use of peer-to-peer file sharing
+    technology to ensure that this capability is not used for the
+    unauthorized distribution, display, performance, or reproduction
+    of copyrighted work is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management configuration.
+  rules: []
+  description: |-
+    The organization:
+    a. Uses software and associated documentation in accordance with contract agreements and copyright laws;
+    b. Tracks the use of software and associated documentation protected by quantity licenses to control copying and distribution; and
+    c. Controls and documents the use of peer-to-peer file sharing technology to ensure that this capability is not used for the unauthorized distribution, display, performance, or reproduction of copyrighted work.
+
+    Supplemental Guidance:  Software license tracking can be accomplished by manual methods (e.g., simple spreadsheets) or automated methods (e.g., specialized tracking applications) depending on organizational needs. Related controls: AC-17, CM-8, SC-7.
+
+    References:  None.
+  title: >-
+    CM-10 - SOFTWARE USAGE RESTRICTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-10(1)
+  status: not applicable
+  notes: |-
+    Establishment of organizational restrictions on open source software
+    is outside the scope of Red Hat Advanced Cluster Management configuration.
+  rules: []
+  description: |-
+    The organization establishes the following restrictions on the use of open source software: [Assignment: organization-defined restrictions].
+
+    Supplemental Guidance:  Open source software refers to software that is available in source code form. Certain software rights normally reserved for copyright holders are routinely provided under software license agreements that permit individuals to study, change, and improve the software. From a security perspective, the major advantage of open source software is that it provides organizations with the ability to examine the source code. However, there are also various licensing issues associated with open source software including, for example, the constraints on derivative use of such software.
+  title: >-
+    CM-10(1) - SOFTWARE USAGE RESTRICTIONS | OPEN SOURCE SOFTWARE
+  levels:
+  - high
+  - moderate
+- id: CM-11
+  status: pending
+  notes: |-
+    Section a: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-371
+    Section b: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-371
+    Section c: A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-371
+  rules: []
+  description: "The organization:\n a. Establishes [Assignment: organization-defined\
+    \ policies] governing the installation of software by users;\n b. Enforces software\
+    \ installation policies through [Assignment: organization-defined methods]; and\n\
+    \ c. Monitors policy compliance at [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  If provided the necessary privileges, users have the\
+    \ ability to install software in organizational information systems. To maintain\
+    \ control over the types of software installed, organizations identify permitted\
+    \ and prohibited actions regarding software installation. Permitted software installations\
+    \ may include, for example, updates and security patches to existing software\
+    \ and downloading applications from organization-approved \u201Capp stores.\u201D\
+    \ Prohibited software installations may include, for example, software with unknown\
+    \ or suspect pedigrees or software that organizations consider potentially malicious.\
+    \ The policies organizations select governing user-installed software may be organization-developed\
+    \ or provided by some external entity. Policy enforcement methods include procedural\
+    \ methods (e.g., periodic examination of user accounts), automated methods (e.g.,\
+    \ configuration settings implemented on organizational information systems), or\
+    \ both. Related controls: AC-3, CM-2, CM-3, CM-5, CM-6, CM-7, PL-4.\n\nReferences:\
+    \ None.\n\nCM-11 (c) [Continuously (via CM-7 (5))]"
+  title: >-
+    CM-11 - USER-INSTALLED SOFTWARE
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-11(1)
+  status: not applicable
+  notes: |-
+    The information system alerting organization-defined personnel or roles when the
+    unauthorized installation of software is detected is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes and is the responsibility of the underlying
+    OpenShift and/or third-party products.
+  rules: []
+  description: |-
+    The information system alerts [Assignment: organization-defined personnel or roles] when the unauthorized installation of software is detected.
+
+    Supplemental Guidance:  Related controls: CA-7, SI-4.
+  title: >-
+    CM-11(1) - USER-INSTALLED SOFTWARE | ALERTS FOR UNAUTHORIZED INSTALLATIONS
+  levels:
+  - high
+- id: CM-11(2)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-372
+  rules: []
+- id: CP-1
+  status: not applicable
+  notes: |-
+    Section a: Developing an organization-level contingency planning policy is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Review and updating an organizational-level contingency planning
+    policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A contingency planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the contingency planning policy and associated contingency planning controls; and
+     b. Reviews and updates the current:
+       1. Contingency planning policy [Assignment: organization-defined frequency]; and
+       2. Contingency planning procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the CP family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  Federal Continuity Directive 1; NIST Special Publications 800-12, 800-34, 800-100.
+
+    CP-1 (b) (1) [at least annually]
+    CP-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    CP-1 - CONTINGENCY PLANNING POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-2
+  status: not applicable
+  notes: |-
+    Section a: Developing an organization-level contingency planning policy is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Distribution of an organizational-level contingency planning
+    policy is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: Coordinating contingency planning activities with incident handling
+    activities is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section d: Reviewing organizational contingency plans for the information system
+    at an organization-defined frequency is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section e: Organizational processes to update the contingency plan are outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section f: Organizational communication plans regarding the contingency plan are outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section g: Protection of the contingency plan from unauthorized disclosure and
+    modification is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops a contingency plan for the information system that:
+       1. Identifies essential missions and business functions and associated contingency requirements;
+       2. Provides recovery objectives, restoration priorities, and metrics;
+       3. Addresses contingency roles, responsibilities, assigned individuals with contact information;
+       4. Addresses maintaining essential missions and business functions despite an information system disruption, compromise, or failure;
+       5. Addresses eventual, full information system restoration without deterioration of the security safeguards originally planned and implemented; and
+       6. Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+     b. Distributes copies of the contingency plan to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements];
+     c. Coordinates contingency planning activities with incident handling activities;
+     d. Reviews the contingency plan for the information system [Assignment: organization-defined frequency];
+     e. Updates the contingency plan to address changes to the organization, information system, or environment of operation and problems encountered during contingency plan implementation, execution, or testing;
+     f. Communicates contingency plan changes to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements]; and
+     g. Protects the contingency plan from unauthorized disclosure and modification.
+
+    Supplemental Guidance:  Contingency planning for information systems is part of an overall organizational program for achieving continuity of operations for mission/business functions. Contingency planning addresses both information system restoration and implementation of alternative mission/business processes when systems are compromised. The effectiveness of contingency planning is maximized by considering such planning throughout the phases of the system development life cycle. Performing contingency planning on hardware, software, and firmware development can be an effective means of achieving information system resiliency. Contingency plans reflect the degree of restoration required for organizational information systems since not all systems may need to fully recover to achieve the level of continuity of operations desired. Information system recovery objectives reflect applicable laws, Executive Orders, directives, policies, standards, regulations, and guidelines. In addition to information system availability, contingency plans also address other security-related events resulting in a reduction in mission and/or business effectiveness, such as malicious attacks compromising the confidentiality or integrity of information systems. Actions addressed in contingency plans include, for example, orderly/graceful degradation, information system shutdown, fallback to a manual mode, alternate information flows, and operating in modes reserved for when systems are under attack. By closely coordinating contingency planning with incident handling activities, organizations can ensure that the necessary contingency planning activities are in place and activated in the event of a security incident. Related controls: AC-14, CP-6, CP-7, CP-8, CP-9, CP-10, IR-4, IR-8, MP-2, MP-4, MP-5, PM-8, PM-11.
+
+    References: Federal Continuity Directive 1; NIST Special Publication 800-34.
+
+    CP-2 (d) [at least annually]
+    CP-2 Requirement: For JAB authorizations the contingency lists include designated FedRAMP personnel.
+  title: >-
+    CP-2 - CONTINGENCY PLAN
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-2(1)
+  status: not applicable
+  notes: |-
+    Coordinating contingency plan development with organizational elements
+    responsible for related plans is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization coordinates contingency plan development with organizational elements responsible for related plans.
+
+    Supplemental Guidance:  Plans related to contingency plans for organizational information systems include, for example, Business Continuity Plans, Disaster Recovery Plans, Continuity of Operations Plans, Crisis Communications Plans, Critical Infrastructure Plans, Cyber Incident Response Plans, Insider Threat Implementation Plan, and Occupant Emergency Plans.
+  title: >-
+    CP-2(1) - CONTINGENCY PLAN | COORDINATE WITH RELATED PLANS
+  levels:
+  - high
+  - moderate
+- id: CP-2(2)
+  status: pending
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    A complete control response is planned. Engineering progress can be tracked via:
+    https://issues.redhat.com/browse/ACM-373
+  rules: []
+  description: |-
+    The organization conducts capacity planning so that necessary capacity for information processing, telecommunications, and environmental support exists during contingency operations.
+
+    Supplemental Guidance:  Capacity planning is needed because different types of threats (e.g., natural disasters, targeted cyber attacks) can result in a reduction of the available processing, telecommunications, and support services originally intended to support the organizational missions/business functions. Organizations may need to anticipate degraded operations during contingency operations and factor such degradation into capacity planning.
+  title: >-
+    CP-2(2) - CONTINGENCY PLAN | CAPACITY PLANNING
+  levels:
+  - high
+  - moderate
+- id: CP-2(3)
+  status: not applicable
+  notes: |-
+    Planning for the resumption of essential missions and business
+    functions within an organization-defined time period of contingency
+    plan activation is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization plans for the resumption of essential missions and business functions within
+    [Assignment: organization-defined time period] of contingency plan activation.
+
+    Supplemental Guidance:  Organizations may choose to carry out the contingency planning activities in this control enhancement as part of organizational business continuity planning including, for example, as part of business impact analyses. The time period for resumption of essential missions/business functions may be dependent on the severity/extent of disruptions
+    to the information system and its supporting infrastructure. Related control: PE-12.
+  title: >-
+    CP-2(3) - CONTINGENCY PLAN | RESUME ESSENTIAL MISSIONS / BUSINESS FUNCTIONS
+  levels:
+  - high
+  - moderate
+- id: CP-2(4)
+  status: not applicable
+  notes: |-
+    Planning for the resumption of all missions and business
+    functions within an organization-defined time period of contingency
+    plan activation is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization plans for the resumption of all missions and business functions within
+    [Assignment: organization-defined time period] of contingency plan activation.
+
+    Supplemental Guidance:  Organizations may choose to carry out the contingency planning activities in this control enhancement as part of organizational business continuity planning including, for example, as part of business impact analyses. The time period for resumption of all missions/business functions may be dependent on the severity/extent of disruptions to the information system and its supporting infrastructure. Related control: PE-12.
+    CP-2 (4) [time period defined in service provider and organization  SLA]
+  title: >-
+    CP-2(4) - CONTINGENCY PLAN | RESUME ALL MISSIONS / BUSINESS FUNCTIONS
+  levels:
+  - high
+- id: CP-2(5)
+  status: not applicable
+  notes: |-
+    Planning for the continuance of essential missions and business
+    functions with little or no loss of operational continuity and
+    sustainment of that continuity until full information system
+    restoration at primary processing and/or storage sites
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization plans for the continuance of essential missions and business functions with little or no loss of operational continuity and sustains that continuity until full information system restoration at primary processing and/or storage sites.
+
+    Supplemental Guidance:  Organizations may choose to carry out the contingency planning activities in this control enhancement as part of organizational business continuity planning including, for example, as part of business impact analyses. Primary processing and/or storage sites defined by organizations as part of contingency planning may change depending on the circumstances associated with the contingency (e.g., backup sites may become primary sites). Related control: PE-12.
+  title: >-
+    CP-2(5) - CONTINGENCY PLAN | CONTINUE ESSENTIAL MISSIONS / BUSINESS FUNCTIONS
+  levels:
+  - high
+- id: CP-2(6)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: CP-2(7)
+  status: not applicable
+  notes: |-
+    Coordination of organizational contingency plans with the
+    contingency plans of external service providers to ensure that
+    contingency requirements can be satisfied is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CP-2(8)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization identifies critical information system assets supporting essential missions and business functions.
+
+    Supplemental Guidance:  Organizations may choose to carry out the contingency planning activities in this control enhancement as part of organizational business continuity planning including, for example, as part of business impact analyses. Organizations identify critical information system assets so that additional safeguards and countermeasures can be employed (above and beyond those safeguards and countermeasures routinely implemented) to help ensure that organizational missions/business functions can continue to be conducted during contingency operations. In addition, the identification of critical information assets facilitates the prioritization of organizational resources. Critical information system assets include technical and operational aspects. Technical aspects include, for example, information technology services, information system components, information technology products, and mechanisms. Operational aspects include, for example, procedures (manually executed operations) and personnel (individuals operating technical safeguards and/or executing manual procedures). Organizational program protection plans can provide assistance in identifying critical assets. Related controls: SA-14, SA-15.
+  title: >-
+    CP-2(8) - CONTINGENCY PLAN | IDENTIFY CRITICAL ASSETS
+  levels:
+  - high
+  - moderate
+- id: CP-3
+  status: not applicable
+  notes: |-
+    Section a: Providing contingency training to information system users consistent
+    with assigned roles and responsibilities within an organization-defined
+    time period of assuming a contingency role or responsibility is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Providing contingency training to information system users consistent
+    with assigned roles and responsibilities when required by information
+    system changes is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: Providing contingency training to information system users consistent
+    with assigned roles and responsibilities at an organization-defined
+    frequency is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization provides contingency training to information system\
+    \ users consistent with assigned roles and responsibilities:\n a. Within [Assignment:\
+    \ organization-defined time period] of assuming a contingency role or responsibility;\n\
+    \ b. When required by information system changes; and\n c. [Assignment: organization-defined\
+    \ frequency] thereafter.\n\nSupplemental Guidance:  Contingency training provided\
+    \ by organizations is linked to the assigned roles and responsibilities of organizational\
+    \ personnel to ensure that the appropriate content and level of detail is included\
+    \ in such training. For example, regular users may only need to know\nwhen and\
+    \ where to report for duty during contingency operations and if normal duties\
+    \ are affected; system administrators may require additional training on how to\
+    \ set up information systems at alternate processing and storage sites; and managers/senior\
+    \ leaders may receive more specific training on how to conduct mission-essential\
+    \ functions in designated off-site locations and how to establish communications\
+    \ with other governmental entities for purposes of coordination on\ncontingency-related\
+    \ activities. Training for contingency roles/responsibilities reflects the specific\
+    \ continuity requirements in the contingency plan. Related controls: AT-2, AT-3,\
+    \ CP-2, IR-2. \n\nReferences: Federal Continuity Directive 1; NIST Special Publications\
+    \ 800-16, 800-50.\n\nCP-3 (a) [ten (10) days]\nCP-3 (c) [at least annually]"
+  title: >-
+    CP-3 - CONTINGENCY TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-3(1)
+  status: not applicable
+  notes: |-
+    Incorporating simulated events into contingency training to
+    facilitate effective response by personnel in crisis
+    situations is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization incorporates simulated events into contingency training to facilitate effective response by personnel in crisis situations.
+  title: >-
+    CP-3(1) - CONTINGENCY TRAINING | SIMULATED EVENTS
+  levels:
+  - high
+- id: CP-3(2)
+  status: not applicable
+  notes: |-
+    Employment of automated mechanisms to provide a more thorough and
+    realistic contingency training environment is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CP-4
+  status: not applicable
+  notes: |-
+    Section a: Testing the contingency plan for the information system at an
+    organization-defined frequency using organization-defined tests
+    to determine the effectiveness of the plan and the organizational
+    readiness to execute the plan is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational reviews of the contingency plan test results is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Organizational process to initiate corrective actions, if needed,
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Tests the contingency plan for the information\
+    \ system [Assignment: organization-defined frequency] using [Assignment: organization-defined\
+    \ tests] to determine the effectiveness of the plan and the organizational readiness\
+    \ to execute the plan;\n b. Reviews the contingency plan test results; and\n c.\
+    \ Initiates corrective actions, if needed.\n\nSupplemental Guidance:  Methods\
+    \ for testing contingency plans to determine the effectiveness of the plans and\
+    \ to identify potential weaknesses in the plans include, for example, walk-through\
+    \ and tabletop exercises, checklists, simulations (parallel, full interrupt),\
+    \ and comprehensive exercises. Organizations conduct testing based on the continuity\
+    \ requirements in contingency plans and include a determination of the effects\
+    \ on organizational operations, assets, and individuals arising due to contingency\
+    \ operations. Organizations have flexibility and discretion in the breadth, depth,\
+    \ and timelines of corrective actions. Related controls: CP-2, CP-3, IR-3.\n\n\
+    References: Federal Continuity Directive 1; FIPS Publication 199; NIST Special\
+    \ Publications 800-34, 800-84.\n\nCP-4 (a)-1 [at least annually] \nCP-4 (a)-2\
+    \ [functional exercises]\nCP-4 (a) Requirement: The service provider develops\
+    \ test plans in accordance with NIST Special Publication 800-34 (as amended);\
+    \ plans are approved by the JAB/AO prior to initiating testing."
+  title: >-
+    CP-4 - CONTINGENCY PLAN TESTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-4(1)
+  status: not applicable
+  notes: |-
+    Coordinating contingency plan testing with organizational
+    elements responsible for related plans is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization coordinates contingency plan testing with organizational elements responsible for related plans.
+
+    Supplemental Guidance:  Plans related to contingency plans for organizational information systems include, for example, Business Continuity Plans, Disaster Recovery Plans, Continuity of Operations Plans, Crisis Communications Plans, Critical Infrastructure Plans, Cyber Incident Response Plans, and Occupant Emergency Plans. This control enhancement does not require organizations to create organizational elements to handle related plans or to align such elements with specific plans. It does require, however, that if such organizational elements are responsible for related plans, organizations should coordinate with those elements. Related controls: IR-8, PM-8.
+  title: >-
+    CP-4(1) - CONTINGENCY PLAN TESTING | COORDINATE WITH RELATED PLANS
+  levels:
+  - high
+  - moderate
+- id: CP-4(2)
+  status: not applicable
+  notes: |-
+    Section a: Organizational testing of the contingency plan at the alternate
+    processing site to familiarize contingency personnel with the
+    facility and available resources is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational testing of the contingency plan at the alternate
+    processing site to evaluate the capabilities of the alternate
+    processing site to support contingency operations is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization tests the contingency plan at the alternate processing site:
+     (a)   To familiarize contingency personnel with the facility and available resources; and
+     (b)   To evaluate the capabilities of the alternate processing site to support contingency operations.
+
+    Supplemental Guidance:  Related control: CP-7.
+  title: >-
+    CP-4(2) - CONTINGENCY PLAN TESTING | ALTERNATE PROCESSING SITE
+  levels:
+  - high
+- id: CP-4(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: CP-4(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: CP-5
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CP-6
+  status: not applicable
+  notes: |-
+    Section a: Establishment of an alternative storage site including
+    necessary agreements to permit the storage and retrieval
+    of information system backup information is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Ensuring that the alternative storage site provides information
+    security safeguards equivalent to that of the primary site
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes an alternate storage site including necessary agreements to permit the storage and retrieval of information system backup information; and
+     b. Ensures that the alternate storage site provides information security safeguards equivalent to that of the primary site.
+
+    Supplemental Guidance:  Alternate storage sites are sites that are geographically distinct from primary storage sites. An alternate storage site maintains duplicate copies of information and data in the event that the primary storage site is not available. Items covered by alternate storage site agreements include, for example, environmental conditions at alternate sites, access rules, physical and environmental protection requirements, and coordination of delivery/retrieval of backup
+    media. Alternate storage sites reflect the requirements in contingency plans so that organizations can maintain essential missions/business functions despite disruption, compromise, or failure in organizational information systems. Related controls: CP-2, CP-7, CP-9, CP-10, MP-4.
+
+    References: NIST Special Publication 800-34.
+  title: >-
+    CP-6 - ALTERNATE STORAGE SITE
+  levels:
+  - high
+  - moderate
+- id: CP-6(1)
+  status: not applicable
+  notes: |-
+    Identification of an alternate storage site that is
+    separated from the primary storage site to reduce
+    susceptibility to the same threats is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization identifies an alternate storage site that is separated from the primary storage site to reduce susceptibility to the same threats.
+
+    Supplemental Guidance:  Threats that affect alternate storage sites are typically defined in organizational assessments of risk and include, for example, natural disasters, structural failures, hostile cyber attacks, and errors of omission/commission. Organizations determine what is considered a sufficient degree of separation between primary and alternate storage sites based on the types of threats that are of concern. For one particular type of threat (i.e., hostile cyber attack), the degree of separation between sites is less relevant. Related control: RA-3.
+  title: >-
+    CP-6(1) - ALTERNATE STORAGE SITE | SEPARATION FROM PRIMARY SITE
+  levels:
+  - high
+  - moderate
+- id: CP-6(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization configures the alternate storage site to facilitate recovery operations in accordance with recovery time and recovery point objectives.
+  title: >-
+    CP-6(2) - ALTERNATE STORAGE SITE | RECOVERY TIME / POINT OBJECTIVES
+  levels:
+  - high
+- id: CP-6(3)
+  status: not applicable
+  notes: |-
+    Identification of potential accessibility problems to the alternate
+    storage site in an event of an area-wide disruption or disaster and
+    the outline of explicit mitigation actions is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization identifies potential accessibility problems to the alternate storage site in the event of an area-wide disruption or disaster and outlines explicit mitigation actions.
+
+    Supplemental Guidance:  Area-wide disruptions refer to those types of disruptions that are broad in geographic scope (e.g., hurricane, regional power outage) with such determinations made by organizations based on organizational assessments of risk. Explicit mitigation actions include, for example: (i) duplicating backup information at other alternate storage sites if access problems occur at originally designated alternate sites; or (ii) planning for physical access to retrieve backup information if electronic accessibility to the alternate site is disrupted. Related control: RA-3.
+  title: >-
+    CP-6(3) - ALTERNATE STORAGE SITE | ACCESSIBILITY
+  levels:
+  - high
+  - moderate
+- id: CP-7
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: Ensuring that equipment and supplies required to transfer and resume
+    operations are available at the alternate processing site or contracts
+    are in place to support delivery to the site within the
+    organization-defined time period for transfer/resumption is an
+    organizational control outside the configuration of Red Hat Advanced Cluster Management for
+    Kubernetes.
+    Section c: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The organization:\n a. Establishes an alternate processing site including\
+    \ necessary agreements to permit the transfer and resumption of [Assignment: organization-defined\
+    \ information system operations] for essential missions/business functions within\
+    \ [Assignment: organization-defined time period consistent with recovery time\
+    \ and recovery point objectives] when the primary processing capabilities are\
+    \ unavailable;\n b. Ensures that equipment and supplies required to transfer and\
+    \ resume operations are available at the alternate processing site or contracts\
+    \ are in place to support delivery to the site within the organization-defined\
+    \ time period for transfer/resumption; and \n c. Ensures that the alternate processing\
+    \ site provides information security safeguards equivalent to that of the primary\
+    \ site.\n\nSupplemental Guidance:  Alternate processing sites are sites that are\
+    \ geographically distinct from primary processing sites. An alternate processing\
+    \ site provides processing capability in the event that the primary processing\
+    \ site is not available. Items covered by alternate processing site agreements\
+    \ include, for example, environmental conditions at alternate sites, access rules,\
+    \ physical and environmental protection requirements, and coordination for the\
+    \ transfer/assignment of personnel. Requirements are specifically allocated to\
+    \ alternate processing sites that reflect the requirements in contingency plans\
+    \ to maintain essential missions/business functions despite disruption, compromise,\
+    \ or failure in organizational information systems. Related controls: CP-2, CP-6,\
+    \ CP-8, CP-9, CP-10, MA-6.\n\nReferences: NIST Special Publication 800-34.\n\n\
+    CP-7 (a) Requirement: The service provider defines a time period consistent with\
+    \ the recovery time objectives and business impact analysis."
+  title: >-
+    CP-7 - ALTERNATE PROCESSING SITE
+  levels:
+  - high
+  - moderate
+- id: CP-7(1)
+  status: not applicable
+  notes: |-
+    Identification of an alternate processing site that is
+    separated from the primary processing site to reduce
+    susceptibility to the same threats is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization identifies an alternate processing site that is separated from the primary processing site to reduce susceptibility to the same threats.
+
+    Supplemental Guidance:  Threats that affect alternate processing sites are typically defined in organizational assessments of risk and include, for example, natural disasters, structural failures, hostile cyber attacks, and errors of omission/commission. Organizations determine what is considered a sufficient degree of separation between primary and alternate processing sites based on the types of threats that are of concern. For one particular type of threat (i.e., hostile cyber attack), the degree of separation between sites is less relevant. Related control: RA-3.
+
+    CP-7 (1) Guidance: The service provider may determine what is considered a sufficient degree of separation between the primary and alternate processing sites, based on the types of threats that are of concern. For one particular type of threat (i.e., hostile cyber attack), the degree of separation between sites will be less relevant.
+  title: >-
+    CP-7(1) - ALTERNATE PROCESSING SITE | SEPARATION FROM PRIMARY SITE
+  levels:
+  - high
+  - moderate
+- id: CP-7(2)
+  status: not applicable
+  notes: |-
+    Identification of potential accessibility problems to the
+    alternate processing site in the event of an area-wide
+    disruption or disaster and outline of explicit mitigation
+    actions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization identifies potential accessibility problems to the alternate processing site in the event of an area-wide disruption or disaster and outlines explicit mitigation actions.
+
+    Supplemental Guidance:  Area-wide disruptions refer to those types of disruptions that are broad in geographic scope (e.g., hurricane, regional power outage) with such determinations made by organizations based on organizational assessments of risk. Related control: RA-3.
+  title: >-
+    CP-7(2) - ALTERNATE PROCESSING SITE | ACCESSIBILITY
+  levels:
+  - high
+  - moderate
+- id: CP-7(3)
+  status: not applicable
+  notes: |-
+    Development of alternate processing site agreements that contain
+    priority-of-service provisions in accordance with organizational
+    availability requirements (including recovery time objectives)
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization develops alternate processing site agreements that contain priority-of-service provisions in accordance with organizational availability requirements (including recovery time objectives).
+
+    Supplemental Guidance:  Priority-of-service agreements refer to negotiated agreements with service providers that ensure that organizations receive priority treatment consistent with their availability requirements and the availability of information resources at the alternate processing site.
+  title: >-
+    CP-7(3) - ALTERNATE PROCESSING SITE | PRIORITY OF SERVICE
+  levels:
+  - high
+  - moderate
+- id: CP-7(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization prepares the alternate processing site so that the site is ready to be used as the operational site supporting essential missions and business functions.
+
+    Supplemental Guidance:  Site preparation includes, for example, establishing configuration settings for information system components at the alternate processing site consistent with the requirements for such settings at the primary site and ensuring that essential supplies and other logistical considerations are in place. Related controls: CM-2, CM-6.
+  title: >-
+    CP-7(4) - ALTERNATE PROCESSING SITE | PREPARATION FOR USE
+  levels:
+  - high
+- id: CP-7(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CP-7(6)
+  status: not applicable
+  notes: |-
+    Organizational planning and preparation for circumstances
+    that preclude returning to the primary processing site
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CP-8
+  status: not applicable
+  notes: |-
+    Establishment of alternate telecommunications services
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization establishes alternate telecommunications services including necessary agreements to permit the resumption of [Assignment: organization-defined information system operations] for essential missions and business functions within [Assignment: organization- defined time period] when the primary telecommunications capabilities are unavailable at either the primary or alternate processing or storage sites.
+
+    Supplemental Guidance:  This control applies to telecommunications services (data and voice) for primary and alternate processing and storage sites. Alternate telecommunications services reflect the continuity requirements in contingency plans to maintain essential missions/business functions despite the loss of primary telecommunications services. Organizations may specify different time periods for primary/alternate sites. Alternate telecommunications services include, for example, additional organizational or commercial ground-based circuits/lines or satellites in lieu of ground- based communications. Organizations consider factors such as availability, quality of service, and access when entering into alternate telecommunications agreements. Related controls: CP-2, CP-6, CP-7.
+
+    References: NIST Special Publication 800-34; National Communications Systems Directive 3-10; Web: http://www.dhs.gov/telecommunications-service-priority-tsp.
+
+    CP-8 Requirement: The service provider defines a time period consistent with the recovery time objectives and business impact analysis.
+  title: >-
+    CP-8 - TELECOMMUNICATIONS SERVICES
+  levels:
+  - high
+  - moderate
+- id: CP-8(1)
+  status: not applicable
+  notes: |-
+    Section a: Development of primary and alternate telecommunications service
+    agreements that contain priority-of-service provisions in accordance
+    with organizational availability requirements (including recovery
+    time objectives) is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Requests for Telecommunications Service Priority for all
+    telecommunucations services used for national security emergency
+    preparedness in the event that the primary and/or alternate
+    telecommunications services are provided by a common carrier
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Develops primary and alternate telecommunications service agreements that contain priority- of-service provisions in accordance with organizational availability requirements (including recovery time objectives); and
+     (b)   Requests Telecommunications Service Priority for all telecommunications services used for national security emergency preparedness in the event that the primary and/or alternate telecommunications services are provided by a common carrier.
+
+    Supplemental Guidance:  Organizations consider the potential mission/business impact in situations where telecommunications service providers are servicing other organizations with similar priority-of-service provisions.
+  title: >-
+    CP-8(1) - TELECOMMUNICATIONS SERVICES | PRIORITY OF SERVICE PROVISIONS
+  levels:
+  - high
+  - moderate
+- id: CP-8(2)
+  status: not applicable
+  notes: |-
+    Obtaining alternate telecommunications services to reduce
+    the likelihood of sharing a single point of failure with
+    primary telecommunications services is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization obtains alternate telecommunications services to reduce the likelihood of sharing a single point of failure with primary telecommunications services.
+  title: >-
+    CP-8(2) - TELECOMMUNICATIONS SERVICES | SINGLE POINTS OF FAILURE
+  levels:
+  - high
+  - moderate
+- id: CP-8(3)
+  status: not applicable
+  notes: |-
+    Obtaining alternate telecommunications services from providers
+    that are separated from primary service providers to reduce
+    susceptibility to the same threats is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization obtains alternate telecommunications services from providers that are separated from primary service providers to reduce susceptibility to the same threats.
+
+    Supplemental Guidance:  Threats that affect telecommunications services are typically defined in organizational assessments of risk and include, for example, natural disasters, structural failures, hostile cyber/physical attacks, and errors of omission/commission. Organizations seek to reduce common susceptibilities by, for example, minimizing shared infrastructure among telecommunications service providers and achieving sufficient geographic separation between services. Organizations may consider using a single service provider in situations where the service provider can provide alternate telecommunications services meeting the separation needs addressed in the risk assessment.
+  title: >-
+    CP-8(3) - TELECOMMUNICATIONS SERVICES | SEPARATION OF PRIMARY / ALTERNATE PROVIDERS
+  levels:
+  - high
+- id: CP-8(4)
+  status: not applicable
+  notes: |-
+    Section a: Requiring primary and alternate telecommunications service
+    providers to have contingency plans is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Reviewing provider contingency plans to ensure that the plans
+    meet organizational contingecny requirements is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Obtaining evidence of contingency testing/training by providers
+    at an organization-defined frequency is outside the plannedscope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Requires primary and alternate telecommunications service providers to have contingency plans;
+     (b)   Reviews provider contingency plans to ensure that the plans meet organizational contingency requirements; and
+     (c)   Obtains evidence of contingency testing/training by providers [Assignment: organization- defined frequency].
+
+    Supplemental Guidance:  Reviews of provider contingency plans consider the proprietary nature of such plans. In some situations, a summary of provider contingency plans may be sufficient evidence for organizations to satisfy the review requirement. Telecommunications service providers may also participate in ongoing disaster recovery exercises in coordination with the Department of Homeland Security, state, and local governments. Organizations may use these types of activities to satisfy evidentiary requirements related to service provider contingency plan reviews, testing, and training.
+
+    CP-8 (4) (c) [annually]
+  title: >-
+    CP-8(4) - TELECOMMUNICATIONS SERVICES | PROVIDER CONTINGENCY PLAN
+  levels:
+  - high
+- id: CP-8(5)
+  status: not applicable
+  notes: |-
+    Testing alternate telecommunication services at
+    an organization-defined frequency is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: CP-9
+  status: not applicable
+  notes: |-
+    Section a: The customer will be responsible for conducting daily incremental and
+    weekly full backups of user-level information contained in the
+    information system. Additional requirements and guidance include
+    maintaining at least three backup copies of user-level information (at
+    least one of which is available online) or provides an equivalent
+    alternative. A successful control response will detail how backups of
+    user-level information occurs, and how three backup copies are
+    maintained.
+
+    Conducting backups of user-level information to include the backups of
+    a centralized identity provider is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: The customer will be responsible for conducting daily incremental and
+    weekly full backups of system-level information contained in the
+    information system. Additional requirements and guidance include
+    maintaining at least three backup copies of system-level information (at
+    least one of which is available online) or provides an equivalent
+    alternative. A successful control response will detail how backups of
+    user-level information occurs, and how three backup copies are
+    maintained.
+
+    Conducting backups of system-level information is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: The customer will be responsible for conducting daily incremental and
+    weekly full backups of information system documentation including
+    security-related documentation.
+
+    Conducting backups on information system and security-related documentation
+    is an organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section d: The customer will be responsible for protecting the confidentiality,
+    integrity, and available of backup information at storage locations.
+    Additional requirements and guidance include determining
+    what elements of the cloud environment require the Information System
+    Backup control. The customer will determine how Information System
+    Backup is going to be verified and appropriate periodicity of the
+    check.
+
+    Protecting the confidentiality, integrity, and availability of backup
+    information at separate storage locations an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+    a. Conducts backups of user-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+    b. Conducts backups of system-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+    c. Conducts backups of information system documentation including security-related documentation [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives]; and
+    d. Protects the confidentiality, integrity, and availability of backup information at storage locations.
+
+    Supplemental Guidance:  System-level information includes, for example, system-state information, operating system and application software, and licenses. User-level information includes any information other than system-level information. Mechanisms employed by organizations to protect the integrity of information system backups include, for example, digital signatures and cryptographic hashes. Protection of system backup information while in transit is beyond the
+    scope of this control. Information system backups reflect the requirements in contingency plans as well as other organizational requirements for backing up information. Related controls: CP-2, CP-6, MP-4, MP-5, SC-13.
+
+    References: NIST Special Publication 800-34.
+
+    CP-9 (a) [daily incremental; weekly full]
+    CP-9 (b) [daily incremental; weekly full]
+    CP-9 (c) [daily incremental; weekly full]
+    CP-9 Requirement: The service provider shall determine what elements of the cloud environment require the Information System Backup control. The service provider shall determine how Information System Backup is going to be verified and appropriate periodicity of the check.
+    CP-9 (a) Requirement: The service provider maintains at least three backup copies of user-level information (at least one of which is available online) or provides an equivalent alternative.
+    CP-9 (b) Requirement: The service provider maintains at least three backup copies of system-level information (at least one of which is available online) or provides an equivalent alternative.
+    CP-9 (c) Requirement: The service provider maintains at least three backup copies of information system documentation including security information (at least one of which is available online) or provides an equivalent alternative.
+  title: >-
+    CP-9 - INFORMATION SYSTEM BACKUP
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-9(1)
+  status: not applicable
+  notes: |-
+    The testing of backup information to verify media reliability
+    and information integrity is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization tests backup information [Assignment: organization-defined\
+    \ frequency] to verify media reliability and information integrity.\n \nSupplemental\
+    \ Guidance:  Related control: CP-4.\n\nCP-9 (1). [at least monthly]"
+  title: >-
+    CP-9(1) - INFORMATION SYSTEM BACKUP | TESTING FOR RELIABILITY / INTEGRITY
+  levels:
+  - high
+  - moderate
+- id: CP-9(2)
+  status: not applicable
+  notes: |-
+    The organization using a sample of backup information in the restoration of selected
+    information system functions as part of contingency plan testing is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization uses a sample of backup information in the restoration of selected information system functions as part of contingency plan testing.
+
+    Supplemental Guidance:  Related control: CP-4.
+  title: >-
+    CP-9(2) - INFORMATION SYSTEM BACKUP | TEST RESTORATION USING SAMPLING
+  levels:
+  - high
+- id: CP-9(3)
+  status: not applicable
+  notes: |-
+    Storing backup copies of organization-defined critical information
+    system software and other security-related information in a separate
+    facility or in a fire-rated container that is not collocated with the
+    operational system is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization stores backup copies of [Assignment: organization-defined critical information system software and other security-related information] in a separate facility or in a fire-rated container that is not collocated with the operational system.
+
+    Supplemental Guidance:  Critical information system software includes, for example, operating systems, cryptographic key management systems, and intrusion detection/prevention systems. Security-related information includes, for example, organizational inventories of hardware, software, and firmware components. Alternate storage sites typically serve as separate storage facilities for organizations. Related controls: CM-2, CM-8.
+  title: >-
+    CP-9(3) - INFORMATION SYSTEM BACKUP | SEPARATE STORAGE FOR CRITICAL INFORMATION
+  levels:
+  - high
+  - moderate
+- id: CP-9(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CP-9(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization transfers information system backup information to the alternate storage site [Assignment: organization-defined time period and transfer rate consistent with the recovery time and recovery point objectives].
+
+    Supplemental Guidance:  Information system backup information can be transferred to alternate storage sites either electronically or by physical shipment of storage media.
+
+    CP-9 (5) [time period and transfer rate consistent with the recovery time and recovery point objectives defined in the service provider and organization  SLA].
+  title: >-
+    CP-9(5) - INFORMATION SYSTEM BACKUP | TRANSFER TO ALTERNATE STORAGE SITE
+  levels:
+  - high
+- id: CP-9(6)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: CP-9(7)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: CP-10
+  status: not applicable
+  notes: |-
+    The customer will be responsible for documenting how to reconstitute
+    their Red Hat Advanced Cluster Management for Kubernetes environment. A successful control
+    response will detail processes used to fully recover/restore the Red Hat Advanced Cluster
+    Management for Kubernetes environment.
+  rules: []
+  description: |-
+    The organization provides for the recovery and reconstitution of the information system to a known state after a disruption, compromise, or failure.
+
+    Supplemental Guidance:  Recovery is executing information system contingency plan activities to restore organizational missions/business functions. Reconstitution takes place following recovery and includes activities for returning organizational information systems to fully operational states. Recovery and reconstitution operations reflect mission and business priorities, recovery point/time and reconstitution objectives, and established organizational metrics consistent with contingency plan requirements. Reconstitution includes the deactivation of any interim information system capabilities that may have been needed during recovery operations. Reconstitution also includes assessments of fully restored information system capabilities, reestablishment of continuous monitoring activities, potential information system reauthorizations, and activities to prepare the systems against future disruptions, compromises, or failures. Recovery/reconstitution capabilities employed by organizations can include both automated mechanisms and manual procedures. Related controls: CA-2, CA-6, CA-7, CP-2, CP-6, CP-7, CP-9, SC-24.
+
+    References: Federal Continuity Directive 1; NIST Special Publication 800-34.
+  title: >-
+    CP-10 - INFORMATION SYSTEM RECOVERY AND
+
+    RECONSTITUTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-10(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CP-10(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system implements transaction recovery for systems that are transaction-based.
+
+    Supplemental Guidance:  Transaction-based information systems include, for example, database management systems and transaction processing systems. Mechanisms supporting transaction recovery include, for example, transaction rollback and transaction journaling.
+  title: >-
+    CP-10(2) - INFORMATION SYSTEM RECOVERY AND RECONSTITUTION | TRANSACTION RECOVERY
+  levels:
+  - high
+  - moderate
+- id: CP-10(3)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CP-10(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization provides the capability to restore information system components within [Assignment: organization-defined restoration time-periods] from configuration-controlled and integrity-protected information representing a known, operational state for the components.
+
+    Supplemental Guidance:  Restoration of information system components includes, for example, reimaging which restores components to known, operational states. Related control: CM-2.
+
+    CP-10 (4) [time period consistent with the restoration time-periods defined in the service provider and organization  SLA]
+  title: >-
+    CP-10(4) - INFORMATION SYSTEM RECOVERY AND RECONSTITUTION | RESTORE WITHIN TIME
+    PERIOD
+  levels:
+  - high
+- id: CP-10(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: CP-10(6)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: CP-11
+  status: not applicable
+  notes: |-
+    The Red Hat Advanced Cluster Management for Kubernetes providing the capability to employ
+    organization-defined alternative communications protocols in support of maintaining
+    continuity of operations is the responsibility of the underlying operations layer which is
+    OpenShift.
+  rules: []
+- id: CP-12
+  status: pending
+  notes: |-
+    A complete control response is planned. Progress can be tracked via:
+  rules: []
+- id: CP-13
+  status: not applicable
+  notes: |-
+    Employment of organization-defined alternative or
+    supplemental security mechanisms for satisfying
+    organization-defined security functions when the primary
+    means of implementing Red Hat Advanced Cluster Management for Kubernetes security function
+    is unavailable or compromised is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration guidance.
+  rules: []
+- id: IA-1
+  status: not applicable
+  notes: |-
+    Section a: Developing organization-level identification and authentication
+    policy and procedures are outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section a.1: An identification and authentication policy that addresses purpose, scope, roles,
+    responsibilities, management commitment, coordination among organizational entities,
+    and compliance is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+    Section a.2: Procedures to facilitate the implementation of the identification and authentication
+    policy and associated identification and authentication controls
+    is an organizational control outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Review and updating an organizational-level identification and authentication
+    policy and procedures are outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b.1: Reviewing and updating the current identification and authentication policy is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b.2: Reviewing and updating the current identification and authentication procedures is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An identification and authentication\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the identification and authentication policy\
+    \ and associated identification and authentication controls; and\n b. Reviews\
+    \ and updates the current:\n   1. Identification and authentication policy [Assignment:\
+    \ organization-defined frequency]; and\n   2. Identification and authentication\
+    \ procedures [Assignment: organization-defined frequency].\n\nSupplemental Guidance:\
+    \  This control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ IA family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  FIPS\
+    \ Publication 201; NIST Special Publications 800-12, 800-63, 800-73, 800-76, 800-78,\
+    \ 800-100.\n\nIA-1 (b) (1) [at least annually] \nIA-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    IA-1 - IDENTIFICATION AND AUTHENTICATION POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system uniquely identifies and authenticates organizational users (or processes acting on behalf of organizational users).
+
+    Supplemental Guidance:  Organizational users include employees or individuals that organizations deem to have equivalent status of employees (e.g., contractors, guest researchers). This control applies to all accesses other than: (i) accesses that are explicitly identified and documented in AC-14; and (ii) accesses that occur through authorized use of group authenticators without individual authentication. Organizations may require unique identification of individuals in group accounts (e.g., shared privilege accounts) or for detailed accountability of individual activity. Organizations employ passwords, tokens, or biometrics to authenticate user identities, or in the case multifactor authentication, or some combination thereof. Access to organizational information systems is defined as either local access or network access. Local access is any access to organizational information systems by users (or processes acting on behalf of users) where such access is
+    obtained by direct connections without the use of networks. Network access is access to organizational information systems by users (or processes acting on behalf of users) where such access is obtained through network connections (i.e., nonlocal accesses). Remote access is a type of network access that involves communication through external networks (e.g., the Internet). Internal networks include local area networks and wide area networks. In addition, the use of encrypted virtual private networks (VPNs) for network connections between organization- controlled endpoints and non-organization controlled endpoints may be treated as internal networks from the perspective of protecting the confidentiality and integrity of information traversing the network.
+
+    Organizations can satisfy the identification and authentication requirements in this control by complying with the requirements in Homeland Security Presidential Directive 12 consistent with the specific organizational implementation plans. Multifactor authentication requires the use of two or more different factors to achieve authentication. The factors are defined as: (i) something you know (e.g., password, personal identification number [PIN]); (ii) something you have (e.g.,
+    cryptographic identification device, token); or (iii) something you are (e.g., biometric). Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD common access card. In addition to identifying and authenticating users at the information system level
+    (i.e., at logon), organizations also employ identification and authentication mechanisms at the application level, when necessary, to provide increased information security. Identification and authentication requirements for other than organizational users are described in IA-8. Related controls: AC-2, AC-3, AC-14, AC-17, AC-18, IA-4, IA-5, IA-8.
+
+    References: HSPD-12; OMB Memoranda 04-04, 06-16, 11-11; FIPS Publication 201; NIST Special Publications 800-63, 800-73, 800-76, 800-78; FICAM Roadmap and Implementation Guidance; Web: http://idmanagement.gov.
+  title: >-
+    IA-2 - IDENTIFICATION AND AUTHENTICATION
+
+    (ORGANIZATIONAL USERS)
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements multifactor authentication for network access to privileged accounts.
+
+    Supplemental Guidance:  Related control: AC-6.
+  title: >-
+    IA-2(1) - IDENTIFICATION AND AUTHENTICATION | NETWORK ACCESS TO PRIVILEGED ACCOUNTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements multifactor authentication for network access to non- privileged accounts.
+  title: >-
+    IA-2(2) - IDENTIFICATION AND AUTHENTICATION | NETWORK ACCESS TO NON-PRIVILEGED
+    ACCOUNTS
+  levels:
+  - high
+  - moderate
+- id: IA-2(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements multifactor authentication for local access to privileged accounts.
+
+    Supplemental Guidance:  Related control: AC-6.
+  title: >-
+    IA-2(3) - IDENTIFICATION AND AUTHENTICATION | LOCAL ACCESS TO PRIVILEGED ACCOUNTS
+  levels:
+  - high
+  - moderate
+- id: IA-2(4)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements multifactor authentication for local access to non-privileged accounts.
+  title: >-
+    IA-2(4) - IDENTIFICATION AND AUTHENTICATION | LOCAL ACCESS TO NON-PRIVILEGED ACCOUNTS
+  levels:
+  - high
+- id: IA-2(5)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization requires individuals to be authenticated with an individual authenticator when a group authenticator is employed.
+
+    Supplemental Guidance:  Requiring individuals to use individual authenticators as a second level of authentication helps organizations to mitigate the risk of using group authenticators.
+  title: >-
+    IA-2(5) - IDENTIFICATION AND AUTHENTICATION (ORGANIZATIONAL USERS) |
+
+    GROUP AUTHENTICATION
+  levels:
+  - high
+  - moderate
+- id: IA-2(6)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-2(7)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-2(8)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements replay-resistant authentication mechanisms for network access to privileged accounts.
+
+    Supplemental Guidance:  Authentication processes resist replay attacks if it is impractical to achieve successful authentications by replaying previous authentication messages. Replay- resistant techniques include, for example, protocols that use nonces or challenges such as Transport Layer Security (TLS) and time synchronous or challenge-response one-time authenticators.
+  title: >-
+    IA-2(8) - IDENTIFICATION AND AUTHENTICATION | NETWORK ACCESS TO PRIVILEGED ACCOUNTS
+    - REPLAY RESISTANT
+  levels:
+  - high
+  - moderate
+- id: IA-2(9)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements replay-resistant authentication mechanisms for network access to non-privileged accounts.
+
+    Supplemental Guidance:  Authentication processes resist replay attacks if it is impractical to achieve successful authentications by recording/replaying previous authentication messages. Replay-resistant techniques include, for example, protocols that use nonces or challenges such as Transport Layer Security (TLS) and time synchronous or challenge-response one-time authenticators.
+  title: >-
+    IA-2(9) - IDENTIFICATION AND AUTHENTICATION | NETWORK ACCESS TO NON-PRIVILEGED
+    ACCOUNTS - REPLAY RESISTANT
+  levels:
+  - high
+- id: IA-2(10)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-2(11)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements multifactor authentication for remote access to privileged and non-privileged accounts such that one of the factors is provided by a device separate from the system gaining access and the device meets [Assignment: organization-defined strength of mechanism requirements].
+
+    Supplemental Guidance:  For remote access to privileged/non-privileged accounts, the purpose of requiring a device that is separate from the information system gaining access for one of the factors during multifactor authentication is to reduce the likelihood of compromising authentication credentials stored on the system. For example, adversaries deploying malicious code on organizational information systems can potentially compromise such credentials resident on the system and subsequently impersonate authorized users. Related control: AC-6.
+
+    IA-2 (11) [FIPS 140-2, NIAP Certification, or NSA approval]
+    IA-2 (11) Guidance: PIV=separate device. Please refer to NIST SP 800-157 Guidelines for Derived Personal Identity Verification (PIV) Credentials.
+  title: >-
+    IA-2(11) - IDENTIFICATION AND AUTHENTICATION | REMOTE ACCESS - SEPARATE DEVICE
+  levels:
+  - high
+  - moderate
+- id: IA-2(12)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system accepts and electronically verifies Personal Identity Verification (PIV)
+    credentials.
+
+    Supplemental Guidance:  This control enhancement applies to organizations implementing logical access control systems (LACS) and physical access control systems (PACS). Personal Identity Verification (PIV) credentials are those credentials issued by federal agencies that conform to FIPS Publication 201 and supporting guidance documents. OMB Memorandum 11-11 requires federal agencies to continue implementing the requirements specified in HSPD-12 to enable agency-wide use of PIV credentials. Related controls: AU-2, PE-3, SA-4.
+
+    IA-2 (12) Guidance: Include Common Access Card (CAC), i.e., the DoD technical implementation of PIV/FIPS 201/HSPD-12.
+  title: >-
+    IA-2(12) - IDENTIFICATION AND AUTHENTICATION | ACCEPTANCE OF PIV CREDENTIALS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2(13)
+  status: not applicable
+  notes: |-
+    Implementing out-of-band authentication methods is an organizational
+    control outside the configuration guidance of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-3
+  status: pending
+  notes: |-
+    A control response for IA-3 is planned.
+  rules: []
+  description: |-
+    The information system uniquely identifies and authenticates [Assignment: organization- defined specific and/or types of devices] before establishing a [Selection (one or more): local; remote; network] connection.
+
+    Supplemental Guidance: Organizational devices requiring unique device-to-device identification and authentication may be defined by type, by device, or by a combination of type/device. Information systems typically use either shared known information (e.g., Media Access Control [MAC] or Transmission Control Protocol/Internet Protocol [TCP/IP] addresses) for device identification or organizational authentication solutions (e.g., IEEE 802.1x and Extensible Authentication Protocol [EAP], Radius server with EAP-Transport Layer Security [TLS] authentication, Kerberos) to identify/authenticate devices on local and/or wide area networks. Organizations determine the required strength of authentication mechanisms by the security categories of information systems. Because of the challenges of applying this control on large scale, organizations are encouraged to only apply the control to those limited number (and type) of devices that truly need to support this capability. Related controls: AC-17, AC-18, AC-19, CA-3, IA-4, IA-5.
+
+    References: None.
+  title: >-
+    IA-3 - DEVICE IDENTIFICATION AND AUTHENTICATION
+  levels:
+  - high
+  - moderate
+- id: IA-3(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-3(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: IA-3(3)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-3(4)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-4
+  status: not applicable
+  notes: |-
+    Section a: Receiving authorization from organization-defined personnel or roles to assign
+    an individual, group, role, or device identifier is an organizational procedural
+    requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Selecting an identifier that identifies an individual, group, role, or device
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section c: Assigning the identifier to the intended individual, group, role, or device
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section d: Preventing reuse of identifiers for organization-defined time period is an organizational
+    procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section e: Disabling the identifier after organization-defined time period of inactivity
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: "The organization manages information system identifiers by:\n a. Receiving\
+    \ authorization from [Assignment: organization-defined personnel or roles] to\
+    \ assign an individual, group, role, or device identifier;\n b. Selecting an identifier\
+    \ that identifies an individual, group, role, or device;\n c. Assigning the identifier\
+    \ to the intended individual, group, role, or device;\n d. Preventing reuse of\
+    \ identifiers for [Assignment: organization-defined time period]; and\n e. Disabling\
+    \ the identifier after [Assignment: organization-defined time period of inactivity].\n\
+    \nSupplemental Guidance:  Common device identifiers include, for example, media\
+    \ access control (MAC), Internet protocol (IP) addresses, or device-unique token\
+    \ identifiers. Management of individual identifiers is not applicable to shared\
+    \ information system accounts (e.g., guest and anonymous accounts). Typically,\
+    \ individual identifiers are the user names of the information system accounts\
+    \ assigned to those individuals. In such instances, the account management activities\
+    \ of AC-2 use account names provided by IA-4. This control also addresses individual\
+    \ identifiers not necessarily associated with information system accounts (e.g.,\
+    \ identifiers used in physical security control databases accessed by badge reader\
+    \ systems for access to information systems). Preventing reuse of identifiers\
+    \ implies preventing the assignment of previously used individual, group, role,\
+    \ or device identifiers to different individuals, groups, roles, or devices. Related\
+    \ controls: AC-2, IA-2, IA-3, IA-5, IA-8, SC-37.\n\nReferences: FIPS Publication\
+    \ 201; NIST Special Publications 800-73, 800-76, 800-78.\nIA-4(a) [at a minimum,\
+    \ the ISSO (or similar role within the organization)]  \nIA-4 (d) [at least two\
+    \ (2) years]\nIA-4 (e) [thirty-five (35) days] (See additional requirements and\
+    \ guidance.)\nIA-4 (e) Requirement: The service provider defines the time period\
+    \ of inactivity for device identifiers.\nGuidance: For DoD clouds, see DoD cloud\
+    \ website for specific DoD requirements that go above and beyond FedRAMP http://iase.disa.mil/cloud_security/Pages/index.aspx."
+  title: >-
+    IA-4 - IDENTIFIER MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-4(1)
+  status: not applicable
+  notes: |-
+    The organization prohibiting the use of information system account identifiers
+    that are the same as public identifiers for individual electronic mail accounts
+    is an organizational control outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-4(2)
+  status: not applicable
+  notes: |-
+    The organization requireing that the registration process to receive an individual
+    identifier includes supervisor authorization is an organizational procedural requirement
+    outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-4(3)
+  status: not applicable
+  notes: |-
+    The organization requireing multiple forms of certification of individual
+    identification be presented to the registration authority is an organizational procedural requirement
+    outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-4(4)
+  status: not applicable
+  notes: |-
+    The organization manages individual identifiers by uniquely identifying
+    each individual as an organization-defined characteristic identifying individual status
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization manages individual identifiers by uniquely identifying each individual as
+    [Assignment: organization-defined characteristic identifying individual status].
+
+    Supplemental Guidance:  Characteristics identifying the status of individuals include, for example, contractors and foreign nationals. Identifying the status of individuals by specific characteristics provides additional information about the people with whom organizational personnel are communicating. For example, it might be useful for a government employee to know that one of the individuals on an email message is a contractor. Related control: AT-2.
+
+    IA-4 (4) [contractors; foreign nationals]
+  title: >-
+    IA-4(4) - IDENTIFIER MANAGEMENT | IDENTIFY USER STATUS
+  levels:
+  - high
+  - moderate
+- id: IA-4(5)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-4(6)
+  status: not applicable
+  notes: |-
+    Coordination with organization-defined external
+    organizations for cross-organization management
+    of identifiers is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-4(7)
+  status: not applicable
+  notes: |-
+    Organizational requirements that the user registration
+    process to receive an individual identifier be conducted
+    in person before a designated registration authority
+    is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-5
+  status: not applicable
+  notes: |-
+    Section a: Verifying, as part of the initial authenticator distribution, the identity
+    of the individual, group, role, or device receiving the authenticator
+    is an organizational procedural requirement
+    outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Establishing initial authenticator content for authenticators defined by the organization
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section c: Ensuring that authenticators have sufficient strength of mechanism for their intended use
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section d: Establishing and implementing administrative procedures for initial authenticator distribution,
+    for lost/compromised or damaged authenticators, and for revoking authenticators
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section e: Changing default content of authenticators prior to information system installation
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section f: Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section g: Changing/refreshing authenticators by organization-defined time period by authenticator type
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section h: Protecting authenticator content from unauthorized disclosure and modification
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section i: Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section j: Changing authenticators for group/role accounts when membership to those accounts changes
+    is an organizational procedural requirement outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization manages information system authenticators by:
+      a. Verifying, as part of the initial authenticator distribution, the identity of the individual, group, role, or device receiving the authenticator;
+      b. Establishing initial authenticator content for authenticators defined by the organization;
+      c. Ensuring that authenticators have sufficient strength of mechanism for their intended use;
+      d. Establishing and implementing administrative procedures for initial authenticator distribution, for lost/compromised or damaged authenticators, and for revoking authenticators;
+      e. Changing default content of authenticators prior to information system installation;
+      f. Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators;
+      g. Changing/refreshing authenticators [Assignment: organization-defined time period by authenticator type];
+      h. Protecting authenticator content from unauthorized disclosure and modification;
+      i. Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators; and
+      j. Changing authenticators for group/role accounts when membership to those accounts changes.
+
+    Supplemental Guidance: Individual authenticators include, for example, passwords, tokens, biometrics, PKI certificates, and key cards. Initial authenticator content is the actual content (e.g., the initial password) as opposed to requirements about authenticator content (e.g., minimum password length). In many cases, developers ship information system components with factory default authentication credentials to allow for initial installation and configuration. Default authentication credentials are often well known, easily discoverable, and present a significant security risk. The requirement to protect individual authenticators may be implemented via control PL-4 or PS-6 for authenticators in the possession of individuals and by controls AC-3, AC-6, and SC-28 for authenticators stored within organizational information systems (e.g., passwords stored in hashed or encrypted formats, files containing encrypted or hashed passwords accessible with administrator privileges). Information systems support individual authenticator management by organization-defined settings and restrictions for various authenticator characteristics including, for example, minimum password length, password composition, validation time window for time synchronous one-time tokens, and number of allowed rejections during the verification stage of biometric authentication. Specific actions that can be taken to safeguard authenticators include, for example, maintaining possession of individual authenticators, not loaning or sharing individual authenticators with others, and reporting lost, stolen, or compromised authenticators immediately. Authenticator management includes issuing and revoking, when no longer needed, authenticators for temporary access such as that required for remote maintenance. Device authenticators include, for example, certificates and passwords. Related controls: AC-2, AC-3, AC-6, CM-6, IA-2, IA-4, IA-8, PL-4, PS-5, PS-6, SC-12, SC-13, SC-17, SC-28.
+
+    References: OMB Memoranda 04-04, 11-11; FIPS Publication 201; NIST Special Publications 800-73, 800-63, 800-76, 800-78; FICAM Roadmap and Implementation Guidance
+
+
+
+    IA-5 Requirement: Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 3. Link https://pages.nist.gov/800-63-3
+  title: >-
+    IA-5 - AUTHENTICATOR MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-5(1)
+  status: not applicable
+  notes: |-
+    Section a: Enforcing a minimum password complexity of organization-defined requirements for case sensitivity,
+    number of characters, mix of upper-case letters, lower-case letters, numbers, and special
+    characters, including minimum requirements for each type is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Enforcing at least an organization-defined number of changed characters when new passwords are created
+    is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section c: Storing and transmitting only cryptographically-protected passwords
+    is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section d: Enforcing password minimum and maximum lifetime restrictions of organization-defined numbers for
+    lifetime minimum and maximum is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section e: Prohibiting password reuse for organization-defined number generations
+    is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section f: Allowing the use of a temporary password for system logons with an immediate change
+    to a permanent password is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system, for password-based authentication:
+     (a)   Enforces minimum password complexity of [Assignment: organization-defined requirements for case sensitivity, number of characters, mix of upper-case letters, lower-case letters, numbers, and special characters, including minimum requirements for each type];
+     (b)   Enforces at least the following number of changed characters when new passwords are created: [Assignment: organization-defined number];
+     (c)   Stores and transmits only encrypted representations of passwords;
+     (d)   Enforces password minimum and maximum lifetime restrictions of [Assignment: organization- defined numbers for lifetime minimum, lifetime maximum];
+     (e)   Prohibits password reuse for [Assignment: organization-defined number] generations; and
+     (f) Allows the use of a temporary password for system logons with an immediate change to a permanent password.
+
+    Supplemental Guidance:  This control enhancement applies to single-factor authentication of individuals using passwords as individual or group authenticators, and in a similar manner, when passwords are part of multifactor authenticators. This control enhancement does not apply when passwords are used to unlock hardware authenticators (e.g., Personal Identity Verification cards). The implementation of such password mechanisms may not meet all of the requirements in the enhancement. Encrypted representations of passwords include, for example, encrypted versions of passwords and one-way cryptographic hashes of passwords. The number of changed characters refers to the number of changes required with respect to the total number of positions in the current password. Password lifetime restrictions do not apply to temporary passwords. Related control: IA-6.
+
+    IA-5 (1) (b) [at least fifty percent (50%)]
+    IA-5 (1) (e) [twenty four (24)]
+    IA-5 (1) (a), and (d) Additional FedRAMP Requirements and Guidance:
+    Guidance: If password policies are compliant with NIST SP 800-63B Memorized Secret (Section 5.1.1) Guidance, the control may be considered compliant
+  title: >-
+    IA-5(1) - AUTHENTICATOR MANAGEMENT | PASSWORD-BASED AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-5(2)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section c: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section d: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system, for PKI-based authentication:
+     (a)   Validates certifications by constructing and verifying a certification path to an accepted trust anchor including checking certificate status information;
+     (b)   Enforces authorized access to the corresponding private key;
+     (c)   Maps the authenticated identity to the account of the individual or group; and
+     (d)   Implements a local cache of revocation data to support path discovery and validation in case of inability to access revocation information via the network.
+
+    Supplemental Guidance:  Status information for certification paths includes, for example, certificate revocation lists or certificate status protocol responses. For PIV cards, validation of certifications involves the construction and verification of a certification path to the Common Policy Root trust anchor including certificate policy processing. Related control: IA-6.
+  title: >-
+    IA-5(2) - AUTHENTICATOR MANAGEMENT | PKI-BASED AUTHENTICATION
+  levels:
+  - high
+  - moderate
+- id: IA-5(3)
+  status: not applicable
+  notes: |-
+    Organizational requirements that the registration process to
+    receive organization-defined types of and/or specific authenticators
+    be conducted either in person and/or by a trusted third party before
+    organization-defined registration authority with authorization by
+    organization-defined personnel or roles is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization requires that the registration process to receive\
+    \ [Assignment: organization- defined types of and/or specific authenticators]\
+    \ be conducted [Selection: in person; by a trusted third party] before [Assignment:\
+    \ organization-defined registration authority] with authorization by [Assignment:\
+    \ organization-defined personnel or roles].\n\nIA-5 (3)-1 [All hardware/biometric\
+    \ (multifactor authenticators] \nIA-5 (3)-2 [in person]"
+  title: >-
+    IA-5(3) - AUTHENTICATOR MANAGEMENT | IN-PERSON OR TRUSTED THIRD-PARTY REGISTRATION
+  levels:
+  - high
+  - moderate
+- id: IA-5(4)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated tools to determine if password authenticators are sufficiently strong to satisfy [Assignment: organization-defined requirements].
+
+    Supplemental Guidance:  This control enhancement focuses on the creation of strong passwords and the characteristics of such passwords (e.g., complexity) prior to use, the enforcement of which is carried out by organizational information systems in IA-5 (1). Related controls: CA-2, CA-7, RA-5.
+
+    IA-5 (4) [complexity as identified in IA-5 (1) Control Enhancement Part (a)]
+    IA-5 (4) Guidance: If automated mechanisms which enforce password authenticator strength at creation are not used, automated mechanisms must be used to audit strength of created password authenticators.
+  title: >-
+    IA-5(4) - AUTHENTICATOR MANAGEMENT | AUTOMATED SUPPORT FOR PASSWORD STRENGTH DETERMINATION
+  levels:
+  - high
+  - moderate
+- id: IA-5(5)
+  status: not applicable
+  notes: |-
+    The organization requireing developers/installers of information system
+    components to provide unique authenticators or change default
+    authenticators prior to delivery/installation is an organizational process
+    outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-5(6)
+  status: not applicable
+  notes: |-
+    The organization protects authenticators commensurate with the security
+    category of the information to which use of the authenticator permits access
+    is an organizational process outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization protects authenticators commensurate with the security category of the information to which use of the authenticator permits access.
+
+    Supplemental Guidance:  For information systems containing multiple security categories of information without reliable physical or logical separation between categories, authenticators used to grant access to the systems are protected commensurate with the highest security category of information on the systems.
+  title: >-
+    IA-5(6) - AUTHENTICATOR MANAGEMENT | PROTECTION OF AUTHENTICATORS
+  levels:
+  - high
+  - moderate
+- id: IA-5(7)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization ensures that unencrypted static authenticators are not embedded in applications or access scripts or stored on function keys.
+
+    Supplemental Guidance:  Organizations exercise caution in determining whether embedded or stored authenticators are in encrypted or unencrypted form. If authenticators are used in the manner stored, then those representations are considered unencrypted authenticators. This is irrespective of whether that representation is perhaps an encrypted version of something else (e.g., a password).
+  title: >-
+    IA-5(7) - AUTHENTICATOR MANAGEMENT | NO EMBEDDED UNENCRYPTED STATIC AUTHENTICATORS
+  levels:
+  - high
+  - moderate
+- id: IA-5(8)
+  status: not applicable
+  notes: |-
+    Organizational implementation of organization-defined security
+    safeguards to manage the risk of compromise due to individuals having
+    accounts on multiple information systems is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined security safeguards] to manage the risk of compromise due to individuals having accounts on multiple information systems.
+
+    Supplemental Guidance:  When individuals have accounts on multiple information systems, there is the risk that the compromise of one account may lead to the compromise of other accounts if individuals use the same authenticators. Possible alternatives include, for example: (i) having different authenticators on all systems; (ii) employing some form of single sign-on mechanism; or (iii) including some form of one-time passwords on all systems.
+
+    IA-5 (8) [different authenticators on different systems]
+  title: >-
+    IA-5(8) - AUTHENTICATOR MANAGEMENT | MULTIPLE INFORMATION SYSTEM ACCOUNTS
+  levels:
+  - high
+- id: IA-5(9)
+  status: not applicable
+  notes: |-
+    Organizational coordination with organization-defined
+    external organizations for cross-organization management
+    of credentials is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-5(10)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-5(11)
+  status: not applicable
+  notes: |-
+    Employment of mechanisms that satisfy organization-defined
+    token quality requirements is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system, for hardware token-based authentication, employs mechanisms that satisfy [Assignment: organization-defined token quality requirements].
+
+    Supplemental Guidance:  Hardware token-based authentication typically refers to the use of PKI-based tokens, such as the U.S. Government Personal Identity Verification (PIV) card. Organizations define specific requirements for tokens, such as working with a particular PKI.
+  title: >-
+    IA-5(11) - AUTHENTICATOR MANAGEMENT | HARDWARE TOKEN-BASED AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-5(12)
+  status: not applicable
+  notes: |-
+    Employment of mechanisms that satisfy organization-defined
+    biometric quality requirements is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: IA-5(13)
+  status: pending
+  notes: |-
+    A control response is planned. Engineering progress can be tracked via:
+  rules: []
+  description: |-
+    The information system prohibits the use of cached authenticators after [Assignment: organization-defined time period].
+  title: >-
+    IA-5(13) - AUTHENTICATOR MANAGEMENT | EXPIRATION OF CACHED AUTHENTICATORS
+  levels:
+  - high
+- id: IA-5(14)
+  status: pending
+  notes: |-
+    A control response is planned. Engineering progress can be tracked via:
+  rules: []
+- id: IA-5(15)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-6
+  status: supported
+  notes: |-
+    By default, Red Hat Advanced Cluster Management for Kubernetes session key and account login
+    passwords are obscured by not being displayed on output or by asterisks.
+  rules: []
+  description: |-
+    The information system obscures feedback of authentication information during the authentication process to protect the information from possible exploitation/use by unauthorized individuals.
+
+    Supplemental Guidance:  The feedback from information systems does not provide information that would allow unauthorized individuals to compromise authentication mechanisms. For some types of information systems or system components, for example, desktops/notebooks with relatively large monitors, the threat (often referred to as shoulder surfing) may be significant. For other types of systems or components, for example, mobile devices with 2-4 inch screens, this threat may be less significant, and may need to be balanced against the increased likelihood of typographic input errors due to the small keyboards. Therefore, the means for obscuring the authenticator feedback is selected accordingly. Obscuring the feedback of authentication information includes, for example, displaying asterisks when users type passwords into input devices, or displaying feedback for a very limited time before fully obscuring it. Related control: PE-18.
+
+    Control Enhancements:  None.
+
+    References:  None.
+  title: >-
+    IA-6 - AUTHENTICATOR FEEDBACK
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-7
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements mechanisms for authentication to a cryptographic module that meet the requirements of applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance for such authentication.
+
+    Supplemental Guidance:  Authentication mechanisms may be required within a cryptographic module to authenticate an operator accessing the module and to verify that the operator is authorized to assume the requested role and perform services within that role. Related controls: SC-12, SC-13.
+
+    Control Enhancements:  None.
+
+    References:  FIPS Publication 140; Web: csrc.nist.gov/groups/STM/cmvp/index.html.
+  title: >-
+    IA-7 - CRYPTOGRAPHIC MODULE AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system uniquely identifies and authenticates non-organizational users (or processes acting on behalf of non-organizational users).
+
+    Supplemental Guidance:  Non-organizational users include information system users other than organizational users explicitly covered by IA-2. These individuals are uniquely identified and authenticated for accesses other than those accesses explicitly identified and documented in AC-14. In accordance with the E-Authentication E-Government initiative, authentication of non- organizational users accessing federal information systems may be required to protect federal, proprietary, or privacy-related information (with exceptions noted for national security systems). Organizations use risk assessments to determine authentication needs and consider scalability, practicality, and security in balancing the need to ensure ease of use for access to federal information and information systems with the need to protect and adequately mitigate risk. IA-2 addresses identification and authentication requirements for access to information systems by organizational users. Related controls: AC-2, AC-14, AC-17, AC-18, IA-2, IA-4, IA-5, MA-4, RA-3, SA-12, SC-8.
+
+    References: OMB Memoranda 04-04, 11-11, 10-06-2011; FICAM Roadmap and Implementation Guidance; FIPS Publication 201; NIST Special Publications 800-63, 800-116; National Strategy for Trusted Identities in Cyberspace; Web: http://idmanagement.gov.
+  title: >-
+    IA-8 - IDENTIFICATION AND AUTHENTICATION (NON- ORGANIZATIONAL USERS)
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(1)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system accepts and electronically verifies Personal Identity Verification (PIV) credentials from other federal agencies.
+
+    Supplemental Guidance:  This control enhancement applies to logical access control systems (LACS) and physical access control systems (PACS). Personal Identity Verification (PIV) credentials are those credentials issued by federal agencies that conform to FIPS Publication 201 and supporting guidance documents. OMB Memorandum 11-11 requires federal agencies to continue implementing the requirements specified in HSPD-12 to enable agency-wide use of PIV credentials. Related controls: AU-2, PE-3, SA-4.
+  title: >-
+    IA-8(1) - IDENTIFICATION AND AUTHENTICATION | ACCEPTANCE OF PIV CREDENTIALS FROM
+    OTHER AGENCIES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(2)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system accepts only FICAM-approved third-party credentials.
+
+    Supplemental Guidance:  This control enhancement typically applies to organizational information systems that are accessible to the general public, for example, public-facing websites. Third-party credentials are those credentials issued by nonfederal government entities approved by the Federal Identity, Credential, and Access Management (FICAM) Trust Framework Solutions initiative. Approved third-party credentials meet or exceed the set of minimum federal government-wide technical, security, privacy, and organizational maturity requirements. This allows federal government relying parties to trust such credentials at their approved assurance levels. Related control: AU-2.
+  title: >-
+    IA-8(2) - IDENTIFICATION AND AUTHENTICATION | ACCEPTANCE OF THIRD-PARTY CREDENTIALS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(3)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs only FICAM-approved information system components in [Assignment:
+    organization-defined information systems] to accept third-party credentials.
+
+    Supplemental Guidance:  This control enhancement typically applies to information systems that are accessible to the general public, for example, public-facing websites. FICAM-approved information system components include, for example, information technology products and software libraries that have been approved by the Federal Identity, Credential, and Access Management conformance program. Related control: SA-4.
+  title: >-
+    IA-8(3) - IDENTIFICATION AND AUTHENTICATION | USE OF FICAM-APPROVED PRODUCTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(4)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system conforms to FICAM-issued profiles.
+
+    Supplemental Guidance:  This control enhancement addresses open identity management standards. To ensure that these standards are viable, robust, reliable, sustainable (e.g., available in commercial information technology products), and interoperable as documented, the United States Government assesses and scopes identity management standards and technology implementations against applicable federal legislation, directives, policies, and requirements. The result is FICAM-issued implementation profiles of approved protocols (e.g., FICAM authentication protocols such as SAML 2.0 and OpenID 2.0, as well as other protocols such as the FICAM Backend Attribute Exchange). Related control: SA-4.
+  title: >-
+    IA-8(4) - IDENTIFICATION AND AUTHENTICATION | USE OF FICAM-ISSUED PROFILES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(5)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for identification and authentication.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-9
+  status: not applicable
+  notes: |-
+    The organization identifying and authenticating organization-defined
+    information system services using organization-defined security safeguards
+    is an organizational control outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-9(1)
+  status: not applicable
+  notes: |-
+    The organization ensuring that service providers receive, validate, and
+    transmit identification and authentication information is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-9(2)
+  status: not applicable
+  notes: |-
+    The organization ensuring that identification and authentication decisions
+    are transmitted between organization-defined services that are consistent
+    with organizational policies is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-10
+  status: not applicable
+  notes: |-
+    Requiring that individuals accessing the information system employ
+    organization-defined supplemental authentication techniques or
+    mechanisms under specific organization-defined circumstances or
+    situations is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: IA-11
+  status: pending
+  notes: |-
+    A control response is planned. Engineering progress can be tracked via:
+  rules: []
+- id: IR-1
+  status: not applicable
+  notes: |-
+    Section a: Developing, documenting, and dissemintating to organization-defined
+    personnel or roles of incident response policies and procedures is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section a.1: Developing, documenting, and dissemintating to organization-defined
+    personnel or roles an incident response policy that addresses purpose,
+    scope, roles, responsibilities, management commitment, coordination
+    among organizational entities, and compliance is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section a.2: Developing, documenting, and dissemintating to organization-defined
+    personnel or roles procedures to facilitate the implementation of the
+    incident response policy and associated incident response controls is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: Reviewing and updating incident response policy and procedures is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b.1: Reviewing and updating the current incident response policy on an
+    organzation-defined frequency is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b.2: Reviewing and updating the current incident response procedures on an
+    organization-defined frequency is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An incident response policy\
+    \ that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the incident response policy and associated\
+    \ incident response controls; and\n b. Reviews and updates the current:\n   1.\
+    \ Incident response policy [Assignment: organization-defined frequency]; and\n\
+    \   2. Incident response procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the IR family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-61, 800-83, 800-100.\n\n\
+    IR-1 (b) (1) [at least annually] \nIR-1 (b) (2) [at least annually or whenever\
+    \ a significant change occurs]"
+  title: >-
+    IR-1 - INCIDENT RESPONSE POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-2
+  status: not applicable
+  notes: |-
+    Section a: Providing incident response training to information system users
+    consistent with assigned roles and responsibilities within an
+    organization-defined time period of assuming an incident response role
+    or responsibility is an organizational control outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Providing incident response training to information system users
+    consistent with assigned roles and responsibilities when required by
+    information system changes is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section c: Providing incident response training to information system users
+    consistent with assigned roles and responsibilities on a TBD time
+    thereafter is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization provides incident response training to information system users consistent with assigned roles and responsibilities:
+     a. Within [Assignment: organization-defined time period] of assuming an incident response role or responsibility;
+     b. When required by information system changes; and
+     c. [Assignment: organization-defined frequency] thereafter.
+
+    Supplemental Guidance:  Incident response training provided by organizations is linked to the assigned roles and responsibilities of organizational personnel to ensure the appropriate content and level of detail is included in such training. For example, regular users may only need to know who to call or how to recognize an incident on the information system; system administrators may require additional training on how to handle/remediate incidents; and incident responders may receive more specific training on forensics, reporting, system recovery, and restoration. Incident response training includes user training in the identification and reporting of suspicious activities, both from external and internal sources. Related controls: AT-3, CP-3, IR-8.
+
+    References: NIST Special Publications 800-16, 800-50.
+
+    IR-2 (a) [within ten (10) days]
+    IR-2 (c) [at least annually]
+  title: >-
+    IR-2 - INCIDENT RESPONSE TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-2(1)
+  status: not applicable
+  notes: |-
+    Incorporating simulated events into incident response training to
+    facilitate effective response by personnel in crisis situations is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization incorporates simulated events into incident response training to facilitate effective response by personnel in crisis situations.
+  title: >-
+    IR-2(1) - INCIDENT RESPONSE TRAINING | SIMULATED EVENTS
+  levels:
+  - high
+- id: IR-2(2)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to provide a more thorough and realistic
+    incident response training environment is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to provide a more thorough and realistic incident response training environment.
+  title: >-
+    IR-2(2) - INCIDENT RESPONSE TRAINING | AUTOMATED TRAINING ENVIRONMENTS
+  levels:
+  - high
+- id: IR-3
+  status: not applicable
+  notes: |-
+    Testing the incident response capability for the information system on
+    an organization-defined frequency using organization-defined tests to
+    determine the incident response effectiveness and documents the results
+    is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization tests the incident response capability for the information system [Assignment: organization-defined frequency] using [Assignment: organization-defined tests] to determine the incident response effectiveness and documents the results.
+
+    Supplemental Guidance:  Organizations test incident response capabilities to determine the overall effectiveness of the capabilities and to identify potential weaknesses or deficiencies. Incident response testing includes, for example, the use of checklists, walk-through or tabletop exercises, simulations (parallel/full interrupt), and comprehensive exercises. Incident response testing can also include a determination of the effects on organizational operations (e.g., reduction in mission capabilities), organizational assets, and individuals due to incident response. Related controls: CP-4, IR-8.
+
+    References:  NIST Special Publications 800-84, 800-115.
+
+    IR-3-1 [at least every six (6) months, including functional at least annually]
+    IR-3-2 Requirement: The service provider defines tests and/or exercises in accordance with NIST Special Publication 800-61 (as amended). Functional Testing must occur prior to testing for initial authorization. Annual functional testing may be concurrent with required penetration tests (see CA-8). The service provider provides test plans to the JAB/AO annually. Test plans are approved and accepted by the JAB/AO prior to test commencing.
+  title: >-
+    IR-3 - INCIDENT RESPONSE TESTING
+  levels:
+  - high
+  - moderate
+- id: IR-3(1)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to more thoroughly and effectively test
+    the incident response capability is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: IR-3(2)
+  status: not applicable
+  notes: |-
+    Coordinating incident response testing with organizational elements
+    responsible for related plans is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization coordinates incident response testing with organizational elements responsible for related plans.
+
+    Supplemental Guidance:  Organizational plans related to incident response testing include, for example, Business Continuity Plans, Contingency Plans, Disaster Recovery Plans, Continuity of Operations Plans, Crisis Communications Plans, Critical Infrastructure Plans, and
+    Occupant Emergency Plans.
+  title: >-
+    IR-3(2) - INCIDENT RESPONSE TESTING | COORDINATION WITH RELATED PLANS
+  levels:
+  - high
+  - moderate
+- id: IR-4
+  status: not applicable
+  notes: |-
+    Section a: Implementing an incident handling capability for security incidents that
+    includes preparation, detection and analysis, containment, eradication,
+    and recovery is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Coordinating incident handling activities with contingency planning
+    activities is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section c: Incorporating lessons learned from ongoing incident handling activities
+    into incident response procedures, training, and testing, and implements
+    the resulting changes accordingly is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization:\na. Implements an incident handling capability for\
+    \ security incidents that includes preparation, detection and analysis, containment,\
+    \ eradication, and recovery;\nb. Coordinates incident handling activities with\
+    \ contingency planning activities; and\nc. Incorporates lessons learned from ongoing\
+    \ incident handling activities into incident response procedures, training, and\
+    \ testing/exercises, and implements the resulting changes accordingly.\n\nSupplemental\
+    \ Guidance:  Organizations recognize that incident response capability is dependent\
+    \ on the capabilities of organizational information systems and the mission/business\
+    \ processes being supported by those systems. Therefore, organizations consider\
+    \ incident response as part of the definition, design, and development of mission/business\
+    \ processes and information systems. Incident-related information can be obtained\
+    \ from a variety of sources including, for example, audit monitoring, network\
+    \ monitoring, physical access monitoring, user/administrator reports, and reported\
+    \ supply chain events. Effective incident handling capability includes coordination\
+    \ among many organizational entities including, for example, mission/business\
+    \ owners, information system owners, authorizing officials, human resources offices,\
+    \ physical and personnel security offices, legal departments, operations personnel,\
+    \ procurement offices, and the risk executive (function). Related controls: AU-6,\
+    \ CM-6, CP-2, CP-4, IR-2, IR-3, IR-8, PE-6, SC-5, SC-7, SI-3, SI-4, SI-7.\n\n\
+    References: Executive Order 13587; NIST Special Publication 800-61.\n\n \nIR-4\
+    \ Requirement: The service provider ensures that individuals conducting incident\
+    \ handling meet personnel security requirements commensurate with the criticality/sensitivity\
+    \ of the information being processed, stored, and transmitted by the information\
+    \ system."
+  title: >-
+    IR-4 - INCIDENT HANDLING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-4(1)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to support the incident handling process
+    is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to support the incident handling process.
+
+    Supplemental Guidance:  Automated mechanisms supporting incident handling processes include, for example, online incident management systems.
+  title: >-
+    IR-4(1) - INCIDENT HANDLING | AUTOMATED INCIDENT HANDLING PROCESSES
+  levels:
+  - high
+  - moderate
+- id: IR-4(2)
+  status: not applicable
+  notes: |-
+    Including dynamic reconfiguration of organization-defined information
+    system components as part of the incident response capability is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization includes dynamic reconfiguration of [Assignment: organization-defined information system components] as part of the incident response capability.
+
+    Supplemental Guidance:  Dynamic reconfiguration includes, for example, changes to router rules, access control lists, intrusion detection/prevention system parameters, and filter rules for firewalls and gateways. Organizations perform dynamic reconfiguration of information systems, for example, to stop attacks, to misdirect attackers, and to isolate components of systems, thus limiting the extent of the damage from breaches or compromises. Organizations include time frames for achieving the reconfiguration of information systems in the definition of the reconfiguration capability, considering the potential need for rapid response in order to effectively address sophisticated cyber threats. Related controls: AC-2, AC-4, AC-16, CM-2, CM-3, CM-4.
+
+    IR-4 (2) [all network, data storage, and computing devices]
+  title: >-
+    IR-4(2) - INCIDENT HANDLING | DYNAMIC RECONFIGURATION
+  levels:
+  - high
+- id: IR-4(3)
+  status: not applicable
+  notes: |-
+    Identifying organization-defined classes of incidents and
+    organization-defined actions to take in response to classes of incidents
+    to ensure continuation of organizational missions and business
+    functions. is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization identifies [Assignment: organization-defined classes of incidents] and [Assignment: organization-defined actions to take in response to classes of incidents] to ensure continuation of organizational missions and business functions.
+
+    Supplemental Guidance:  Classes of incidents include, for example, malfunctions due to design/implementation errors and omissions, targeted malicious attacks, and untargeted malicious attacks. Appropriate incident response actions include, for example, graceful degradation, information system shutdown, fall back to manual mode/alternative technology whereby the system operates differently, employing deceptive measures, alternate information flows, or operating in a mode that is reserved solely for when systems are under attack.
+  title: >-
+    IR-4(3) - INCIDENT HANDLING | CONTINUITY OF OPERATIONS
+  levels:
+  - high
+- id: IR-4(4)
+  status: not applicable
+  notes: |-
+    Correlating incident information and individual incident responses to
+    achieve an organization-wide perspective on incident awareness and
+    response is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization correlates incident information and individual incident responses to achieve an organization-wide perspective on incident awareness and response.
+
+    Supplemental Guidance:  Sometimes the nature of a threat event, for example, a hostile cyber attack, is such that it can only be observed by bringing together information from different sources including various reports and reporting procedures established by organizations.
+  title: >-
+    IR-4(4) - INCIDENT HANDLING | INFORMATION CORRELATION
+  levels:
+  - high
+- id: IR-4(5)
+  status: not applicable
+  notes: |-
+    Implementing a configurable capability to automatically disable the
+    information system if organization-defined security violations are
+    detected is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: IR-4(6)
+  status: not applicable
+  notes: |-
+    Implementing incident handling capability for insider threats is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization implements incident handling capability for insider threats.
+
+    Supplemental Guidance:  While many organizations address insider threat incidents as an inherent part of their organizational incident response capability, this control enhancement provides additional emphasis on this type of threat and the need for specific incident handling capabilities (as defined within organizations) to provide appropriate and timely responses.
+  title: >-
+    IR-4(6) - INCIDENT HANDLING | INSIDER THREATS - SPECIFIC CAPABILITIES
+  levels:
+  - high
+- id: IR-4(7)
+  status: not applicable
+  notes: |-
+    Coordinating incident handling capability for insider threats across
+    organization-defined components or elements of the organization is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: IR-4(8)
+  status: not applicable
+  notes: |-
+    Coordinating with organization-defined external organizations to
+    correlate and share organization-defined incident information to achieve
+    a cross-organization perspective on incident awareness and more
+    effective incident responses is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization coordinates with [Assignment: organization-defined\
+    \ external organizations] to correlate and share [Assignment: organization-defined\
+    \ incident information] to achieve a cross- organization perspective on incident\
+    \ awareness and more effective incident responses.\n\nSupplemental Guidance: \
+    \ The coordination of incident information with external organizations including,\
+    \ for example, mission/business partners, military/coalition partners, customers,\
+    \ and multitiered developers, can provide significant benefits. Cross-organizational\
+    \ coordination with respect to incident handling can serve as an important risk\
+    \ management capability. This capability allows organizations to leverage critical\
+    \ information from a variety of sources to effectively respond to information\
+    \ security-related incidents potentially affecting the organization\u2019s operations,\
+    \ assets, and individuals.\n\nIR-4 (8) [external organizations including consumer\
+    \ incident responders and network defenders and the appropriate CIRT/CERT (such\
+    \ as US-CERT, DOD CERT, IC CERT)]"
+  title: >-
+    IR-4(8) - INCIDENT HANDLING | CORRELATION WITH EXTERNAL ORGANIZATIONS
+  levels:
+  - high
+- id: IR-4(9)
+  status: not applicable
+  notes: |-
+    Employing organization-defined dynamic response capabilities to
+    effectively respond to security incidents is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: IR-4(10)
+  status: not applicable
+  notes: |-
+    Coordinating incident handling activities involving supply chain events
+    with other organizations involved in the supply chain is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: IR-5
+  status: not applicable
+  notes: |-
+    Tracking and documenting information system security incidents is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization tracks and documents information system security incidents.
+
+    Supplemental Guidance:  Documenting information system security incidents includes, for example, maintaining records about each incident, the status of the incident, and other pertinent information necessary for forensics, evaluating incident details, trends, and handling. Incident information can be obtained from  a variety of sources including, for example, incident reports, incident response teams, audit monitoring, network monitoring, physical access monitoring, and user/administrator reports. Related controls: AU-6, IR-8, PE-6, SC-5, SC-7, SI-3, SI-4, SI-7.
+
+    References: NIST Special Publication 800-61.
+  title: >-
+    IR-5 - INCIDENT MONITORING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-5(1)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to assist in the tracking of security
+    incidents and in the collection and analysis of incident information is
+    an organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to assist in the tracking of security incidents and in the collection and analysis of incident information.
+
+    Supplemental Guidance:  Automated mechanisms for tracking security incidents and collecting/analyzing incident information include, for example, the Einstein network monitoring device and monitoring online Computer Incident Response Centers (CIRCs) or other electronic databases of incidents. Related controls: AU-7, IR-4.
+  title: >-
+    IR-5(1) - INCIDENT MONITORING | AUTOMATED TRACKING / DATA COLLECTION / ANALYSIS
+  levels:
+  - high
+- id: IR-6
+  status: not applicable
+  notes: |-
+    Section a: Requiring personnel to report suspected security incidents to the
+    organizational incident response capability within an
+    organization-defined time period is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Reporting security incident information to organization-defined
+    authorities is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Requires personnel to report suspected security incidents to the organizational incident response capability within [Assignment: organization-defined time period]; and
+     b. Reports security incident information to [Assignment: organization-defined authorities].
+
+    Supplemental Guidance:  The intent of this control is to address both specific incident reporting requirements within an organization and the formal incident reporting requirements for federal agencies and their subordinate organizations. Suspected security incidents include, for example, the receipt of suspicious email communications that can potentially contain malicious code. The types of security incidents reported, the content and timeliness of the reports, and the designated reporting authorities reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Current federal policy requires that all federal agencies (unless specifically exempted from such requirements) report security incidents to the United States Computer Emergency Readiness Team (US-CERT) within specified time frames designated in the US-CERT Concept of Operations for Federal Cyber Security Incident Handling. Related controls: IR-4, IR-5, IR-8.
+
+    References: NIST Special Publication 800-61; Web: http://www.us-cert.gov.
+
+    IR-6 (a) [US-CERT incident reporting timelines as specified in NIST Special Publication 800-61 (as amended)]
+    IR-6 Requirement: Reports security incident information according to FedRAMP Incident Communications Procedure.
+  title: >-
+    IR-6 - INCIDENT REPORTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-6(1)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to assist in the reporting of security
+    incidents is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to assist in the reporting of security incidents.
+
+    Supplemental Guidance:  Related control: IR-7.
+  title: >-
+    IR-6(1) - INCIDENT REPORTING | AUTOMATED REPORTING
+  levels:
+  - high
+  - moderate
+- id: IR-6(2)
+  status: not applicable
+  notes: |-
+    Reporting information system vulnerabilities associated with reported
+    security incidents to organization-defined personnel or roles is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: IR-6(3)
+  status: not applicable
+  notes: |-
+    Providing security incident information to other organizations involved
+    in the supply chain for information systems or information system
+    components related to the incident is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: IR-7
+  status: not applicable
+  notes: |-
+    Providing an incident response support resource, integral to the
+    organizational incident response capability that offers advice and
+    assistance to users of the information system for the handling and
+    reporting of security incidents is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization provides an incident response support resource, integral to the organizational incident response capability that offers advice and assistance to users of the information system for the handling and reporting of security incidents.
+
+    Supplemental Guidance:  Incident response support resources provided by organizations include, for example, help desks, assistance groups, and access to forensics services, when required. Related controls: AT-2, IR-4, IR-6, IR-8, SA-9.
+  title: >-
+    IR-7 - INCIDENT RESPONSE ASSISTANCE
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-7(1)
+  status: not applicable
+  notes: |-
+    Employing automated mechanisms to increase the availability of incident
+    response-related information and support is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to increase the availability of incident response- related information and support.
+
+    Supplemental Guidance:  Automated mechanisms can provide a push and/or pull capability for users to obtain incident response assistance. For example, individuals might have access to a website to query the assistance capability, or conversely, the assistance capability may have the ability to proactively send information to users (general distribution or targeted) as part of increasing understanding of current response capabilities and support.
+  title: >-
+    IR-7(1) - INCIDENT RESPONSE ASSISTANCE | AUTOMATION SUPPORT FOR AVAILABILITY OF
+    INFORMATION / SUPPORT
+  levels:
+  - high
+  - moderate
+- id: IR-7(2)
+  status: not applicable
+  notes: |-
+    Section a: Establishing a direct, cooperative relationship between its incident
+    response capability and external providers of information system
+    protection capability is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Identifying organizational incident response team members to the
+    external providers is an organizational control outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Establishes a direct, cooperative relationship between its incident response capability and external providers of information system protection capability; and
+     (b)   Identifies organizational incident response team members to the external providers.
+
+    Supplemental Guidance:  External providers of information system protection capability include, for example, the Computer Network Defense program within the U.S. Department of Defense. External providers help to protect, monitor, analyze, detect, and respond to unauthorized activity within organizational information systems and networks.
+  title: >-
+    IR-7(2) - INCIDENT RESPONSE ASSISTANCE | COORDINATION WITH EXTERNAL PROVIDERS
+  levels:
+  - high
+  - moderate
+- id: IR-8
+  status: not applicable
+  notes: |-
+    Section a: The development of an incident response plan is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section a.1: Developing an incident response plan that provides the organization with
+    a roadmap for implementing its incident response capability is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section a.2: Developing an incident response plan that describes the structure and
+    organization of the incident response capability is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section a.3: Developing an incident response plan that provides a high-level approach
+    for how the incident response capability fits into the overall
+    organization is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section a.4: Developing an incident response plan that meets the unique requirements
+    of the organization, which relate to mission, size, structure, and
+    functions is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section a.5: Developing an incident response plan that defines reportable incidents
+    is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+    Section a.6: Developing an incident response plan that provides metrics for measuring
+    the incident response capability within the organization is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section a.7: Developing an incident response plan that defines the resources and
+    management support needed to effectively maintain and mature an incident
+    response capability is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section a.8: Developing an incident response plan that is reviewed and approved by
+    organization-defined personnel or roles is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Distributing copies of the incident response plan to
+    organization-defined incident response personnel and organizational
+    elements is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section c: Reviewing the incident response plan on an organization-defined
+    frequency is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section d: Updating he incident response plan to address system/organizational
+    changes or problems encountered during plan implementation, execution,
+    or testing is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section e: Communicating incident response plan changes to organization-defined
+    incident response personnel and organizational elements is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section f: Protecting the incident response plan from unauthorized disclosure and
+    modification is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops an incident response plan that:
+       1. Provides the organization with a roadmap for implementing its incident response capability;
+       2. Describes the structure and organization of the incident response capability;
+       3. Provides a high-level approach for how the incident response capability fits into the overall organization;
+       4. Meets the unique requirements of the organization, which relate to mission, size, structure, and functions;
+       5. Defines reportable incidents;
+       6. Provides metrics for measuring the incident response capability within the organization;
+       7. Defines the resources and management support needed to effectively maintain and mature an incident response capability; and
+       8. Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+     b. Distributes copies of the incident response plan to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements];
+     c. Reviews the incident response plan [Assignment: organization-defined frequency];
+     d. Updates the incident response plan to address system/organizational changes or problems encountered during plan implementation, execution, or testing;
+      e. Communicates incident response plan changes to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements]; and
+    f. Protects the incident response plan from unauthorized disclosure and modification.
+
+    Supplemental Guidance:  It is important that organizations develop and implement a coordinated approach to incident response. Organizational missions, business functions, strategies, goals, and objectives for incident response help to determine the structure of incident response capabilities. As part of a comprehensive incident response capability, organizations consider the coordination and sharing of information with external organizations, including, for example, external service providers and organizations involved in the supply chain for organizational information systems. Related controls: MP-2, MP-4, MP-5.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publication 800-61.
+
+    IR-8 (b) [see additional FedRAMP Requirements and Guidance]
+    IR-8 (c) [at least annually]
+    IR-8 (e) [see additional FedRAMP Requirements and Guidance]
+    IR-8 (b) Requirement: The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.
+    IR-8 (e) Requirement: The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.
+  title: >-
+    IR-8 - INCIDENT RESPONSE PLAN
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-9
+  status: not applicable
+  notes: |-
+    Section a: Responding to information spills by identifying the specific information
+    involved in the information system contamination is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section b: Responding to information spills by alerting organization-defined
+    personnel or roles of the information spill using a method of
+    communication not associated with the spill is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: Responding to information spills by isolating the contaminated
+    information system or system component is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section d: Responding to information spills by eradicating the information from the
+    contaminated information system or component is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section e: Responding to information spills by identifying other information
+    systems or system components that may have been subsequently
+    contaminated is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section f: Responding to information spills by performing other
+    organization-defined actions is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization responds to information spills by:
+     a. Identifying the specific information involved in the information system contamination;
+     b. Alerting [Assignment: organization-defined personnel or roles] of the information spill using a method of communication not associated with the spill;
+     c. Isolating the contaminated information system or system component;
+     d. Eradicating the information from the contaminated information system or component;
+     e. Identifying other information systems or system components that may have been subsequently contaminated; and
+     f. Performing other [Assignment: organization-defined actions].
+    Supplemental Guidance: Information spillage refers to instances where either classified or sensitive information is inadvertently placed on information systems that are not authorized to process such information. Such information spills often occur when information that is initially thought to be of lower sensitivity is transmitted to an information system and then is subsequently determined to be of higher sensitivity. At that point, corrective action is required. The nature of the organizational response is generally based upon the degree of sensitivity of the spilled information (e.g., security category or classification level), the security capabilities of the information system, the specific nature of contaminated storage media, and the access authorizations (e.g., security clearances) of individuals with authorized access to the contaminated system. The methods used to communicate information about the spill after the fact do not involve methods directly associated with the actual spill to minimize the risk of further spreading the contamination before such contamination is isolated and eradicated.
+
+    References: None.
+  title: >-
+    IR-9 - INFORMATION SPILLAGE RESPONSE
+  levels:
+  - high
+  - moderate
+- id: IR-9(1)
+  status: not applicable
+  notes: |-
+    Assigning organization-defined personnel or roles with responsibility
+    for responding to information spills is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization assigns [Assignment: organization-defined personnel or roles] with responsibility for responding to information spills.
+  title: >-
+    IR-9(1) - INFORMATION SPILLAGE RESPONSE | RESPONSIBLE PERSONNEL
+  levels:
+  - high
+  - moderate
+- id: IR-9(2)
+  status: not applicable
+  notes: |-
+    Providing information spillage response training organization-defined
+    frequency is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization provides information spillage response training [Assignment: organization- defined frequency].
+
+    IR-9 (2) [at least annually]
+  title: >-
+    IR-9(2) - INFORMATION SPILLAGE RESPONSE | TRAINING
+  levels:
+  - high
+  - moderate
+- id: IR-9(3)
+  status: not applicable
+  notes: |-
+    Implementing organization-defined procedures to ensure that
+    organizational personnel impacted by information spills can continue to
+    carry out assigned tasks while contaminated systems are undergoing
+    corrective actions is an organizational control outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined procedures] to ensure that organizational personnel impacted by information spills can continue to carry out assigned tasks while contaminated systems are undergoing corrective actions.
+
+    Supplemental Guidance:  Correction actions for information systems contaminated due to information spillages may be very time-consuming. During those periods, personnel may not have access to the contaminated systems, which may potentially affect their ability to conduct organizational business.
+  title: >-
+    IR-9(3) - INFORMATION SPILLAGE RESPONSE | POST-SPILL OPERATIONS
+  levels:
+  - high
+  - moderate
+- id: IR-9(4)
+  status: not applicable
+  notes: |-
+    Employing organization-defined security safeguards for personnel exposed
+    to information not within assigned access authorizations is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs [Assignment: organization-defined security safeguards] for personnel exposed to information not within assigned access authorizations.
+
+    Supplemental Guidance:  Security safeguards include, for example, making personnel exposed to spilled information aware of the federal laws, directives, policies, and/or regulations regarding the information and the restrictions imposed based on exposure to such information.
+  title: >-
+    IR-9(4) - INFORMATION SPILLAGE RESPONSE | EXPOSURE TO UNAUTHORIZED PERSONNEL
+  levels:
+  - high
+  - moderate
+- id: IR-10
+  status: not applicable
+  notes: |-
+    Establishing an integrated team of forensic/malicious code analysts,
+    tool developers, and real-time operations personnel is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+- id: MA-1
+  status: not applicable
+  notes: |-
+    Section a: Developing, documenting, and disseminating to organization-defined personnel or roles
+    system maintenance policy and produres is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section a.1: A system maintenance policy that addresses purpose, scope, roles, responsibilities,
+    management commitment, coordination among organizational entities, and compliance
+    is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section a.2: Procedures to facilitate the implementation of the access control policy and
+    associated access controls is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Reviewing and updating the current system maintenance policy and produres is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b.1: Reviewing and updating the current system maintenance policy per an organization-defined frequency
+    is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b.2: Reviewing and updating the current system maintenance procedures per an organization-defined frequency
+    is an organizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A system maintenance policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the system maintenance policy and associated system maintenance controls; and
+     b. Reviews and updates the current:
+       1. System maintenance policy [Assignment: organization-defined frequency]; and
+       2. System maintenance procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the MA family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    MA-1 (b) (1) [at least annually]
+    MA-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    MA-1 - SYSTEM MAINTENANCE POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-2
+  status: not applicable
+  notes: |-
+    Section a: Scheduling, performing, documenting, and reviewing records of maintenance and repairs
+    on information system components in accordance with manufacturer or vendor specifications
+    and/or organizational requirements is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Approveing and monitoring all maintenance activities, whether performed on site or
+    remotely and whether the equipment is serviced on site or removed to another location
+    is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Requiring that organization-defined personnel or roles explicitly approve the removal
+    of the information system or system components from organizational facilities for
+    off-site maintenance or repairs is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section d: Sanitizing equipment to remove all information from associated media prior to removal
+    from organizational facilities for off-site maintenance or repairs
+    is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section e: Checking all potentially impacted security controls to verify that the controls are still
+    functioning properly following maintenance or repair actions is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section f: Including organization-defined maintenance-related information in organizational maintenance records
+    is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Schedules, performs, documents, and reviews records of maintenance and repairs on information system components in accordance with manufacturer or vendor specifications and/or organizational requirements;
+     b. Approves and monitors all maintenance activities, whether performed on site or remotely and whether the equipment is serviced on site or removed to another location;
+     c. Requires that [Assignment: organization-defined personnel or roles] explicitly approve the removal of the information system or system components from organizational facilities for off-site maintenance or repairs;
+     d. Sanitizes equipment to remove all information from associated media prior to removal from organizational facilities for off-site maintenance or repairs;
+     e. Checks all potentially impacted security controls to verify that the controls are still functioning properly following maintenance or repair actions; and
+     f. Includes [Assignment: organization-defined maintenance-related information] in organizational maintenance records.
+
+    Supplemental Guidance:  This control addresses the information security aspects of the information system maintenance program and applies to all types of maintenance to any system component (including applications) conducted by any local or nonlocal entity (e.g., in-contract, warranty, in- house, software maintenance agreement). System maintenance also includes those components not directly associated with information processing and/or data/information retention such as scanners, copiers, and printers. Information necessary for creating effective maintenance records includes, for example: (i) date and time of maintenance; (ii) name of individuals or group performing the maintenance; (iii) name of escort, if necessary; (iv) a description of the maintenance performed; and (v) information system components/equipment removed or replaced (including identification numbers, if applicable). The level of detail included in maintenance records can be informed by
+    the security categories of organizational information systems. Organizations consider supply chain issues associated with replacement components for information systems. Related controls: CM-3, CM-4, MA-4, MP-6, PE-16, SA-12, SI-2.
+
+    References: None.
+  title: >-
+    MA-2 - CONTROLLED MAINTENANCE
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-2(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MA-2(2)
+  status: not applicable
+  notes: |-
+    Section a: Employing automated mechanisms to schedule, conduct, and document
+    maintenance and repairs reflects organizational procedures/policies and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: Producing up-to date, accurate, and complete records of all
+    maintenance and repair actions requested, scheduled, in process, and completed
+    reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Employs automated mechanisms to schedule, conduct, and document maintenance and repairs; and
+     (b)   Produces up-to date, accurate, and complete records of all maintenance and repair actions requested, scheduled, in process, and completed.
+
+    Supplemental Guidance:  Related controls: CA-7, MA-3.
+
+    References:  None.
+  title: >-
+    MA-2(2) - CONTROLLED MAINTENANCE | AUTOMATED MAINTENANCE ACTIVITIES
+  levels:
+  - high
+- id: MA-3
+  status: not applicable
+  notes: |-
+    The organization approveing, controlling, and monitoring information system maintenance tools
+    is an orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization approves, controls, and monitors information system\
+    \ maintenance tools.\n\nSupplemental Guidance:  This control addresses security-related\
+    \ issues associated with maintenance tools used specifically for diagnostic and\
+    \ repair actions on organizational information systems. Maintenance tools can\
+    \ include hardware, software, and firmware items. Maintenance tools are potential\
+    \ vehicles for transporting malicious code, either intentionally or unintentionally,\
+    \ into a facility and subsequently into organizational information systems. Maintenance\
+    \ tools can include, for example, hardware/software diagnostic test equipment\
+    \ and hardware/software packet sniffers. This control does not cover hardware/software\
+    \ components that may support information system maintenance, yet are a part of\
+    \ the system, for example, the software implementing \u201Cping,\u201D \u201C\
+    ls,\u201D \u201Cipconfig,\u201D or the hardware and software implementing the\
+    \ monitoring port of an Ethernet switch. Related controls: MA-2, MA-5, MP-6.\n\
+    \nReferences: NIST Special Publication 800-88."
+  title: >-
+    MA-3 - MAINTENANCE TOOLS
+  levels:
+  - high
+  - moderate
+- id: MA-3(1)
+  status: not applicable
+  notes: |-
+    The organization inspecting the maintenance tools carried into a facility
+    by maintenance personnel for improper or unauthorized modifications is an
+    orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization inspects the maintenance tools carried into a facility by maintenance personnel for improper or unauthorized modifications.
+
+    Supplemental Guidance:  If, upon inspection of maintenance tools, organizations determine that the tools have been modified in an improper/unauthorized manner or contain malicious code, the incident is handled consistent with organizational policies and procedures for incident handling. Related control: SI-7.
+  title: >-
+    MA-3(1) - MAINTENANCE TOOLS | INSPECT TOOLS
+  levels:
+  - high
+  - moderate
+- id: MA-3(2)
+  status: not applicable
+  notes: |-
+    Checking media containing diagnostic and test programs for
+    malicious code before the media are used in the information
+    system is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization checks media containing diagnostic and test programs for malicious code before the media are used in the information system.
+
+    Supplemental Guidance:  If, upon inspection of media containing maintenance diagnostic and test programs, organizations determine that the media contain malicious code, the incident is handled consistent with organizational incident handling policies and procedures. Related control: SI-3.
+  title: >-
+    MA-3(2) - MAINTENANCE TOOLS | INSPECT MEDIA
+  levels:
+  - high
+  - moderate
+- id: MA-3(3)
+  status: not applicable
+  notes: |-
+    Section a: Preventing the unauthorized removal of maintenance equipment containing
+    organizational information by verifying that there is no organizational
+    information contained on the equipment is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Preventing the unauthorized removal of maintenance equipment containing
+    organizational information by sanitizing or destroying the equipment is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Preventing the unauthorized removal of maintenance equipment containing
+    organizational information by retaining the equipment within the
+    facility is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section d: Preventing the unauthorized removal of maintenance equipment containing
+    organizational information by obtaining an exception from
+    organization-defined personnel or roles explicity authorizing removal
+    of the equipment from the facility is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization prevents the unauthorized removal of maintenance\
+    \ equipment containing organizational information by:\n (a)   Verifying that there\
+    \ is no organizational information contained on the equipment; \n (b)   Sanitizing\
+    \ or destroying the equipment;\n (c)   Retaining the equipment within the facility;\
+    \ or\n (d)   Obtaining an exemption from [Assignment: organization-defined personnel\
+    \ or roles] explicitly authorizing removal of the equipment from the facility.\n\
+    \nSupplemental Guidance:  Organizational information includes all information\
+    \ specifically owned by organizations and information provided to organizations\
+    \ in which organizations serve as information stewards.\n\nMA-3 (3) (d) [the information\
+    \ owner explicitly authorizing removal of the equipment from the facility]"
+  title: >-
+    MA-3(3) - MAINTENANCE TOOLS | PREVENT UNAUTHORIZED REMOVAL
+  levels:
+  - high
+  - moderate
+- id: MA-3(4)
+  status: not applicable
+  notes: |-
+    The information system restricting the use of maintenance tools to
+    authorized personnel only applies to OpenShift and is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MA-4
+  status: not applicable
+  notes: |-
+    Section a: Approving and monitoring nonlocal maintenance and diagnostic activities is an
+    orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Allowing the use of nonlocal maintenance and diagnostic tools only as consistent with
+    organizational policy and documented in the security plan for the information system is an
+    orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for authentication management.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section d: The maintaining of records for nonlocal maintenance and diagnostic activities is an
+    orgnaizational control outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section e: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for session management.
+
+    This control is applicable to the OpenShift and is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Approves and monitors nonlocal maintenance and diagnostic activities;
+     b. Allows the use of nonlocal maintenance and diagnostic tools only as consistent with organizational policy and documented in the security plan for the information system;
+     c. Employs strong authenticators in the establishment of nonlocal maintenance and diagnostic sessions;
+     d. Maintains records for nonlocal maintenance and diagnostic activities; and
+     e. Terminates session and network connections when nonlocal maintenance is completed.
+
+    Supplemental Guidance:  Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the Internet) or an internal network. Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection. Authentication techniques used in the establishment of nonlocal maintenance and diagnostic sessions reflect the network access requirements in IA-2. Typically, strong authentication requires authenticators that are resistant to replay attacks and employ multifactor authentication. Strong authenticators include, for example, PKI where certificates are stored on a token protected by a password, passphrase, or biometric.  Enforcing requirements in MA-4 is accomplished in part by other controls. Related controls: AC-2, AC-3, AC-6, AC-17, AU-2, AU-3, IA-2, IA-4, IA-5, IA-8, MA-2, MA-5, MP-6, PL-2, SC-7, SC-10, SC-17.
+
+    References: FIPS Publications 140-2, 197, 201; NIST Special Publications 800-63, 800-88; CNSS Policy 15.
+  title: >-
+    MA-4 - NONLOCAL MAINTENANCE
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-4(1)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for session auditing.
+
+    This control is applicable to the OpenShift and is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Reviewing the records of the maintenance and diagnostic sessions
+    is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MA-4(2)
+  status: not applicable
+  notes: |-
+    The organization documenting in the security plan for the information system,
+    the policies and procedures for the establishment and use of nonlocal maintenance
+    and diagnostic connections is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization documents in the security plan for the information system, the policies and procedures for the establishment and use of nonlocal maintenance and diagnostic connections.
+  title: >-
+    MA-4(2) - NONLOCAL MAINTENANCE | DOCUMENT NONLOCAL MAINTENANCE
+  levels:
+  - high
+  - moderate
+- id: MA-4(3)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: Removing the component to be serviced from the information system prior
+    to nonlocal maintenance or diagnostic services, sanitizes the component
+    (with regard to organizational information) before removal from organizational
+    facilities, and after the service is performed, inspects and sanitizes the component
+    (with regard to potentially malicious software) before reconnecting the component
+    to the information system is an organizational control outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Requires that nonlocal maintenance and diagnostic services be performed from an information system that implements a security capability comparable to the capability implemented on the system being serviced; or
+     (b)   Removes the component to be serviced from the information system and prior to nonlocal maintenance or diagnostic services, sanitizes the component (with regard to organizational information) before removal from organizational facilities, and after the service is performed, inspects and sanitizes the component (with regard to potentially malicious software) before reconnecting the component to the information system.
+
+    Supplemental Guidance:  Comparable security capability on information systems, diagnostic tools, and equipment providing maintenance services implies that the implemented security controls on those systems, tools, and equipment are at least as comprehensive as the controls on the information system being serviced. Related controls: MA-3, SA-12, SI-3, SI-7.
+  title: >-
+    MA-4(3) - NONLOCAL MAINTENANCE | COMPARABLE SECURITY / SANITIZATION
+  levels:
+  - high
+- id: MA-4(4)
+  status: not applicable
+  notes: |-
+    Section a: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for authentication management.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for authentication management.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b.1: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for authentication management.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+    Section b.2: Red Hat Advanced Cluster Management for Kubernetes
+    relies on OpenShift for authentication management.
+
+    This control is applicable to the OpenShift identity service provider
+    and outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: MA-4(5)
+  status: not applicable
+  notes: |-
+    Section a: Approval of each nonlocal maintenance session by
+    organization-defined personnel or roles is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Notification of organization-defined personnel or roles of
+    the date and time of planned nonlocal maintenance is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MA-4(6)
+  status: pending
+  notes: |-
+    A control response is planned. Engineering progress can be tracked via:
+  rules: []
+  description: |-
+    The information system implements cryptographic mechanisms to protect the integrity and confidentiality of nonlocal maintenance and diagnostic communications.
+
+    Supplemental Guidance:  Related controls: SC-8, SC-13.
+  title: >-
+    MA-4(6) - NONLOCAL MAINTENANCE | CRYPTOGRAPHIC PROTECTION
+  levels:
+  - high
+- id: MA-4(7)
+  status: pending
+  notes: |-
+    A control response is planned. Engineering progress can be tracked via:
+  rules: []
+- id: MA-5
+  status: not applicable
+  notes: |-
+    Section a: Establishing a process for maintenance personnel authorization and
+    maintaining a list of authorized maintenance organizations or personnel
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Ensuring that non-escorted personnel performing maintenance on
+    the information system have required access authorizations is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Designating organizational personnel with required access
+    authorizations and technical competence to supervise the
+    maintenance activities of personnel who do not possess
+    the required access authorizations is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes a process for maintenance personnel authorization and maintains a list of authorized maintenance organizations or personnel;
+     b. Ensures that non-escorted personnel performing maintenance on the information system have required access authorizations; and
+     c. Designates organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations.
+
+    Supplemental Guidance:  This control applies to individuals performing hardware or software maintenance on organizational information systems, while PE-2 addresses physical access for individuals whose maintenance duties place them within the physical protection perimeter of the systems (e.g., custodial staff, physical plant maintenance personnel). Technical competence of supervising individuals relates to the maintenance performed on the information systems while having required access authorizations refers to maintenance on and near the systems. Individuals not previously identified as authorized maintenance personnel, such as information technology manufacturers, vendors, systems integrators, and consultants, may require privileged access to organizational information systems, for example, when required to conduct maintenance activities with little or no notice. Based on organizational assessments of risk, organizations may issue temporary credentials to these individuals. Temporary credentials may be for one-time use or for very limited time periods. Related controls: AC-2, IA-8, MP-2, PE-2, PE-3, PE-4, RA-3.
+
+    References: None.
+  title: >-
+    MA-5 - MAINTENANCE PERSONNEL
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-5(1)
+  status: not applicable
+  notes: |-
+    Section a: Implementing organizational procedures for the use of maintenance
+    personnel that lack appropriate security clearances or are not U.S.
+    citizens is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Development and implementation of alternate security safeguards
+    in the event an information system component cannot be sanitized,
+    removed, or disconnected from the system, is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Implements procedures for the use of maintenance personnel that lack appropriate security clearances or are not U.S. citizens, that include the following requirements:
+        (1)   Maintenance personnel who do not have needed access authorizations, clearances, or formal access approvals are escorted and supervised during the performance of maintenance and diagnostic activities on the information system by approved organizational personnel who are fully cleared, have appropriate access authorizations, and are technically qualified;
+       (2)   Prior to initiating maintenance or diagnostic activities by personnel who do not have needed access authorizations, clearances or formal access approvals, all volatile information storage components within the information system are sanitized and all nonvolatile storage media are removed or physically disconnected from the system and secured; and
+     (b)   Develops and implements alternate security safeguards in the event an information system component cannot be sanitized, removed, or disconnected from the system.
+
+    Supplemental Guidance:  This control enhancement denies individuals who lack appropriate security clearances (i.e., individuals who do not possess security clearances or possess security clearances at a lower level than required) or who are not U.S. citizens, visual and
+    electronic access to any classified information, Controlled Unclassified Information (CUI), or any other sensitive information contained on organizational information systems. Procedures for the use of maintenance personnel can be documented in security plans for the information systems. Related controls: MP-6, PL-2.
+  title: >-
+    MA-5(1) - MAINTENANCE PERSONNEL | INDIVIDUALS WITHOUT APPROPRIATE ACCESS
+  levels:
+  - high
+  - moderate
+- id: MA-5(2)
+  status: not applicable
+  notes: |-
+    Organizational processes ensuring that personnel performing
+    maintenance and diagnostic activities on an information system
+    processing, storing, or transmitting classified information
+    possess security clearances and formal access approvals for at
+    least the highest classification level and for all compartments
+    of information on the system, is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: MA-5(3)
+  status: not applicable
+  notes: |-
+    Organizational processes ensuring that personnel performing
+    maintenance and diagnostic activities on an information system
+    processing, storing, or transmitting classified information are
+    U.S. citizens, is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MA-5(4)
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes that ensure cleared foreign nationals (i.e.
+    foreign nationals with appropriate security clearances), are used
+    to conduct maintenance and diagnostic activities on classified
+    information systems only when the systems are jointly owned and
+    operated by the United States and foreign allied governments, or
+    owned and operated solely by foreign allied governments, is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational processes that ensure approvals, consents, and detailed
+    operational conditions regarding the use of foreign nationals to
+    conduct maintenance and diagnostic activities on classified information
+    systems are fully documented within Memoranda of Agreements, is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MA-5(5)
+  status: not applicable
+  notes: |-
+    Organizational processes ensuring that non-escorted personnel
+    performing maintenance activities not directly associated with
+    the information system but in the physical proximity of the
+    system, have required access authorizations, is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MA-6
+  status: not applicable
+  notes: |-
+    The organization obtaining maintenance support and/or spare parts for
+    organization-defined information system components within an organization-defined
+    time period of failure is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization obtains maintenance support and/or spare parts for [Assignment: organization-defined information system components] within [Assignment: organization-defined time period] of failure.
+
+    Supplemental Guidance:  Organizations specify the information system components that result in increased risk to organizational operations and assets, individuals, other organizations, or the Nation when the functionality provided by those components is not operational. Organizational actions to obtain maintenance support typically include having appropriate contracts in place. Related controls: CM-8, CP-2, CP-7, SA-14, SA-15.
+
+    References: None.
+  title: >-
+    MA-6 - TIMELY MAINTENANCE
+  levels:
+  - high
+  - moderate
+- id: MA-6(1)
+  status: not applicable
+  notes: |-
+    The organization performs preventive maintenance on organization-defined
+    information system components at organization-defined time intervals
+    is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: MA-6(2)
+  status: not applicable
+  notes: |-
+    The organization performs predictive maintenance on organization-defined
+    information system components at organization-defined time intervals is
+    an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: MA-6(3)
+  status: not applicable
+  notes: |-
+    The organization employs automated mechanisms to transfer predictive
+    maintenance data to a computerized maintenance management system is
+    an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: MP-1
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A media protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the media protection policy and associated media protection controls; and
+     b. Reviews and updates the current:
+       1. Media protection policy [Assignment: organization-defined frequency]; and
+       2. Media protection procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the MP family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    MP-1 (b) (1) [at least annually]
+    MP-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    MP-1 - MEDIA PROTECTION POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-2
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization restricts access to [Assignment: organization-defined types of digital and/or non-digital media] to [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:   Information system media includes both digital and non-digital media. Digital media includes, for example, diskettes, magnetic tapes, external/removable hard disk drives, flash drives, compact disks, and digital video disks. Non-digital media includes, for example, paper and microfilm. Restricting non-digital media access includes, for example, denying access to patient medical records in a community hospital unless the individuals seeking access to such records are authorized healthcare providers. Restricting access to digital media includes, for example, limiting access to design specifications stored on compact disks in the media library to the project leader and the individuals on the development team. Related controls: AC-3, IA-2, MP-4, PE-2, PE-3, PL-2.
+
+    MP-2-1 [any digital and non-digital media deemed sensitive]
+  title: >-
+    MP-2 - MEDIA ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-2(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-2(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-3
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Marks information system media indicating the distribution limitations, handling caveats, and applicable security markings (if any) of the information; and
+     b. Exempts [Assignment: organization-defined types of information system media] from marking as long as the media remain within [Assignment: organization-defined controlled areas].
+
+    Supplemental Guidance:  The term security marking refers to the application/use of human-readable security attributes. The term security labeling refers to the application/use of security attributes with regard to internal data structures within information systems (see AC-16). Information system media includes both digital and non-digital media. Digital media includes, for example, diskettes, magnetic tapes, external/removable hard disk drives, flash drives, compact disks, and digital video disks. Non-digital media includes, for example, paper and microfilm. Security
+    marking is generally not required for media containing information determined by organizations to be in the public domain or to be publicly releasable. However, some organizations may require markings for public information indicating that the information is publicly releasable. Marking of information system media reflects applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance. Related controls: AC-16, PL-2, RA-3.
+
+    Control Enhancements:  None.
+
+    References:  FIPS Publication 199.
+
+    MP-3 (b)-1 [no removable media types]
+    MP-3 (b)-2 [organization-defined security safeguards not applicable]
+    MP-3 (b) Guidance: Second parameter not-applicable
+  title: >-
+    MP-3 - MEDIA MARKING
+  levels:
+  - high
+  - moderate
+- id: MP-4
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Physically controls and securely stores [Assignment:\
+    \ organization-defined types of digital and/or non-digital media] within [Assignment:\
+    \ organization-defined controlled areas]; and\n b. Protects information system\
+    \ media until the media are destroyed or sanitized using approved equipment, techniques,\
+    \ and procedures.\n\nSupplemental Guidance:  Information system media includes\
+    \ both digital and non-digital media. Digital media includes, for example, diskettes,\
+    \ magnetic tapes, external/removable hard disk drives, flash drives, compact disks,\
+    \ and digital video disks. Non-digital media includes, for example, paper and\
+    \ microfilm. Physically controlling information system media includes, for example,\
+    \ conducting inventories, ensuring procedures are in place to allow individuals\
+    \ to check out and return media to the media library, and maintaining accountability\
+    \ for all stored media. Secure storage includes, for example, a locked drawer,\
+    \ desk, or cabinet, or a controlled media library. The type of media storage is\
+    \ commensurate with the security category and/or classification of the information\
+    \ residing on the media. Controlled areas are areas for which organizations provide\
+    \ sufficient physical and procedural safeguards to meet the requirements established\
+    \ for protecting information and/or information systems. For media containing\
+    \ information determined by organizations to be in the public domain, to be publicly\
+    \ releasable, or to have limited or no adverse impact on organizations or individuals\
+    \ if accessed by other than authorized personnel, fewer safeguards may be needed.\
+    \ In these situations, physical access controls provide adequate protection. Related\
+    \ controls: CP-6, CP-9, MP-2, MP-7, PE-3.\n\nReferences: FIPS Publication 199;\
+    \ NIST Special Publications 800-56, 800-57, 800-111.\n\nMP-4 (a)-1 [all types\
+    \ of digital and non-digital media with sensitive information] \nMP-4 (a)-2 [see\
+    \ additional FedRAMP requirements and guidance]\nMP-4 (a) Requirement: The service\
+    \ provider defines controlled areas within facilities where the information and\
+    \ information system reside."
+  title: >-
+    MP-4 - MEDIA STORAGE
+  levels:
+  - high
+  - moderate
+- id: MP-4(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-4(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-5
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section d: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Protects and controls [Assignment: organization-defined types of information system media] during transport outside of controlled areas using [Assignment: organization-defined security safeguards];
+     b. Maintains accountability for information system media during transport outside of controlled areas;
+     c. Documents activities associated with the transport of information system media; and
+     d. Restricts the activities associated with the transport of information system media to authorized personnel.
+
+    Supplemental Guidance:  Information system media includes both digital and non-digital media. Digital media includes, for example, diskettes, magnetic tapes, external/removable hard disk drives, flash drives, compact disks, and digital video disks. Non-digital media includes, for example, paper and microfilm. This control also applies to mobile devices with information
+    storage capability (e.g., smart phones, tablets, E-readers), that are transported outside of controlled areas. Controlled areas are areas or spaces for which organizations provide sufficient physical and/or procedural safeguards to meet the requirements established for protecting information and/or information systems.
+
+    Physical and technical safeguards for media are commensurate with the security category or classification of the information residing on the media. Safeguards to protect media during transport include, for example, locked containers and cryptography. Cryptographic mechanisms can provide confidentiality and integrity protections depending upon the mechanisms used. Activities associated with transport include the actual transport as well as those activities such as releasing media for transport and ensuring that media enters the appropriate transport processes. For the actual transport, authorized transport and courier personnel may include individuals from outside the organization (e.g., U.S. Postal Service or a commercial transport or delivery service). Maintaining accountability of media during transport includes, for example, restricting transport activities to authorized personnel, and tracking and/or obtaining explicit records of transport activities as the media moves through the transportation system to prevent and detect loss, destruction, or tampering. Organizations establish documentation requirements for activities associated with the transport of information system media in accordance with organizational assessments of risk to include the flexibility to define different record-keeping methods for the different types of media transport as part of an overall system of transport-related records. Related controls: AC-19, CP-9, MP-3, MP-4, RA-3, SC-8, SC-13, SC-28.
+
+    References: FIPS Publication 199; NIST Special Publication 800-60.
+
+    MP-5 (a) [all media with sensitive information] [prior to leaving secure/controlled environment: for digital media, encryption using a FIPS 140-2 validated encryption module; for non-digital media, secured in locked container]
+
+    MP-5 (a) Requirement: The service provider defines security measures to protect digital and non-digital media in transport.  The security measures are approved and accepted by the JAB.
+  title: >-
+    MP-5 - MEDIA TRANSPORT
+  levels:
+  - high
+  - moderate
+- id: MP-5(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-5(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-5(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-5(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements cryptographic mechanisms to protect the confidentiality and integrity of information stored on digital media during transport outside of controlled areas.
+
+    Supplemental Guidance:  This control enhancement applies to both portable storage devices (e.g., USB memory sticks, compact disks, digital video disks, external/removable hard disk drives) and mobile devices with storage capability (e.g., smart phones, tablets, E-readers). Related control: MP-2.
+
+    References:  FIPS Publication 199; NIST Special Publication 800-60.
+  title: >-
+    MP-5(4) - MEDIA TRANSPORT | CRYPTOGRAPHIC PROTECTION
+  levels:
+  - high
+  - moderate
+- id: MP-6
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Sanitizes [Assignment: organization-defined information system media] prior to disposal, release out of organizational control, or release for reuse using [Assignment: organization- defined sanitization techniques and procedures] in accordance with applicable federal and organizational standards and policies; and
+     b. Employs sanitization mechanisms with the strength and integrity commensurate with the security category or classification of the information.
+
+    Supplemental Guidance:   This control applies to all information system media, both digital and non- digital, subject to disposal or reuse, whether or not the media is considered removable. Examples include media found in scanners, copiers, printers, notebook computers, workstations, network components, and mobile devices. The sanitization process removes information from the media such that the information cannot be retrieved or reconstructed. Sanitization techniques, including clearing, purging, cryptographic erase, and destruction, prevent the disclosure of information to unauthorized individuals when such media is reused or released for disposal. Organizations determine the appropriate sanitization methods recognizing that destruction is sometimes necessary when other methods cannot be applied to media requiring sanitization. Organizations use discretion on the employment of approved sanitization techniques and procedures for media containing information deemed to be in the public domain or publicly releasable, or deemed to have no adverse impact on organizations or individuals if released for reuse or disposal. Sanitization of non-digital media includes, for example, removing a classified appendix from an otherwise unclassified document, or redacting selected sections or words from a document by obscuring the redacted sections/words in a manner equivalent in effectiveness to removing them from the document. NSA standards and policies control the sanitization process for media containing classified information. Related controls: MA-2, MA-4, RA-3, SC-4.
+
+    References: FIPS Publication 199; NIST Special Publications 800-60, 800-88; Web: http://www.nsa.gov/ia/mitigation_guidance/media_destruction_guidance/index.shtml.
+
+    MP-6(a)-2 [techniques and procedures IAW NIST SP 800-88 and Section 5.9: Reuse and Disposal of Storage Media and Hardware]
+  title: >-
+    MP-6 - MEDIA SANITIZATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-6(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization reviews, approves, tracks, documents, and verifies media sanitization and disposal actions.
+
+    Supplemental Guidance:  Organizations review and approve media to be sanitized to ensure compliance with records-retention policies. Tracking/documenting actions include, for example, listing personnel who reviewed and approved sanitization and disposal actions, types of media sanitized, specific files stored on the media, sanitization methods used, date and time of the sanitization actions, personnel who performed the sanitization, verification actions taken, personnel who performed the verification, and disposal action taken.
+    Organizations verify that the sanitization of the media was effective prior to disposal. Related control: SI-12.
+  title: >-
+    MP-6(1) - MEDIA SANITIZATION | REVIEW / APPROVE / TRACK / DOCUMENT / VERIFY
+  levels:
+  - high
+- id: MP-6(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization tests sanitization equipment and procedures [Assignment: organization-defined frequency] to verify that the intended sanitization is being achieved.
+
+    Supplemental Guidance: Testing of sanitization equipment and procedures may be conducted by qualified and authorized external entities (e.g., other federal agencies or external service providers).
+
+    MP-6 (2) [at least every six (6) months]
+    MP-6 (2) Guidance: Equipment and procedures may be tested or validated for effectiveness
+  title: >-
+    MP-6(2) - MEDIA SANITIZATION | EQUIPMENT TESTING
+  levels:
+  - high
+  - moderate
+- id: MP-6(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization applies non-destructive sanitization techniques to portable storage devices prior to connecting such devices to the information system under the following circumstances: [Assignment: organization-defined circumstances requiring sanitization of portable storage devices].
+
+    Supplemental Guidance:  This control enhancement applies to digital media containing classified information and Controlled Unclassified Information (CUI). Portable storage devices can be the source of malicious code insertions into organizational information systems. Many of
+    these devices are obtained from unknown and potentially untrustworthy sources and may contain malicious code that can be readily transferred to information systems through USB ports or other entry portals. While scanning such storage devices is always recommended, sanitization provides additional assurance that the devices are free of malicious code to include code capable of initiating zero-day attacks. Organizations consider nondestructive sanitization of portable storage devices when such devices are first purchased from the manufacturer or vendor prior to initial use or when organizations lose a positive chain of custody for the devices. Related control: SI-3.
+  title: >-
+    MP-6(3) - MEDIA SANITIZATION | NONDESTRUCTIVE TECHNIQUES
+  levels:
+  - high
+- id: MP-6(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-6(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-6(6)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: MP-6(7)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-6(8)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-7
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes does not utilize or have access to media such as optical
+    drives, USB devices, etc. Therefore, this control is not applicable to
+    Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization [Selection: restricts; prohibits] the use of [Assignment: organization- defined types of information system media] on [Assignment: organization-defined information systems or system components] using [Assignment: organization-defined security safeguards].
+
+    Supplemental Guidance:  Information system media includes both digital and non-digital media. Digital media includes, for example, diskettes, magnetic tapes, external/removable hard disk drives, flash drives, compact disks, and digital video disks. Non-digital media includes, for example, paper and microfilm. This control also applies to mobile devices with information storage capability (e.g., smart phones, tablets, E-readers). In contrast to MP-2, which restricts user access to media, this control restricts the use of certain types of media on information systems, for example, restricting/prohibiting the use of flash drives or external hard disk drives. Organizations can employ technical and nontechnical safeguards (e.g., policies, procedures, rules of behavior) to restrict the use of information system media. Organizations may restrict the use of portable storage devices, for example, by using physical cages on workstations to prohibit access to certain external ports, or disabling/removing the ability to insert, read or write to such devices. Organizations may also limit the use of portable storage devices to only approved devices including, for example, devices provided by the organization, devices provided by other approved organizations, and devices that are not personally owned. Finally, organizations may restrict the use of portable storage devices based on the type of device, for example, prohibiting the use of writeable, portable storage devices, and implementing this restriction by disabling or removing the capability to write to such devices. Related controls: AC-19, PL-4.
+
+    References: None.
+  title: >-
+    MP-7 - MEDIA USE
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-7(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization prohibits the use of portable storage devices in organizational information systems when such devices have no identifiable owner.
+
+    Supplemental Guidance:  Requiring identifiable owners (e.g., individuals, organizations, or projects) for portable storage devices reduces the risk of using such technologies by allowing organizations to assign responsibility and accountability for addressing known vulnerabilities in the devices (e.g., malicious code insertion). Related control: PL-4.
+  title: >-
+    MP-7(1) - MEDIA USE | PROHIBIT USE WITHOUT OWNER
+  levels:
+  - high
+  - moderate
+- id: MP-7(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-8
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section d: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-8(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-8(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-8(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: MP-8(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-1
+  status: not applicable
+  notes: |-
+    Section a: Development, documentation, and dissemination of a physical
+    and environmental protection policy reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+
+    Section b: Organizational review and updates to the physical and
+    environmental protection policy reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A physical and environmental\
+    \ protection policy that addresses purpose, scope, roles, responsibilities, management\
+    \ commitment, coordination among organizational entities, and compliance; and\n\
+    \   2. Procedures to facilitate the implementation of the physical and environmental\
+    \ protection policy and associated physical and environmental protection controls;\
+    \ and\n b. Reviews and updates the current:\n   1. Physical and environmental\
+    \ protection policy [Assignment: organization-defined frequency]; and\n   2. Physical\
+    \ and environmental protection procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the PE family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-100.\n\nPE-1 (b) (1) [at\
+    \ least annually] \nPE-1 (b) (2) [at least annually or whenever a significant\
+    \ change occurs]"
+  title: >-
+    PE-1 - PHYSICAL AND ENVIRONMENTAL PROTECTION
+
+    POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-2
+  status: not applicable
+  notes: |-
+    Section a: Development, approval, and maintenance of a list
+    of individuals with authorized access to the facility
+    where the information system resides reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+
+    Section b: Issuing authorization credentials for facility access
+    reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section c: Reviewing the access list detailing authorized facility
+    access by individuals at an organization-defined frequency
+    reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section d: Removal of individuals from the facility access list when access
+    is no longer required reflects organizational procedure/policy
+    and is not applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, approves, and maintains a list of individuals with authorized access to the facility where the information system resides;
+     b. Issues authorization credentials for facility access;
+     c. Reviews the access list detailing authorized facility access by individuals [Assignment: organization-defined frequency]; and
+     d. Removes individuals from the facility access list when access is no longer required.
+
+    Supplemental Guidance:  This control applies to organizational employees and visitors. Individuals (e.g., employees, contractors, and others) with permanent physical access authorization credentials are not considered visitors. Authorization credentials include, for example, badges, identification cards, and smart cards. Organizations determine the strength of authorization credentials needed (including level of forge-proof badges, smart cards, or identification cards) consistent with federal standards, policies, and procedures. This control only applies to areas within facilities that have not been designated as publicly accessible. Related controls: PE-3, PE-4, PS-3.
+
+    References: None
+
+
+    PE-2 (c) [at least every ninety (90) days]
+  title: >-
+    PE-2 - PHYSICAL ACCESS AUTHORIZATIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-2(1)
+  status: not applicable
+  notes: |-
+    Authorizing physical access to the facility where the information
+    system resides based on position or role reflects organizational
+    procedures/policy and is not applicable to component-level
+    configuration.
+  rules: []
+- id: PE-2(2)
+  status: not applicable
+  notes: |-
+    Requiring two forms of identification from an organization-defined
+    list of acceptable forms of identification for visitor access to
+    the facility where the information system resides reflects
+    organizational procedure/policy and is not applicable to
+    component-level configuration.
+  rules: []
+- id: PE-2(3)
+  status: not applicable
+  notes: |-
+    Restricting unescorted access to the facility where the
+    information system resides reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+  rules: []
+- id: PE-3
+  status: not applicable
+  notes: |-
+    Section a: Enforcing physical access authorizations at organization-defined
+    entry/exit points to the facility where the information system resides
+    reflects organizational procedure/policy and is not applicable to
+    component-level configuration.
+
+    Section b: Maintaining physical access audit logs for organization-defined
+    entry/exit points reflects organizational procedure/policy and
+    is not applicable to component-level configuration.
+
+    Section c: Providing organization-defined security safeguards to control access
+    to areas within the facility officially designated as publicly
+    accessible reflects organizational procedure/policy and
+    is not applicable to component-level configuration.
+
+    Section d: Escorting visitors and monitoring visitor activity during
+    organization-defined circumstances requiring visitor escorts
+    and monitoring reflects organizational procedure/policy and
+    is not applicable to component-level configuration.
+
+    Section e: Securing keys, combinations, and other physical access devices
+    reflects organizational procedure/policy and
+    is not applicable to component-level configuration.
+
+    Section f: Inventory of organization-defined physical access devices
+    at an organization-defined frequency reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+
+    Section g: Changing combinations and keys at an organization-defined frequency
+    and/or when keys are lost, combinations are compromised, or individuals
+    are transferred or terminated, reflects organizational procedure/policy
+    and is not applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Enforces physical access authorizations at [Assignment: organization-defined entry/exit points to the facility where the information system resides] by;
+       1. Verifying individual access authorizations before granting access to the facility; and
+       2. Controlling ingress/egress to the facility using [Selection (one or more): [Assignment: organization-defined physical access control systems/devices]; guards];
+     b. Maintains physical access audit logs for [Assignment: organization-defined entry/exit points];
+     c. Provides [Assignment: organization-defined security safeguards] to control access to areas within the facility officially designated as publicly accessible;
+     d. Escorts visitors and monitors visitor activity [Assignment: organization-defined circumstances requiring visitor escorts and monitoring];
+     e. Secures keys, combinations, and other physical access devices;
+     f. Inventories [Assignment: organization-defined physical access devices] every [Assignment: organization-defined frequency]; and
+     g. Changes combinations and keys [Assignment: organization-defined frequency] and/or when keys are lost, combinations are compromised, or individuals are transferred or terminated.
+
+    Supplemental Guidance:  This control applies to organizational employees and visitors. Individuals (e.g., employees, contractors, and others) with permanent physical access authorization credentials are not considered visitors. Organizations determine the types of facility guards needed including, for example, professional physical security staff or other personnel such as administrative staff or information system users. Physical access devices include, for example, keys, locks, combinations, and card readers. Safeguards for publicly accessible areas within organizational facilities include, for example, cameras, monitoring by guards, and isolating selected information systems and/or system components in secured areas. Physical access control systems comply with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance. The Federal Identity, Credential, and Access Management Program provides implementation guidance for identity, credential, and access management capabilities for physical access control systems. Organizations have flexibility in the types of audit logs employed. Audit logs can be procedural (e.g., a written log of individuals accessing the facility and when such access occurred), automated (e.g., capturing ID provided by a PIV card), or some combination thereof. Physical access points can include facility access points, interior access points to information systems and/or components requiring supplemental access controls, or both. Components of organizational information systems (e.g., workstations, terminals) may be located in areas designated as publicly accessible with organizations safeguarding access to such devices. Related controls: AU-2, AU-6, MP-2, MP-4, PE-2, PE-4, PE-5, PS-3, RA-3.
+
+    Supplemental Guidance: Related controls: CA-2, CA-7.
+
+    PE-3 (a) (2) [CSP defined physical access control systems/devices AND guards]
+    PE-3 (d) [in all circumstances within restricted access area where the information system resides]
+    PE-3 (f) [at least annually]
+    PE-3 (g) [at least annually]
+  title: >-
+    PE-3 - PHYSICAL ACCESS CONTROL
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-3(1)
+  status: not applicable
+  notes: |-
+    Enforcing physical access authorizations to the information system
+    in addition to the physical access controls for the facility at
+    organization-defined physical spaces containing one or more components
+    of the information system reflects organizational procedure/policy
+    and is not applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization enforces physical access authorizations to the information system in addition to the physical access controls for the facility at [Assignment: organization-defined physical spaces containing one or more components of the information system].
+
+    Supplemental Guidance:  This control enhancement provides additional physical security for those areas within facilities where there is a concentration of information system components (e.g., server rooms, media storage areas, data and communications centers). Related control: PS-2.
+  title: >-
+    PE-3(1) - PHYSICAL ACCESS CONTROL | INFORMATION SYSTEM ACCESS
+  levels:
+  - high
+- id: PE-3(2)
+  status: not applicable
+  notes: |-
+    Performing security checks at an organization-defined
+    frequency at the physical boundary of the facility or information
+    system for unauthorized exfiltration of information or removal
+    of information system components reflects organizational
+    procedure/policy and is not applicable to
+    component-level configuration.
+  rules: []
+- id: PE-3(3)
+  status: not applicable
+  notes: |-
+    Employing guards and/or alarms to monitor every physical access
+    point to the facility where the information system resides 24 hours
+    per day, 7 days per week, reflects organizational procedure/policy and
+    is not applicable to component-level configuration.
+  rules: []
+- id: PE-3(4)
+  status: not applicable
+  notes: |-
+    Using lockable physical casings to protect organization-defined
+    information system components from unauthorized physical access
+    reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+- id: PE-3(5)
+  status: not applicable
+  notes: |-
+    Employing organization-defined security safeguards to
+    detect and/or prevent physical tampering or alteration of
+    organization-defined hardware components within the information
+    system reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+- id: PE-3(6)
+  status: not applicable
+  notes: |-
+    Employing a penetration testing process that includes, at an
+    organization-defined frequency, unannounced attempts to bypass or
+    circumvent security controls associated with physical access points
+    to the facility reflects organizational procedure/policy and is
+    not applicable to component-level configuration.
+  rules: []
+- id: PE-4
+  status: not applicable
+  notes: |-
+    Controlling physical access to organization-defined information
+    system distribution and transmission lines within organizational
+    facilities using organizaiton-defined security safeguards reflects
+    organizational procedure/policy and is not applicable to
+    component-level configuration.
+  rules: []
+  description: |-
+    The organization controls physical access to [Assignment: organization-defined information system distribution and transmission lines] within organizational facilities using [Assignment: organization-defined security safeguards].
+
+    Supplemental Guidance:  Physical security safeguards applied to information system distribution and transmission lines help to prevent accidental damage, disruption, and physical tampering. In addition, physical safeguards may be necessary to help prevent eavesdropping or in transit modification of unencrypted transmissions. Security safeguards to control physical access to system distribution and transmission lines include, for example: (i) locked wiring closets; (ii) disconnected or locked spare jacks; and/or (iii) protection of cabling by conduit or cable trays. Related controls: MP-2, MP-4, PE-2, PE-3, PE-5, SC-7, SC-8.
+
+    Control Enhancements:  None.
+
+    References:  NSTISSI No. 7003.
+  title: >-
+    PE-4 - ACCESS CONTROL FOR TRANSMISSION MEDIUM
+  levels:
+  - high
+  - moderate
+- id: PE-5
+  status: not applicable
+  notes: |-
+    Controlling physical access to information system output devices to
+    prevent unauthorized individuals from obtaining the output reflects
+    organizational policy/procedures and is not applicable to
+    component-level configuration.
+  rules: []
+  description: |-
+    The organization controls physical access to information system output devices to prevent unauthorized individuals from obtaining the output.
+
+    Supplemental Guidance:  Controlling physical access to output devices includes, for example, placing output devices in locked rooms or other secured areas and allowing access to authorized individuals only, and placing output devices in locations that can be monitored by organizational personnel. Monitors, printers, copiers, scanners, facsimile machines, and audio devices are examples of information system output devices. Related controls: PE-2, PE-3, PE-4, PE-18.
+
+    References: None.
+  title: >-
+    PE-5 - ACCESS CONTROL FOR OUTPUT DEVICES
+  levels:
+  - high
+  - moderate
+- id: PE-5(1)
+  status: not applicable
+  notes: |-
+    Section a: Controlling physical access to output from organization-defined
+    output devices reflects organizational procedures/policy and
+    is outside the scope of component-level configuration.
+
+    Section b: Ensuring that only authorized individuals receive output
+    from the device reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+  rules: []
+- id: PE-5(2)
+  status: not applicable
+  notes: |-
+    Section a: Controlling physical access to output from organization-defined
+    output devices reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+
+    Section b: Linking individual identity to receipt of the output
+    from the device reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+  rules: []
+- id: PE-5(3)
+  status: not applicable
+  notes: |-
+    Marking organization-defined information system output devices
+    indicating the appropriate security marking of the information
+    permitted to be output from the device reflects organizational
+    procedure/policy and is outside the scope of component-level
+    configuration.
+  rules: []
+- id: PE-6
+  status: not applicable
+  notes: |-
+    Section a: Monitoring physical access to the facility where the information
+    system resides to detect and respond to physical security incidents
+    reflects organizational procedure/policy and is outside the scope
+    of component-level configuration.
+
+    Section b: Reviewing physical access logs at an organization-defined
+    frequency and upon occurence of organization-defined events
+    or potential indications of events, reflects organizational
+    procedure/policy and is not applicable to component-level
+    configuration.
+
+    Section c: Coordinating results of reviews and investigations with
+    the organizational incident response capability reflects
+    organizational procedure/policy and is not applicable to
+    component-level configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Monitors physical access to the facility where the information system resides to detect and respond to physical security incidents;
+     b. Reviews physical access logs [Assignment: organization-defined frequency] and upon occurrence of [Assignment: organization-defined events or potential indications of events]; and
+     c. Coordinates results of reviews and investigations with the organizational incident response capability.
+
+    Supplemental Guidance:  Organizational incident response capabilities include investigations of and responses to detected physical security incidents. Security incidents include, for example, apparent security violations or suspicious physical access activities. Suspicious physical access activities include, for example: (i) accesses outside of normal work hours; (ii) repeated accesses to areas not normally accessed; (iii) accesses for unusual lengths of time; and (iv) out-of-sequence accesses. Related controls: CA-7, IR-4, IR-8.
+
+    References: None.
+
+    PE-6 (b) [at least monthly]
+  title: >-
+    PE-6 - MONITORING PHYSICAL ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-6(1)
+  status: not applicable
+  notes: |-
+    Monitoring physical intrusion alarms and surveillance
+    equipment reflects organizational procedure/policy and is
+    not applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization monitors physical intrusion alarms and surveillance equipment.
+  title: >-
+    PE-6(1) - MONITORING PHYSICAL ACCESS | INTRUSION ALARMS / SURVEILLANCE EQUIPMENT
+  levels:
+  - high
+  - moderate
+- id: PE-6(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-6(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-6(4)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization monitors physical access to the information system in addition to the physical access monitoring of the facility as [Assignment: organization-defined physical spaces containing one or more components of the information system].
+
+    Supplemental Guidance:  This control enhancement provides additional monitoring for those areas within facilities where there is a concentration of information system components (e.g., server rooms, media storage areas, communications centers). Related controls: PS-2, PS-3.
+  title: >-
+    PE-6(4) - MONITORING PHYSICAL ACCESS | MONITORING PHYSICAL ACCESS TO INFORMATION
+    SYSTEMS
+  levels:
+  - high
+- id: PE-7
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-8
+  status: not applicable
+  notes: |-
+    Section a: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Maintains visitor access records to the facility where the information system resides for [Assignment: organization-defined time period]; and
+     b. Reviews visitor access records [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Visitor access records include, for example, names and organizations of persons visiting, visitor signatures, forms of identification, dates of access, entry and departure times, purposes of visits, and names and organizations of persons visited. Visitor access records are not required for publicly accessible areas.
+
+    References: None.
+
+    PE-8 (a) [for a minimum of one (1) year]
+    PE-8 (b) [at least monthly]
+  title: >-
+    PE-8 - VISITOR ACCESS RECORDS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-8(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to facilitate the maintenance and review of visitor access records.
+  title: >-
+    PE-8(1) - VISITOR ACCESS RECORDS | AUTOMATED RECORDS MAINTENANCE / REVIEW
+  levels:
+  - high
+- id: PE-8(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-9
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization protects power equipment and power cabling for the information system from damage and destruction.
+
+    Supplemental Guidance:  Organizations determine the types of protection necessary for power equipment and cabling employed at different locations both internal and external to organizational facilities and environments of operation. This includes, for example, generators and power cabling outside of buildings, internal cabling and uninterruptable power sources within an office or data center, and power sources for self-contained entities such as vehicles and satellites. Related control: PE-4.
+
+    References: None.
+  title: >-
+    PE-9 - POWER EQUIPMENT AND CABLING
+  levels:
+  - high
+  - moderate
+- id: PE-9(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-9(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-10
+  status: not applicable
+  notes: |-
+    Section a: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Provides the capability of shutting off power to the information system or individual system components in emergency situations;
+     b. Places emergency shutoff switches or devices in [Assignment: organization-defined location by information system or system component] to facilitate safe and easy access for personnel; and
+     c. Protects emergency power shutoff capability from unauthorized activation.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Related control: PE-15.
+
+    References: None.
+  title: >-
+    PE-10 - EMERGENCY SHUTOFF
+  levels:
+  - high
+  - moderate
+- id: PE-10(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-11
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization provides a short-term uninterruptible power supply to facilitate [Selection (one or more): an orderly shutdown of the information system; transition of the information system to long-term alternate power] in the event of a primary power source loss.
+
+    Supplemental Guidance:  Related controls: AT-3, CP-2, CP-7.
+
+    References: None.
+  title: >-
+    PE-11 - EMERGENCY POWER
+  levels:
+  - high
+  - moderate
+- id: PE-11(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization provides a long-term alternate power supply for the information system that is capable of maintaining minimally required operational capability in the event of an extended loss of the primary power source.
+
+    Supplemental Guidance:  This control enhancement can be satisfied, for example, by the use of a secondary commercial power supply or other external power supply. Long-term alternate power supplies for the information system can be either manually or automatically activated.
+  title: >-
+    PE-11(1) - EMERGENCY POWER | LONG-TERM ALTERNATE POWER SUPPLY - MINIMAL OPERATIONAL
+    CAPABILITY
+  levels:
+  - high
+- id: PE-11(2)
+  status: not applicable
+  notes: |-
+    Section a: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-12
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs and maintains automatic emergency lighting for the information system that activates in the event of a power outage or disruption and that covers emergency exits and evacuation routes within the facility.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Related controls: CP-2, CP-7.
+
+    References: None.
+  title: >-
+    PE-12 - EMERGENCY LIGHTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-12(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-13
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs and maintains fire suppression and detection devices/systems for the information system that are supported by an independent energy source.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Fire suppression and detection devices/systems include, for example, sprinkler systems, handheld fire extinguishers, fixed fire hoses, and smoke detectors.
+
+    References: None.
+  title: >-
+    PE-13 - FIRE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-13(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs fire detection devices/systems for the information system that activate automatically and notify [Assignment: organization-defined personnel or roles] and [Assignment: organization-defined emergency responders] in the event of a fire.
+
+    Supplemental Guidance:  Organizations can identify specific personnel, roles, and emergency responders in the event that individuals on the notification list must have appropriate access authorizations and/or clearances, for example, to obtain access to facilities where classified operations are taking place or where there are information systems containing classified information.
+
+    PE-13 (1) -1 [service provider building maintenance/physical security personnel]
+    PE-13 (1) -2 [service provider emergency responders with incident response responsibilities]
+  title: >-
+    PE-13(1) - FIRE PROTECTION | DETECTION DEVICES / SYSTEMS
+  levels:
+  - high
+- id: PE-13(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs fire suppression devices/systems for the information system that provide automatic notification of any activation to Assignment: organization-defined personnel or roles] and [Assignment: organization-defined emergency responders].
+
+    Supplemental Guidance:  Organizations can identify specific personnel, roles, and emergency responders in the event that individuals on the notification list must have appropriate access authorizations and/or clearances, for example, to obtain access to facilities where classified operations are taking place or where there are information systems containing classified information.
+  title: >-
+    PE-13(2) - FIRE PROTECTION | SUPPRESSION DEVICES / SYSTEMS
+  levels:
+  - high
+  - moderate
+- id: PE-13(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs an automatic fire suppression capability for the information system when the facility is not staffed on a continuous basis.
+  title: >-
+    PE-13(3) - FIRE PROTECTION | AUTOMATIC FIRE SUPPRESSION
+  levels:
+  - high
+  - moderate
+- id: PE-13(4)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-14
+  status: not applicable
+  notes: |-
+    Section a: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Maintains temperature and humidity levels within the facility where the information system resides at [Assignment: organization-defined acceptable levels]; and
+     b. Monitors temperature and humidity levels [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources, for example, data centers, server rooms, and mainframe computer rooms. Related control: AT-3.
+
+    References: None.
+
+    PE-14 (a) [consistent with American Society of Heating, Refrigerating and Air-conditioning Engineers (ASHRAE) document entitled Thermal Guidelines for Data Processing Environments]
+
+    PE-14 (b) [continuously]
+    PE-14 (a) Requirements:  The service provider measures temperature at server inlets and humidity levels by dew point.
+  title: >-
+    PE-14 - TEMPERATURE AND HUMIDITY CONTROLS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-14(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-14(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs temperature and humidity monitoring that provides an alarm or notification of changes potentially harmful to personnel or equipment.
+  title: >-
+    PE-14(2) - TEMPERATURE AND HUMIDITY CONTROLS | MONITORING WITH ALARMS / NOTIFICATIONS
+  levels:
+  - high
+  - moderate
+- id: PE-15
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization protects the information system from damage resulting from water leakage by providing master shutoff or isolation valves that are accessible, working properly, and known to key personnel.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Isolation valves can be employed in addition to or in lieu of master shutoff valves to shut off water supplies in specific areas of concern, without affecting entire organizations. Related control: AT-3.
+
+    References: None.
+  title: >-
+    PE-15 - WATER DAMAGE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-15(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to detect the presence of water in the vicinity of the information system and alerts [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:  Automated mechanisms can include, for example, water detection sensors, alarms, and notification systems.
+
+    PE-15 (1) [service provider building maintenance/physical security personnel]
+  title: >-
+    PE-15(1) - WATER DAMAGE PROTECTION | AUTOMATION SUPPORT
+  levels:
+  - high
+- id: PE-16
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization authorizes, monitors, and controls [Assignment: organization-defined types of information system components] entering and exiting the facility and maintains records of those items.
+
+    Supplemental Guidance:  Effectively enforcing authorizations for entry and exit of information system components may require restricting access to delivery areas and possibly isolating the areas from the information system and media libraries. Related controls: CM-3, MA-2, MA-3, MP-5, SA-12.
+
+    References: None.
+
+    PE-16 [all information system components]
+  title: >-
+    PE-16 - DELIVERY AND REMOVAL
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-17
+  status: not applicable
+  notes: |-
+    Section a: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Employs [Assignment: organization-defined security controls] at alternate work sites;
+     b. Assesses as feasible, the effectiveness of security controls at alternate work sites; and
+     c. Provides a means for employees to communicate with information security personnel in case of security incidents or problems.
+
+    Supplemental Guidance:  Alternate work sites may include, for example, government facilities or private residences of employees. While commonly distinct from alternative processing sites, alternate work sites may provide readily available alternate locations as part of contingency operations. Organizations may define different sets of security controls for specific alternate work sites or types of sites depending on the work-related activities conducted at those sites. This control supports the contingency planning activities of organizations and the federal telework initiative. Related controls: AC-17, CP-7.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publication 800-46.
+  title: >-
+    PE-17 - ALTERNATE WORK SITE
+  levels:
+  - high
+  - moderate
+- id: PE-18
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization positions information system components within the facility to minimize potential damage from [Assignment: organization-defined physical and environmental hazards] and to minimize the opportunity for unauthorized access.
+
+    Supplemental Guidance:  Physical and environmental hazards include, for example, flooding, fire, tornados, earthquakes, hurricanes, acts of terrorism, vandalism, electromagnetic pulse, electrical interference, and other forms of incoming electromagnetic radiation. In addition, organizations consider the location of physical entry points where unauthorized individuals, while not being granted access, might nonetheless be in close proximity to information systems and therefore increase the potential for unauthorized access to organizational communications (e.g., through the use of wireless sniffers or microphones). Related controls: CP-2, PE-19, RA-3.
+
+    References: None.
+
+    PE-18 [physical and environmental hazards identified during threat assessment]
+  title: >-
+    PE-18 - LOCATION OF INFORMATION SYSTEM COMPONENTS
+  levels:
+  - high
+- id: PE-18(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-19
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-19(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PE-20
+  status: not applicable
+  notes: |-
+    Section a: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PL-1
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A security planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the security planning policy and associated security planning controls; and
+     b. Reviews and updates the current:
+       1. Security planning policy [Assignment: organization-defined frequency]; and
+       2. Security planning procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the PL family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-18, 800-100.
+
+    PL-1 (b) (1) [at least annually]
+    PL-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    PL-1 - SECURITY PLANNING POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: PL-2
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section c: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section d: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section e: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The organization:\n a. Develops a security plan for the information\
+    \ system that:\n   1. Is consistent with the organization\u2019s enterprise architecture;\n\
+    \   2. Explicitly defines the authorization boundary for the system;\n   3. Describes\
+    \ the operational context of the information system in terms of missions and business\
+    \ processes;\n   4. Provides the security categorization of the information system\
+    \ including supporting rationale;\n   5. Describes the operational environment\
+    \ for the information system and relationships with or connections to other information\
+    \ systems;\n   6. Provides an overview of the security requirements for the system;\n\
+    \   7. Identifies any relevant overlays, if applicable;\n   8. Describes the security\
+    \ controls in place or planned for meeting those requirements including a rationale\
+    \ for the tailoring and supplementation decisions; and\n   9. Is reviewed and\
+    \ approved by the authorizing official or designated representative prior to plan\
+    \ implementation;\n b. Distributes copies of the security plan and communicates\
+    \ subsequent changes to the plan to [Assignment: organization-defined personnel\
+    \ or roles];\n c. Reviews the security plan for the information system [Assignment:\
+    \ organization-defined frequency];\n d. Updates the plan to address changes to\
+    \ the information system/environment of operation or problems identified during\
+    \ plan implementation or security control assessments; and\n e. Protects the security\
+    \ plan from unauthorized disclosure and modification.\n\nSupplemental Guidance:\
+    \  Security plans relate security requirements to a set of security controls and\
+    \ control enhancements. Security plans also describe, at a high level, how the\
+    \ security controls and control enhancements meet those security requirements,\
+    \ but do not provide detailed, technical descriptions of the specific design or\
+    \ implementation of the controls/enhancements. Security plans contain sufficient\
+    \ information (including the specification of parameter values for assignment\
+    \ and selection statements either explicitly or by reference) to enable a design\
+    \ and implementation that is unambiguously compliant with the intent of the plans\
+    \ and subsequent determinations of risk to organizational operations and assets,\
+    \ individuals, other organizations, and the Nation if the plan is implemented\
+    \ as intended. Organizations can also apply tailoring guidance to the security\
+    \ control baselines in Appendix D and CNSS Instruction 1253 to develop overlays\
+    \ for community-wide use or to address specialized requirements, technologies,\
+    \ or missions/environments of operation (e.g., DoD-tactical, Federal Public Key\
+    \ Infrastructure, or Federal Identity, Credential, and Access Management, space\
+    \ operations). Appendix I provides guidance on developing overlays.\n\nSecurity\
+    \ plans need not be single documents; the plans can be a collection of various\
+    \ documents including documents that already exist. Effective security plans make\
+    \ extensive use of references to policies, procedures, and additional documents\
+    \ (e.g., design and implementation specifications) where more detailed information\
+    \ can be obtained. This reduces the documentation requirements associated with\
+    \ security programs and maintains security-related information in other established\
+    \ management/operational areas related to enterprise architecture, system development\
+    \ life cycle, systems engineering, and acquisition. For example, security plans\
+    \ do not contain detailed contingency plan or incident response plan information\
+    \ but instead provide explicitly or by reference, sufficient information to define\
+    \ what needs to be accomplished by those plans. Related controls: AC-2, AC-6,\
+    \ AC-14, AC-17, AC-20, CA-2, CA-3, CA-7, CM-9, CP-2, IR-8, MA-4, MA-5, MP-2, MP-4,\
+    \ MP-5, PL-7, PM-1, PM-7, PM-8, PM-9, PM-11, SA-5, SA-17.\n\nReferences: NIST\
+    \ Special Publication 800-18.\n\nPL-2 (c) [at least annually]"
+  title: >-
+    PL-2 - SYSTEM SECURITY PLAN
+  levels:
+  - high
+  - moderate
+  - low
+- id: PL-2(1)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-7.
+  rules: []
+- id: PL-2(2)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-8.
+  rules: []
+- id: PL-2(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization plans and coordinates security-related activities affecting the information system with [Assignment: organization-defined individuals or groups] before conducting such activities in order to reduce the impact on other organizational entities.
+
+    Supplemental Guidance:  Security-related activities include, for example, security assessments, audits, hardware and software maintenance, patch management, and contingency plan testing. Advance planning and coordination includes emergency and nonemergency (i.e., planned or nonurgent unplanned) situations. The process defined by organizations to plan and coordinate security-related activities can be included in security plans for information systems or other documents, as appropriate. Related controls: CP-4, IR-4.
+  title: >-
+    PL-2(3) - SYSTEM SECURITY PLAN | PLAN / COORDINATE WITH OTHER ORGANIZATIONAL ENTITIES
+  levels:
+  - high
+  - moderate
+- id: PL-3
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-2.
+  rules: []
+- id: PL-4
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section c: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section d: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes and makes readily available to individuals requiring access to the information system, the rules that describe their responsibilities and expected behavior with regard to information and information system usage;
+     b. Receives a signed acknowledgment from such individuals, indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing access to information and the information system;
+     c. Reviews and updates the rules of behavior [Assignment: organization-defined frequency]; and d. Requires individuals who have signed a previous version of the rules of behavior to read and
+    resign when the rules of behavior are revised/updated.
+
+    Supplemental Guidance: This control enhancement applies to organizational users. Organizations consider rules of behavior based on individual user roles and responsibilities, differentiating, for example, between rules that apply to privileged users and rules that apply to general users. Establishing rules of behavior for some types of non-organizational users including, for example, individuals who simply receive data/information from federal information systems, is often not feasible given the large number of such users and the limited nature of their interactions with the systems. Rules of behavior for both organizational and non-organizational users can also be established in AC-8, System Use Notification. PL-4 b. (the signed acknowledgment portion of this control) may be satisfied by the security awareness training and role-based security training programs conducted by organizations if such training includes rules of behavior. Organizations can use electronic signatures for acknowledging rules of behavior. Related controls: AC-2, AC-6, AC-8, AC-9, AC-17, AC-18, AC-19, AC-20, AT-2, AT-3, CM-11, IA-2, IA-4, IA-5, MP-7, PS-6, PS-8, SA-5.
+
+    References: NIST Special Publication 800-18.
+
+    PL-4 (c) [annually]
+  title: >-
+    PL-4 - RULES OF BEHAVIOR
+  levels:
+  - high
+  - moderate
+  - low
+- id: PL-4(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization includes in the rules of behavior, explicit restrictions on the use of social media/networking sites and posting organizational information on public websites.
+
+    Supplemental Guidance:  This control enhancement addresses rules of behavior related to the use of social media/networking sites: (i) when organizational personnel are using such sites for official duties or in the conduct of official business; (ii) when organizational information is involved in social media/networking transactions; and (iii) when personnel are accessing social media/networking sites from organizational information systems. Organizations also address specific rules that prevent unauthorized entities from obtaining and/or inferring non- public organizational information (e.g., system account information, personally identifiable information) from social media/networking sites.
+  title: >-
+    PL-4(1) - RULES OF BEHAVIOR | SOCIAL MEDIA AND NETWORKING RESTRICTIONS
+  levels:
+  - high
+  - moderate
+- id: PL-5
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into Appendix J, AR-2.
+  rules: []
+- id: PL-6
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-2.
+  rules: []
+- id: PL-7
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: PL-8
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section c: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The organization:\n a. Develops an information security architecture\
+    \ for the information system that:\n   1. Describes the overall philosophy, requirements,\
+    \ and approach to be taken with regard to protecting the confidentiality, integrity,\
+    \ and availability of organizational information;\n   2. Describes how the information\
+    \ security architecture is integrated into and supports the enterprise architecture;\
+    \ and\n   3. Describes any information security assumptions about, and dependencies\
+    \ on, external services;\n b. Reviews and updates the information security architecture\
+    \ [Assignment: organization-defined frequency] to reflect updates in the enterprise\
+    \ architecture; and\n c. Ensures that planned information security architecture\
+    \ changes are reflected in the security plan, the security Concept of Operations\
+    \ (CONOPS), and organizational procurements/acquisitions.\n\nSupplemental Guidance:\
+    \  This control addresses actions taken by organizations in the design and development\
+    \ of information systems. The information security architecture at the individual\
+    \ information system level is consistent with and complements the more global,\
+    \ organization-wide information security architecture described in PM-7 that is\
+    \ integral to and developed as part of the enterprise architecture. The information\
+    \ security architecture includes an architectural description, the placement/allocation\
+    \ of security functionality (including security controls), security-related information\
+    \ for external interfaces, information being exchanged across the interfaces,\
+    \ and the protection mechanisms associated with each interface. In addition, the\
+    \ security architecture can include other important security-related information,\
+    \ for example, user roles and access privileges assigned to each role, unique\
+    \ security requirements, the types of information processed, stored, and transmitted\
+    \ by the information system, restoration priorities of information and information\
+    \ system services, and any other specific protection needs.\n\nIn today\u2019\
+    s modern architecture, it is becoming less common for organizations to control\
+    \ all information resources. There are going to be key dependencies on external\
+    \ information services and service providers. Describing such dependencies in\
+    \ the information security architecture is important to developing a comprehensive\
+    \ mission/business protection strategy. Establishing, developing, documenting,\
+    \ and maintaining under configuration control, a baseline configuration for organizational\
+    \ information systems is critical to implementing and maintaining an effective\
+    \ information security architecture. The development of the information security\
+    \ architecture is coordinated with the Senior Agency Official for Privacy (SAOP)/Chief\
+    \ Privacy Officer (CPO) to ensure that security controls needed to support privacy\
+    \ requirements are identified and effectively implemented. PL-8 is primarily directed\
+    \ at organizations (i.e., internally focused) to help ensure that organizations\
+    \ develop an information security architecture for the information system, and\
+    \ that the security architecture is integrated with or tightly coupled to the\
+    \ enterprise architecture through the organization-wide information security architecture.\
+    \ In contrast, SA-17 is primarily directed at external information technology\
+    \ product/system developers and integrators (although SA-17 could be used internally\
+    \ within organizations for in-house system development). SA-17, which is complementary\
+    \ to PL-8, is selected when organizations outsource the development of information\
+    \ systems or information system components to external entities, and there is\
+    \ a need to demonstrate/show consistency with the organization\u2019s enterprise\
+    \ architecture and information security architecture. Related controls: CM-2,\
+    \ CM-6, PL-2, PM-7, SA-5, SA-17, Appendix J.\n\nReferences: None.\n\nPL-8 (b)\
+    \ [at least annually or when a significant change occurs]\nPL-8 (b) Guidance:\
+    \ Significant change is defined in NIST Special Publication 800-37 Revision 1,\
+    \ Appendix F, page F-7."
+  title: >-
+    PL-8 - INFORMATION SECURITY ARCHITECTURE
+  levels:
+  - high
+  - moderate
+- id: PL-8(1)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: PL-8(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PL-9
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-1
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section d: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-2
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-3
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-4
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-5
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-6
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-7
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-8
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-9
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-10
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-11
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-12
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-13
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-14
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-15
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PM-16
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PS-1
+  status: not applicable
+  notes: |-
+    Section a: Organizational development, documentation, and dissemination of
+    a personnel security policy to organization-defined personnel
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section a.1: Organizational development, documentation, and dissemination of
+    a personnel security policy to organization-defined personnel
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section a.2: Organizational development, documentation, and dissemination of
+    a personnel security policy to organization-defined personnel
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational reviews and updates to the personnel security policy
+    and personnel security procedures at an organization-defined frequency
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b.1: Organizational development, documentation, and dissemination of
+    a personnel security policy to organization-defined personnel
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b.2: Organizational development, documentation, and dissemination of
+    a personnel security policy to organization-defined personnel
+    is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A personnel security policy\
+    \ that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the personnel security policy and associated\
+    \ personnel security controls; and\n b. Reviews and updates the current:\n   1.\
+    \ Personnel security policy [Assignment: organization-defined frequency]; and\n\
+    \   2. Personnel security procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the PS family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-100.\n\nPS-1 (b) (1) [at\
+    \ least annually] \nPS-1 (b) (2) [at least annually or whenever a significant\
+    \ change occurs]"
+  title: >-
+    PS-1 - PERSONNEL SECURITY POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-2
+  status: not applicable
+  notes: |-
+    Section a: Organizational assignment of a risk designation to all organizational
+    positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational establishment of screening criteria for individuals
+    filling those positions is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section c: Organizational review and updating of position risk
+    designations at an organization-defined frequency is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Assigns a risk designation to all organizational positions;
+     b. Establishes screening criteria for individuals filling those positions; and
+     c. Reviews and updates position risk designations [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Position risk designations reflect Office of Personnel Management policy and guidance. Risk designations can guide and inform the types of authorizations individuals receive when accessing organizational information and information systems. Position screening criteria include explicit information security role appointment requirements (e.g., training, security clearances). Related controls: AT-3, PL-2, PS-3.
+
+    Control Enhancements:  None.
+
+    References:  5 C.F.R. 731.106(a).
+
+    PS-2 (c) [at least annually]
+  title: >-
+    PS-2 - POSITION RISK DESIGNATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-3
+  status: not applicable
+  notes: |-
+    Section a: Organizational screening of individuals prior to authorizing access
+    to the information system is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section b: Organizational processes to rescreen individuals according to
+    organization-defined conditions requiring rescreening and,
+    where rescreening is so indicated, the frequency of such
+    rescreening, is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Screens individuals prior to authorizing access to the information system; and
+     b. Rescreens individuals according to [Assignment: organization-defined conditions requiring rescreening and, where rescreening is so indicated, the frequency of such rescreening].
+
+    Supplemental Guidance:  Personnel screening and rescreening activities reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, guidance, and specific criteria established for the risk designations of assigned positions. Organizations may define different rescreening conditions and frequencies for personnel accessing information systems based on types of information processed, stored, or transmitted by the systems. Related controls: AC-2, IA-4, PE-2, PS-2.
+
+    References: 5 C.F.R. 731.106; FIPS Publications 199, 201; NIST Special Publications 800-60, 800-73, 800-76, 800-78; ICD 704.
+
+    PS-3 (b) [for national security clearances; a reinvestigation is required during the fifth (5th) year for top secret security clearance, the tenth (10th) year for secret security clearance, and fifteenth (15th) year for confidential security clearance.
+
+    For moderate risk law enforcement and high impact public trust level, a reinvestigation is required during the fifth (5th) year.  There is no reinvestigation for other moderate risk positions or any low risk positions]
+  title: >-
+    PS-3 - PERSONNEL SCREENING
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-3(1)
+  status: not applicable
+  notes: |-
+    Organizational processes ensuring that individuals accessing an
+    information system processing, storing, or transmitting classified
+    information are cleared and indoctrinated to the highest classification
+    level of the information to which they have access on the system,
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PS-3(2)
+  status: not applicable
+  notes: |-
+    Organizational processes ensuring that individuals accessing an
+    information system processing, storing, or transmitting types of
+    classified information which require formal indoctrination, are
+    formally indoctrinated for all of the relevant types of information
+    to which they have access on the system, are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PS-3(3)
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes ensuring that individuals accessing an
+    information system processing, storing, or transmitting information
+    requiring special protection have valid access authorizations that are
+    demonstrated by assigned official government dutues, are outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational processes ensuring that individuals accessing an
+    information system processing, storing, or transmitting information
+    requiring special protection satisgy organization-defined additional
+    personnel screening criteria, are outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization ensures that individuals accessing an information\
+    \ system processing, storing, or transmitting information requiring special protection:\n\
+    \ (a)   Have valid access authorizations that are demonstrated by assigned official\
+    \ government duties; and\n (b)   Satisfy [Assignment: organization-defined additional\
+    \ personnel screening criteria].\n\nSupplemental Guidance:  Organizational information\
+    \ requiring special protection includes, for example, Controlled Unclassified\
+    \ Information (CUI) and Sources and Methods Information (SAMI). Personnel security\
+    \ criteria include, for example, position sensitivity background screening requirements.\n\
+    \nPS-3 (3) (b) [personnel screening criteria \u2013 as required by specific information]"
+  title: >-
+    PS-3(3) - PERSONNEL SCREENING | INFORMATION WITH SPECIAL PROTECTION MEASURES
+  levels:
+  - high
+  - moderate
+- id: PS-4
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes ensuring that, upon termination of individual
+    employment, information system access is disabled within an
+    organization-defined time period, are outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational processes ensuring that, upon termination of individual
+    employment, any authenticators/credentials associated with the individual
+    are terminated/revoked, are outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Organizational processes ensuring that, upon termination of individual
+    employment, exit interviews are conducted that include a discussion of
+    organization-defined information security topics, are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section d: Organizational processes ensuring that, upon termination of individual
+    employment, all security-related organizational information
+    system-related property is retrieved, are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section e: Organizational processes ensuring that, upon termination of individual
+    employment, the organization retains access to organizational
+    information systems formerly controlled by the terminated individual,
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section f: Organizational processes ensuring that, upon termination of individual
+    employment, the organization notifies organization-defined personnel
+    or roles within an organization-defined time period, are outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization, upon termination of individual employment:
+     a. Disables information system access within [Assignment: organization-defined time period];
+     b. Terminates/revokes any authenticators/credentials associated with the individual;
+     c. Conducts exit interviews that include a discussion of [Assignment: organization-defined information security topics];
+     d. Retrieves all security-related organizational information system-related property;
+     e. Retains access to organizational information and information systems formerly controlled by terminated individual; and
+     f. Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].
+
+    Supplemental Guidance:  Information system-related property includes, for example, hardware authentication tokens, system administration technical manuals, keys, identification cards, and building passes. Exit interviews ensure that terminated individuals understand the security constraints imposed by being former employees and that proper accountability is achieved for information system-related property. Security topics of interest at exit interviews can include, for example, reminding terminated individuals of nondisclosure agreements and potential limitations on future employment. Exit interviews may not be possible for some terminated individuals, for example, in cases related to job abandonment, illnesses, and nonavailability of supervisors. Exit interviews are important for individuals with security clearances. Timely execution of termination actions is essential for individuals terminated for cause. In certain situations, organizations consider disabling the information system accounts of individuals that are being terminated prior to the individuals being notified. Related controls: AC-2, IA-4, PE-2, PS-5, PS-6.
+
+    References: None.
+
+    PS-4 (a) [eight (8) hours]
+  title: >-
+    PS-4 - PERSONNEL TERMINATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-4(1)
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes which notify terminated individuals of
+    applicable, legally binding post-employment requirements for
+    the protection of organizational information are outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational processes requiring terminated individuals
+    to sign an acknowledgement of post-employment requirements
+    as part of the organizational termination process
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PS-4(2)
+  status: not applicable
+  notes: |-
+    Organizational employment of automated mechanisms to notify
+    organization-defined personnel or roles upon termination of
+    an individual, is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization employs automated mechanisms to notify [Assignment:\
+    \ organization-defined personnel or roles] upon termination of an individual.\n\
+    \nSupplemental Guidance:  In organizations with a large number of employees, not\
+    \ all personnel who need to know about termination actions receive the appropriate\
+    \ notifications\u2014or, if such notifications are received, they may not occur\
+    \ in a timely manner. Automated mechanisms\ncan be used to send automatic alerts\
+    \ or notifications to specific organizational personnel or roles (e.g., management\
+    \ personnel, supervisors, personnel security officers, information security officers,\
+    \ systems administrators, or information technology administrators) when individuals\
+    \ are terminated. Such automatic alerts or notifications can be conveyed in a\
+    \ variety of ways, including, for example, telephonically, via electronic mail,\
+    \ via text message, or via websites.\n\nPS-4 (2) [access control personnel responsible\
+    \ for disabling access to the system]"
+  title: >-
+    PS-4(2) - PERSONNEL TERMINATION | AUTOMATED NOTIFICATION
+  levels:
+  - high
+- id: PS-5
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to review and confirm ongoing operational
+    need for current logical and physical access authorizations to
+    information systems/facilities when individuals are reassigned or
+    transferred to other positions within the organization are
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational processes to initiate organization-defined transfer
+    or reassignment actions within organization-defined time period
+    following the formal transfer action are outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Organizational processes to modify access authorizations as needed to
+    correspond with any changes in oeprational need due to reassignment
+    or transfer are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section d: Organizational notifications of organization-defined personnel
+    or roles within an organization-defined time period are outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Reviews and confirms ongoing operational need\
+    \ for current logical and physical access authorizations to information systems/facilities\
+    \ when individuals are reassigned or transferred to other positions within the\
+    \ organization;\n b. Initiates [Assignment: organization-defined transfer or reassignment\
+    \ actions] within [Assignment: organization-defined time period following the\
+    \ formal transfer action];\n c. Modifies access authorization as needed to correspond\
+    \ with any changes in operational need due to reassignment or transfer; and\n\
+    \ d. Notifies [Assignment: organization-defined personnel or roles] within [Assignment:\
+    \ organization-defined time period].\n\nSupplemental Guidance:  This control applies\
+    \ when reassignments or transfers of individuals are permanent or of such extended\
+    \ durations as to make the actions warranted. Organizations define actions appropriate\
+    \ for the types of reassignments or transfers, whether permanent or extended.\
+    \ Actions that may be required for personnel transfers or reassignments to other\
+    \ positions within organizations include, for example: (i) returning old and issuing\
+    \ new keys, identification cards, and building passes; (ii) closing information\
+    \ system accounts and establishing new accounts; (iii) changing information system\
+    \ access authorizations (i.e., privileges); and (iv) providing for access to official\
+    \ records to which individuals had access at previous work locations and in previous\
+    \ information system accounts. Related controls: AC-2, IA-4, PE-2, PS-4.\n\nControl\
+    \ Enhancements:  None.\n\nReferences:  None.\n\nPS-5 (b)-2 [twenty-four (24) hours]\
+    \ \nPS-5 (d)-2 [twenty-four (24) hours]"
+  title: >-
+    PS-5 - PERSONNEL TRANSFER
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-6
+  status: not applicable
+  notes: |-
+    Section a: Organizational process to develop and document access agreements for
+    organizational information systems are outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational reviews and updates to the access agreements at an
+    organization-defined frequency are outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Organizational processes that ensure individuals requiring access to
+    organizational information and information systems sign and re-sign
+    access agreements are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c.1: Organizational processes that ensure individuals requiring access to
+    organizational information and information systems sign and re-sign
+    access agreements are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c.2: Organizational processes that ensure individuals requiring access to
+    organizational information and information systems sign and re-sign
+    access agreements are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops and documents access agreements for organizational information systems;
+     b. Reviews and updates the access agreements [Assignment: organization-defined frequency]; and
+     c. Ensures that individuals requiring access to organizational information and information systems:
+       1. Sign appropriate access agreements prior to being granted access; and
+       2. Re-sign access agreements to maintain access to organizational information systems when access agreements have been updated or [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: Access agreements include, for example, nondisclosure agreements, acceptable use agreements, rules of behavior, and conflict-of-interest agreements. Signed access agreements include an acknowledgement that individuals have read, understand, and agree to abide by the constraints associated with organizational information systems to which access is authorized. Organizations can use electronic signatures to acknowledge access agreements unless specifically prohibited by organizational policy. Related control: PL-4, PS-2, PS-3, PS-4, PS-8.
+
+    References: None.
+
+    PS-6 (b) [at least annually]
+    PS-6 (c) (2) [at least annually and any time there is a change to the user's level of access]
+  title: >-
+    PS-6 - ACCESS AGREEMENTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-6(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: PS-6(2)
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes that ensure access to classified information
+    requiring special protection is granted only to individuals who
+    have a valid access authorization that is demonstrated by assigned
+    official government duties are outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Section b: Organizational processes that ensure access to classified information
+    requiring special protection is granted only to individuals who
+    satisfy associated personnel security criteria are outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Organizational processes that ensure access to classified information
+    requiring special protection is granted only to individuals who
+    have read, understood, and signed a nondisclosure agreement are
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PS-6(3)
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to notify individuals of applicable, legally
+    binding post-employment requirements for protection of organizational
+    information are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational processes which require individuals to sign
+    an acknowledgement of these requirements, if applicable, as
+    part of granting initial access to covered information, are
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: PS-7
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to establish security requirements including
+    security roles and responsibilities for third-party providers are
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational processes requiring third-party providers to comply
+    with personnel security polocies and procedures established by
+    the organization are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section c: Organizational processes to document presonnel security requirements
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section d: Organizational processes to require third-party providers to notify
+    organization-defined personnel or roles of any personnel transfers or
+    terminations of third-party personnel who possess organizational
+    credentials and/or badges, or who have information system privileges
+    within an organization-defined time period, are outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section e: Organizational monitoring of provider compliance is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Establishes personnel security requirements\
+    \ including security roles and responsibilities for third-party providers;\n b.\
+    \ Requires third-party providers to comply with personnel security policies and\
+    \ procedures established by the organization;\n c. Documents personnel security\
+    \ requirements;\n d. Requires third-party providers to notify [Assignment: organization-defined\
+    \ personnel or roles] of any personnel transfers or terminations of third-party\
+    \ personnel who possess organizational credentials and/or badges, or who have\
+    \ information system privileges within [Assignment: organization-defined time\
+    \ period]; and\n e. Monitors provider compliance.\n\nSupplemental Guidance: Third-party\
+    \ providers include, for example, service bureaus, contractors, and other organizations\
+    \ providing information system development, information technology services, outsourced\
+    \ applications, and network and security management. Organizations explicitly\
+    \ include personnel security requirements in acquisition-related documents. Third-party\
+    \ providers may have personnel working at organizational facilities with credentials,\
+    \ badges, or information system privileges issued by organizations. Notifications\
+    \ of third-party personnel changes ensure appropriate termination of privileges\
+    \ and credentials. Organizations define the transfers and terminations deemed\
+    \ reportable by security-related characteristics that include, for example, functions,\
+    \ roles, and nature of credentials/privileges associated with individuals transferred\
+    \ or terminated. \n\nRelated controls: PS-2, PS-3, PS-4, PS-5, PS-6, SA-9, SA-21.\n\
+    \nControl Enhancements:  None.\n\nReferences:  NIST Special Publication 800-35.\n\
+    \nPS-7 (d)-2 [terminations: immediately; transfers: within twenty-four (24) hours]"
+  title: >-
+    PS-7 - THIRD-PARTY PERSONNEL SECURITY
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-8
+  status: not applicable
+  notes: |-
+    Section a: Organizational employment of a formal sanctions process for individuals
+    failing to comply with established information security policies
+    and procedures is outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+
+    Section b: Organizational notification of organization-defined personnel
+    or roles within an organization-defined time period when a formal
+    employee santions process is initiated, identifying the individual
+    sanctioned and the reason for the sanction.
+  rules: []
+  description: |-
+    The organization:
+     a. Employs a formal sanctions process for individuals failing to comply with established information security policies and procedures; and
+     b. Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period] when a formal employee sanctions process is initiated, identifying the individual sanctioned and the reason for the sanction.
+
+    Supplemental Guidance: Organizational sanctions processes reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Sanctions processes are described in access agreements and can be included as part of general personnel policies and procedures for organizations. Organizations consult with the Office of the General Counsel regarding matters of employee sanctions. Related controls: PL-4, PS-6.
+
+    Control Enhancements:  None.
+
+    References:  None.
+
+    PS-8(b)-1 [at a minimum, the ISSO and/or similar role within the organization]
+  title: >-
+    PS-8 - PERSONNEL SANCTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-1
+  status: not applicable
+  notes: |-
+    Section a: Organizational development, documentation, and dissemination to
+    organization-defined personnel or roles a risk assessment policy
+    and procedures is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section a.1: Organizational development, documentation, and dissemination to
+    organization-defined personnel or roles a risk assessment policy
+    and procedures is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section a.2: Organizational development, documentation, and dissemination to
+    organization-defined personnel or roles a risk assessment policy
+    and procedures is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Organizational review and updates to the risk assessment policy
+    and risk assessment procedures is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b.1: Organizational review and updates to the risk assessment policy
+    and risk assessment procedures is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b.2: Organizational review and updates to the risk assessment policy
+    and risk assessment procedures is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A risk assessment policy that\
+    \ addresses purpose, scope, roles, responsibilities, management commitment, coordination\
+    \ among organizational entities, and compliance; and\n   2. Procedures to facilitate\
+    \ the implementation of the risk assessment policy and associated risk assessment\
+    \ controls; and\n b. Reviews and updates the current:\n   1. Risk assessment policy\
+    \ [Assignment: organization-defined frequency]; and\n   2. Risk assessment procedures\
+    \ [Assignment: organization-defined frequency].\n\nSupplemental Guidance:  This\
+    \ control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ RA family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-30, 800-100.\n\nRA-1 (b) (1) [at least annually]\
+    \ \nRA-1 (b) (2) [at least annually or whenever a significant change occurs]"
+  title: >-
+    RA-1 - RISK ASSESSMENT POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-2
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to categorize information and information
+    systems in accordance with applicable federal laws, Executive
+    Orders, directives, policies, regulations, standards, and
+    guidance, are outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Organizational processes to document the security categorization
+    results (including supporting rationale) in the security plan for
+    the information system are outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Organizational processes to ensure that the authorizing official
+    or authorizing official designated representative reviews and
+    approved the security categorization decision are outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Categorizes information and the information system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+     b. Documents the security categorization results (including supporting rationale) in the security plan for the information system; and
+     c. Ensures that the security categorization decision is reviewed and approved by the authorizing official or authorizing official designated representative.
+
+    Supplemental Guidance:  Clearly defined authorization boundaries are a prerequisite for effective security categorization decisions. Security categories describe the potential adverse impacts to organizational operations, organizational assets, and individuals if organizational information and information systems are comprised through a loss of confidentiality, integrity, or availability. Organizations conduct the security categorization process as an organization-wide activity with the involvement of chief information officers, senior information security officers, information system owners, mission/business owners, and information owners/stewards. Organizations also consider the potential adverse impacts to other organizations and, in accordance with the USA PATRIOT Act of 2001 and Homeland Security Presidential Directives, potential national-level adverse impacts. Security categorization processes carried out by organizations facilitate the development of inventories of information assets, and along with CM-8, mappings to specific information system components where information is processed, stored, or transmitted. Related controls: CM-8, MP-4, RA-3, SC-7.
+
+    Control Enhancements:  None.
+
+    References:  FIPS Publication 199; NIST Special Publications 800-30, 800-39, 800-60.
+  title: >-
+    RA-2 - SECURITY CATEGORIZATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-3
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to conduct an assessment of risk,
+    including the likelihood and magnitude of harm, from the unauthorized
+    access, use, disclosure, disruption, modification, or desctruction of
+    the information system and the information it processes, stores, or
+    transmits, are outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Organizational processes to document risk assessment results in
+    security plans, risk assessment reports, or organization-defined
+    documents, are outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: Organizational processes to review risk assessment results at
+    an organization-defined frequency are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section d: Organizational processes to disseminate risk assessment results to
+    organization-defined personnel or roles are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section e: Organizational processes to update the risk assessment at an
+    organization-defined frequency or whenever there are significant
+    changes to the information system or environment of operation
+    (including the identification of new threats and vulnerabilities),
+    or other conditions that may impact the security state of the system,
+    are outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Conducts an assessment of risk, including the\
+    \ likelihood and magnitude of harm, from the unauthorized access, use, disclosure,\
+    \ disruption, modification, or destruction of the information system and the information\
+    \ it processes, stores, or transmits;\n b. Documents risk assessment results in\
+    \ [Selection: security plan; risk assessment report; [Assignment: organization-defined\
+    \ document]];\n c. Reviews risk assessment results [Assignment: organization-defined\
+    \ frequency];\n d. Disseminates risk assessment results to [Assignment: organization-defined\
+    \ personnel or roles]; and\n e. Updates the risk assessment [Assignment: organization-defined\
+    \ frequency] or whenever there are significant changes to the information system\
+    \ or environment of operation (including the identification of new threats and\
+    \ vulnerabilities), or other conditions that may impact the security state of\
+    \ the system.\n\nSupplemental Guidance:  Clearly defined authorization boundaries\
+    \ are a prerequisite for effective risk assessments. Risk assessments take into\
+    \ account threats, vulnerabilities, likelihood, and impact to organizational operations\
+    \ and assets, individuals, other organizations, and the Nation based on the operation\
+    \ and use of information systems. Risk assessments also take into account risk\
+    \ from external parties (e.g., service providers, contractors operating information\
+    \ systems on behalf of the organization, individuals accessing organizational\
+    \ information systems, outsourcing\nentities). In accordance with OMB policy and\
+    \ related E-authentication initiatives, authentication of public users accessing\
+    \ federal information systems may also be required to protect nonpublic or privacy-related\
+    \ information. As such, organizational assessments of risk also address public\
+    \ access to federal information systems.\n\nRisk assessments (either formal or\
+    \ informal) can be conducted at all three tiers in the risk management hierarchy\
+    \ (i.e., organization level, mission/business process level, or information system\
+    \ level) and at any phase in the system development life cycle. Risk assessments\
+    \ can also be conducted at various steps in the Risk Management Framework, including\
+    \ categorization, security control selection, security control implementation,\
+    \ security control assessment, information\nsystem authorization, and security\
+    \ control monitoring. RA-3 is noteworthy in that the control must be partially\
+    \ implemented prior to the implementation of other controls in order to complete\
+    \ the\nfirst two steps in the Risk Management Framework. Risk assessments can\
+    \ play an important role in security control selection processes, particularly\
+    \ during the application of tailoring guidance, which includes security control\
+    \ supplementation. Related controls: RA-2, PM-9.\n\nControl Enhancements: None.\n\
+    \nReferences:  OMB Memorandum 04-04; NIST Special Publication 800-30, 800-39;\
+    \ Web:idmanagement.gov.\n\nRA-3 (b) [security assessment report]\n \nRA-3 (c)\
+    \ [at least annually or whenever a significant change occurs]\n \nRA-3 (e) [annually]\
+    \  \nRA-3 Guidance: Significant change is defined in NIST Special Publication\
+    \ 800-37 Revision 1, Appendix F.\nRA-3 (d) Requirement: Include all Authorizing\
+    \ Officials; for JAB authorizations to include FedRAMP."
+  title: >-
+    RA-3 - RISK ASSESSMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-4
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: RA-5
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: The organization employing vulnerability scanning tools and techniques that facilitate
+    interoperability among tools and automate parts of the vulnerability management process by
+    using standards reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+
+    To facilitate creation of organizational procedures/policies, Red Hat Advanced Cluster
+    Management for Kubernetes provides functionality to employ vulnerability scanning tools
+    and automate parts of the vulnerability management process via a security policy.
+    Documentation on how to create a security policy can be viewed at:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk
+    Section c: The organization analyzing vulnerability scan reports and results from security control
+    assessments reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section d: The organization remediating legitimate vulnerabilities organization-defined response
+    times in accordance with an organizational assessment of risk reflects organizational
+    procedures/policies, and is not applicable to the configuration of Red Hat Advanced Cluster
+    Management for Kubernetes.
+
+    To facilitate creation of organizational procedures/policies, Red Hat Advanced Cluster
+    Management for Kubernetes provides functionality to remediate identified vulnerabilities
+    via a security policy. Documentation on how to create a security policy can be viewed at:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/security/index?lb_target=production#governance-and-risk
+    Section e: Organizational processes to share information obtained from the
+    vulnerability scanning process and security control assessments
+    with organization-defined personnel or roles to help eliminate
+    similar vulnerabilities in other information systems (i.e.,
+    systemic weaknesses or deficiences) are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Scans for vulnerabilities in the information\
+    \ system and hosted applications [Assignment: organization-defined frequency and/or\
+    \ randomly in accordance with organization-defined process] and when new vulnerabilities\
+    \ potentially affecting the system/applications are identified and reported;\n\
+    \ b. Employs vulnerability scanning tools and techniques that facilitate interoperability\
+    \ among tools and automate parts of the vulnerability management process by using\
+    \ standards for:\n   1. Enumerating platforms, software flaws, and improper configurations;\n\
+    \   2. Formatting checklists and test procedures; and\n   3. Measuring vulnerability\
+    \ impact;\n c. Analyzes vulnerability scan reports and results from security control\
+    \ assessments;\n d. Remediates legitimate vulnerabilities [Assignment: organization-defined\
+    \ response times], in accordance with an organizational assessment of risk; and\n\
+    \ e. Shares information obtained from the vulnerability scanning process and security\
+    \ control assessments with [Assignment: organization-defined personnel or roles]\
+    \ to help eliminate similar vulnerabilities in other information systems (i.e.,\
+    \ systemic weaknesses or deficiencies).\n\nSupplemental Guidance:  Security categorization\
+    \ of information systems guides the frequency and comprehensiveness of vulnerability\
+    \ scans. Organizations determine the required vulnerability scanning for all information\
+    \ system components, ensuring that potential sources of vulnerabilities such as\
+    \ networked printers, scanners, and copiers are not overlooked. Vulnerability\
+    \ analyses for custom software applications may require additional approaches\
+    \ such as static analysis, dynamic analysis, binary analysis, or a hybrid of the\
+    \ three approaches. Organizations can employ these analysis approaches in a variety\
+    \ of tools (e.g., web-based application scanners, static analysis tools, binary\
+    \ analyzers) and in source code reviews. Vulnerability scanning includes, for\
+    \ example: (i) scanning for patch levels; (ii) scanning for functions, ports,\
+    \ protocols, and services that should not be accessible to users or devices; and\
+    \ (iii) scanning for improperly configured or incorrectly operating information\
+    \ flow control mechanisms. Organizations consider using tools that express vulnerabilities\
+    \ in the Common Vulnerabilities and Exposures (CVE) naming convention and that\
+    \ use the Open Vulnerability Assessment Language (OVAL) to determine/test for\
+    \ the presence of vulnerabilities. Suggested sources for vulnerability information\
+    \ include the Common Weakness Enumeration (CWE) listing and the National Vulnerability\
+    \ Database (NVD). In addition, security control assessments such as red team exercises\
+    \ provide other sources of potential vulnerabilities for which to scan. Organizations\
+    \ also consider using tools that express vulnerability impact by the\n\nCommon\
+    \ Vulnerability Scoring System (CVSS). Related controls: CA-2, CA-7, CM-4, CM-6,\
+    \ RA-2, RA-3, SA-11, SI-2.\n\nReferences: NIST Special Publications 800-40, 800-70,\
+    \ 800-115; Web: http://cwe.mitre.org, http://nvd.nist.gov.\n\nRA-5 (a) [monthly\
+    \ operating system/infrastructure; monthly web applications and databases]\nRA-5\
+    \ (d) [high-risk vulnerabilities mitigated within thirty (30) days from date of\
+    \ discovery; moderate-risk vulnerabilities mitigated within ninety (90) days from\
+    \ date of discovery; low risk vulnerabilities mitigated within one hundred and\
+    \ eighty (180) days from date of discovery]\nRA-5 Guidance: See the FedRAMP Documents\
+    \ page under Key Cloud Service Provider (CSP) Documents> Vulnerability Scanning\
+    \ Requirements \nhttps://www.FedRAMP.gov/documents/\nRA-5 (a) Requirement: an\
+    \ accredited independent assessor scans operating systems/infrastructure, web\
+    \ applications, and databases once annually.\nRA-5 (e) Requirement: to include\
+    \ all Authorizing Officials; for JAB authorizations to include FedRAMP"
+  title: >-
+    RA-5 - VULNERABILITY SCANNING
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-5(1)
+  status: not applicable
+  notes: |-
+    The organization determining what information about the information system is discoverable
+    by adversaries and subsequently takes organization-defined corrective actions against
+    discoverable information reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization employs vulnerability scanning tools that include the capability to readily update the information system vulnerabilities to be scanned.
+
+    Supplemental Guidance:  The vulnerabilities to be scanned need to be readily updated as new vulnerabilities are discovered, announced, and scanning methods developed. This updating process helps to ensure that potential vulnerabilities in the information system are identified and addressed as quickly as possible. Related controls: SI-3, SI-7.
+  title: >-
+    RA-5(1) - VULNERABILITY SCANNING | UPDATE TOOL CAPABILITY
+  levels:
+  - high
+  - moderate
+- id: RA-5(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization updates the information system vulnerabilities scanned [Selection (one or more): [Assignment: organization-defined frequency]; prior to a new scan; when new vulnerabilities are identified and reported].
+
+    Supplemental Guidance:  Related controls: SI-3, SI-5.
+
+    RA-5 (2) [prior to a new scan]
+  title: >-
+    RA-5(2) - VULNERABILITY SCANNING | UPDATE BY FREQUENCY / PRIOR TO NEW SCAN / WHEN
+    IDENTIFIED
+  levels:
+  - high
+  - moderate
+- id: RA-5(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization employs vulnerability scanning procedures that can identify the breadth and depth of coverage (i.e., information system components scanned and vulnerabilities checked).
+  title: >-
+    RA-5(3) - VULNERABILITY SCANNING | BREADTH / DEPTH OF COVERAGE
+  levels:
+  - high
+  - moderate
+- id: RA-5(4)
+  status: pending
+  notes: |-
+    The organization determining what information about the information system is discoverable
+    by adversaries and subsequently takes organization-defined corrective actions against
+    discoverable information reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization determines what information about the information system is discoverable by adversaries and subsequently takes [Assignment: organization-defined corrective actions].
+
+    Supplemental Guidance:  Discoverable information includes information that adversaries could obtain without directly compromising or breaching the information system, for example, by collecting information the system is exposing or by conducting extensive searches of the web. Corrective actions can include, for example, notifying appropriate organizational personnel, removing designated information, or changing the information system to make designated information less relevant or attractive to adversaries. Related control: AU-13.
+
+    RA-5 (4) [notify appropriate service provider personnel and follow procedures for organization  and service provider-defined corrective actions]
+  title: >-
+    RA-5(4) - VULNERABILITY SCANNING | DISCOVERABLE INFORMATION
+  levels:
+  - high
+- id: RA-5(5)
+  status: not applicable
+  notes: |-
+    The information system implementing privileged access authorization to
+    organization-identified information system components for selected organization-defined
+    vulnerability scanning activities is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the underlying OpenShift
+    layer to provide and implement privileged access.
+  rules: []
+  description: "The information system implements privileged access authorization\
+    \ to [Assignment: organization- identified information system components] for\
+    \ selected [Assignment: organization-defined vulnerability scanning activities].\n\
+    \nSupplemental Guidance:  In certain situations, the nature of the vulnerability\
+    \ scanning may be more intrusive or the information system component that is the\
+    \ subject of the scanning may contain highly sensitive information. Privileged\
+    \ access authorization to selected system components facilitates more thorough\
+    \ vulnerability scanning and also protects the sensitive nature of such scanning.\n\
+    \nRA-5 (5)-1 [operating systems / web applications / databases] \nRA-5 (5)-2 [all\
+    \ scans]"
+  title: >-
+    RA-5(5) - VULNERABILITY SCANNING | PRIVILEGED ACCESS
+  levels:
+  - high
+  - moderate
+- id: RA-5(6)
+  status: not applicable
+  notes: |-
+    The organization employing automated mechanisms to compare the results of vulnerability
+    scans over time to determine trends in information system vulnerabilities is an
+    organizational process/procedure outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to compare the results of vulnerability scans over time to determine trends in information system vulnerabilities.
+
+    Supplemental Guidance:  Related controls: IR-4, IR-5, SI-4.
+
+    RA-5 (6) Guidance: include in Continuous Monitoring ISSO digest/report to JAB/AO
+  title: >-
+    RA-5(6) - VULNERABILITY SCANNING | AUTOMATED TREND ANALYSES
+  levels:
+  - high
+  - moderate
+- id: RA-5(7)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: RA-5(8)
+  status: not applicable
+  notes: |-
+    Organizational review of historic audit logs to determine if a
+    vulnerability identified in the information system has been
+    previously exploited is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization reviews historic audit logs to determine if a vulnerability\
+    \ identified in the information system has been previously exploited.\n\nSupplemental\
+    \ Guidance:  Related control: AU-6.\n\nRA-5 (8) Requirements: This enhancement\
+    \ is required for all high vulnerability scan findings. \nGuidance: While scanning\
+    \ tools may label findings as high or critical, the intent of the control is based\
+    \ around NIST's definition of high vulnerability."
+  title: >-
+    RA-5(8) - VULNERABILITY SCANNING | REVIEW HISTORIC AUDIT LOGS
+  levels:
+  - high
+  - moderate
+- id: RA-5(9)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST.
+  rules: []
+- id: RA-5(10)
+  status: not applicable
+  notes: |-
+    Organizational processes to correlate the output from vulnerability
+    scanning tools to determine the presence of
+    multi-vulnerability/multi-hop attack vectors are outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: "The organization correlates the output from vulnerability scanning\
+    \ tools to determine the presence of multi-vulnerability/multi-hop attack vectors.\n\
+    \n \nRA-5 (10) Guidance: If multiple tools are not used, this control is not applicable."
+  title: >-
+    RA-5(10) - VULNERABILITY SCANNING | CORRELATE SCANNING INFORMATION
+  levels:
+  - high
+- id: RA-6
+  status: not applicable
+  notes: |-
+    Organizational employment of a technical surveillance countermeasures
+    survey at organization-defined locations at an organization-defined
+    frequency or when organization-defeined events or indicators
+    occur is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-1
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to develop, document, and disseminate to
+    organization-defined personnel or roles a system and services
+    acquisition policy is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section a.1: Organizational processes to develop, document, and disseminate to
+    organization-defined personnel or roles a system and services
+    acquisition policy is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section a.2: Organizational processes to develop, document, and disseminate to
+    organization-defined personnel or roles a system and services
+    acquisition policy is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: Organizational review and updates to the current system and services
+    acquisition policy and procedures at an organization-defined frequency
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section b.1: Organizational review and updates to the current system and services
+    acquisition policy and procedures at an organization-defined frequency
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section b.2: Organizational review and updates to the current system and services
+    acquisition policy and procedures at an organization-defined frequency
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A system and services acquisition policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the system and services acquisition policy and associated system and services acquisition controls; and
+     b. Reviews and updates the current:
+       1. System and services acquisition policy [Assignment: organization-defined frequency]; and
+       2.  System and services acquisition procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the SA family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    SA-1 (b) (1)  [at least annually]
+    SA-1 (b) (2)  [at least annually or whenever a significant change occurs]
+  title: >-
+    SA-1 - SYSTEM AND SERVICES ACQUISITION POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-2
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to determine information security requirements
+    for the information system or information system service in
+    mission/business process planning are outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational processes to determine, document, and allocate the
+    resources required to protect the information system or information
+    system service as part of its capital planning and investment control
+    process are outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section c: Organizational processes to establish a discrete line item for
+    information security in organizational programming and budgeting
+    documentation are outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Determines information security requirements\
+    \ for the information system or information system service in mission/business\
+    \ process planning;\n b. Determines, documents, and allocates the resources required\
+    \ to protect the information system or information system service as part of its\
+    \ capital planning and investment control process; and\n c. Establishes a discrete\
+    \ line item for information security in organizational programming and budgeting\
+    \ documentation.\n\nSupplemental Guidance:  Resource allocation for information\
+    \ security includes funding for the initial information system or information\
+    \ system service acquisition and funding for the sustainment of the system/service.\
+    \ Related controls: PM-3, PM-11.\n\nControl Enhancements:  None.\n \nReferences:\
+    \  NIST Special Publication 800-65."
+  title: >-
+    SA-2 - ALLOCATION OF RESOURCES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-3
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to manage the information system using
+    organization-defined system development life cycle that incorporates
+    information security considerations are outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational processes to define and document information security
+    roles and responsibilities throughout the system development life cycle
+    are outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section c: Organizational processes to identify individuals having information
+    security roles and responsibilities are outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section d: Organizational processes to integrate the organizational information
+    security risk management process into system development life cycle
+    activities are outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Manages the information system using [Assignment: organization-defined system development life cycle] that incorporates information security considerations;
+     b. Defines and documents information security roles and responsibilities throughout the system development life cycle;
+     c. Identifies individuals having information security roles and responsibilities; and
+     d. Integrates the organizational information security risk management process into system development life cycle activities.
+
+    Supplemental Guidance:  A well-defined system development life cycle provides the foundation for the successful development, implementation, and operation of organizational information systems. To apply the required security controls within the system development life cycle requires a basic understanding of information security, threats, vulnerabilities, adverse impacts, and risk to critical missions/business functions. The security engineering principles in SA-8 cannot be properly applied if individuals that design, code, and test information systems and system components (including information technology products) do not understand security. Therefore, organizations include qualified personnel, for example, chief information security officers, security architects, security engineers, and information system security officers in system development life cycle activities to ensure that security requirements are incorporated into organizational information systems. It is equally important that developers include individuals on the development team that possess the requisite security expertise and skills to ensure that needed security capabilities are effectively integrated into the information system. Security awareness and training programs can help ensure that individuals having key security roles and responsibilities have the appropriate experience, skills, and expertise to conduct assigned system development life cycle activities. The effective integration of security requirements into enterprise architecture also helps to ensure that important security considerations are addressed early in the system development life cycle and that those considerations are directly related to the organizational mission/business processes. This process also facilitates the integration of the information security architecture into the enterprise architecture, consistent with organizational risk management and information security strategies. Related controls: AT-3, PM-7, SA-8.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-37, 800-64.
+  title: >-
+    SA-3 - SYSTEM DEVELOPMENT LIFE CYCLE
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-4
+  status: not applicable
+  notes: |-
+    Section a: Organizational processes to include security functional requirements in
+    acquisition contracts are outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: Organizational processes to include security strength requirements in
+    acquisition contracts are outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section c: Organizational processes to include security assurance requirements in
+    acquisition contracts are outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section d: Organizational processes to include security-related documentation
+    requirements in acquisition contracts are outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section e: Organizational processes to include requirements for protecting
+    security-related documentation in acquisition contracts are outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section f: Organizational processes to include a description of the information
+    system development environment and environment in which the system is
+    intended to operate in acqusition contracts are outside the scope of Red
+    Hat Advanced Cluster Management for Kubernetes configuration.
+    Section g: Organizational processes to include acceptance criteria in acqusition
+    contracts are outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization includes the following requirements, descriptions, and criteria, explicitly or by reference, in the acquisition contract for the information system, system component, or information system service in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, guidelines, and organizational mission/business needs:
+      a. Security functional requirements;
+     b. Security strength requirements;
+     c. Security assurance requirements;
+     d. Security-related documentation requirements;
+     e. Requirements for protecting security-related documentation;
+     f. Description of the information system development environment and environment in which the system is intended to operate; and
+     g. Acceptance criteria.
+
+    Supplemental Guidance:  Information system components are discrete, identifiable information technology assets (e.g., hardware, software, or firmware) that represent the building blocks of an information system. Information system components include commercial information technology products. Security functional requirements include security capabilities, security functions, and security mechanisms. Security strength requirements associated with such capabilities, functions, and mechanisms include degree of correctness, completeness, resistance to direct attack, and resistance to tampering or bypass. Security assurance requirements include: (i) development processes, procedures, practices, and methodologies; and (ii) evidence from development and assessment activities providing grounds for confidence that the required security functionality has been implemented and the required security strength has been achieved. Security documentation requirements address all phases of the system development life cycle.
+
+    Security functionality, assurance, and documentation requirements are expressed in terms of security controls and control enhancements that have been selected through the tailoring process. The security control tailoring process includes, for example, the specification of parameter values through the use of assignment and selection statements and the specification of platform dependencies and implementation information. Security documentation provides user and administrator guidance regarding the implementation and operation of security controls. The level of detail required in security documentation is based on the security category or classification level of the information system and the degree to which organizations depend on the stated security capability, functions, or mechanisms to meet overall risk response expectations (as defined in the organizational risk management strategy). Security requirements can also include organizationally mandated configuration settings specifying allowed functions, ports, protocols, and services. Acceptance criteria for information systems, information system components, and information system services are defined in the same manner as such criteria for any organizational acquisition or procurement. The Federal Acquisition Regulation (FAR) Section 7.103 contains information security requirements from FISMA. Related controls: CM-6, PL-2, PS-7, SA-3, SA-5, SA-8, SA-11, SA-12.
+
+    References: HSPD-12; ISO/IEC 15408; FIPS Publications 140-2, 201; NIST Special Publications 800-23, 800-35, 800-36, 800-37, 800-64, 800-70, 800-137; Federal Acquisition Regulation; Web: http://www.niap-ccevs.org, http://fips201ep.cio.gov, http://www.acquisition.gov/far.
+
+    SA-4 Requirement: The service provider must comply with Federal Acquisition Regulation (FAR) Subpart 7.103, and Section 889 of the John S. McCain National Defense Authorization Act (NDAA) for Fiscal Year 2019 (Pub. L. 115-232), and FAR Subpart 4.21, which implements Section 889 (as well as any added updates related to FISMA to address security concerns in the system acquisitions process).
+
+    SA-4 Guidance: The use of Common Criteria (ISO/IEC 15408) evaluated products is strongly preferred.
+    See https://www.niap-ccevs.org/Product/
+  title: >-
+    SA-4 - ACQUISITION PROCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-4(1)
+  status: supported
+  notes: |-
+    A complete control response is planned. Official documentation is needed
+    and is currently being worked.
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to provide a description of the functional properties of the security controls to be employed.
+
+    Supplemental Guidance:  Functional properties of security controls describe the functionality (i.e., security capability, functions, or mechanisms) visible at the interfaces of the controls and specifically exclude functionality and data structures internal to the operation of the controls. Related control: SA-5.
+  title: >-
+    SA-4(1) - ACQUISITION PROCESS | FUNCTIONAL PROPERTIES OF SECURITY CONTROLS
+  levels:
+  - high
+  - moderate
+- id: SA-4(2)
+  status: supported
+  notes: |-
+    A complete control response is planned. Official documentation is needed
+    and is currently being worked.
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to provide design and implementation information for the security controls to be employed that includes: [Selection (one or more): security-relevant external system interfaces; high-level design; low-level design; source code or hardware schematics; [Assignment: organization-defined design/implementation information]] at [Assignment: organization-defined level of detail].
+
+    Supplemental Guidance:  Organizations may require different levels of detail in design and implementation documentation for security controls employed in organizational information systems, system components, or information system services based on mission/business requirements, requirements for trustworthiness/resiliency, and requirements for analysis and testing. Information systems can be partitioned into multiple subsystems. Each subsystem within the system can contain one or more modules. The high-level design for the system is expressed in terms of multiple subsystems and the interfaces between subsystems providing security-relevant functionality. The low-level design for the system is expressed in terms of modules with particular emphasis on software and firmware (but not excluding hardware) and the interfaces between modules providing security-relevant functionality. Source code and hardware schematics are typically referred to as the implementation representation of the information system. Related control: SA-5.
+
+    SA-4 (2)-1 [at a minimum to include security-relevant external system interfaces; high-level design; low-level design; source code or network and data flow diagram; [organization-defined design/implementation information]]
+  title: >-
+    SA-4(2) - ACQUISITION PROCESS | DESIGN / IMPLEMENTATION INFORMATION FOR SECURITY
+    CONTROLS
+  levels:
+  - high
+  - moderate
+- id: SA-4(3)
+  status: supported
+  notes: |-
+    A complete control response is planned. Official documentation is needed
+    and is currently being worked.
+  rules: []
+- id: SA-4(4)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into CM-8 (9).
+  rules: []
+- id: SA-4(5)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-4(5)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-453
+    Section b: A control response to SA-4(5)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-453
+  rules: []
+- id: SA-4(6)
+  status: not applicable
+  notes: |-
+    Section a: Organizational employment of only government off-the-shelf (GOTS) or
+    commercial off-the-shelf (COTS) information assurance (IA) and
+    IA-enabled information technology products that compose an NSA-approved
+    solution to protect classified information when the networks used to
+    transmit the information are at a lower classificiation level than the
+    information transmitted, is an organizational control outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section b: Organizational assurance that these products have been evaluated and/or
+    validated by NSA or in accordance with NSA-approved procedures is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: SA-4(7)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-4(7)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-454
+    Section b: A control response to SA-4(7)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-454
+  rules: []
+- id: SA-4(8)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-455
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to produce a plan for the continuous monitoring of security control effectiveness that contains [Assignment: organization-defined level of detail].
+
+    Supplemental Guidance:  The objective of continuous monitoring plans is to determine if the complete set of planned, required, and deployed security controls within the information system, system component, or information system service continue to be effective over time based on the inevitable changes that occur. Developer continuous monitoring plans include a sufficient level of detail such that the information can be incorporated into the continuous monitoring strategies and programs implemented by organizations. Related control: CA-7.
+
+    SA-4 (8) [at least the minimum requirement as defined in control CA-7]
+    SA-4 (8) Guidance: CSP must use the same security standards regardless of where the system component or information system service is acquired.
+  title: >-
+    SA-4(8) - ACQUISITION PROCESS | CONTINUOUS MONITORING PLAN
+  levels:
+  - high
+  - moderate
+- id: SA-4(9)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-377
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to identify early in the system development life cycle, the functions, ports, protocols, and services intended for organizational use.
+
+    Supplemental Guidance:  The identification of functions, ports, protocols, and services early in the system development life cycle (e.g., during the initial requirements definition and design phases) allows organizations to influence the design of the information system, information system component, or information system service. This early involvement in the life cycle helps organizations to avoid or minimize the use of functions, ports, protocols, or services that pose unnecessarily high risks and understand the trade-offs involved in blocking specific
+    ports, protocols, or services (or when requiring information system service providers to do so). Early identification of functions, ports, protocols, and services avoids costly retrofitting of security controls after the information system, system component, or information system service has been implemented. SA-9 describes requirements for external information system services with organizations identifying which functions, ports, protocols, and services are provided from external sources. Related controls: CM-7, SA-9.
+  title: >-
+    SA-4(9) - ACQUISITION PROCESS | FUNCTIONS / PORTS / PROTOCOLS / SERVICES IN USE
+  levels:
+  - high
+  - moderate
+- id: SA-4(10)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization employs only information technology products on the FIPS 201-approved products list for Personal Identity Verification (PIV) capability implemented within organizational information systems.
+
+    Supplemental Guidance:  Related controls: IA-2; IA-8.
+  title: >-
+    SA-4(10) - ACQUISITION PROCESS | USE OF APPROVED PIV PRODUCTS
+  levels:
+  - high
+  - moderate
+- id: SA-5
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section a.1: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section a.2: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section a.3: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b.1: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b.2: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b.3: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section d: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section e: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization:\n a. Obtains administrator documentation for the\
+    \ information system, system component, or information system service that describes:\n\
+    \   1. Secure configuration, installation, and operation of the system, component,\
+    \ or service;\n   2. Effective use and maintenance of security functions/mechanisms;\
+    \ and\n   3. Known vulnerabilities regarding configuration and use of administrative\
+    \ (i.e., privileged) functions;\n b. Obtains user documentation for the information\
+    \ system, system component, or information system service that describes:\n  \
+    \ 1. User-accessible security functions/mechanisms and how to effectively use\
+    \ those security functions/mechanisms;\n   2. Methods for user interaction, which\
+    \ enables individuals to use the system, component, or service in a more secure\
+    \ manner; and\n   3. User responsibilities in maintaining the security of the\
+    \ system, component, or service;\n c. Documents attempts to obtain information\
+    \ system, system component, or information system service documentation when such\
+    \ documentation is either unavailable or nonexistent and [Assignment: organization-defined\
+    \ actions] in response;\n d. Protects documentation as required, in accordance\
+    \ with the risk management strategy; and e. Distributes documentation to [Assignment:\
+    \ organization-defined personnel or roles]. \n\nSupplemental Guidance:  This control\
+    \ helps organizational personnel understand the implementation and operation of\
+    \ security controls associated with information systems, system components, and\
+    \ information system services. Organizations consider establishing specific measures\
+    \ to determine the quality/completeness of the content provided. The inability\
+    \ to obtain needed documentation may occur, for example, due to the age of the\
+    \ information system/component or lack of support from developers and contractors.\
+    \ In those situations, organizations may need to recreate selected documentation\
+    \ if such documentation is essential to the effective implementation or operation\
+    \ of security controls. The level of protection provided for selected information\
+    \ system, component, or service documentation is commensurate with the security\
+    \ category or classification of the system. For example, documentation associated\
+    \ with a key DoD weapons system or command and control system would typically\
+    \ require a higher level of protection than a routine administrative system. Documentation\
+    \ that addresses information system vulnerabilities may also require an increased\
+    \ level of protection. Secure operation of the information system, includes, for\
+    \ example, initially starting the system and resuming secure system operation\
+    \ after any lapse in system operation. Related controls: CM-6, CM-8, PL-2, PL-4,\
+    \ PS-2, SA-3, SA-4.\n\nReferences: None.\n\nSA-5E [at a minimum, the ISSO (or\
+    \ similar role within the organization)]"
+  title: >-
+    SA-5 - INFORMATION SYSTEM DOCUMENTATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-5(1)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (1).
+  rules: []
+- id: SA-5(2)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (2).
+  rules: []
+- id: SA-5(3)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (3).
+  rules: []
+- id: SA-5(4)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (4).
+  rules: []
+- id: SA-5(5)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (5).
+  rules: []
+- id: SA-6
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into CM-10 and SI-7.
+  rules: []
+- id: SA-7
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into CM-11 and SI-7.
+  rules: []
+- id: SA-8
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization applies information system security engineering principles in the specification, design, development, implementation, and modification of the information system.
+
+    Supplemental Guidance:  Organizations apply security engineering principles primarily to new development information systems or systems undergoing major upgrades. For legacy systems, organizations apply security engineering principles to system upgrades and modifications to the extent feasible, given the current state of hardware, software, and firmware within those systems. Security engineering principles include, for example: (i) developing layered protections; (ii) establishing sound security policy, architecture, and controls as the foundation for design; (iii) incorporating security requirements into the system development life cycle; (iv) delineating physical and logical security boundaries; (v) ensuring that system developers are trained on how to build secure software; (vi) tailoring security controls to meet organizational and operational needs; (vii) performing threat modeling to identify use cases, threat agents, attack vectors, and attack patterns as well as compensating controls and design patterns needed to mitigate risk; and (viii) reducing risk to acceptable levels, thus enabling informed risk management decisions. Related controls: PM-7, SA-3, SA-4, SA-17, SC-2, SC-3.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publication 800-27.
+  title: >-
+    SA-8 - SECURITY ENGINEERING PRINCIPLES
+  levels:
+  - high
+  - moderate
+- id: SA-9
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Requires that providers of external information system services comply with organizational information security requirements and employ [Assignment: organization-defined security controls] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+     b. Defines and documents government oversight and user roles and responsibilities with regard to external information system services; and
+     c. Employs [Assignment: organization-defined processes, methods, and techniques] to monitor security control compliance by external service providers on an ongoing basis.
+
+    Supplemental Guidance:  External information system services are services that are implemented outside of the authorization boundaries of organizational information systems. This includes services that are used by, but not a part of, organizational information systems. FISMA and OMB policy require that organizations using external service providers that are processing, storing, or transmitting federal information or operating information systems on behalf of the federal government ensure that such providers meet the same security requirements that federal agencies are required to meet. Organizations establish relationships with external service providers in a variety of ways including, for example, through joint ventures, business partnerships, contracts, interagency agreements, lines of business arrangements, licensing agreements, and supply chain exchanges. The responsibility for managing risks from the use of external information system services remains with authorizing officials. For services external to organizations, a chain of trust requires that organizations establish and retain a level of confidence that each participating provider in the potentially complex consumer-provider relationship provides adequate protection for the services rendered. The extent and nature of this chain of trust varies based on the relationships between organizations and the external providers. Organizations document the basis for trust relationships so the relationships can be monitored over time. External information system services documentation includes government, service providers, end user security roles and responsibilities, and service-level agreements. Service-level agreements define expectations of performance for security controls, describe measurable outcomes, and identify remedies and response requirements for identified instances of noncompliance. Related controls: CA-3, IR-7, PS-7.
+
+    References: NIST Special Publication 800-35.
+
+    SA-9 (a) [FedRAMP Security Controls Baseline(s) if Federal information is processed or stored within the external system]
+    SA-9 (c) [Federal/FedRAMP Continuous Monitoring requirements must be met for external systems where Federal information is processed or stored]
+  title: >-
+    SA-9 - EXTERNAL INFORMATION SYSTEM SERVICES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-9(1)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Conducts an organizational assessment of risk prior to the acquisition or outsourcing of dedicated information security services; and
+     (b)   Ensures that the acquisition or outsourcing of dedicated information security services is approved by [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:  Dedicated information security services include, for example, incident monitoring, analysis and response, operation of information security-related devices such as firewalls, or key management services. Related controls: CA-6, RA-3.
+  title: >-
+    SA-9(1) - EXTERNAL INFORMATION SYSTEMS | RISK ASSESSMENTS /
+
+    ORGANIZATIONAL APPROVALS
+  levels:
+  - high
+  - moderate
+- id: SA-9(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization requires providers of [Assignment: organization-defined external information system services] to identify the functions, ports, protocols, and other services required for the use of such services.
+
+    Supplemental Guidance:  Information from external service providers regarding the specific functions, ports, protocols, and services used in the provision of such services can be particularly useful when the need arises to understand the trade-offs involved in restricting certain functions/services or blocking certain ports/protocols. Related control: CM-7.
+
+    SA-9 (2) [all external systems where Federal information is processed or stored]
+  title: >-
+    SA-9(2) - EXTERNAL INFORMATION SYSTEMS | IDENTIFICATION OF FUNCTIONS / PORTS /
+    PROTOCOLS / SERVICES
+  levels:
+  - high
+  - moderate
+- id: SA-9(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-9(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization employs [Assignment: organization-defined security safeguards] to ensure that the interests of [Assignment: organization-defined external service providers] are consistent with and reflect organizational interests.
+
+    Supplemental Guidance:  As organizations increasingly use external service providers, the possibility exists that the interests of the service providers may diverge from organizational interests. In such situations, simply having the correct technical, procedural, or operational safeguards in place may not be sufficient if the service providers that implement and control those safeguards are not operating in a manner consistent with the interests of the consuming organizations. Possible actions that organizations might take to address such concerns include, for example, requiring background checks for selected service provider personnel, examining ownership records, employing only trustworthy service providers (i.e., providers with which organizations have had positive experiences), and conducting periodic/unscheduled visits to service provider facilities.
+
+    SA-9 (4)-2 [all external systems where Federal information is processed or stored]
+  title: >-
+    SA-9(4) - EXTERNAL INFORMATION SYSTEMS | CONSISTENT INTERESTS OF CONSUMERS AND
+    PROVIDERS
+  levels:
+  - high
+  - moderate
+- id: SA-9(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization restricts the location of [Selection (one or more): information processing; information/data; information system services] to [Assignment: organization-defined locations] based on [Assignment: organization-defined requirements or conditions].
+
+    Supplemental Guidance:  The location of information processing, information/data storage, or information system services that are critical to organizations can have a direct impact on the ability of those organizations to successfully execute their missions/business functions. This situation exists when external providers control the location of processing, storage or services. The criteria external providers use for the selection of processing, storage, or service locations may be different from organizational criteria. For example, organizations may want to ensure that data/information storage locations are restricted to certain locations to facilitate incident response activities (e.g., forensic analyses, after-the-fact investigations) in case of information security breaches/compromises. Such incident response activities may be adversely affected
+    by the governing laws or protocols in the locations where processing and storage occur and/or the locations from which information system services emanate.
+
+    SA-9 (5)-1 [information processing, information data, AND information services]
+    SA-9 (5)-2 [U.S./U.S. Territories or geographic locations where there is U.S. jurisdiction]
+    SA-9 (5)-3 [all High impact data, systems, or services]
+  title: >-
+    SA-9(5) - EXTERNAL INFORMATION SYSTEMS | PROCESSING, STORAGE, AND SERVICE LOCATION
+  levels:
+  - high
+  - moderate
+- id: SA-10
+  status: pending
+  notes: |-
+    Section a: A control response to SA-10(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-378
+    Section b: A control response to SA-10(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-378
+    Section c: A control response to SA-10(c) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-378
+    Section d: A control response to SA-10(d) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-378
+    Section e: A control response to SA-10(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-378
+  rules: []
+  description: "The organization requires the developer of the information system,\
+    \ system component, or information system service to:\n a. Perform configuration\
+    \ management during system, component, or service [Selection (one or more): design;\
+    \ development; implementation; operation];\n b. Document, manage, and control\
+    \ the integrity of changes to [Assignment: organization-defined configuration\
+    \ items under configuration management];\n c. Implement only organization-approved\
+    \ changes to the system, component, or service;\n d. Document approved changes\
+    \ to the system, component, or service and the potential security impacts of such\
+    \ changes; and\n e. Track security flaws and flaw resolution within the system,\
+    \ component, or service and report findings to [Assignment: organization-defined\
+    \ personnel].\n \nSupplemental Guidance:  This control also applies to organizations\
+    \ conducting internal information systems development and integration. Organizations\
+    \ consider the quality and completeness of the configuration management activities\
+    \ conducted by developers as evidence of applying effective security safeguards.\
+    \ Safeguards include, for example, protecting from unauthorized modification or\
+    \ destruction, the master copies of all material used to generate security-relevant\
+    \ portions of the system hardware, software, and firmware. Maintaining the integrity\
+    \ of changes to the information system, information system component, or information\
+    \ system service requires configuration control throughout the system development\
+    \ life cycle to track authorized changes and prevent unauthorized changes. Configuration\
+    \ items that are placed under configuration management (if existence/use is required\
+    \ by other security controls) include: the formal model; the functional, high-level,\
+    \ and low-level design specifications; other design data; implementation documentation;\
+    \ source code and hardware schematics; the running version of the object code;\
+    \ tools for comparing new versions of security-relevant hardware descriptions\
+    \ and software/firmware source code with previous versions; and test fixtures\
+    \ and documentation. Depending on the mission/business needs of organizations\
+    \ and the nature of the contractual relationships in place, developers may provide\
+    \ configuration management support during the operations and maintenance phases\
+    \ of the life cycle. Related controls: CM-3, CM-4, CM-9, SA-12, SI-2.\n\nReferences:\
+    \ NIST Special Publication 800-128.\n\nSA-10 (a) [development, implementation,\
+    \ AND operation]\nSA-10 (e)  Requirement: for JAB authorizations, track security\
+    \ flaws and flaw resolution within the system, component, or service and report\
+    \ findings to organization-defined personnel, to include FedRAMP."
+  title: >-
+    SA-10 - DEVELOPER CONFIGURATION MANAGEMENT
+  levels:
+  - high
+  - moderate
+- id: SA-10(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to enable integrity verification of software and firmware components.
+
+    Supplemental Guidance:  This control enhancement allows organizations to detect unauthorized changes to software and firmware components through the use of tools, techniques, and/or mechanisms provided by developers. Integrity checking mechanisms can also address counterfeiting of software and firmware components. Organizations verify the integrity of software and firmware components, for example, through secure one-way hashes provided by developers. Delivered software and firmware components also include any updates to such components. Related control: SI-7.
+  title: >-
+    SA-10(1) - DEVELOPER CONFIGURATION MANAGEMENT | SOFTWARE /
+
+    FIRMWARE INTEGRITY VERIFICATION
+  levels:
+  - high
+  - moderate
+- id: SA-10(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-10(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-10(4)
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-456
+  rules: []
+- id: SA-10(5)
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-457
+  rules: []
+- id: SA-10(6)
+  status: pending
+  notes: |-
+    A control response is planned. Progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-458
+  rules: []
+- id: SA-11
+  status: pending
+  notes: |-
+    Section a: A control response to SA-11(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-382
+    Section b: A control response to SA-11(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-382
+    Section c: A control response to SA-11(c) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-382
+    Section d: A control response to SA-11(d) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-382
+    Section e: A control response to SA-11(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-382
+  rules: []
+  description: "The organization requires the developer of the information system,\
+    \ system component, or information system service to:\n a. Create and implement\
+    \ a security assessment plan;\n b. Perform [Selection (one or more): unit; integration;\
+    \ system; regression] testing/evaluation at [Assignment: organization-defined\
+    \ depth and coverage];\n c. Produce evidence of the execution of the security\
+    \ assessment plan and the results of the security testing/evaluation;\n d. Implement\
+    \ a verifiable flaw remediation process; and\n e. Correct flaws identified during\
+    \ security testing/evaluation.\n\nSupplemental Guidance:  Developmental security\
+    \ testing/evaluation occurs at all post\u2010design phases of the system development\
+    \ life cycle. Such testing/evaluation confirms that the required security controls\
+    \ are implemented correctly, operating as intended, enforcing the desired security\
+    \ policy, and meeting established security requirements. Security properties of\
+    \ information systems may be affected by the interconnection of system components\
+    \ or changes to those components. These interconnections or changes (e.g., upgrading\
+    \ or replacing applications and operating systems) may adversely affect previously\
+    \ implemented security controls. This control provides additional types of security\
+    \ testing/evaluation that developers can conduct to reduce or eliminate potential\
+    \ flaws. Testing custom software applications may require approaches such as static\
+    \ analysis, dynamic analysis, binary analysis, or a hybrid of the three approaches.\
+    \ Developers can employ these analysis approaches in a variety of tools (e.g.,\
+    \ web-based application scanners, static analysis tools, binary analyzers) and\
+    \ in source code reviews. Security assessment plans provide the specific activities\
+    \ that developers plan to carry out including the types of analyses, testing,\
+    \ evaluation, and reviews of software and firmware components, the degree of rigor\
+    \ to be applied, and the types of artifacts produced during those processes. The\
+    \ depth of security testing/evaluation refers to the rigor and level of detail\
+    \ associated with the assessment process (e.g., black box, gray box, or white\
+    \ box testing). The coverage of security testing/evaluation refers to the scope\
+    \ (i.e., number and type) of the artifacts included in the assessment process.\
+    \ Contracts specify the acceptance criteria for security assessment plans, flaw\
+    \ remediation processes, and the evidence that the plans/processes have been diligently\
+    \ applied. Methods for reviewing and protecting assessment plans, evidence, and\
+    \ documentation are commensurate with the security category or classification\
+    \ level of the information system. Contracts may specify documentation protection\
+    \ requirements. Related controls: CA-2, CM-4, SA-3, SA-4, SA-5, SI-2.\n\nReferences:\
+    \ ISO/IEC 15408; NIST Special Publication 800-53A; Web: http://nvd.nist.gov, http://cwe.mitre.org,\
+    \ http://cve.mitre.org, http://capec.mitre.org."
+  title: >-
+    SA-11 - DEVELOPER SECURITY TESTING AND EVALUATION
+  levels:
+  - high
+  - moderate
+- id: SA-11(1)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-459
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to employ static code analysis tools to identify common flaws and document the results of the analysis.
+
+    Supplemental Guidance:  Static code analysis provides a technology and methodology for security reviews. Such analysis can be used to identify security vulnerabilities and enforce security coding practices. Static code analysis is most effective when used early in the development process, when each code change can be automatically scanned for potential weaknesses. Static analysis can provide clear remediation guidance along with defects to enable developers to fix such defects. Evidence of correct implementation of static analysis can include, for example, aggregate defect density for critical defect types, evidence that defects were inspected by developers or security professionals, and evidence that defects were fixed. An excessively high density of ignored findings (commonly referred to as ignored or false positives) indicates a potential problem with the analysis process or tool. In such cases, organizations weigh the validity of the evidence against evidence from other sources.
+
+    SA-11 (1) Requirement: The service provider documents in the Continuous Monitoring Plan, how newly developed code for the information system is reviewed.
+  title: >-
+    SA-11(1) - DEVELOPER SECURITY TESTING AND EVALUATION | STATIC CODE ANALYSIS
+  levels:
+  - high
+  - moderate
+- id: SA-11(2)
+  status: pending
+  notes: |-
+    A control response to SA-11(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-460
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to perform threat and vulnerability analyses and subsequent testing/evaluation of the as-built system, component, or service.
+
+    Supplemental Guidance:  Applications may deviate significantly from the functional and design specifications created during the requirements and design phases of the system development life cycle. Therefore, threat and vulnerability analyses of information systems, system components, and information system services prior to delivery are critical to the effective operation of those systems, components, and services. Threat and vulnerability analyses at this phase of the life cycle help to ensure that design or implementation changes have been accounted for, and that any new vulnerabilities created as a result of those changes have been reviewed and mitigated. Related controls: PM-15, RA-5.
+  title: >-
+    SA-11(2) - DEVELOPER SECURITY TESTING AND EVALUATION | THREAT AND VULNERABILITY
+    ANALYSES
+  levels:
+  - high
+  - moderate
+- id: SA-11(3)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-11(3)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-461
+    Section b: A control response to SA-11(3)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-461
+  rules: []
+- id: SA-11(4)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes meets this control
+    through the Opensource model where pull requests (PR's) are manually
+    reviewed before being merged into the source code repository.
+  rules: []
+- id: SA-11(5)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+  rules: []
+- id: SA-11(6)
+  status: pending
+  notes: |-
+    A control response to SA-11(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-463
+  rules: []
+- id: SA-11(7)
+  status: pending
+  notes: |-
+    A control response to SA-11(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-464
+  rules: []
+- id: SA-11(8)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+      https://issues.redhat.com/browse/ACM-465
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to employ dynamic code analysis tools to identify common flaws and document the results of the analysis.
+
+    Supplemental Guidance:  Dynamic code analysis provides run-time verification of software programs, using tools capable of monitoring programs for memory corruption, user privilege issues, and other potential security problems. Dynamic code analysis employs run-time tools to help to ensure that security functionality performs in the manner in which it was designed. A specialized type of dynamic analysis, known as fuzz testing, induces program failures by deliberately introducing malformed or random data into software programs. Fuzz testing strategies derive from the intended use of applications and the functional and design specifications for the applications.
+
+    SA-11 (8) Requirement: The service provider documents in the Continuous Monitoring Plan, how newly developed code for the information system is reviewed.
+  title: >-
+    SA-11(8) - DEVELOPER SECURITY TESTING AND EVALUATION | DYNAMIC CODE ANALYSIS
+  levels:
+  - high
+  - moderate
+- id: SA-12
+  status: pending
+  notes: |-
+    A control response to SA-12 is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-406
+  rules: []
+  description: |-
+    The organization protects against supply chain threats to the information system, system component, or information system service by employing [Assignment: organization-defined security safeguards] as part of a comprehensive, defense-in-breadth information security strategy.
+
+    Supplemental Guidance:  Information systems (including system components that compose those systems) need to be protected throughout the system development life cycle (i.e., during design, development, manufacturing, packaging, assembly, distribution, system integration, operations, maintenance, and retirement). Protection of organizational information systems is accomplished through threat awareness, by the identification, management, and reduction of vulnerabilities at each phase of the life cycle and the use of complementary, mutually reinforcing strategies to respond to risk. Organizations consider implementing a standardized process to address supply chain risk with respect to information systems and system components, and to educate the acquisition workforce on threats, risk, and required security controls. Organizations use the acquisition/procurement processes to require supply chain entities to implement necessary security safeguards to: (i) reduce the likelihood of unauthorized modifications at each stage in the supply chain; and (ii) protect information systems and information system components, prior to taking delivery of such systems/components. This control enhancement also applies to information
+    system services. Security safeguards include, for example: (i) security controls for development systems, development facilities, and external connections to development systems; (ii) vetting development personnel; and (iii) use of tamper-evident packaging during shipping/warehousing. Methods for reviewing and protecting development plans, evidence, and documentation are commensurate with the security category or classification level of the information system. Contracts may specify documentation protection requirements. Related controls: AT-3, CM-8, IR-
+    4, PE-16, PL-8, SA-3, SA-4, SA-8, SA-10, SA-14, SA-15, SA-18, SA-19, SC-29, SC-30, SC-38, SI-7.
+
+    References: NIST Special Publication 800-161; NIST Interagency Report 7622.
+
+    SA-12 [organization and service provider-defined personnel security requirements, approved HW/SW vendor list/process, and secure SDLC procedures]
+  title: >-
+    SA-12 - SUPPLY CHAIN PROTECTION
+  levels:
+  - high
+- id: SA-12(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(3)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-12(1).
+  rules: []
+- id: SA-12(4)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-12(13).
+  rules: []
+- id: SA-12(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(6)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-12(1).
+  rules: []
+- id: SA-12(7)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(8)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(9)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(10)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-464
+  rules: []
+- id: SA-12(11)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(12)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(13)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(14)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-12(15)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-13
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-14
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-14(1)
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-20.
+  rules: []
+- id: SA-15
+  status: pending
+  notes: |-
+    Section a: A control response to SA-15(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/TBD
+    Section a.1: A control response to SA-15(a)(1) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/TBD
+    Section a.2: A control response to SA-15(a)(2) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/TBD
+    Section a.3: A control response to SA-15(a)(3) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/TBD
+    Section a.4: A control response to SA-15(a)(4) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/TBD
+    Section b: A control response to SA-15(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/TBD
+  rules: []
+  description: "The organization:\n a. Requires the developer of the information system,\
+    \ system component, or information system service to follow a documented development\
+    \ process that:\n   1. Explicitly addresses security requirements;\n   2. Identifies\
+    \ the standards and tools used in the development process;\n   3. Documents the\
+    \ specific tool options and tool configurations used in the development process;\
+    \ and\n   4. Documents, manages, and ensures the integrity of changes to the process\
+    \ and/or tools used in development; and\n b. Reviews the development process,\
+    \ standards, tools, and tool options/configurations [Assignment: organization-defined\
+    \ frequency] to determine if the process, standards, tools, and tool options/configurations\
+    \ selected and employed can satisfy [Assignment: organization- defined security\
+    \ requirements].\n\nSupplemental Guidance:  Development tools include, for example,\
+    \ programming languages and computer-aided design (CAD) systems. Reviews of development\
+    \ processes can include, for example, the use of maturity models to determine\
+    \ the potential effectiveness of such processes. Maintaining the integrity of\
+    \ changes to tools and processes enables accurate supply chain risk assessment\
+    \ and mitigation, and requires robust configuration control throughout the life\
+    \ cycle (including design, development, transport, delivery, integration, and\
+    \ maintenance) to track authorized changes and prevent unauthorized changes. Related\
+    \ controls: SA-3, SA-8.\n\nReferences: None.\n\nSA-15 (b)-1 [as needed and as\
+    \ dictated by the current threat posture] \nSA-15 (b)-2 [organization and service\
+    \ provider- defined security requirements]"
+  title: >-
+    SA-15 - DEVELOPMENT PROCESS, STANDARDS, AND
+
+    TOOLS
+  levels:
+  - high
+- id: SA-15(1)
+  status: supported
+  notes: |-
+    Section a: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-469
+    Section b: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-469
+  rules: []
+- id: SA-15(2)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-474
+  rules: []
+- id: SA-15(3)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+  rules: []
+- id: SA-15(4)
+  status: supported
+  notes: |-
+    Section a: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+    Section b: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+    Section c: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+  rules: []
+- id: SA-15(5)
+  status: pending
+  notes: |-
+    A control response to is planned. Progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-475
+  rules: []
+- id: SA-15(6)
+  status: pending
+  notes: |-
+    A control response to is planned. Progress can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-476
+  rules: []
+- id: SA-15(7)
+  status: supported
+  notes: |-
+    Section a: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+    Section b: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+    Section c: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+    Section d: A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+  rules: []
+- id: SA-15(8)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-477
+  rules: []
+- id: SA-15(9)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-15(10)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://TBD
+  rules: []
+- id: SA-15(11)
+  status: supported
+  notes: |-
+    A complete control response is planned. To assist with this
+    organizational control, documentation is being planned. Progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-478
+  rules: []
+- id: SA-16
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to provide [Assignment: organization-defined training] on the correct use and operation of the implemented security functions, controls, and/or mechanisms.
+
+    Supplemental Guidance:  This control applies to external and internal (in-house) developers. Training of personnel is an essential element to ensure the effectiveness of security controls implemented within organizational information systems. Training options include, for example, classroom-style training, web-based/computer-based training, and hands-on training. Organizations can also request sufficient training materials from developers to conduct in-house training or offer self- training to organizational personnel. Organizations determine the type of training necessary and may require different types of training for different security functions, controls, or mechanisms. Related controls: AT-2, AT-3, SA-5.
+
+    References:  None.
+  title: >-
+    SA-16 - DEVELOPER-PROVIDED TRAINING
+  levels:
+  - high
+- id: SA-17
+  status: pending
+  notes: |-
+    Section a: A control response to SA-17(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-383
+    Section b: A control response to SA-17(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-383
+    Section c: A control response to SA-17(c) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-383
+  rules: []
+  description: "The organization requires the developer of the information system,\
+    \ system component, or information system service to produce a design specification\
+    \ and security architecture that:\n a. Is consistent with and supportive of the\
+    \ organization\u2019s security architecture which is established within and is\
+    \ an integrated part of the organization\u2019s enterprise architecture;\n b.\
+    \ Accurately and completely describes the required security functionality, and\
+    \ the allocation of security controls among physical and logical components; and\n\
+    \ c. Expresses how individual security functions, mechanisms, and services work\
+    \ together to provide required security capabilities and a unified approach to\
+    \ protection.\n\nSupplemental Guidance:  This control is primarily directed at\
+    \ external developers, although it could also be used for internal (in-house)\
+    \ development. In contrast, PL-8 is primarily directed at internal developers\
+    \ to help ensure that organizations develop an information security architecture\
+    \ and such security architecture is integrated or tightly coupled to the enterprise\
+    \ architecture. This distinction is important if/when organizations outsource\
+    \ the development of information systems, information system components, or information\
+    \ system services to external entities, and there is a requirement to demonstrate\
+    \ consistency with the organization\u2019s enterprise architecture and information\
+    \ security architecture. Related controls: PL-8, PM-7, SA-3, SA-8.\n\nReferences:\
+    \ None."
+  title: >-
+    SA-17 - DEVELOPER SECURITY ARCHITECTURE AND DESIGN
+  levels:
+  - high
+- id: SA-17(1)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-17(2)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-17(2)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-479
+    Section b: A control response to SA-17(2)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-479
+  rules: []
+- id: SA-17(3)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-17(3)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-480
+    Section b: A control response to SA-17(3)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-480
+    Section c: A control response to SA-17(3)(c) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-480
+    Section d: A control response to SA-17(3)(d) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-480
+    Section e: A control response to SA-17(3)(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-480
+  rules: []
+- id: SA-17(4)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-17(4)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-481
+    Section b: A control response to SA-17(4)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-481
+    Section c: A control response to SA-17(4)(c) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-481
+    Section d: A control response to SA-17(4)(d) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-481
+    Section e: A control response to SA-17(4)(e) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-481
+  rules: []
+- id: SA-17(5)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-17(5)(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-484
+    Section b: A control response to SA-17(5)(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-484
+  rules: []
+- id: SA-17(6)
+  status: pending
+  notes: |-
+    A control response to SA-17(6) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-485
+  rules: []
+- id: SA-17(7)
+  status: pending
+  notes: |-
+    A control response to SA-17(7) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-486
+  rules: []
+- id: SA-18
+  status: not applicable
+  notes: |-
+    Implementing a tamper protection program for the information system,
+    system component, or information system service is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SA-18(1)
+  status: not applicable
+  notes: |-
+    Employing anti-tamper technologies and techniques during multiple phases
+    in the system development life cycle including design, development,
+    integration, operations, and maintenance is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SA-18(2)
+  status: not applicable
+  notes: |-
+    Inspecting organization-defined information systems, system components,
+    or devices at random or at an organization-defined frequency, upon
+    organization-defined indications of need for inspection to detect
+    tampering is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: SA-19
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-19(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-19(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-19(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-19(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-20
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-21
+  status: pending
+  notes: |-
+    Section a: A control response to SA-21(a) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-487
+    Section b: A control response to SA-21(b) is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-487
+  rules: []
+- id: SA-21(1)
+  status: pending
+  notes: |-
+    Section a: A control response to SA-21 is planned. Progress
+    can be tracked at:
+
+    https://issues.redhat.com/browse/ACM-488
+  rules: []
+- id: SA-22
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SA-22(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SC-1
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+    Section a.1: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+    Section a.2: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+    Section b.1: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+    Section b.2: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A system and communications\
+    \ protection policy that addresses purpose, scope, roles, responsibilities, management\
+    \ commitment, coordination among organizational entities, and compliance; and\n\
+    \   2. Procedures to facilitate the implementation of the system and communications\
+    \ protection policy and associated system and communications protection controls;\
+    \ and\n b. Reviews and updates the current:\n   1. System and communications protection\
+    \ policy [Assignment: organization-defined frequency]; and\n   2. System and communications\
+    \ protection procedures [Assignment: organization-defined frequency].\n\nSupplemental\
+    \ Guidance:  This control addresses the establishment of policy and procedures\
+    \ for the effective implementation of selected security controls and control enhancements\
+    \ in the SC family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-100.\n\nSC-1 (b) (1) [at least annually]  \n\
+    SC-1 (b) (2) [at least annually or whenever a significant change occurs]"
+  title: >-
+    SC-1 - SYSTEM AND COMMUNICATIONS PROTECTION
+
+    POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-2
+  status: not applicable
+  notes: |-
+    The customer is responsible for separating user functionality
+    including user interface services) from information system management
+    functionality. A successful control response will indicate how user
+    and management functionality access is separated.
+  rules: []
+  description: |-
+    The information system separates user functionality (including user interface services) from information system management functionality.
+
+    Supplemental Guidance:  Information system management functionality includes, for example, functions necessary to administer databases, network components, workstations, or servers, and typically requires privileged user access. The separation of user functionality from information system management functionality is either physical or logical. Organizations implement separation of system management-related functionality from user functionality by using different computers, different central processing units, different instances of operating systems, different network addresses, virtualization techniques, or combinations of these or other methods, as appropriate. This type of separation includes, for example, web administrative interfaces that use separate authentication methods for users of any other information system resources. Separation of system and user functionality may include isolating administrative interfaces on different domains and with additional access controls. Related controls: SA-4, SA-8, SC-3.
+
+    References: None.
+  title: >-
+    SC-2 - APPLICATION PARTITIONING
+  levels:
+  - high
+  - moderate
+- id: SC-2(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+- id: SC-3
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+  description: |-
+    The information system isolates security functions from nonsecurity functions.
+
+    Supplemental Guidance:  The information system isolates security functions from nonsecurity functions by means of an isolation boundary (implemented via partitions and domains). Such isolation controls access to and protects the integrity of the hardware, software, and firmware that perform those security functions. Information systems implement code separation (i.e., separation of security functions from nonsecurity functions) in a number of ways, including, for example, through the provision of security kernels via processor rings or processor modes. For non-kernel code, security function isolation is often achieved through file system protections that serve to protect the code on disk, and address space protections that protect executing code. Information systems restrict access to security functions through the use of access control mechanisms and by implementing least privilege capabilities. While the ideal is for all of the code within the security function isolation boundary to only contain security-relevant code, it is sometimes necessary to include nonsecurity functions within the isolation boundary as an exception. Related controls: AC-
+    3, AC-6, SA-4, SA-5, SA-8, SA-13, SC-2, SC-7, SC-39.
+
+    References: None.
+  title: >-
+    SC-3 - SECURITY FUNCTION ISOLATION
+  levels:
+  - high
+- id: SC-3(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+- id: SC-3(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+- id: SC-3(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+- id: SC-3(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of OpenShift.
+  rules: []
+- id: SC-3(5)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes implements security
+    functions as a layered structure minimizing interactions between layers
+    (ie, between OpenShift and RHACM) and avoiding any dependence by lower
+    layers on the functionality or correctness of higher levels.
+  rules: []
+- id: SC-4
+  status: not applicable
+  notes: |-
+    The customer is responsible for preventing unauthorized and
+    unintended information transfer via shared system resources. A
+    successful control response will discuss how this is prevented.
+
+    However, to aide in such processes, note that Red Hat Advanced Cluster
+    Management for Kubernetes provides the capability to implement
+    Role-based Access Control (RBAC) which determine what resources users
+    have access to. Documentation on the Red Hat Advanced Cluster Management
+    for Kubernetes RBAC capabilities can be found at
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/security/security#role-based-access-control
+  rules: []
+  description: |-
+    The information system prevents unauthorized and unintended information transfer via shared system resources.
+
+    Supplemental Guidance:  This control prevents information, including encrypted representations of information, produced by the actions of prior users/roles (or the actions of processes acting on behalf of prior users/roles) from being available to any current users/roles (or current processes) that obtain access to shared system resources (e.g., registers, main memory, hard disks) after those resources have been released back to information systems. The control of information in shared resources is also commonly referred to as object reuse and residual information protection. This control does not address: (i) information remanence which refers to residual representation of data that has been nominally erased or removed; (ii) covert channels (including storage and/or timing channels) where shared resources are manipulated to violate information flow restrictions; or (iii) components within information systems for which there are only single users/roles. Related controls: AC-3, AC-4, MP-6.
+
+    References: None.
+  title: >-
+    SC-4 - INFORMATION IN SHARED RESOURCES
+  levels:
+  - high
+  - moderate
+- id: SC-4(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-4.
+  rules: []
+- id: SC-4(2)
+  status: not applicable
+  notes: |-
+    Preventing unauthorized information transfer via shared resources in
+    accordance with organization-defined procedures when system processing
+    explicitly switches between different information classification levels
+    or security categories is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: SC-5
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-384
+  rules: []
+  description: |-
+    The information system protects against or limits the effects of the following types of denial of service attacks: [Assignment: organization-defined types of denial of service attacks or reference to source for such information] by employing [Assignment: organization-defined security safeguards].
+
+    Supplemental Guidance:  A variety of technologies exist to limit, or in some cases, eliminate the effects of denial of service attacks. For example, boundary protection devices can filter certain types of packets to protect information system components on internal organizational networks from being directly affected by denial of service attacks. Employing increased capacity and bandwidth combined with service redundancy may also reduce the susceptibility to denial of service attacks. Related controls: SC-6, SC-7.
+
+    References: None.
+  title: >-
+    SC-5 - DENIAL OF SERVICE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-5(1)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-489
+  rules: []
+- id: SC-5(2)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-490
+  rules: []
+- id: SC-5(3)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-6
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes provides by default
+    resource allocation.
+
+    More information about resource allocation for Red Hat Advanced Cluster
+    Management for Kubernetes can be found at:
+
+    https://issues.redhat.com/browse/ACM-491
+  rules: []
+  description: |-
+    The information system protects the availability of resources by allocating [Assignment: organization-defined resources] by [Selection (one or more); priority; quota; [Assignment: organization-defined security safeguards]].
+
+    Supplemental Guidance:  Priority protection helps prevent lower-priority processes from delaying or interfering with the information system servicing any higher-priority processes. Quotas prevent users or processes from obtaining more than predetermined amounts of resources. This control does not apply to information system components for which there are only single users/roles.
+
+    Control Enhancements:  None.
+
+    References:  None.
+  title: >-
+    SC-6 - RESOURCE AVAILABILITY
+  levels:
+  - high
+  - moderate
+- id: SC-7
+  status: not applicable
+  notes: |-
+    Section a: Monitoring and controlling communications at the external boundary of
+    the system and at key internal boundaries within the system is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+    Section b: Implementing subnetworks for publicly accessible system components that
+    are either physically or logically separated from internal
+    organizational networks is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section c: Connecting to external networks or information systems only through
+    managed interfaces consisting of boundary protection devices arranged in
+    accordance with an organizational security architecture is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The information system:
+     a. Monitors and controls communications at the external boundary of the system and at key internal boundaries within the system;
+     b. Implements subnetworks for publicly accessible system components that are [Selection: physically; logically] separated from internal organizational networks; and
+     c. Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture.
+
+    Supplemental Guidance:  Managed interfaces include, for example, gateways, routers, firewalls, guards, network-based malicious code analysis and virtualization systems, or encrypted tunnels implemented within a security architecture (e.g., routers protecting firewalls or application gateways residing on protected subnetworks). Subnetworks that are physically or logically separated from internal networks are referred to as demilitarized zones or DMZs. Restricting or prohibiting interfaces within organizational information systems includes, for example, restricting external web traffic to designated web servers within managed interfaces and prohibiting external traffic that appears to be spoofing internal addresses. Organizations consider the shared nature of commercial telecommunications services in the implementation of security controls associated with the use of such services. Commercial telecommunications services are commonly based on network components and consolidated management systems shared by all attached commercial customers, and may also include third party-provided access lines and other service elements. Such transmission services may represent sources of increased risk despite contract security provisions. Related controls: AC-4, AC-17, CA-3, CM-7, CP-8, IR-4, RA-3, SC-5, SC-13.
+
+    References: FIPS Publication 199; NIST Special Publications 800-41, 800-77.
+  title: >-
+    SC-7 - BOUNDARY PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-7(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-7.
+  rules: []
+- id: SC-7(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-7.
+  rules: []
+- id: SC-7(3)
+  status: pending
+  notes: |-
+    The customer will be responsible for ensuring managed interfaces deny
+    network traffic by default and allow network communications traffic
+    by exception (i.e. deny all, permit by exception).
+
+    To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-385
+  rules: []
+  description: |-
+    The organization limits the number of external network connections to the information system.
+
+    Supplemental Guidance:  Limiting the number of external network connections facilitates more comprehensive monitoring of inbound and outbound communications traffic. The Trusted Internet Connection (TIC) initiative is an example of limiting the number of external network connections.
+  title: >-
+    SC-7(3) - BOUNDARY PROTECTION | ACCESS POINTS
+  levels:
+  - high
+  - moderate
+- id: SC-7(4)
+  status: not applicable
+  notes: |-
+    Section a: Implementing a managed interface for each external telecommunication
+    service is addressed at the network infrastructure layer and is an
+    organizational control outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+    Section b: Establishing a traffic flow policy for each managed interface for each
+    external telecommuncation service is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration and is typically handled at the network infrastructure
+    layer.
+    Section c: Protecting the confidentiality and integrity of the information being
+    transmitted across each interface is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration and is typically handled at the network infrastructure
+    layer.
+    Section d: Documenting each exception to the traffic flow policy with a supporting
+    mission/business need and duration of that need is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration and is typically handled at the network
+    infrastructure layer.
+    Section e: Reviewing exceptions to the traffic flow policy per the organizationally
+    defined frequency and removing exceptions that are no longer supported
+    by an explicit mission/business need is an organizational control
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration and is typically handled at the network infrastructure
+    layer.
+  rules: []
+  description: "The organization:\n (a)   Implements a managed interface for each\
+    \ external telecommunication service; \n (b)   Establishes a traffic flow policy\
+    \ for each managed interface;\n (c)   Protects the confidentiality and integrity\
+    \ of the information being transmitted across each interface;\n (d)   Documents\
+    \ each exception to the traffic flow policy with a supporting mission/business\
+    \ need and duration of that need; and\n (e)   Reviews exceptions to the traffic\
+    \ flow policy [Assignment: organization-defined frequency] and removes exceptions\
+    \ that are no longer supported by an explicit mission/business need.\n\nSupplemental\
+    \ Guidance:  Related control: SC-8.\n\nSC-7 (4) (e) [at least every ninety (90)\
+    \ days or whenever there is a change in the threat environment that warrants a\
+    \ review of the exceptions]"
+  title: >-
+    SC-7(4) - BOUNDARY PROTECTION | EXTERNAL TELECOMMUNICATIONS SERVICES
+  levels:
+  - high
+  - moderate
+- id: SC-7(5)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for ensuring managed interfaces deny
+    network traffic by default and allow network communications traffic
+    by exception (i.e. deny all, permit by exception).
+
+    To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/CMP-424
+  rules: []
+  description: |-
+    The information system at managed interfaces denies network communications traffic by default and allows network communications traffic by exception (i.e., deny all, permit by exception).
+
+    Supplemental Guidance:  This control enhancement applies to both inbound and outbound network communications traffic. A deny-all, permit-by-exception network communications traffic policy ensures that only those connections which are essential and approved are allowed.
+  title: >-
+    SC-7(5) - BOUNDARY PROTECTION | DENY BY DEFAULT / ALLOW BY EXCEPTION
+  levels:
+  - high
+  - moderate
+- id: SC-7(6)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-7(18).
+  rules: []
+- id: SC-7(7)
+  status: not applicable
+  notes: |-
+    In conjunction with a remote device, prventing the device from
+    simultaneously establishing non-remote connections with the system and
+    communicating via some other connection to resources in external
+    networks is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system, in conjunction with a remote device, prevents the device from simultaneously establishing non-remote connections with the system and communicating via some other connection to resources in external networks.
+
+    Supplemental Guidance:  This control enhancement is implemented within remote devices (e.g., notebook computers) through configuration settings to disable split tunneling in those devices, and by preventing those configuration settings from being readily configurable by users. This control enhancement is implemented within the information system by the detection of split tunneling (or of configuration settings that allow split tunneling) in the remote device, and by prohibiting the connection if the remote device is using split tunneling. Split tunneling might be desirable by remote users to communicate with local information system resources such as printers/file servers. However, split tunneling would in effect allow unauthorized external connections, making the system more vulnerable to attack and to exfiltration of organizational information. The use of VPNs for remote connections, when adequately provisioned with appropriate security controls, may provide the organization with sufficient assurance that it can effectively treat such connections as non-remote connections from the confidentiality and integrity perspective. VPNs thus provide a means for allowing non-remote communications paths from remote devices. The use of an adequately provisioned VPN does not eliminate the need for preventing split tunneling.
+  title: >-
+    SC-7(7) - BOUNDARY PROTECTION | PREVENT SPLIT TUNNELING FOR REMOTE DEVICES
+  levels:
+  - high
+  - moderate
+- id: SC-7(8)
+  status: not applicable
+  notes: |-
+    Routing organization-defined internal communications traffic to
+    organization-defined external networks through authenticated proxy
+    servers at managed interfaces is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system routes [Assignment: organization-defined internal communications traffic] to [Assignment: organization-defined external networks] through authenticated proxy servers at managed interfaces.
+
+    Supplemental Guidance:  External networks are networks outside of organizational control. A proxy server is a server (i.e., information system or application) that acts as an intermediary for clients requesting information system resources (e.g., files, connections, web pages, or services) from other organizational servers. Client requests established through an initial connection to the proxy server are evaluated to manage complexity and to provide additional protection by limiting direct connectivity. Web content filtering devices are one of the most common proxy servers providing access to the Internet. Proxy servers support logging individual Transmission Control Protocol (TCP) sessions and blocking specific Uniform Resource Locators (URLs), domain names, and Internet Protocol (IP) addresses. Web proxies can be configured with organization-defined lists of authorized and unauthorized websites. Related controls: AC-3, AU-2.
+  title: >-
+    SC-7(8) - BOUNDARY PROTECTION | ROUTE TRAFFIC TO AUTHENTICATED PROXY SERVERS
+  levels:
+  - high
+  - moderate
+- id: SC-7(9)
+  status: not applicable
+  notes: |-
+    Section a: Detecting and denying outgoing communications traffic posing a threat to
+    external information systems is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+    Section b: Auditing the identity of internal users associated with denied
+    communications is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+- id: SC-7(10)
+  status: not applicable
+  notes: |-
+    Preventing the unauthorized exfiltration of information across managed
+    interfaces is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization prevents the unauthorized exfiltration of information across managed interfaces.
+
+    Supplemental Guidance:  Safeguards implemented by organizations to prevent unauthorized exfiltration of information from information systems include, for example: (i) strict adherence to protocol formats; (ii) monitoring for beaconing from information systems; (iii) monitoring for steganography; (iv) disconnecting external network interfaces except when explicitly needed; (v) disassembling and reassembling packet headers; and (vi) employing traffic profile analysis to detect deviations from the volume/types of traffic expected within organizations or call backs to command and control centers. Devices enforcing strict adherence to protocol formats include, for example, deep packet inspection firewalls and XML gateways. These devices verify adherence to protocol formats and specification at the application layer and serve to identify vulnerabilities that cannot be detected by devices operating at the network or transport layers. This control enhancement is closely associated with cross-domain solutions and system guards enforcing information flow requirements. Related control: SI-3.
+  title: >-
+    SC-7(10) - BOUNDARY PROTECTION | PREVENT UNAUTHORIZED EXFILTRATION
+  levels:
+  - high
+- id: SC-7(11)
+  status: not applicable
+  notes: |-
+    Only allowing incoming communications from organization-defined authorized
+    sources to be routed to organization-defined authorized destinations is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SC-7(12)
+  status: not applicable
+  notes: |-
+    Implementing organization-defined host-based boundary protection
+    mechanisms at organization-defined information system components is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined host-based boundary protection mechanisms] at [Assignment: organization-defined information system components].
+
+    Supplemental Guidance:  Host-based boundary protection mechanisms include, for example, host-based firewalls. Information system components employing host-based boundary protection mechanisms include, for example, servers, workstations, and mobile devices.
+
+    SC-7(12)-1 [Host Intrusion Prevention System (HIPS), Host Intrusion Detection System (HIDS), or minimally a host-based firewall]
+  title: >-
+    SC-7(12) - BOUNDARY PROTECTION | HOST-BASED PROTECTION
+  levels:
+  - high
+  - moderate
+- id: SC-7(13)
+  status: not applicable
+  notes: |-
+    Isolating organization-defined information security tools, mechanisms,
+    and support components from other internal information system components
+    by implementing physically separate subnetworks with managed interfaces
+    to other components of the system is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization isolates [Assignment: organization-defined information security tools, mechanisms, and support components] from other internal information system components by implementing physically separate subnetworks with managed interfaces to other components of the system.
+
+    Supplemental Guidance:  Physically separate subnetworks with managed interfaces are useful, for example, in isolating computer network defenses from critical operational processing networks to prevent adversaries from discovering the analysis and forensics techniques of organizations. Related controls: SA-8, SC-2, SC-3.
+    SC-7 (13) Requirement: The service provider defines key information security tools, mechanisms, and support components associated with system and security administration and isolates those tools, mechanisms, and support components from other internal information system components via physically or logically separate subnets.
+    Guidance: Examples include: information security tools, mechanisms, and support components such as, but not limited to PKI, patching infrastructure, cyber defense tools, special purpose gateway, vulnerability tracking systems, internet access points (IAPs); network element and data center administrative/management traffic; Demilitarized Zones (DMZs), Server farms/computing centers,  centralized audit log servers etc.
+  title: >-
+    SC-7(13) - BOUNDARY PROTECTION | ISOLATION OF SECURITY TOOLS /
+
+    MECHANISMS / SUPPORT COMPONENTS
+  levels:
+  - high
+  - moderate
+- id: SC-7(14)
+  status: not applicable
+  notes: |-
+    Protecting against unauthorized physical connections at
+    organization-defined managed interfaces is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SC-7(15)
+  status: not applicable
+  notes: |-
+    Protecting against unauthorized physical connections at
+    organization-defined managed interfaces is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SC-7(16)
+  status: not applicable
+  notes: |-
+    Preventing discovery of specific system components composing a managed
+    interface is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: SC-7(17)
+  status: not applicable
+  notes: |-
+    Enforcing adherence to protocol formats is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SC-7(18)
+  status: not applicable
+  notes: |-
+    Failing securely in the event of an operational failure of a boundary
+    protection device is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: "The information system fails securely in the event of an operational\
+    \ failure of a boundary protection device.\n \nSupplemental Guidance:  Fail secure\
+    \ is a condition achieved by employing information system mechanisms to ensure\
+    \ that in the event of operational failures of boundary protection devices at\
+    \ managed interfaces (e.g., routers, firewalls, guards, and application gateways\
+    \ residing on protected subnetworks commonly referred to as demilitarized zones),\
+    \ information systems do not enter into unsecure states where intended security\
+    \ properties no longer hold. Failures of boundary protection devices cannot lead\
+    \ to, or cause information external to the devices to enter the devices, nor can\
+    \ failures permit unauthorized information releases. Related controls: CP-2, SC-24."
+  title: >-
+    SC-7(18) - BOUNDARY PROTECTION | FAIL SECURE
+  levels:
+  - high
+  - moderate
+- id: SC-7(19)
+  status: not applicable
+  notes: |-
+    Blocking both inbound and outbound communications traffic between
+    organization-defined communication clients that are independently
+    configured by end users and external service providers is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SC-7(20)
+  status: not applicable
+  notes: |-
+    Providing the capability to dynamically isolate/segregate
+    organization-defined information system components from other components
+    of the system is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system provides the capability to dynamically isolate/segregate [Assignment: organization-defined information system components] from other components of the system.
+
+    Supplemental Guidance:  The capability to dynamically isolate or segregate certain internal components of organizational information systems is useful when it is necessary to partition or separate certain components of dubious origin from those components possessing greater
+    trustworthiness. Component isolation reduces the attack surface of organizational information systems. Isolation of selected information system components is also a means of limiting the damage from successful cyber attacks when those attacks occur.
+  title: >-
+    SC-7(20) - BOUNDARY PROTECTION | DYNAMIC ISOLATION / SEGREGATION
+  levels:
+  - high
+- id: SC-7(21)
+  status: not applicable
+  notes: |-
+    Employing boundary protection mechanisms to separate
+    organization-defined information system components supporting
+    organization-defined missions and/or business functions is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization employs boundary protection mechanisms to separate [Assignment: organization-defined information system components] supporting [Assignment: organization- defined missions and/or business functions].
+
+    Supplemental Guidance:  Organizations can isolate information system components performing different missions and/or business functions. Such isolation limits unauthorized information flows among system components and also provides the opportunity to deploy greater levels of protection for selected components. Separating system components with boundary protection mechanisms provides the capability for increased protection of individual components and to more effectively control information flows between those components. This type of enhanced protection limits the potential harm from cyber attacks and errors. The degree of separation provided varies depending upon the mechanisms chosen. Boundary protection mechanisms include, for example, routers, gateways, and firewalls separating system components into physically separate networks or subnetworks, cross-domain devices separating subnetworks, virtualization techniques, and encrypting information flows among system components using distinct encryption keys. Related controls: CA-9, SC-3.
+  title: >-
+    SC-7(21) - BOUNDARY PROTECTION | ISOLATION OF INFORMATION SYSTEM COMPONENTS
+  levels:
+  - high
+- id: SC-7(22)
+  status: not applicable
+  notes: |-
+    Implementing separate network addresses (i.e., different subnets) to
+    connect to systems in different security domains is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SC-7(23)
+  status: not applicable
+  notes: |-
+    Disabling feedback to senders on protocol format validation failure is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SC-8
+  status: supported
+  notes: |-
+    The customer will be responsible for configuring TLS for transmitted
+    information.
+
+    To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-386
+  rules: []
+  description: |-
+    The information system protects the [Selection (one or more): confidentiality; integrity] of transmitted information.
+
+    Supplemental Guidance:  This control applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. Protecting the confidentiality and/or integrity of organizational information can be accomplished by physical means (e.g., by employing physical distribution systems) or by logical means (e.g., employing encryption techniques). Organizations relying on commercial providers offering transmission services as commodity services rather than as fully dedicated services (i.e., services which can be highly specialized to individual customer needs), may find it difficult to obtain the necessary assurances regarding the implementation of needed security controls for transmission confidentiality/integrity. In such situations, organizations determine what types of confidentiality/integrity services are available in standard, commercial telecommunication service packages. If it is infeasible or impractical to obtain the necessary security controls and assurances of control effectiveness through appropriate contracting vehicles, organizations implement appropriate compensating security controls or explicitly accept the additional risk. Related controls: AC-17, PE-4.
+
+    References: FIPS Publications 140-2, 197; NIST Special Publications 800-52, 800-77, 800-81, 800-113; CNSS Policy 15; NSTISSI No. 7003.
+
+    SC-8 [confidentiality AND integrity]
+  title: >-
+    SC-8 - TRANSMISSION CONFIDENTIALITY AND INTEGRITY
+  levels:
+  - high
+  - moderate
+- id: SC-8(1)
+  status: not applicable
+  notes: |-
+    Implementing cryptographic mechanisms during transmission unless
+    otherwise protected by organization-defined alternative physical
+    safeguards is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: "The information system implements cryptographic mechanisms to [Selection\
+    \ (one or more): prevent unauthorized disclosure of information; detect changes\
+    \ to information] during transmission unless otherwise protected by [Assignment:\
+    \ organization-defined alternative physical safeguards].\n\nSupplemental Guidance:\
+    \ Encrypting information for transmission protects information from unauthorized\
+    \ disclosure and modification. Cryptographic mechanisms implemented to protect\
+    \ information integrity include, for example, cryptographic hash functions which\
+    \ have common application in digital signatures, checksums, and message authentication\
+    \ codes. Alternative physical security safeguards include, for example, protected\
+    \ distribution systems. Related control: SC-13.\n\nSC-8 (1)-1 [prevent unauthorized\
+    \ disclosure of information AND detect changes to information] \nSC-8 (1)-2 [a\
+    \ hardened or alarmed carrier Protective Distribution System (PDS)]"
+  title: >-
+    SC-8(1) - TRANSMISSION CONFIDENTIALITY AND INTEGRITY | CRYPTOGRAPHIC OR ALTERNATE
+    PHYSICAL PROTECTION
+  levels:
+  - high
+  - moderate
+- id: SC-8(2)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes utilizes TLS to
+    maintain the confidentiality or integrity of information during
+    preparation for transmission and during reception.
+
+    To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/CMP-492
+  rules: []
+- id: SC-8(3)
+  status: not applicable
+  notes: |-
+    Implementing cryptographic mechanisms to protect message externals
+    unless otherwise protected by organization-defined alternative physical
+    safeguards is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: SC-8(4)
+  status: not applicable
+  notes: |-
+    Implementing cryptographic mechanisms to conceal or randomize
+    communication patterns unless otherwise protected by
+    organization-defined alternative physical safeguards is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SC-9
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-8.
+  rules: []
+- id: SC-10
+  status: not applicable
+  notes: |-
+    The customer will be responsible for terminating network connections
+    at the end of the session or after no longer than 30 minutes of
+    inactivity. A successful control response will document the technical
+    means on how this is established.
+  rules: []
+  description: |-
+    The information system terminates the network connection associated with a communications session at the end of the session or after [Assignment: organization-defined time period] of inactivity.
+    Supplemental Guidance:  This control applies to both internal and external networks. Terminating network connections associated with communications sessions include, for example, de-allocating associated TCP/IP address/port pairs at the operating system level, or de-allocating networking assignments at the application level if multiple application sessions are using a single, operating system-level network connection. Time periods of inactivity may be established by organizations and include, for example, time periods by type of network access or for specific network accesses.
+    Control Enhancements:  None.
+
+    References:  None.
+    SC-10  [no longer than ten (10) minutes for privileged sessions and no longer than fifteen (15) minutes for user sessions]
+  title: >-
+    SC-10 - NETWORK DISCONNECT
+  levels:
+  - high
+  - moderate
+- id: SC-11
+  status: not applicable
+  notes: |-
+    Establishing a trusted communications path between the user and the
+    organization-defined security functions to include at a minimum,
+    information system authentication and re-authentication, is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+- id: SC-11(1)
+  status: not applicable
+  notes: |-
+    Providing a trusted communications path that is logically isolated and
+    distinguishable from other paths is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SC-12
+  status: not applicable
+  notes: |-
+    Establishing and manages cryptographic keys for required cryptography
+    employed within the information system in accordance with
+    organization-defined requirements for key generation, distribution,
+    storage, access, and destruction is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization establishes and manages cryptographic keys for required cryptography employed within the information system in accordance with [Assignment: organization-defined requirements for key generation, distribution, storage, access, and destruction].
+
+    Supplemental Guidance:  Cryptographic key management and establishment can be performed using manual procedures or automated mechanisms with supporting manual procedures. Organizations define key management requirements in accordance with applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance, specifying appropriate options, levels, and parameters. Organizations manage trust stores to ensure that only approved trust anchors are in such trust stores. This includes certificates with visibility external to organizational information systems and certificates related to the internal operations of systems. Related controls: SC-13, SC-17.
+
+    References: NIST Special Publications 800-56, 800-57.
+
+    SC-12 Guidance: Federally approved cryptography
+  title: >-
+    SC-12 - CRYPTOGRAPHIC KEY ESTABLISHMENT AND
+
+    MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-12(1)
+  status: not applicable
+  notes: |-
+    Maintaining availability of information in the event of the loss of
+    cryptographic keys by users is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization maintains availability of information in the event of the loss of cryptographic keys by users.
+
+    Supplemental Guidance:  Escrowing of encryption keys is a common practice for ensuring availability in the event of loss of keys (e.g., due to forgotten passphrase).
+  title: >-
+    SC-12(1) - CRYPTOGRAPHIC KEY ESTABLISHMENT AND MANAGEMENT | AVAILABILITY
+  levels:
+  - high
+- id: SC-12(2)
+  status: not applicable
+  notes: |-
+    Producing, controlling, and distributing symmetric cryptographic keys
+    using NIST FIPS-compliant or NSA-approved key management technology and
+    processes is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization produces, controls, and distributes symmetric cryptographic keys using [Selection: NIST FIPS-compliant; NSA-approved] key management technology and processes.
+
+    SC-12 (2) [NIST FIPS-compliant]
+  title: >-
+    SC-12(2) - CRYPTOGRAPHIC KEY ESTABLISHMENT AND MANAGEMENT |
+
+    SYMMETRIC KEYS
+  levels:
+  - high
+  - moderate
+- id: SC-12(3)
+  status: not applicable
+  notes: |-
+    Producing, controlling, and distributing asymmetric cryptographic keys
+    using NSA-approved key management technology and processes is outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: "The organization produces, controls, and distributes asymmetric cryptographic\
+    \ keys using [Selection: NSA-approved key management technology and processes;\
+    \ approved PKI Class 3 certificates or prepositioned keying material; approved\
+    \ PKI Class 3 or Class 4 certificates and hardware security tokens that protect\
+    \ the user\u2019s private key]."
+  title: >-
+    SC-12(3) - CRYPTOGRAPHIC KEY ESTABLISHMENT AND MANAGEMENT |
+
+    ASYMMETRIC KEYS
+  levels:
+  - high
+  - moderate
+- id: SC-12(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-12.
+  rules: []
+- id: SC-12(5)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-12.
+  rules: []
+- id: SC-13
+  status: not applicable
+  notes: |-
+    Implementing organization-defined cryptographic uses and type of
+    cryptography required for each use in accordance with applicable federal
+    laws, Executive Orders, directives, policies, regulations, and standards
+    is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: |-
+    The information system implements [Assignment: organization-defined cryptographic uses and type of cryptography required for each use] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+
+    Supplemental Guidance:  Cryptography can be employed to support a variety of security solutions including, for example, the protection of classified and Controlled Unclassified Information, the provision of digital signatures, and the enforcement of information separation when authorized individuals have the necessary clearances for such information but lack the necessary formal access approvals. Cryptography can also be used to support random number generation and hash generation. Generally applicable cryptographic standards include FIPS-validated cryptography and NSA-approved cryptography. This control does not impose any requirements on organizations to use cryptography. However, if cryptography is required based on the selection of other security controls, organizations define each type of cryptographic use and the type of cryptography required (e.g., protection of classified information: NSA-approved cryptography; provision of digital signatures: FIPS-validated cryptography). Related controls: AC-2, AC-3, AC-7, AC-17, AC-18, AU-9, AU-10, CM-11, CP-9, IA-3, IA-7, MA-4, MP-2, MP-4, MP-5, SA-4, SC-8, SC-12, SC-28, SI-7.
+
+    References: FIPS Publication 140; Web: http://csrc.nist.gov/cryptval, http://www.cnss.gov.
+
+    SC-13 [FIPS-validated or NSA-approved cryptography]
+  title: >-
+    SC-13 - CRYPTOGRAPHIC PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-13(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-13.
+  rules: []
+- id: SC-13(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-13.
+  rules: []
+- id: SC-13(3)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-13.
+  rules: []
+- id: SC-13(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-13.
+  rules: []
+- id: SC-14
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-2,
+    AC-3, AC-5, AC-6, SI-3, SI-4, SI-5, SI-7, SI-10.
+  rules: []
+- id: SC-15
+  status: not applicable
+  notes: |-
+    Section a: Examples of collaborative computing devices include networked white
+    boards, TV conference cameras, and remote video systems. This control is
+    not applicable because Red Hat Advanced Cluster Management for
+    Kubernetes is not a collaborative computing device.
+    Section b: Examples of collaborative computing devices include networked white
+    boards, TV conference cameras, and remote video systems. This control is
+    not applicable because Red Hat Advanced Cluster Management for
+    Kubernetes is not a collaborative computing device.
+  rules: []
+  description: |-
+    The information system:
+     a. Prohibits remote activation of collaborative computing devices with the following exceptions: [Assignment: organization-defined exceptions where remote activation is to be allowed]; and
+     b. Provides an explicit indication of use to users physically present at the devices.
+
+    Supplemental Guidance:  Collaborative computing devices include, for example, networked white boards, cameras, and microphones. Explicit indication of use includes, for example, signals to users when collaborative computing devices are activated. Related control: AC-21.
+
+    References: None.
+
+    SC-15 (a) [no exceptions]
+    SC-15 Requirement: The information system provides disablement (instead of physical disconnect) of collaborative computing devices in a manner that supports ease of use.
+  title: >-
+    SC-15 - COLLABORATIVE COMPUTING DEVICES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-15(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-15(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-15(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-15(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-16
+  status: not applicable
+  notes: |-
+    Implementing cryptographic mechanisms during transmission unless
+    otherwise protected by organization-defined alternative physical
+    safeguards is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: SC-16(1)
+  status: not applicable
+  notes: |-
+    Implementing cryptographic mechanisms during transmission unless
+    otherwise protected by organization-defined alternative physical
+    safeguards is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: SC-17
+  status: supported
+  notes: |-
+    To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-387
+  rules: []
+  description: |-
+    The organization issues public key certificates under an [Assignment: organization- defined certificate policy] or obtains public key certificates from an approved service provider.
+
+    Supplemental Guidance:  For all certificates, organizations manage information system trust stores to ensure only approved trust anchors are in the trust stores. This control addresses both certificates with visibility external to organizational information systems and certificates related to the internal operations of systems, for example, application-specific time services. Related control: SC-12.
+
+    Control Enhancements:  None.
+
+    References:  OMB Memorandum 05-24; NIST Special Publications 800-32, 800-63.
+  title: >-
+    SC-17 - PUBLIC KEY INFRASTRUCTURE CERTIFICATES
+  levels:
+  - high
+  - moderate
+- id: SC-18
+  status: supported
+  notes: |-
+    Section a: To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-388
+    Section b: To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-388
+    Section c: To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-388
+  rules: []
+  description: |-
+    The organization:
+     a. Defines acceptable and unacceptable mobile code and mobile code technologies;
+     b. Establishes usage restrictions and implementation guidance for acceptable mobile code and mobile code technologies; and
+     c. Authorizes, monitors, and controls the use of mobile code within the information system.
+
+    Supplemental Guidance:  Decisions regarding the employment of mobile code within organizational information systems are based on the potential for the code to cause damage to the systems if used maliciously. Mobile code technologies include, for example, Java, JavaScript, ActiveX, Postscript, PDF, Shockwave movies, Flash animations, and VBScript. Usage restrictions and implementation guidance apply to both the selection and use of mobile code installed on servers and mobile code downloaded and executed on individual workstations and devices (e.g., smart phones). Mobile code policy and procedures address preventing the development, acquisition, or introduction of unacceptable mobile code within organizational information systems. Related controls: AU-2, AU-12, CM-2, CM-6, SI-3.
+
+    References: NIST Special Publication 800-28; DoD Instruction 8552.01.
+  title: >-
+    SC-18 - MOBILE CODE
+  levels:
+  - high
+  - moderate
+- id: SC-18(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-18(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-18(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-18(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-18(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-19
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes usage restrictions and implementation guidance for Voice over Internet Protocol (VoIP) technologies based on the potential to cause damage to the information system if used maliciously; and
+     b. Authorizes, monitors, and controls the use of VoIP within the information system.
+
+    Supplemental Guidance:  Related controls: CM-6, SC-7, SC-15.
+
+    References:  NIST Special Publication 800-58.
+  title: >-
+    SC-19 - VOICE OVER INTERNET PROTOCOL
+  levels:
+  - high
+  - moderate
+- id: SC-20
+  status: not applicable
+  notes: |-
+    Section a: Providing additional data origin authentication and integrity
+    verification artifacts along with the authoritative name resolution data
+    the system returns in response to external name/address resolution
+    queries is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for secure name and dns enforcement.
+    Section b: Providing the means to indicate the security status of child zones and
+    (if the child supports secure resolution services) to enable
+    verification of a chain of trust among parent and child domains, when
+    operating as part of a distributed, hierarchical namespace is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on OpenShift
+    for secure name and dns enforcement.
+  rules: []
+  description: "The information system:\n a. Provides additional data origin and integrity\
+    \ artifacts along with the authoritative name resolution data the system returns\
+    \ in response to external name/address resolution queries; and\n b. Provides the\
+    \ means to indicate the security status of child zones and (if the child supports\
+    \ secure resolution services) to enable verification of a chain of trust among\
+    \ parent and child domains, when operating as part of a distributed, hierarchical\
+    \ namespace.\n \nSupplemental Guidance:  This control enables external clients\
+    \ including, for example, remote Internet clients, to obtain origin authentication\
+    \ and integrity verification assurances for the host/service name to network address\
+    \ resolution information obtained through the service. Information systems that\
+    \ provide name and address resolution services include, for example, domain name\
+    \ system (DNS) servers. Additional artifacts include, for example, DNS Security\
+    \ (DNSSEC) digital signatures and cryptographic keys. DNS resource records are\
+    \ examples of authoritative data. The means to indicate the security status of\
+    \ child zones includes, for example, the use of delegation signer resource records\
+    \ in the DNS. The DNS security controls reflect (and are referenced from) OMB\
+    \ Memorandum 08-23. Information systems that use technologies other than the DNS\
+    \ to map between host/service names and network addresses provide other means\
+    \ to assure the authenticity and integrity of response data. Related controls:\
+    \ AU-10, SC-8, SC-12, SC-13, SC-21, SC-22.    \n\nReferences: OMB Memorandum 08-23;\
+    \ NIST Special Publication 800-81."
+  title: >-
+    SC-20 - SECURE NAME /ADDRESS RESOLUTION SERVICE
+
+    (AUTHORITATIVE SOURCE)
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-20(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-20.
+  rules: []
+- id: SC-20(2)
+  status: not applicable
+  notes: |-
+    Providing data origin and integrity protection artifacts for internal
+    name/address resolution queries is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+  rules: []
+- id: SC-21
+  status: not applicable
+  notes: |-
+    Requesting and performs data origin authentication and data integrity
+    verification on the name/address resolution responses the system
+    receives from authoritative sources is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system requests and performs data origin authentication and data integrity verification on the name/address resolution responses the system receives from authoritative sources.
+
+    Supplemental Guidance:  Each client of name resolution services either performs this validation on its own, or has authenticated channels to trusted validation providers. Information systems that provide name and address resolution services for local clients include, for example, recursive resolving or caching domain name system (DNS) servers. DNS client resolvers either perform validation of DNSSEC signatures, or clients use authenticated channels to recursive resolvers that perform such validations. Information systems that use technologies other than the DNS to map between host/service names and network addresses provide other means to enable clients to verify the authenticity and integrity of response data. Related controls: SC-20, SC-22.
+
+    References: NIST Special Publication 800-81.
+  title: >-
+    SC-21 - SECURE NAME /ADDRESS RESOLUTION SERVICE
+
+    (RECURSIVE OR CACHING RESOLVER)
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-21(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-21.
+  rules: []
+- id: SC-22
+  status: not applicable
+  notes: |-
+    Collectively providing name/address resolution service for an
+    organization are fault-tolerant and implement internal/external role
+    separation is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+  description: "The information systems that collectively provide name/address resolution\
+    \ service for an organization are fault-tolerant and implement internal/external\
+    \ role separation.\n \nSupplemental Guidance:  Information systems that provide\
+    \ name and address resolution services include, for example, domain name system\
+    \ (DNS) servers. To eliminate single points of failure and to enhance redundancy,\
+    \ organizations employ at least two authoritative domain name system servers,\
+    \ one configured as the primary server and the other configured as the secondary\
+    \ server. Additionally, organizations typically deploy the servers in two geographically\
+    \ separated network subnetworks (i.e., not located in the same physical facility).\
+    \ For role separation, DNS servers with internal roles only process name and address\
+    \ resolution requests from within organizations (i.e., from internal clients).\
+    \ DNS servers with external roles only process name and address resolution information\
+    \ requests from clients external to organizations (i.e., on external networks\
+    \ including\nthe Internet). Organizations specify clients that can access authoritative\
+    \ DNS servers in particular roles (e.g., by address ranges, explicit lists). Related\
+    \ controls: SC-2, SC-20, SC-21, SC-24.\n\nControl Enhancements:  None.\n\nReferences:\
+    \  NIST Special Publication 800-81."
+  title: >-
+    SC-22 - ARCHITECTURE AND PROVISIONING FOR
+
+    NAME/ADDRESS RESOLUTION SERVICE
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-23
+  status: pending
+  notes: |-
+    The customer will be responsible for guarding against, for
+    example, man in the middle or session hijacking attacks for
+    connections to the customer application, for example via the
+    use of TLS. A successful control response will address the
+    various types of attacks against session authenticity and the
+    mechanisms used to protect against those attacks.
+
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-407
+  rules: []
+  description: |-
+    The information system protects the authenticity of communications sessions.
+
+    Supplemental Guidance:  This control addresses communications protection at the session, versus packet level (e.g., sessions in service-oriented architectures providing web-based services) and establishes grounds for confidence at both ends of communications sessions in ongoing identities of other parties and in the validity of information transmitted. Authenticity protection includes, for example, protecting against man-in-the-middle attacks/session hijacking and the insertion of false information into sessions. Related controls: SC-8, SC-10, SC-11.
+
+    References: NIST Special Publications 800-52, 800-77, 800-95.
+  title: >-
+    SC-23 - SESSION AUTHENTICITY
+  levels:
+  - high
+  - moderate
+- id: SC-23(1)
+  status: not applicable
+  notes: |-
+    Invalidating session identifiers upon user logout or other session
+    termination is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+  description: |-
+    The information system invalidates session identifiers upon user logout or other session termination.
+
+    Supplemental Guidance:  This control enhancement curtails the ability of adversaries from capturing and continuing to employ previously valid session IDs.
+  title: >-
+    SC-23(1) - SESSION AUTHENTICITY | INVALIDATE SESSION IDENTIFIERS AT LOGOUT
+  levels:
+  - high
+- id: SC-23(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-12 (1).
+  rules: []
+- id: SC-23(3)
+  status: not applicable
+  notes: |-
+    Generating a unique session identifier for each session with
+    organization-defined randomness requirements and recognizes only session
+    identifiers that are system-generated is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SC-23(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-23 (3).
+  rules: []
+- id: SC-23(5)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-492
+  rules: []
+- id: SC-24
+  status: supported
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-389
+  rules: []
+  description: "The information system fails to a [Assignment: organization-defined\
+    \ known-state] for [Assignment: organization-defined types of failures] preserving\
+    \ [Assignment: organization-defined system state information] in failure.\n\n\
+    Supplemental Guidance:  Failure in a known state addresses security concerns in\
+    \ accordance with the mission/business needs of organizations. Failure in a known\
+    \ secure state helps to prevent the loss of confidentiality, integrity, or availability\
+    \ of information in the event of failures of organizational information systems\
+    \ or system components. Failure in a known safe state helps to prevent systems\
+    \ from failing to a state that may cause injury to individuals or destruction\
+    \ to property. Preserving information system state information facilitates system\
+    \ restart and return to the operational mode of organizations with less disruption\
+    \ of mission/business processes. Related controls: CP-2, CP- 10, CP-12, SC-7,\
+    \ SC-22. \n\nControl Enhancements:  None. \n\nReferences:  None."
+  title: >-
+    SC-24 - FAIL IN KNOWN STATE
+  levels:
+  - high
+- id: SC-25
+  status: supported
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/TBD
+  rules: []
+- id: SC-26
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-26(1)
+  status: not applicable
+  notes: |-
+    This control has been withdrawn by NIST, and incorporated into SC-35.
+  rules: []
+- id: SC-27
+  status: not applicable
+  notes: |-
+    Including organization-defined platform-independent applications is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SC-28
+  status: not applicable
+  notes: |-
+    Protecting the confidentiality or integrity of organization-defined
+    information at rest is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system protects the [Selection (one or more): confidentiality; integrity] of [Assignment: organization-defined information at rest].
+
+    Supplemental Guidance:  This control addresses the confidentiality and integrity of information at rest and covers user information and system information. Information at rest refers to the state of information when it is located on storage devices as specific components of information systems. System-related information requiring protection includes, for example, configurations or rule sets for firewalls, gateways, intrusion detection/prevention systems, filtering routers, and authenticator content. Organizations may employ different mechanisms to achieve confidentiality and integrity protections, including the use of cryptographic mechanisms and file share scanning. Integrity protection can be achieved, for example, by implementing Write-Once-Read-Many (WORM) technologies. Organizations may also employ other security controls including, for example, secure off-line storage in lieu of online storage when adequate protection of information at rest cannot otherwise be achieved and/or continuous monitoring to identify malicious code at rest. Related controls: AC-3, AC-6, CA-7, CM-3, CM-5, CM-6, PE-3, SC-8, SC-13, SI-3, SI-7.
+
+    References: NIST Special Publications 800-56, 800-57, 800-111.
+
+    SC-28 [confidentiality AND integrity]
+    SC-28 Guidance: The organization supports the capability to use cryptographic mechanisms to protect information at rest.
+  title: >-
+    SC-28 - PROTECTION OF INFORMATION AT REST
+  levels:
+  - high
+  - moderate
+- id: SC-28(1)
+  status: not applicable
+  notes: |-
+    The customer is responsible for implementing cryptographic
+    mechanisms to prevent unauthorzed disclosure and modification of
+    customer data. A successful control response will outline how
+    cryptography is used to ensure integrity of data in rest and
+    transport.
+  rules: []
+  description: |-
+    The information system implements cryptographic mechanisms to prevent unauthorized disclosure and modification of [Assignment: organization-defined information] on [Assignment: organization-defined information system components].
+
+    Supplemental Guidance:  Selection of cryptographic mechanisms is based on the need to protect the confidentiality and integrity of organizational information. The strength of mechanism is commensurate with the security category and/or classification of the information. This control enhancement applies to significant concentrations of digital media in organizational areas designated for media storage and also to limited quantities of media generally associated with information system components in operational environments (e.g., portable storage devices, mobile devices). Organizations have the flexibility to either encrypt all information on storage devices (i.e., full disk encryption) or encrypt specific data structures (e.g., files, records, or fields). Organizations employing cryptographic mechanisms to protect information at rest also consider cryptographic key management solutions. Related controls: AC-19, SC-12.
+
+    SC-28 (1)-2 [all information system components storing customer data deemed sensitive]
+  title: >-
+    SC-28(1) - PROTECTION OF INFORMATION AT REST | CRYPTOGRAPHIC PROTECTION
+  levels:
+  - high
+  - moderate
+- id: SC-28(2)
+  status: not applicable
+  notes: |-
+    Removing from online storage and stores off-line in a secure location
+    organization-defined information is outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SC-29
+  status: not applicable
+  notes: |-
+    Employing a diverse set of information technologies for
+    organization-defined information system components in the implementation
+    of the information system is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+  rules: []
+- id: SC-29(1)
+  status: not applicable
+  notes: |-
+    Employing virtualization techniques to support the deployment of a
+    diversity of operating systems and applications that are changed on an
+    organization-defined frequency is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes.
+  rules: []
+- id: SC-30
+  status: not applicable
+  notes: |-
+    Employing organization-defined concealment and misdirection techniques
+    for organization-defined information systems at organization-defined
+    time periods to confuse and mislead adversaries is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SC-30(1)
+  status: not applicable
+  notes: |-
+    This control has been withdrawn by NIST, and incorporated into SC-29(1).
+  rules: []
+- id: SC-30(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-30(3)
+  status: pending
+  notes: |-
+    To assist with this organizational control, documentation is being
+    planned. Progress can be tracked via:
+
+    https://issues.redhat.com/browse/ACM-493
+  rules: []
+- id: SC-30(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-30(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-31
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-31(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-31(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-31(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-32
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-33
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SC-8.
+  rules: []
+- id: SC-34
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-34(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-34(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-34(3)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-35
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-36
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-36(1)
+  status: pending
+  notes: |-
+    A complete control response is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-502
+  rules: []
+- id: SC-37
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes allows organizations
+    to employ organization-defined out-of-band channels by providing a
+    disconnected configuration. More information on how to configure Red Hat
+    Advanced Cluster Management for Kubernetes in a disconnected
+    environment, refer to the following documentation:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/install/installing#install-on-disconnected-networks
+  rules: []
+- id: SC-37(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-38
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-39
+  status: not applicable
+  notes: |-
+    Maintaining a separate execution domain for each executing process is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The information system maintains a separate execution domain for each executing process.
+
+    Supplemental Guidance:  Information systems can maintain separate execution domains for each executing process by assigning each process a separate address space. Each information system process has a distinct address space so that communication between processes is performed in a manner controlled through the security functions, and one process cannot modify the executing code of another process. Maintaining separate execution domains for executing processes can be achieved, for example, by implementing separate address spaces. This capability is available in most commercial operating systems that employ multi-state processor technologies. Related controls: AC-3, AC-4, AC-6, SA-4, SA-5, SA-8, SC-2, SC-3.
+
+    References: None.
+  title: >-
+    SC-39 - PROCESS ISOLATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-39(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-39(2)
+  status: not applicable
+  notes: |-
+    Maintaining a separate execution domain for each thread in
+    organization-defined multi-threaded processing is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SC-40
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-40(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-40(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-40(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-40(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-41
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-42
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-42(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-42(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-42(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-43
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SC-44
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management
+    for Kubernetes.
+  rules: []
+- id: SI-1
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section a.1: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section a.2: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b.1: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b.2: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A system and information integrity\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the system and information integrity policy\
+    \ and associated system and information integrity controls; and\n b. Reviews and\
+    \ updates the current:\n   1. System and information integrity policy [Assignment:\
+    \ organization-defined frequency]; and\n   2.  System and information integrity\
+    \ procedures [Assignment: organization-defined frequency].\n\nSupplemental Guidance:\
+    \  This control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ SI family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-100.\n\nSI-1 (b) (1) [at least annually] \n\
+    SI-1 (b) (2) [at least annually or whenever a significant change occurs]"
+  title: >-
+    SI-1 - SYSTEM AND INFORMATION INTEGRITY POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-2
+  status: not applicable
+  notes: |-
+    Section a: The customer will be responsible for analyzing their Red Hat Advanced Cluster Management
+    for Kubernetes deployment for flaws, reporting on those flaws, and correcting them. A
+    successful control response will include a discussion of the process by which flaws are
+    discovered and remediated, as well as tools that are used to assist in detection and
+    remediation.
+    Section b: The customer will be responsible for testing Red Hat Advanced Cluster Management for
+    Kubernetes updates related to flaw remediation prior to installation. A successful control
+    response will discuss the testing process (e.g. the nature of the test environment, the
+    types of testing performed, the tools in testing, etc.).
+    Section c: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section d: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+    a. Identifies, reports, and corrects information system flaws;
+    b. Tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation;
+    c. Installs security-relevant software and firmware updates within [Assignment: organization- defined time period] of the release of the updates; and
+    d. Incorporates flaw remediation into the organizational configuration management process.
+    Supplemental Guidance:  Organizations identify information systems affected by announced software flaws including potential vulnerabilities resulting from those flaws, and report this information to designated organizational personnel with information security responsibilities. Security-relevant software updates include, for example, patches, service packs, hot fixes, and anti-virus signatures. Organizations also address flaws discovered during security assessments, continuous monitoring, incident response activities, and system error handling. Organizations take advantage of available resources such as the Common Weakness Enumeration (CWE) or Common Vulnerabilities and Exposures (CVE) databases in remediating flaws discovered in organizational information systems. By incorporating flaw remediation into ongoing configuration management processes, required/anticipated remediation actions can be tracked and verified. Flaw remediation actions that can be tracked and verified include, for example, determining whether organizations follow US-CERT guidance and Information Assurance Vulnerability Alerts. Organization-defined time periods for updating security-relevant software and firmware may vary based on a variety of factors including, for example, the security category of the information system or the criticality of the update (i.e., severity of the vulnerability related to the discovered flaw). Some types of flaw remediation may require more testing than other types. Organizations determine the degree and type of testing needed for the specific type of flaw remediation activity under consideration and also the types of changes that are to be configuration-managed. In some situations, organizations may determine that the testing of software and/or firmware updates is not necessary or practical,
+    for example, when implementing simple anti-virus signature updates. Organizations may also consider in testing decisions, whether security-relevant software or firmware updates are obtained from authorized sources with appropriate digital signatures. Related controls: CA-2, CA-7, CM-3, CM-5, CM-8, MA-2, IR-4, RA-5, SA-10, SA-11, SI-11.
+    SI-2 (c) [thirty (30) days of release of updates]
+  title: >-
+    SI-2 - FLAW REMEDIATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-2(1)
+  status: not applicable
+  notes: |-
+    The organization centrally managing the flaw remediation processes is an organizational
+    control outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the underlying Red Hat
+    Advanced Cluster Management for Kubernetes layer or third party tools for managing flaw
+    remediation.
+  rules: []
+  description: |-
+    The organization centrally manages the flaw remediation process.
+
+    Supplemental Guidance:  Central management is the organization-wide management and implementation of flaw remediation processes. Central management includes planning, implementing, assessing, authorizing, and monitoring the organization-defined, centrally managed flaw remediation security controls.
+  title: >-
+    SI-2(1) - FLAW REMEDIATION | CENTRAL MANAGEMENT
+  levels:
+  - high
+- id: SI-2(2)
+  status: not applicable
+  notes: |-
+    The customer will be required to employ automated mechanisms per an
+    organizational-defined frequency to determine the state of information system components
+    with regard to flaw remediation on their information systems as
+    required by their organizations policy. A successful control response
+    will address the customers use of automated tools such as Nessus to
+    perform periodic and on-demand scans through their system to determine
+    the state of system components with regard to flaw remediation.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the underlying Red Hat
+    Advanced Cluster Management for Kubernetes layer or third party tools for managing flaw
+    remediation.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms [Assignment: organization-defined frequency] to determine the state of information system components with regard to flaw remediation.
+
+    Supplemental Guidance:  Related controls: CM-6, SI-4.
+
+    SI-2 (2) [at least monthly]
+  title: >-
+    SI-2(2) - FLAW REMEDIATION | AUTOMATED FLAW REMEDIATION STATUS
+  levels:
+  - high
+  - moderate
+- id: SI-2(3)
+  status: not applicable
+  notes: |-
+    Section a: The customer is responsible for scanning for flaws in their
+    information systems and for measuring the time between flaw
+    identification and flaw remediation. A successful control response
+    will need to address the time between flaw identification and
+    remediation using timestamps and calculates the time elapsed
+    difference.
+    Section b: The customer will be responsible for scanning for flaws in their
+    information systems and for establishing benchmarks for taking
+    correctie actions according to their organizational policies. A
+    successful control response will need to address the use of
+    benchmarks to remediate high, and moderate risk flaws within a
+    customer defined period after a flaws discovery.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Measures the time between flaw identification and flaw remediation; and
+     (b)   Establishes [Assignment: organization-defined benchmarks] for taking corrective actions.
+
+    Supplemental Guidance:  This control enhancement requires organizations to determine the current time it takes on the average to correct information system flaws after such flaws have been identified, and subsequently establish organizational benchmarks (i.e., time frames) for taking corrective actions. Benchmarks can be established by type of flaw and/or severity of the potential vulnerability if the flaw can be exploited.
+  title: >-
+    SI-2(3) - FLAW REMEDIATION | TIME TO REMEDIATE FLAWS / BENCHMARKS FOR CORRECTIVE
+    ACTIONS
+  levels:
+  - high
+  - moderate
+- id: SI-2(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SI-2.
+  rules: []
+- id: SI-2(5)
+  status: not applicable
+  notes: |-
+    The organization installing security-relevant software and firmware updates automatically
+    to organization-defined information system components is out of scope for direct
+    application to Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the underlying OpenShift layer
+    to install security-relevant software updates. This is done through the Lifecycle Manager
+    (OLM) operator.
+  rules: []
+- id: SI-2(6)
+  status: not applicable
+  notes: |-
+    Removal of previous versions of Red Hat Advanced Cluster Management for Kubernetes an
+    organization policy and procedure control and is out of scope for direct application to
+    Red Hat Advanced Cluster Management for Kubernetes.
+
+    Red Hat Advanced Cluster Management for Kubernetes relies on the underlying OpenShift layer
+    to remove previous versions. This is done through the Lifecycle Manager (OLM) operator.
+  rules: []
+- id: SI-3
+  status: not applicable
+  notes: |-
+    Section a: The customer is responsible for ensuring that they employ malicious code protection at
+    information system entry, and exit points to detect and eradicate malicious code. A
+    successful control response will need to address use of code protection mechanisms to
+    protect assets from malicious software (i.e. Viruses, malware, rootkits, worms, and
+    scripts). In regards to Red Hat Advanced Cluster Management for Kubernetes, this is
+    generally through the use of third party tools.
+    Section b: Updating malicious code protection mechanisms whenever new releases
+    are available in accordance with organizational configuration
+    management policy and procedures is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c: Configuring malicious code protection mechanisms is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c.1: Performing periodic scans of the information system per organization-defined frequency
+    and real-time scans of files from external sources via endpoints or network entry/exit
+    points as the files are downloaded, opened, or executed in accordance with organizational
+    security policy is an organizational control outside
+    the scope of Red Hat Advanced Cluster Management for Kubernetes configuration.
+    Section c.2: Blocking malicious code, quarantining malicious code, sending alerts to administrator, or
+    some other organization-defined action in response to malicious code detection is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+    Section d: Addressing the receipt of false positives during malicious code detection and eradication
+    and the resulting potential impact on the availability of the information system is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+  description: "The organization:\n a. Employs malicious code protection mechanisms\
+    \ at information system entry and exit points to detect and eradicate malicious\
+    \ code;\n b. Updates malicious code protection mechanisms whenever new releases\
+    \ are available in accordance with organizational configuration management policy\
+    \ and procedures;\n c. Configures malicious code protection mechanisms to:\n \
+    \  1. Perform periodic scans of the information system [Assignment: organization-defined\
+    \ frequency] and real-time scans of files from external sources at [Selection\
+    \ (one or more); endpoint; network entry/exit points] as the files are downloaded,\
+    \ opened, or executed in accordance with organizational security policy; and\n\
+    \   2. [Selection (one or more): block malicious code; quarantine malicious code;\
+    \ send alert to administrator; [Assignment: organization-defined action]] in response\
+    \ to malicious code detection; and\n d. Addresses the receipt of false positives\
+    \ during malicious code detection and eradication and the resulting potential\
+    \ impact on the availability of the information system.\n\nSupplemental Guidance:\
+    \  Information system entry and exit points include, for example, firewalls, electronic\
+    \ mail servers, web servers, proxy servers, remote-access servers, workstations,\
+    \ notebook computers, and mobile devices. Malicious code includes, for example,\
+    \ viruses, worms, Trojan horses, and spyware. Malicious code can also be encoded\
+    \ in various formats (e.g., UUENCODE, Unicode), contained within compressed or\
+    \ hidden files, or hidden in files using steganography. Malicious code can be\
+    \ transported by different means including, for example, web accesses, electronic\
+    \ mail, electronic mail attachments, and portable storage devices. Malicious code\
+    \ insertions occur through the exploitation of information system vulnerabilities.\
+    \ Malicious code protection mechanisms include, for example, anti-virus signature\
+    \ definitions and reputation-based technologies. A variety of technologies and\
+    \ methods exist to limit or eliminate the effects of malicious code. Pervasive\
+    \ configuration management and comprehensive software integrity controls may be\
+    \ effective in preventing execution of unauthorized code. In addition to commercial\
+    \ off-the-shelf software, malicious code may also be present in custom-built software.\
+    \ This could include, for example, logic bombs, back doors, and other types of\
+    \ cyber attacks that could affect organizational missions/business functions.\
+    \ Traditional malicious code protection mechanisms cannot always detect such code.\
+    \ In these situations, organizations rely instead on other safeguards including,\
+    \ for example, secure coding practices, configuration management and control,\
+    \ trusted procurement processes, and monitoring practices to help ensure that\
+    \ software does not perform functions other than the functions intended. Organizations\
+    \ may determine that in response to the detection of malicious code, different\
+    \ actions may be warranted. For example, organizations can define actions in response\
+    \ to malicious code detection during periodic scans, actions in response to detection\
+    \ of malicious downloads, and/or actions in response to detection of maliciousness\
+    \ when attempting to open or execute files. Related controls: CM-3, MP-2, SA-4,\
+    \ SA-8, SA-12, SA-13,\nSC-7, SC-26, SC-44, SI-2, SI-4, SI-7.\n\nReferences: NIST\
+    \ Special Publication 800-83. \n\nSI-3 (c) (1)-1 [at least weekly] \nSI-3 (c)\
+    \ (1)-2 [to include endpoints]\nSI-3 (c) (2) [to include blocking and quarantining\
+    \ malicious code and alerting administrator or defined security personnel near-realtime]"
+  title: >-
+    SI-3 - MALICIOUS CODE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-3(1)
+  status: not applicable
+  notes: |-
+    The customer is responsible for ensuring that their malicious code
+    protection mechanisms are centrally managed. A successful control
+    response will need to address that the planning, implementing,
+    assessing, authorizing and monitoring of their malicious code
+    protection mechanism is centered in one location.
+  rules: []
+  description: |-
+    The organization centrally manages malicious code protection mechanisms.
+
+    Supplemental Guidance:  Central management is the organization-wide management and implementation of malicious code protection mechanisms. Central management includes planning, implementing, assessing, authorizing, and monitoring the organization-defined, centrally managed flaw malicious code protection security controls. Related controls: AU-2, SI-8.
+  title: >-
+    SI-3(1) - MALICIOUS CODE PROTECTION | CENTRAL MANAGEMENT
+  levels:
+  - high
+  - moderate
+- id: SI-3(2)
+  status: not applicable
+  notes: |-
+    The customer is responsible for ensuring that they update their
+    malicious code protection mechanisms automatically when new versions/
+    definitions become available. A successful control response will need
+    to address that the employed malicious code protection
+    mechanisms definitions are configured to be updated automatically.
+  rules: []
+  description: |-
+    The information system automatically updates malicious code protection mechanisms.
+
+    Supplemental Guidance:  Malicious code protection mechanisms include, for example, signature definitions. Due to information system integrity and availability concerns, organizations give careful consideration to the methodology used to carry out automatic updates. Related control: SI-8.
+  title: >-
+    SI-3(2) - MALICIOUS CODE PROTECTION | AUTOMATIC UPDATES
+  levels:
+  - high
+  - moderate
+- id: SI-3(3)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-6(10).
+  rules: []
+- id: SI-3(4)
+  status: not applicable
+  notes: |-
+    The information system updating malicious code protection mechanisms only when directed by
+    a privileged user is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes and is the responsiblity of the underlying OpenShift layer which manages
+    updates through the Lifecycle Manager (OLM) operator.
+  rules: []
+- id: SI-3(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-3(6)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-3(7)
+  status: not applicable
+  notes: |-
+    The customer is responsible for ensuring that they implement a
+    nonsignature-based malicious code detection mechanism on their
+    information system. A successful control response will need to address
+    a nonsignature based detection mechanism that can detect, analyze and
+    describe the characteristics or behavior of malicious code and
+    could provide safeguards against malicious code for which signatures
+    do not yet exist.
+  rules: []
+  description: |-
+    The information system implements nonsignature-based malicious code detection mechanisms.
+
+    Supplemental Guidance:  Nonsignature-based detection mechanisms include, for example, the use of heuristics to detect, analyze, and describe the characteristics or behavior of malicious code and to provide safeguards against malicious code for which signatures do not yet exist or for which existing signatures may not be effective. This includes polymorphic malicious code (i.e., code that changes signatures when it replicates). This control enhancement does not preclude the use of signature-based detection mechanisms.
+  title: >-
+    SI-3(7) - MALICIOUS CODE PROTECTION | NONSIGNATURE-BASED DETECTION
+  levels:
+  - high
+  - moderate
+- id: SI-3(8)
+  status: not applicable
+  notes: |-
+    The information system detecting organization-defined unauthorized operating system
+    commands through the kernel application programming interface at organization-defined
+    information system hardware components and issues a warning, audits the command execution,
+    and/or prevents the execution of the command is outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes and is the responsiblity of the underlying OpenShift
+    layer.
+  rules: []
+- id: SI-3(9)
+  status: not applicable
+  notes: |-
+    The information system implements organization-defined security safeguards to authenticate
+    organization-defined remote commands is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes and is the responsiblity of the underlying OpenShift layer.
+  rules: []
+- id: SI-3(10)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section a.1: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section a.2: Monitoring the system to detect unauthorized local, network, and remote connections is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration. Functionality to meet this control can be provided by a third
+    party vendor.
+    Section b: Identifying unauthorized use of the information system through organization-defined
+    techniques and methods is an organizational control outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration. Functionality to meet this control can be
+    provided by a third party vendor.
+    Section c: Deploying monitoring devices is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration. Functionality to meet this
+    control can be provided by a third party vendor.
+    Section c.1: Deploying monitoring devices strategically within the information system to collect
+    organization-determined essential information is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Functionality to
+    meet this control can be provided by a third party vendor.
+    Section c.2: Deploying monitoring devices at ad hoc locations within the system to track specific types
+    of transactions of interest to the organization is an organizational control outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration. Functionality to
+    meet this control can be provided by a third party vendor.
+    Section d: Protecting information obtained from intrusion-monitoring tools from unauthorized access,
+    modification, and deletion is an organizational control outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration. Functionality to meet this
+    control can be provided by a third party vendor.
+    Section e: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section f: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section g: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: "The organization:\n a. Monitors the information system to detect:\n\
+    \   1. Attacks and indicators of potential attacks in accordance with [Assignment:\
+    \ organization- defined monitoring objectives]; and\n   2. Unauthorized local,\
+    \ network, and remote connections;\n b. Identifies unauthorized use of the information\
+    \ system through [Assignment: organization- defined techniques and methods];\n\
+    \ c. Deploys monitoring devices: (i) strategically within the information system\
+    \ to collect organization-determined essential information; and (ii) at ad hoc\
+    \ locations within the system to track specific types of transactions of interest\
+    \ to the organization;\n d. Protects information obtained from intrusion-monitoring\
+    \ tools from unauthorized access, modification, and deletion;\n e. Heightens the\
+    \ level of information system monitoring activity whenever there is an indication\
+    \ of increased risk to organizational operations and assets, individuals, other\
+    \ organizations, or the Nation based on law enforcement information, intelligence\
+    \ information, or other credible sources of information;\n f. Obtains legal opinion\
+    \ with regard to information system monitoring activities in accordance with applicable\
+    \ federal laws, Executive Orders, directives, policies, or regulations; and\n\
+    \ g. Provides [Assignment: or ganization-defined information system monitoring\
+    \ information] to [Assignment: organization-defined personnel or roles] [Selection\
+    \ (one or more): as needed; [Assignment: organization-defined frequency]].\n\n\
+    Supplemental Guidance:  Information system monitoring includes external and internal\
+    \ monitoring. External monitoring includes the observation of events occurring\
+    \ at the information system boundary (i.e., part of perimeter defense and boundary\
+    \ protection). Internal monitoring includes the observation of events occurring\
+    \ within the information system. Organizations can monitor information systems,\
+    \ for example, by observing audit activities in real time or by observing other\
+    \ system aspects such as access patterns, characteristics of access, and other\
+    \ actions. The monitoring objectives may guide determination of the events. Information\
+    \ system monitoring capability is achieved through a variety of tools and techniques\
+    \ (e.g., intrusion detection systems, intrusion prevention systems, malicious\
+    \ code protection software, scanning tools, audit record monitoring software,\
+    \ network monitoring software). Strategic locations for monitoring devices include,\
+    \ for example, selected perimeter locations and near server farms supporting critical\
+    \ applications, with such devices typically being employed at the managed interfaces\
+    \ associated with controls SC-7 and AC-17. Einstein network monitoring devices\
+    \ from the Department of Homeland Security can also be included as monitoring\
+    \ devices. The granularity of monitoring information collected is based on organizational\
+    \ monitoring objectives and the capability of information systems to support such\
+    \ objectives. Specific types of transactions of interest include, for example,\
+    \ Hyper Text Transfer Protocol (HTTP) traffic that bypasses HTTP proxies. Information\
+    \ system monitoring is an integral part of organizational continuous monitoring\
+    \ and incident response programs. Output from system monitoring serves as input\
+    \ to continuous monitoring and incident response programs. A network connection\
+    \ is any connection with a device that communicates through a network (e.g., local\
+    \ area network, Internet). A remote connection is any connection with a device\
+    \ communicating through an external network (e.g., the Internet). Local, network,\
+    \ and remote connections can be either wired or wireless. Related controls: AC-3,\
+    \ AC-4, AC-8, AC-17, AU-2, AU-6, AU-7, AU-9, AU-12, CA-7, IR-4, PE-3, RA-5, SC-7,\
+    \ SC-26, SC-35, SI-3, SI-7.\n\nReferences: NIST Special Publications 800-61, 800-83,\
+    \ 800-92, 800-94, 800-137.\n\n \nSI-4 Guidance: See US-CERT Incident Response\
+    \ Reporting Guidelines."
+  title: >-
+    SI-4 - INFORMATION SYSTEM MONITORING
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-4(1)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for integrating intrusion detection tools into the Red Hat
+    Advanced Cluster Management for Kubernetes environment, and documenting how this capability
+    is integrated into enterprise-wide intrusion detection systems when applicable. A
+    successful control response will address the workflow between local and enterprise
+    intrusion detection systems.
+  rules: []
+  description: |-
+    The organization connects and configures individual intrusion detection tools into an information system-wide intrusion detection system.
+  title: >-
+    SI-4(1) - INFORMATION SYSTEM MONITORING | SYSTEM-WIDE INTRUSION DETECTION SYSTEM
+  levels:
+  - high
+  - moderate
+- id: SI-4(2)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for deploying automated tools to
+    support near real-time analysis of events in their infrastructure.
+    This is frequently provided by corporate services outside the
+    information system, e.g. centralized security operation centers may
+    host an enterprise logging solution. A successful control response
+    will indicate who is responsible for hosting such capabilities, and
+    what technology and processes are in place to support near-realtime
+    analysis of events.
+  rules: []
+  description: |-
+    The organization employs automated tools to support near real-time analysis of events.
+
+    Supplemental Guidance:  Automated tools include, for example, host-based, network-based, transport-based, or storage-based event monitoring tools or Security Information and Event Management (SIEM) technologies that provide real time analysis of alerts and/or notifications generated by organizational information systems.
+  title: >-
+    SI-4(2) - INFORMATION SYSTEM MONITORING | AUTOMATED TOOLS FOR REAL-TIME ANALYSIS
+  levels:
+  - high
+  - moderate
+- id: SI-4(3)
+  status: not applicable
+  notes: |-
+    The organization employing automated tools to integrate intrusion detection tools into
+    access control and flow control mechanisms for rapid response to attacks by enabling
+    reconfiguration of these mechanisms in support of attack isolation and elimination is an
+    organizational control outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration.
+  rules: []
+- id: SI-4(4)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for identifying how and where
+    network traffic is continuously monitored. Frequently this control
+    is inherited from network and Infrastructure as a Service providers,
+    such as Microsoft Azure. A successful control response will indicate
+    if this control is inherited from infrastructure providers, and if
+    not, how network traffic is continuously monitored.
+  rules: []
+  description: |-
+    The information system monitors inbound and outbound communications traffic [Assignment: organization-defined frequency] for unusual or unauthorized activities or conditions.
+
+    Supplemental Guidance:  Unusual/unauthorized activities or conditions related to information system inbound and outbound communications traffic include, for example, internal traffic that indicates the presence of malicious code within organizational information systems or propagating among system components, the unauthorized exporting of information, or signaling to external information systems. Evidence of malicious code is used to identify potentially compromised information systems or information system components.
+
+    SI-4 (4) [continuously]
+  title: >-
+    SI-4(4) - INFORMATION SYSTEM MONITORING | INBOUND AND OUTBOUND COMMUNICATIONS
+    TRAFFIC
+  levels:
+  - high
+  - moderate
+- id: SI-4(5)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for automatic notification of
+    appropriate staff when indicators of compromise are detected.
+    Frequently this is accomplished by automatic alerting to Security
+    Operations Center staff. A successful control response will indicate
+    who is notified, by name or position title(s), and the mechanism of
+    the notification.
+  rules: []
+  description: |-
+    The information system alerts [Assignment: organization-defined personnel or roles] when the following indications of compromise or potential compromise occur: [Assignment: organization- defined compromise indicators].
+
+    Supplemental Guidance:  Alerts may be generated from a variety of sources, including, for example, audit records or inputs from malicious code protection mechanisms, intrusion detection or prevention mechanisms, or boundary protection devices such as firewalls, gateways, and routers. Alerts can be transmitted, for example, telephonically, by electronic mail messages, or by text messaging. Organizational personnel on the notification list can include, for example, system administrators, mission/business owners, system owners, or information system security officers. Related controls: AU-5, PE-6.
+
+    SI-4 (5) Guidance: In accordance with the incident response plan.
+  title: >-
+    SI-4(5) - INFORMATION SYSTEM MONITORING | SYSTEM-GENERATED ALERTS
+  levels:
+  - high
+  - moderate
+- id: SI-4(6)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-6(10).
+  rules: []
+- id: SI-4(7)
+  status: not applicable
+  notes: |-
+    The information system notifying incident response personnel of detected suspicious events
+    and takes least-disruptive actions to terminate suspicious events is outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration and is the responsiblity
+    of the underlying OpenShift layer.
+  rules: []
+- id: SI-4(8)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4(9)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4(10)
+  status: not applicable
+  notes: |-
+    The organization makes provisions so that encrypted communications traffic is visible to
+    information system monitoring tools is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration and is the responsiblity of the underlying
+    OpenShift layer.
+  rules: []
+- id: SI-4(11)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization analyzes outbound communications traffic at the external boundary of the information system and selected [Assignment: organization-defined interior points within the system (e.g., subnetworks, subsystems)] to discover anomalies.
+
+    Supplemental Guidance:  Anomalies within organizational information systems include, for example, large file transfers, long-time persistent connections, unusual protocols and ports in use, and attempted communications with suspected malicious external addresses.
+  title: >-
+    SI-4(11) - INFORMATION SYSTEM MONITORING | ANALYZE COMMUNICATIONS TRAFFIC ANOMALIES
+  levels:
+  - high
+- id: SI-4(12)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4(13)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section c: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4(14)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes infrastructure does not have wireless
+    capabilities.
+  rules: []
+  description: |-
+    The organization employs a wireless intrusion detection system to identify rogue wireless devices and to detect attack attempts and potential compromises/breaches to the information system.
+
+    Supplemental Guidance:  Wireless signals may radiate beyond the confines of organization- controlled facilities. Organizations proactively search for unauthorized wireless connections including the conduct of thorough scans for unauthorized wireless access points. Scans are not limited to those areas within facilities containing information systems, but also include areas outside of facilities as needed, to verify that unauthorized wireless access points are not connected to the systems. Related controls: AC-18, IA-3.
+  title: >-
+    SI-4(14) - INFORMATION SYSTEM MONITORING | WIRELESS INTRUSION DETECTION
+  levels:
+  - high
+  - moderate
+- id: SI-4(15)
+  status: not applicable
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes infrastructure does not have wireless
+    capabilities.
+  rules: []
+- id: SI-4(16)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for aggregating and correlating information from
+    monitoring tools, for multiple system components. This is frequently accomplished with
+    centralized audit reduction tools is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration and is the responsiblity of the underlying
+    OpenShift layer or a third party product.
+  rules: []
+  description: |-
+    The organization correlates information from monitoring tools employed throughout the information system.
+
+    Supplemental Guidance:  Correlating information from different monitoring tools can provide a more comprehensive view of information system activity. The correlation of monitoring tools that usually work in isolation (e.g., host monitoring, network monitoring, anti-virus software) can provide an organization-wide view and in so doing, may reveal otherwise unseen attack patterns. Understanding the capabilities/limitations of diverse monitoring tools and how to maximize the utility of information generated by those tools can help organizations to build, operate, and maintain effective monitoring programs. Related control: AU-6.
+  title: >-
+    SI-4(16) - INFORMATION SYSTEM MONITORING | CORRELATE MONITORING INFORMATION
+  levels:
+  - high
+  - moderate
+- id: SI-4(17)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4(18)
+  status: not applicable
+  notes: |-
+    The organization analyzing outbound communications traffic at the external boundary of the
+    information system (i.e., system perimeter) and at interior points within the system (e.g.,
+    subsystems, subnetworks] to detect covert exfiltration of information is outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration and is the
+    responsiblity of the underlying OpenShift layer or a third party product.
+  rules: []
+  description: |-
+    The organization analyzes outbound communications traffic at the external boundary of the information system (i.e., system perimeter) and at [Assignment: organization-defined interior points within the system (e.g., subsystems, subnetworks)] to detect covert exfiltration of information.
+
+    Supplemental Guidance:  Covert means that can be used for the unauthorized exfiltration of organizational information include, for example, steganography.
+  title: >-
+    SI-4(18) - INFORMATION SYSTEM MONITORING | ANALYZE TRAFFIC / COVERT EXFILTRATION
+  levels:
+  - high
+- id: SI-4(19)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined additional monitoring] of individuals who have been identified by [Assignment: organization-defined sources] as posing an increased level of risk.
+
+    Supplemental Guidance:  Indications of increased risk from individuals can be obtained from a variety of sources including, for example, human resource records, intelligence agencies, law enforcement organizations, and/or other credible sources. The monitoring of individuals is closely coordinated with management, legal, security, and human resources officials within organizations conducting such monitoring and complies with federal legislation, Executive Orders, policies, directives, regulations, and standards.
+  title: >-
+    SI-4(19) - INFORMATION SYSTEM MONITORING | INDIVIDUALS POSING GREATER RISK
+  levels:
+  - high
+- id: SI-4(20)
+  status: not applicable
+  notes: |-
+    The organization implementing additional monitoring of privileged users is outside the
+    scope of Red Hat Advanced Cluster Management for Kubernetes configuration and is the
+    responsiblity of the underlying OpenShift layer or a third party product.
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined additional monitoring] of privileged users.
+  title: >-
+    SI-4(20) - INFORMATION SYSTEM MONITORING | PRIVILEGED USER
+  levels:
+  - high
+- id: SI-4(21)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-4(22)
+  status: not applicable
+  notes: |-
+    The information system detecting network services that have not been authorized or approved
+    by authorization or approval processes and audits or alerts organization-defined personnel
+  rules: []
+  description: |-
+    The information system detects network services that have not been authorized or approved by [Assignment: organization-defined authorization or approval processes] and [Selection (one or more): audits; alerts [Assignment: organization-defined personnel or roles]].
+
+    Supplemental Guidance:  Unauthorized or unapproved network services include, for example, services in service-oriented architectures that lack organizational verification or validation and therefore may be unreliable or serve as malicious rogues for valid services. Related controls: AC-6, CM-7, SA-5, SA-9.
+  title: >-
+    SI-4(22) - INFORMATION SYSTEM MONITORING | UNAUTHORIZED NETWORK SERVICES
+  levels:
+  - high
+- id: SI-4(23)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for installing host-based monitoring mechanisms which is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
+    is the responsiblity of the underlying OpenShift layer.
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined host-based monitoring mechanisms] at [Assignment: organization-defined information system components].
+
+    Supplemental Guidance:  Information system components where host-based monitoring can be implemented include, for example, servers, workstations, and mobile devices. Organizations consider employing host-based monitoring mechanisms from multiple information technology product developers.
+  title: >-
+    SI-4(23) - INFORMATION SYSTEM MONITORING | HOST-BASED DEVICES
+  levels:
+  - high
+  - moderate
+- id: SI-4(24)
+  status: pending
+  notes: |-
+    The information system discovering, collecting, distributing, and uses indicators of
+    compromise is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration and is the responsiblity of the underlying OpenShift layer.
+  rules: []
+  description: |-
+    The information system discovers, collects, distributes, and uses indicators of compromise.
+
+    Supplemental Guidance:  Indicators of compromise (IOC) are forensic artifacts from intrusions that are identified on organizational information systems (at the host or network level). IOCs provide organizations with valuable information on objects or information systems that have been compromised. IOCs for the discovery of compromised hosts can include for example, the creation of registry key values. IOCs for network traffic include, for example, Universal Resource Locator (URL) or protocol elements that indicate malware command and control servers. The rapid distribution and adoption of IOCs can improve information security by reducing the time that information systems and organizations are vulnerable to the same exploit or attack.
+  title: >-
+    SI-4(24) - INFORMATION SYSTEM MONITORING | INDICATORS OF COMPROMISE
+  levels:
+  - high
+- id: SI-5
+  status: not applicable
+  notes: |-
+    Section a: Receiving information system security alerts, advisories, and directives from
+    organization-defined external organizations on an ongoing basis is an organizational
+    procedures/policies outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+
+    How to configure organization notifications for Red Hat security advisories on Red
+    Hat specific products can be accomplished following the following documentation:
+
+    https://access.redhat.com/security/updates/advisory
+    Section b: The organization generating internal security alerts, advisories, and directives as deemed
+    necessary is an organizational procedures/policies outside the scope of Red Hat Advanced
+    Cluster Management for Kubernetes configuration.
+    Section c: Disseminating security alerts, advisories, and directives to organization-defined personnel
+    or roles, organization-defined elements within the organization, organization-defined
+    external organizations are organizational procedures/policies outside the scope of Red Hat
+    Advanced Cluster Management for Kubernetes configuration.
+    Section d: Implementing security directives in accordance with established time frames or notifying
+    the issuing organization of the degree of noncompliance is an organizational
+    procedures/policies outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
+     b. Generates internal security alerts, advisories, and directives as deemed necessary;
+     c. Disseminates security alerts, advisories, and directives to: [Selection (one or more): [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined elements within the organization]; [Assignment: organization-defined external organizations]]; and
+     d. Implements security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.
+
+    Supplemental Guidance:  The United States Computer Emergency Readiness Team (US-CERT) generates security alerts and advisories to maintain situational awareness across the federal government. Security directives are issued by OMB or other designated organizations with the responsibility and authority to issue such directives. Compliance to security directives is essential due to the critical nature of many of these directives and the potential immediate adverse effects
+    on organizational operations and assets, individuals, other organizations, and the Nation should the directives not be implemented in a timely manner. External organizations include, for example, external mission/business partners, supply chain partners, external service providers, and other peer/supporting organizations. Related control: SI-2.
+
+    References: NIST Special Publication 800-40.
+
+    SI-5 (a) [to include US-CERT]
+    SI-5 (c) [to include system security personnel and administrators with configuration/patch-management responsibilities]
+  title: >-
+    SI-5 - SECURITY ALERTS, ADVISORIES, AND DIRECTIVES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-5(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to make security alert and advisory information available throughout the organization.
+
+    Supplemental Guidance:  The significant number of changes to organizational information systems and the environments in which those systems operate requires the dissemination of security-related information to a variety of organizational entities that have a direct interest in the success of organizational missions and business functions. Based on the information provided by the security alerts and advisories, changes may be required at one or more of the three tiers related to the management of information security risk including the governance level, mission/business process/enterprise architecture level, and the information system level.
+  title: >-
+    SI-5(1) - SECURITY ALERTS, ADVISORIES, AND DIRECTIVES | AUTOMATED ALERTS AND ADVISORIES
+  levels:
+  - high
+- id: SI-6
+  status: not applicable
+  notes: |-
+    Section a: The customer will be responsible for verifying the correct operation
+    of security functions within customer-controlled operating systems and
+    software. A successful control response will need to discuss the
+    security functions deemed necessary to verify, as well as the means
+    for testing the correct operation and resolving any issues found.
+    Section b: The customer will be responsible for performing security function
+    verification at customer-specified frequencies and under
+    customer-specified circumstances (to include the requirements stated
+    by FedRAMP). A successful control response will need to address the
+    rationale for selection of the specific frequency and circumstances
+    of security function verification.
+    Section c: The customer will be responsible for notifying appropriate personnel
+    of failed security verification tests. A successful control response
+    will need to outline the personnel or roles selected (to include
+    system administrators and security personnel as required by FedRAMP).
+    Section d: The customer will be responsible for performing appropriate actions
+    in response to anomalies in security unction verifiation. A successful
+    control response will need to discuss the actions taken (to include
+    notification of system administrators and security personnel as
+    required by FedRAMP) as well as the rationale for selecting these
+    actions.
+  rules: []
+  description: |-
+    The information system:
+     a. Verifies the correct operation of [Assignment: organization-defined security functions];
+     b. Performs this verification [Selection (one or more): [Assignment: organization-defined system transitional states]; upon command by user with appropriate privilege; [Assignment: organization-defined frequency]];
+     c. Notifies [Assignment: organization-defined personnel or roles] of failed security verification tests; and
+     d. [Selection (one or more): shuts the information system down; restarts the information system; [Assignment: organization-defined alternative action(s)]] when anomalies are discovered.
+
+    Supplemental Guidance: Transitional states for information systems include, for example, system startup, restart, shutdown, and abort. Notifications provided by information systems include, for example, electronic alerts to system administrators, messages to local computer consoles, and/or hardware indications such as lights. Related controls: CA-7, CM-6.
+
+    References: None.
+
+    SI-6 (b) [to include upon system startup and/or restart and at least monthly]
+    SI-6 (c) [to include system administrators and security personnel]
+    SI-6 (d) [to include notification of system administrators and security personnel]
+  title: >-
+    SI-6 - SECURITY FUNCTION VERIFICATION
+  levels:
+  - high
+  - moderate
+- id: SI-6(1)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SI-6.
+  rules: []
+- id: SI-6(2)
+  status: not applicable
+  notes: |-
+    The information system implementing automated mechanisms to support the management of
+    distributed security testing is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration and is the responsiblity of the underlying OpenShift layer.
+  rules: []
+- id: SI-6(3)
+  status: not applicable
+  notes: |-
+    The organization reports the results of security function verification to
+    organization-defined personnel is an organizational process/procedure outside the scope of
+    Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SI-7
+  status: not applicable
+  notes: |-
+    The customer will be responsible for employing integrity verification
+    tools for customer-controlled operating systems and software. A
+    successful control response will need to discuss the tools in use and
+    the integrity-checking mechanisms these tools employ.
+  rules: []
+  description: |-
+    The organization employs integrity verification tools to detect unauthorized changes to [Assignment: organization-defined software, firmware, and information].
+
+    Supplemental Guidance:  Unauthorized changes to software, firmware, and information can occur due to errors or malicious activity (e.g., tampering). Software includes, for example, operating systems (with key internal components such as kernels, drivers), middleware, and applications. Firmware includes, for example, the Basic Input Output System (BIOS). Information includes metadata such as security attributes associated with information. State-of-the-practice integrity- checking mechanisms (e.g., parity checks, cyclical redundancy checks, cryptographic hashes) and associated tools can automatically monitor the integrity of information systems and hosted applications. Related controls: SA-12, SC-8, SC-13, SI-3.
+
+    References: NIST Special Publications 800-147, 800-155.
+  title: >-
+    SI-7 - SOFTWARE, FIRMWARE, AND INFORMATION
+
+    INTEGRITY
+  levels:
+  - high
+  - moderate
+- id: SI-7(1)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for performing integrity checks at
+    customer-specific frequencies and under customer-specified
+    circumstances (including frequencies and circumstances specified by
+    FedRAMP). A successful control response will need to identify the
+    criteria for performing integrity checking, as well as the rationale
+    for selecting those criteria.
+  rules: []
+  description: "The information system performs an integrity check of [Assignment:\
+    \ organization-defined software, firmware, and information] [Selection (one or\
+    \ more): at startup; at [Assignment: organization-defined transitional states\
+    \ or security-relevant events]; [Assignment: organization- defined frequency]].\n\
+    \nSupplemental Guidance:  Security-relevant events include, for example, the identification\
+    \ of a new threat to which organizational information systems are susceptible,\
+    \ and the installation of new hardware, software, or firmware. Transitional states\
+    \ include, for example, system startup, restart, shutdown, and abort.\n\nSI-7(1)-1\
+    \ [selection to include security relevant events]  \nSI-7(1)-2 [at least monthly]"
+  title: >-
+    SI-7(1) - SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY | INTEGRITY CHECKS
+  levels:
+  - high
+  - moderate
+- id: SI-7(2)
+  status: not applicable
+  notes: |-
+    The organization employing automated tools that provide notification to
+    organization-defined personnel or roles upon discovering discrepancies during integrity
+    verification is outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+  description: |-
+    The organization employs automated tools that provide notification to [Assignment: organization- defined personnel or roles] upon discovering discrepancies during integrity verification.
+
+    Supplemental Guidance:  The use of automated tools to report integrity violations and to notify organizational personnel in a timely matter is an essential precursor to effective risk response. Personnel having an interest in integrity violations include, for example, mission/business owners, information system owners, systems administrators, software developers, systems integrators, and information security officers.
+  title: >-
+    SI-7(2) - SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY | AUTOMATED NOTIFICATIONS
+    OF INTEGRITY VIOLATIONS
+  levels:
+  - high
+- id: SI-7(3)
+  status: not applicable
+  notes: |-
+    The organization employing centrally managed integrity verification tools is an
+    organizational process/procedure outside the scope of Red Hat Advanced Cluster Management
+    for Kubernetes configuration.
+  rules: []
+- id: SI-7(4)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-6(10).
+  rules: []
+- id: SI-7(5)
+  status: not applicable
+  notes: |-
+    The information system automatically shutting the information system down, restarting the
+    information system, implementing organization-defined security safeguards when integrity
+    violations are discovered is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration and is the responsiblity of the underlying OpenShift layer.
+  rules: []
+  description: |-
+    The information system automatically [Selection (one or more): shuts the information system down; restarts the information system; implements [Assignment: organization-defined security safeguards]] when integrity violations are discovered.
+
+    Supplemental Guidance:  Organizations may define different integrity checking and anomaly responses: (i) by type of information (e.g., firmware, software, user data); (ii) by specific information (e.g., boot firmware, boot firmware for a specific types of machines); or (iii) a combination of both. Automatic implementation of specific safeguards within organizational information systems includes, for example, reversing the changes, halting the information system, or triggering audit alerts when unauthorized modifications to critical security files occur.
+  title: >-
+    SI-7(5) - SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY | AUTOMATED RESPONSE TO
+    INTEGRITY VIOLATIONS
+  levels:
+  - high
+- id: SI-7(6)
+  status: not applicable
+  notes: |-
+    The information system implementing cryptographic mechanisms to detect unauthorized changes
+    to software, firmware, and information is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration and is the responsiblity of the underlying
+    OpenShift layer.
+  rules: []
+- id: SI-7(7)
+  status: not applicable
+  notes: |-
+    The customer will be responsible for incorporating the detection of
+    customer-defined security-relevant changes into the customers incident
+    response capability. A successful control response will need to
+    outline the process for deeming particular changes as
+    security-relevant and the means by which the incident response
+    capability is invoked when needed.
+  rules: []
+  description: |-
+    The organization incorporates the detection of unauthorized [Assignment: organization-defined security-relevant changes to the information system] into the organizational incident response capability.
+
+    Supplemental Guidance:  This control enhancement helps to ensure that detected events are tracked, monitored, corrected, and available for historical purposes. Maintaining historical records is important both for being able to identify and discern adversary actions over an extended period of time and for possible legal actions. Security-relevant changes include, for example, unauthorized changes to established configuration settings or unauthorized elevation of information system privileges. Related controls: IR-4, IR-5, SI-4.
+  title: >-
+    SI-7(7) - SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY | INTEGRATION OF DETECTION
+    AND RESPONSE
+  levels:
+  - high
+  - moderate
+- id: SI-7(8)
+  status: not applicable
+  notes: |-
+    The information system, upon detection of a potential integrity violation, provides the
+    capability to audit the event and generates an audit record, alerts current user, alerts
+    organization-defined personnel organization-defined other
+    actions
+  rules: []
+- id: SI-7(9)
+  status: not applicable
+  notes: |-
+    The information system verifying the integrity of the boot process of organization-defined
+    devices is outside the scope of Red Hat Advanced Cluster Management for
+    Kubernetes configuration and is the responsiblity of the underlying OpenShift layer.
+  rules: []
+- id: SI-7(10)
+  status: not applicable
+  notes: |-
+    The information system implementing security safeguards to protect the integrity of boot
+    firmware in organization-defined devices is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration and is the responsiblity of the underlying
+    OpenShift layer.
+  rules: []
+- id: SI-7(11)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-7(12)
+  status: not applicable
+  notes: |-
+    The organization requireing that the integrity of user-installed software be verified prior
+    to execution is outside the scope of Red Hat Advanced Cluster Management for Kubernetes
+    configuration and is the responsiblity of the underlying OpenShift layer.
+  rules: []
+- id: SI-7(13)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-7(14)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     (a)   Prohibits the use of binary or machine-executable code from sources with limited or no warranty and without the provision of source code; and
+     (b)   Provides exceptions to the source code requirement only for compelling mission/operational requirements and with the approval of the authorizing official.
+
+    Supplemental Guidance:  This control enhancement applies to all sources of binary or machine- executable code including, for example, commercial software/firmware and open source software. Organizations assess software products without accompanying source code from sources with limited or no warranty for potential security impacts. The assessments address the fact that these types of software products may be very difficult to review, repair, or extend, given that organizations, in most cases, do not have access to the original source code, and there may be no owners who could make such repairs on behalf of organizations. Related control: SA-5.
+  title: >-
+    SI-7(14) - SOFTWARE, FIRMWARE, AND INFORMATION INTEGRITY | BINARY OR MACHINE EXECUTABLE
+    CODE
+  levels:
+  - high
+- id: SI-7(15)
+  status: not applicable
+  notes: |-
+    The information system implementing cryptographic mechanisms to authenticate software or
+    firmware components prior to installation is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration and is the responsiblity of the underlying
+    OpenShift layer.
+  rules: []
+- id: SI-7(16)
+  status: not applicable
+  notes: |-
+    The organization preventing processes to execute without supervision for more than an
+    organization-defined time period reflects organizational procedures/policies that are
+    not applicable to the configuration of Red Hat Advanced Cluster Management for
+    Kubernetes.
+  rules: []
+- id: SI-8
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section b: This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization:
+     a. Employs spam protection mechanisms at information system entry and exit points to detect and take action on unsolicited messages; and
+     b. Updates spam protection mechanisms when new releases are available in accordance with organizational configuration management policy and procedures.
+
+    Supplemental Guidance:  Information system entry and exit points include, for example, firewalls, electronic mail servers, web servers, proxy servers, remote-access servers, workstations, mobile devices, and notebook/laptop computers. Spam can be transported by different means including, for example, electronic mail, electronic mail attachments, and web accesses. Spam protection mechanisms include, for example, signature definitions. Related controls: AT-2, AT-3, SC-5, SC-7, SI-3.
+
+    References: NIST Special Publication 800-45.
+  title: >-
+    SI-8 - SPAM PROTECTION
+  levels:
+  - high
+  - moderate
+- id: SI-8(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The organization centrally manages spam protection mechanisms.
+
+    Supplemental Guidance:  Central management is the organization-wide management and implementation of spam protection mechanisms. Central management includes planning, implementing, assessing, authorizing, and monitoring the organization-defined, centrally managed spam protection security controls. Related controls: AU-3, SI-2, SI-7.
+  title: >-
+    SI-8(1) - SPAM PROTECTION | CENTRAL MANAGEMENT
+  levels:
+  - high
+  - moderate
+- id: SI-8(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+  description: |-
+    The information system automatically updates spam protection mechanisms.
+  title: >-
+    SI-8(2) - SPAM PROTECTION | AUTOMATIC UPDATES
+  levels:
+  - high
+  - moderate
+- id: SI-8(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-9
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into AC-2, AC-3, AC-5 and AC-6.
+  rules: []
+- id: SI-10
+  status: pending
+  notes: |-
+    A control response for SI-10 is planned. Engineering progress can be
+    tracked via:
+
+    https://issues.redhat.com/browse/ACM-408
+  rules: []
+  description: |-
+    The information system checks the validity of [Assignment: organization-defined information inputs].
+
+    Supplemental Guidance:  Checking the valid syntax and semantics of information system inputs (e.g., character set, length, numerical range, and acceptable values) verifies that inputs match specified definitions for format and content. Software applications typically follow well-defined protocols that use structured messages (i.e., commands or queries) to communicate between software modules or system components. Structured messages can contain raw or unstructured data interspersed with metadata or control information. If software applications use attacker- supplied inputs to construct structured messages without properly encoding such messages, then the attacker could insert malicious commands or special characters that can cause the data to be interpreted as control information or metadata. Consequently, the module or component that receives the tainted output will perform the wrong operations or otherwise interpret the data incorrectly. Prescreening inputs prior to passing to interpreters prevents the content from being unintentionally interpreted as commands. Input validation helps to ensure accurate and correct inputs and prevent attacks such as cross-site scripting and a variety of injection attacks.
+
+    References: None.
+  title: >-
+    SI-10 - INFORMATION INPUT VALIDATION
+  levels:
+  - high
+  - moderate
+- id: SI-10(1)
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section d: This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+    Section c: This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-10(2)
+  status: pending
+  notes: |-
+    The organization ensures that input validation errors are reviewed and resolved within an
+    organization-defined time period is an organizational procedures/policies outside the scope
+    of Red Hat Advanced Cluster Management for Kubernetes configuration.
+  rules: []
+- id: SI-10(3)
+  status: pending
+  notes: |-
+    A control response for SI-10(3) is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-10(4)
+  status: pending
+  notes: |-
+    A control response for SI-10(4) is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-10(5)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-11
+  status: not applicable
+  notes: |-
+    Section a: The information system generating error messages that provide information necessary for
+    corrective actions without revealing information that could be exploited by adversaries is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
+    is the responsiblity of the underlying OpenShift layer.
+    Section b: The information system revealing error messages only to organization-defined personnel is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
+    is the responsiblity of the underlying OpenShift layer.
+  rules: []
+  description: |-
+    The information system:
+     a. Generates error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries; and
+     b. Reveals error messages only to [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:  Organizations carefully consider the structure/content of error messages. The extent to which information systems are able to identify and handle error conditions is guided by organizational policy and operational requirements. Information that could be exploited by adversaries includes, for example, erroneous logon attempts with passwords entered by mistake as the username, mission/business information that can be derived from (if not stated explicitly by) information recorded, and personal information such as account numbers, social security numbers, and credit card numbers. In addition, error messages may provide a covert channel for transmitting information. Related controls: AU-2, AU-3, SC-31.
+
+    Control Enhancements:  None.
+
+    References:  None.
+  title: >-
+    SI-11 - ERROR HANDLING
+  levels:
+  - high
+  - moderate
+- id: SI-12
+  status: not applicable
+  notes: |-
+    The customer will be responsible for handling and retaining
+    information within, or hosted by, Red Hat Advanced Cluster Management for Kubernetes in
+    accordance with applicable federal laws, Executive Orders,
+    directives, policies, regulations, standards, and operational
+    requirements. A successful control response will need to outline
+    the specific requirements applicable to customer information
+    handling and retention, and the means by which those requirements
+    are met.
+  rules: []
+  description: |-
+    The organization handles and retains information within the information system and information output from the system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and operational requirements.
+
+    Supplemental Guidance:  Information handling and retention requirements cover the full life cycle of information, in some cases extending beyond the disposal of information systems. The National Archives and Records Administration provides guidance on records retention. Related controls: AC-16, AU-5, AU-11, MP-2, MP-4.
+
+    Control Enhancements: None.
+
+    References: None.
+  title: >-
+    SI-12 - INFORMATION HANDLING AND RETENTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-13
+  status: pending
+  notes: |-
+    Section a: A control response for SI-13(a) is planned. Engineering progress can be
+    tracked via:
+    Section b: A control response for SI-13(b) is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-13(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedures/policies that are not applicable to the
+    configuration of Red Hat Advanced Cluster Management for Kubernetes.
+  rules: []
+- id: SI-13(2)
+  status: not applicable
+  notes: |-
+    This control was withdrawn by NIST, and incorporated into SI-7(16).
+  rules: []
+- id: SI-13(3)
+  status: pending
+  notes: |-
+    A control response for SI-13(3) is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-13(4)
+  status: not applicable
+  notes: |-
+    Section a: A control response for SI-13(4) is planned. Engineering progress can be
+    tracked via:
+    Section b: A control response for SI-13(4) is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-13(5)
+  status: pending
+  notes: |-
+    A control response for SI-13(5) is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-14
+  status: pending
+  notes: |-
+    A control response for SI-14 is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-14(1)
+  status: supported
+  notes: |-
+    Red Hat Advanced Cluster Management for Kubernetes provides methods for attaining vendor
+    software from trusted vendor sources for online or disconnected environments. Documentation
+    on how to get trusted vendor software for Red Hat Advanced Cluster Management for
+    Kubernetes can be viewed at:
+
+    https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html-single/install/index#install-on-disconnected-networks
+  rules: []
+- id: SI-15
+  status: pending
+  notes: |-
+    A control response for SI-15 is planned. Engineering progress can be
+    tracked via:
+  rules: []
+- id: SI-16
+  status: not applicable
+  notes: |-
+    The information system implementing organization-defined security safeguards to protect its
+    memory from unauthorized code execution is outside the scope of Red Hat Advanced Cluster
+    Management for Kubernetes configuration and is the responsiblity of the underlying
+    operating system layer which OpenShift nodes operate under.
+  rules: []
+  description: |-
+    The information system implements [Assignment: organization-defined security safeguards] to protect its memory from unauthorized code execution.
+
+    Supplemental Guidance:  Some adversaries launch attacks with the intent of executing code in non- executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced with hardware providing the greater strength of mechanism. Related controls: AC-25, SC-3.
+
+    Control Enhancements:  None.
+
+    References:  None.
+  title: >-
+    SI-16 - MEMORY PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-17
+  status: not applicable
+  notes: |-
+    The information system implements fail-safe procedures when failure conditions occur is
+    outside the scope of Red Hat Advanced Cluster Management for Kubernetes configuration and
+    is the responsiblity of the underlying OpenShift layer.
+  rules: []


### PR DESCRIPTION
This migrates the contents of OpenControl towards the control structure.
Currently there are no rules enabled for this, but this facilitates
that.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>