### PR TITLE
Migrate RH IdM NIST evaluation from OpenControl to controls structure

### DIFF
--- a/controls/nist_rhidm.yml
+++ b/controls/nist_rhidm.yml
@@ -1,0 +1,5143 @@
+policy: NIST
+title: Configuration Recommendations for Red Hat Identity Management
+id: nist_rhidm
+version: Revision 4
+source: https://www.fedramp.gov/assets/resources/documents/FedRAMP_Security_Controls_Baseline.xlsx
+levels:
+- id: low
+- id: moderate
+- id: high
+controls:
+- id: AC-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An access control policy that\
+    \ addresses purpose, scope, roles, responsibilities, management commitment, coordination\
+    \ among organizational entities, and compliance; and\n   2. Procedures to facilitate\
+    \ the implementation of the access control policy and associated access controls;\
+    \ and\n b. Reviews and updates the current:\n   1. Access control policy [Assignment:\
+    \ organization-defined frequency]; and\n   2. Access control procedures [Assignment:\
+    \ organization-defined frequency].\n\nSupplemental Guidance: This control addresses\
+    \ the establishment of policy and procedures for the effective implementation\
+    \ of selected security controls and control enhancements in the AC family. Policy\
+    \ and procedures reflect applicable federal laws, Executive Orders, directives,\
+    \ regulations, policies, standards, and guidance. Security program policies and\
+    \ procedures at the organization level may make the need for system-specific policies\
+    \ and procedures unnecessary. The policy can be included as part of the general\
+    \ information security policy for organizations or conversely, can be represented\
+    \ by multiple policies reflecting the complex nature of certain organizations.\
+    \ The procedures can be established for the security program in general and for\
+    \ particular information systems, if needed. \n\nThe organizational risk management\
+    \ strategy is a key factor in establishing policy and procedures. Related control:\
+    \ PM-9.\nControl Enhancements: None.\nReferences: NIST Special Publications 800-12,\
+    \ 800-100.\n\nAC-1 (b) (1) [at least annually] \nAC-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    AC-1 - ACCESS CONTROL POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Identifies and selects the following types of information system accounts to support organizational missions/business functions: [Assignment: organization-defined information system account types];
+     b. Assigns account managers for information system accounts;
+     c. Establishes conditions for group and role membership;
+     d. Specifies authorized users of the information system, group and role membership, and access authorizations (i.e., privileges) and other attributes (as required) for each account;
+     e. Requires approvals by [Assignment: organization-defined personnel or roles] for requests to create information system accounts;
+     f. Creates, enables, modifies, disables, and removes information system accounts in accordance with [Assignment: organization-defined procedures or conditions];
+     g. Monitors the use of, information system accounts;
+     h. Notifies account managers:
+       1. When accounts are no longer required;
+       2. When users are terminated or transferred; and
+       3. When individual information system usage or need-to-know changes;
+     i. Authorizes access to the information system based on:
+       1. A valid access authorization;
+       2. Intended system usage; and
+       3. Other attributes as required by the organization or associated missions/business functions;
+     j. Reviews accounts for compliance with account management requirements [Assignment: organization-defined frequency]; and
+     k. Establishes a process for reissuing shared/group account credentials (if deployed) when individuals are removed from the group.
+    Supplemental Guidance: Information system account types include individual, shared, group, system, guest/anonymous, emergency, developer/manufacturer/vendor, temporary, and service. Some of the account management requirements listed above can be implemented by organizational information systems. The identification of authorized users of the information system and the specification of access privileges reflects the requirements in other security controls in the security plan. Users requiring administrative privileges on information system accounts receive additional scrutiny by appropriate organizational personnel (e.g., system owner, mission/business owner, or chief information security officer) responsible for approving such accounts and privileged access. Organizations may choose to define access privileges or other attributes by account, by type of account, or a combination of both. Other attributes required for authorizing access include, for example, restrictions on time-of-day, day-of-week, and point-of-origin. In defining other account attributes, organizations consider system-related requirements (e.g., scheduled maintenance, system upgrades) and mission/business requirements, (e.g., time zone differences, customer requirements, remote access to support travel requirements). Failure to consider these factors could affect information system availability. Temporary and emergency accounts are accounts intended for short-term use. Organizations establish temporary accounts as a part of normal account activation procedures when there is a need for short-term accounts without the demand for immediacy in account activation. Organizations establish emergency accounts in response to crisis situations and with the need for rapid account activation. Therefore, emergency account activation may bypass normal account authorization processes. Emergency and temporary accounts are not to be confused with infrequently used accounts (e.g., local logon accounts used for special tasks defined by organizations or when network resources are unavailable). Such accounts remain available and are not subject to automatic disabling or removal dates. Conditions for disabling or deactivating accounts include, for example: (i) when shared/group, emergency, or temporary accounts are no longer required; or (ii) when individuals are transferred or terminated. Some types of information system accounts may require specialized training. Related controls: AC-3, AC-4, AC-5, AC-6, AC-10, AC-17, AC-19, AC-20, AU-9, IA-2, IA-4, IA-5, IA-8, CM-5, CM-6, CM-11, MA-3, MA-4, MA-5, PL-4, SC-13.
+
+    References: None.
+
+
+    AC-2 (j) [monthly for privileged accessed, every six (6) months for non-privileged access]
+  title: >-
+    AC-2 - ACCOUNT MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-3
+  status: pending
+  notes: |-
+    'Documentation/guidance for satisfying this control is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/2'
+  rules: []
+  description: |-
+    The information system enforces approved authorizations for logical access to information and system resources in accordance with applicable access control policies.
+
+    Supplemental Guidance: Access control policies (e.g., identity-based policies, role-based policies, attribute-based policies) and access enforcement mechanisms (e.g., access control lists, access control matrices, cryptography) control access between active entities or subjects (i.e., users or processes acting on behalf of users) and passive entities or objects (e.g., devices, files, records, domains) in information systems. In addition to enforcing authorized access at the information system level and recognizing that information systems can host many applications and services in support of organizational missions and business operations, access enforcement mechanisms can also be employed at the application and service level to provide increased information security. Related controls: AC-2, AC-4, AC-5, AC-6, AC-16, AC-17, AC-18, AC-19, AC-20, AC-21, AC-22, AU-9, CM-5, CM-6, CM-11, MA-3, MA-4, MA-5, PE-3.
+
+    References: None.
+  title: >-
+    AC-3 - ACCESS ENFORCEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-7
+  status: pending
+  notes: |-
+    Section a: 'Documentation/guidance on satisfying this control is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/3'
+
+    Section b: 'Documentation/guiodance for this control is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/4'
+  rules: []
+  description: "The information system:\n a. Enforces a limit of [Assignment: organization-defined\
+    \ number] consecutive invalid logon attempts by a user during a [Assignment: organization-defined\
+    \ time period]; and\n b. Automatically [Selection: locks the account/node for\
+    \ an [Assignment: organization-defined time period]; locks the account/node until\
+    \ released by an administrator; delays next logon prompt according to [Assignment:\
+    \ organization-defined delay algorithm]] when the maximum number of unsuccessful\
+    \ attempts is exceeded.\n\nSupplemental Guidance:  This control applies regardless\
+    \ of whether the logon occurs via a local or network connection. Due to the potential\
+    \ for denial of service, automatic lockouts initiated by information systems are\
+    \ usually temporary and automatically release after a predetermined time period\
+    \ established by organizations. If a delay algorithm is selected, organizations\
+    \ may choose to employ different algorithms for different information system components\
+    \ based on the capabilities of those components. Responses to unsuccessful logon\
+    \ attempts may be implemented at both the operating system and the application\
+    \ levels. Related controls: AC-2, AC-9, AC-14, IA-5.\n\nReferences: None.\n\n\
+    AC-7(a)-1 [not more than three (3)]\n \nAC-7(a)-2 [fifteen (15) minutes] \n\n\
+    AC-7(b) [locks the account/node for a minimum of three (3) hours or until unlocked\
+    \ by an administrator]"
+  title: >-
+    AC-7 - UNSUCCESSFUL LOGON ATTEMPTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-8
+  status: pending
+  notes: |-
+    Section a: 'Documentation/guidance for this control is being tracked on
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/5'
+
+    Section b: 'Documentation/guidance for this control is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/6'
+
+    Section c: 'The banner text, as identified in AC-8(a), and banner acknowledgement,
+    as defined in AC-8(b), will be the same regardless of what network(s)
+    the Red Hat Identity Management console is accessed from. This control
+    is not applicable.'
+  rules: []
+  description: "The information system:\n a. Displays to users [Assignment: organization-defined\
+    \ system use notification message or banner] before granting access to the system\
+    \ that provides privacy and security notices consistent with applicable federal\
+    \ laws, Executive Orders, directives, policies, regulations, standards, and guidance\
+    \ and states that:\n   1. Users are accessing a U.S. Government information system;\n\
+    \   2. Information system usage may be monitored, recorded, and subject to audit;\n\
+    \   3. Unauthorized use of the information system is prohibited and subject to\
+    \ criminal and civil penalties; and\n   4. Use of the information system indicates\
+    \ consent to monitoring and recording;\n b. Retains the notification message or\
+    \ banner on the screen until users acknowledge the usage conditions and take explicit\
+    \ actions to log on to or further access the information system; and \n c. For\
+    \ publicly accessible systems:\n   1. Displays system use information [Assignment:\
+    \ organization-defined conditions], before granting further access;\n   2. Displays\
+    \ references, if any, to monitoring, recording, or auditing that are consistent\
+    \ with privacy accommodations for such systems that generally prohibit those activities;\
+    \ and\n   3. Includes a description of the authorized uses of the system.\n\n\
+    Supplemental Guidance:  System use notifications can be implemented using messages\
+    \ or warning banners displayed before individuals log in to information systems.\
+    \ System use notifications are used only for access via logon interfaces with\
+    \ human users and are not required when such human interfaces do not exist. Organizations\
+    \ consider system use notification messages/banners displayed in multiple languages\
+    \ based on specific organizational needs and the demographics of information system\
+    \ users. Organizations also consult with the Office of the General Counsel for\
+    \ legal review and approval of warning banner content.\n\nControl Enhancements:\
+    \  None.\n\nReferences: None.\n\n\nAC-8 (a) [see additional Requirements and Guidance]\n\
+    AC-8 (c) [see additional Requirements and Guidance]\nAC-8 Requirement: The service\
+    \ provider shall determine elements of the cloud environment that require the\
+    \ System Use Notification control. The elements of the cloud environment that\
+    \ require System Use Notification are approved and accepted by the JAB/AO. \n\
+    Requirement: The service provider shall determine how System Use Notification\
+    \ is going to be verified and provide appropriate periodicity of the check. The\
+    \ System Use Notification verification and periodicity are approved and accepted\
+    \ by the JAB/AO.\nGuidance: If performed as part of a Configuration Baseline check,\
+    \ then the % of items requiring setting that are checked and that pass (or fail)\
+    \ check can be provided. \nRequirement: If not performed as part of a Configuration\
+    \ Baseline check, then there must be documented agreement on how to provide results\
+    \ of verification and the necessary periodicity of the verification by the service\
+    \ provider. The documented agreement on how to provide verification of the results\
+    \ are approved and accepted by the JAB/AO."
+  title: >-
+    AC-8 - SYSTEM USE NOTIFICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-14
+  status: supported
+  notes: |-
+    'Regardless of access mechanism, such as the Red Hat Identity Management
+    console, unauthenticated users will only be shown the
+    system use notifications (as defined in AC-8) and login prompt. This is
+    non-configurable behavior.
+
+    External service APIs also require authentication
+    prior to granting resource access.'
+  rules: []
+  description: "The organization:\n a. Identifies [Assignment: organization-defined\
+    \ user actions] that can be performed on the information system without identification\
+    \ or authentication consistent with organizational missions/business functions;\
+    \ and\n b. Documents and provides supporting rationale in the security plan for\
+    \ the information system, user actions not requiring identification or authentication.\n\
+    \nSupplemental Guidance:  This control addresses situations in which organizations\
+    \ determine that no identification or authentication is required in organizational\
+    \ information systems. Organizations may allow a limited number of user actions\
+    \ without identification or authentication including, for example, when individuals\
+    \ access public websites or other publicly accessible federal information systems,\
+    \ when individuals use mobile phones to receive calls, or when facsimiles are\
+    \ received. Organizations also identify actions that normally require identification\
+    \ or authentication but may under certain circumstances (e.g., emergencies), allow\
+    \ identification or authentication mechanisms to be bypassed. Such bypasses may\
+    \ occur, for example, via a software-readable physical switch that commands bypass\
+    \ of the logon functionality and is protected from accidental or unmonitored use.\
+    \ This control does not apply to situations where identification and authentication\
+    \ have already occurred and are not repeated, but rather to situations where identification\
+    \ and authentication have not yet occurred. Organizations may decide that there\
+    \ are no user actions that can be performed on organizational information systems\
+    \ without identification and authentication and thus, the values for assignment\
+    \ statements can be none. Related controls: CP-2, IA-2.\n\nControl Enhancements:\
+    \  None.\n\n(1)   PERMITTED ACTIONS WITHOUT IDENTIFICATION OR AUTHENTICATION |\
+    \ NECESSARY USES\n[Withdrawn: Incorporated into AC-14]. \n\nReferences:  None."
+  title: >-
+    AC-14 - PERMITTED ACTIONS WITHOUT IDENTIFICATION OR
+
+    AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-17
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes and documents usage restrictions, configuration/connection requirements, and implementation guidance for each type of remote access allowed; and
+     b. Authorizes remote access to the information system prior to allowing such connections.
+
+    Supplemental Guidance:  Remote access is access to organizational information systems by users (or processes acting on behalf of users) communicating through external networks (e.g., the Internet). Remote access methods include, for example, dial-up, broadband, and wireless. Organizations often employ encrypted virtual private networks (VPNs) to enhance confidentiality and integrity over remote connections. The use of encrypted VPNs does not make the access non-remote; however, the use of VPNs, when adequately provisioned with appropriate security controls (e.g., employing appropriate encryption techniques for confidentiality and integrity protection) may provide sufficient assurance to the organization that it can effectively treat such connections as internal networks. Still, VPN connections traverse external networks, and the encrypted VPN does not enhance the availability of remote connections. Also, VPNs with encrypted tunnels can affect the organizational capability to adequately monitor network communications traffic for malicious code. Remote access controls apply to information systems other than public web servers or systems designed for public access. This control addresses authorization prior to allowing remote access without specifying the formats for such authorization. While organizations may use interconnection security agreements to authorize remote access connections, such agreements are not required by this control. Enforcing access restrictions for remote connections is addressed in AC-3. Related controls: AC-2, AC-3, AC-18, AC-19, AC-20, CA-3, CA-7, CM-8, IA-2, IA-3, IA-8, MA-4, PE-17, PL-4, SC-10, SI-4.
+
+    References: NIST Special Publications 800-46, 800-77, 800-113, 800-114, 800-121.
+  title: >-
+    AC-17 - REMOTE ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-18
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes usage restrictions, configuration/connection requirements, and implementation guidance for wireless access; and
+     b. Authorizes wireless access to the information system prior to allowing such connections.
+
+    Supplemental Guidance:  Wireless technologies include, for example, microwave, packet radio (UHF/VHF), 802.11x, and Bluetooth. Wireless networks use authentication protocols (e.g., EAP/TLS, PEAP), which provide credential protection and mutual authentication. Related controls: AC-2, AC-3, AC-17, AC-19, CA-3, CA-7, CM-8, IA-2, IA-3, IA-8, PL-4, SI-4.
+
+    References: NIST Special Publications 800-48, 800-94, 800-97.
+  title: >-
+    AC-18 - WIRELESS ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-19
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes usage restrictions, configuration requirements, connection requirements, and implementation guidance for organization-controlled mobile devices; and
+     b. Authorizes the connection of mobile devices to organizational information systems.
+
+    Supplemental Guidance:  A mobile device is a computing device that: (i) has a small form factor such that it can easily be carried by a single individual; (ii) is designed to operate without a physical connection (e.g., wirelessly transmit or receive information); (iii) possesses local, non- removable or removable data storage; and (iv) includes a self-contained power source. Mobile devices may also include voice communication capabilities, on-board sensors that allow the device to capture information, and/or built-in features for synchronizing local data with remote locations. Examples include smart phones, E-readers, and tablets. Mobile devices are typically associated with a single individual and the device is usually in close proximity to the individual; however, the degree of proximity can vary depending upon on the form factor and size of the device. The processing, storage, and transmission capability of the mobile device may be comparable to or merely a subset of desktop systems, depending upon the nature and intended purpose of the device. Due to the large variety of mobile devices with different technical characteristics and capabilities, organizational restrictions may vary for the different classes/types of such devices. Usage restrictions and specific implementation guidance for mobile devices include, for example, configuration management, device identification and authentication, implementation of mandatory protective software (e.g., malicious code detection, firewall), scanning devices for malicious code, updating virus protection software, scanning for critical software updates and patches, conducting primary operating system (and possibly other resident software) integrity checks, and disabling unnecessary hardware (e.g., wireless, infrared). Organizations are cautioned that the need to provide adequate security for mobile devices goes beyond the requirements in this control. Many safeguards and countermeasures for mobile devices are reflected in other security controls in the catalog allocated in the initial control baselines as starting points for the development of security plans and overlays using the tailoring process. There may also be some degree of overlap in the requirements articulated by the security controls within the different families of controls. AC-20 addresses mobile devices that are not organization-controlled. Related controls: AC-3, AC-7, AC-18, AC-20, CA-9, CM-2, IA-2, IA-3, MP-2, MP-4, MP-5, PL-4, SC-7, SC-43, SI-3, SI-4.
+
+    References: OMB Memorandum 06-16; NIST Special Publications 800-114, 800-124, 800-164.
+  title: >-
+    AC-19 - ACCESS CONTROL FOR MOBILE DEVICES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-20
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization establishes terms and conditions, consistent with any trust relationships established with other organizations owning, operating, and/or maintaining external information systems, allowing authorized individuals to:
+     a. Access the information system from external information systems; and
+     b. Process, store, or transmit organization-controlled information using external information systems.
+
+    Supplemental Guidance:  External information systems are information systems or components of information systems that are outside of the authorization boundary established by organizations and for which organizations typically have no direct supervision and authority over the application of required security controls or the assessment of control effectiveness. External information systems include, for example: (i) personally owned information systems/devices (e.g., notebook computers, smart phones, tablets, personal digital assistants); (ii) privately owned computing and communications devices resident in commercial or public facilities (e.g., hotels, train stations, convention centers, shopping malls, or airports); (iii) information systems owned or controlled by nonfederal governmental organizations; and (iv) federal information systems that are not owned by, operated by, or under the direct supervision and authority of organizations. This control also addresses the use of external information systems for the processing, storage, or transmission of
+    organizational information, including, for example, accessing cloud services (e.g., infrastructure as a service, platform as a service, or software as a service) from organizational information systems.
+
+    For some external information systems (i.e., information systems operated by other federal agencies, including organizations subordinate to those agencies), the trust relationships that have been established between those organizations and the originating organization may be such, that no explicit terms and conditions are required. Information systems within these organizations
+    would not be considered external. These situations occur when, for example, there are pre-existing sharing/trust agreements (either implicit or explicit) established between federal agencies or organizations subordinate to those agencies, or when such trust agreements are specified by applicable laws, Executive Orders, directives, or policies. Authorized individuals include, for example, organizational personnel, contractors, or other individuals with authorized access to organizational information systems and over which organizations have the authority to impose rules of behavior with regard to system access. Restrictions that organizations impose on authorized individuals need not be uniform, as those restrictions may vary depending upon the
+    trust relationships between organizations. Therefore, organizations may choose to impose different security restrictions on contractors than on state, local, or tribal governments.
+
+    This control does not apply to the use of external information systems to access public interfaces to organizational information systems (e.g., individuals accessing federal information through www.usa.gov). Organizations establish terms and conditions for the use of external information systems in accordance with organizational security policies and procedures. Terms and conditions address as a minimum: types of applications that can be accessed on organizational information systems from external information systems; and the highest security category of information that can be processed, stored, or transmitted on external information systems. If terms and conditions with the owners of external information systems cannot be established, organizations may impose restrictions on organizational personnel using those external systems. Related controls: AC-3, AC-17, AC-19, CA-3, PL-4, SA-9.
+
+    References: FIPS Publication 199.
+  title: >-
+    AC-20 - USE OF EXTERNAL INFORMATION SYSTEMS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AC-22
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Designates individuals authorized to post information onto a publicly accessible information system;
+     b. Trains authorized individuals to ensure that publicly accessible information does not contain nonpublic information;
+     c. Reviews the proposed content of information prior to posting onto the publicly accessible information system to ensure that nonpublic information is not included; and
+     d. Reviews the content on the publicly accessible information system for nonpublic information [Assignment: organization-defined frequency] and removes such information, if discovered.
+
+    Supplemental Guidance:  In accordance with federal laws, Executive Orders, directives, policies, regulations, standards, and/or guidance, the general public is not authorized access to nonpublic information (e.g., information protected under the Privacy Act and proprietary information). This control addresses information systems that are controlled by the organization and accessible to the general public, typically without identification or authentication. The posting of information on
+    non-organization information systems is covered by organizational policy. Related controls: AC-3, AC-4, AT-2, AT-3, AU-13.
+
+    Control Enhancements: None.
+
+    References: None.
+
+    AC-22 (d) [at least quarterly]
+  title: >-
+    AC-22 - PUBLICLY ACCESSIBLE CONTENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-1
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A security awareness and training\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2.  Procedures\
+    \ to facilitate the implementation of the security awareness and training policy\
+    \ and associated security awareness and training controls; and\n b. Reviews and\
+    \ updates the current:\n   1. Security awareness and training policy [Assignment:\
+    \ organization-defined frequency]; and\n   2.  Security awareness and training\
+    \ procedures [Assignment: organization-defined frequency].\n\nSupplemental Guidance:\
+    \  This control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ AT family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-16, 800-50, 800-100.\n\nAT-1 (b) (1) [at least\
+    \ annually or whenever a significant change occurs] \nAT-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    AT-1 - SECURITY AWARENESS AND TRAINING POLICY ANDPROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-2
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization provides basic security awareness training to information system users (including managers, senior executives, and contractors):
+     a. As part of initial training for new users;
+     b. When required by information system changes; and
+     c. [Assignment: organization-defined frequency] thereafter.
+
+    Supplemental Guidance:  Organizations determine the appropriate content of security awareness training and security awareness techniques based on the specific organizational requirements and the information systems to which personnel have authorized access. The content includes a basic understanding of the need for information security and user actions to maintain security and to respond to suspected security incidents. The content also addresses awareness of the need for operations security. Security awareness techniques can include, for example, displaying posters, offering supplies inscribed with security reminders, generating email advisories/notices from senior organizational officials, displaying logon screen messages, and conducting information security awareness events. Related controls: AT-3, AT-4, PL-4.
+
+    References: C.F.R. Part 5 Subpart C (5 C.F.R. 930.301); Executive Order 13587; NIST Special Publication 800-50.
+
+    AT-2 (c) [at least annually]
+  title: >-
+    AT-2 - SECURITY AWARENESS TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-2(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+- id: AT-2(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization includes security awareness training on recognizing and reporting potential indicators of insider threat.
+
+    Supplemental Guidance:  Potential indicators and possible precursors of insider threat can include behaviors such as inordinate, long-term job dissatisfaction, attempts to gain access to information not required for job performance, unexplained access to financial resources, bullying or sexual harassment of fellow employees, workplace violence, and other serious violations of organizational policies, procedures, directives, rules, or practices. Security awareness training includes how to communicate employee and management concerns regarding potential indicators of insider threat through appropriate organizational channels in accordance with established organizational policies and procedures. Related controls: PL-4, PM-12, PS-3, PS-6.
+
+    References:  C.F.R. Part 5 Subpart C (5 C.F.R 930.301); Executive Order 13587; NIST Special Publication 800-50.
+  title: >-
+    AT-2(2) - SECURITY AWARENESS | INSIDER THREAT
+  levels:
+  - high
+  - moderate
+- id: AT-3
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section c: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization provides role-based security training to personnel with assigned security roles and responsibilities:
+    a. Before authorizing access to the information system or performing assigned duties;
+    b. When required by information system changes; and
+    c. [Assignment: organization-defined frequency] thereafter.
+
+    Supplemental Guidance:  Organizations determine the appropriate content of security training based on the assigned roles and responsibilities of individuals and the specific security requirements of organizations and the information systems to which personnel have authorized access. In addition, organizations provide enterprise architects, information system developers, software developers, acquisition/procurement officials, information system managers, system/network administrators, personnel conducting configuration management and auditing activities, personnel performing independent verification and validation activities, security control assessors, and other personnel having access to system-level software, adequate security-related technical training specifically tailored for their assigned duties. Comprehensive role-based training addresses management, operational, and technical roles and responsibilities covering physical, personnel, and technical safeguards and countermeasures. Such training can include for example, policies, procedures, tools, and artifacts for the organizational security roles defined. Organizations also provide the training necessary for individuals to carry out their responsibilities related to operations and
+    supply chain security within the context of organizational information security programs. Role-based security training also applies to contractors providing services to federal agencies. Related controls: AT-2, AT-4, PL-4, PS-7, SA-3, SA-12, SA-16.
+
+    References: C.F.R. Part 5 Subpart C (5 C.F.R. 930.301); NIST Special Publications 800-16, 800-50.
+
+    AT-3 (c) [at least annually]
+  title: >-
+    AT-3 - ROLE-BASED SECURITY TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-3(1)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+- id: AT-3(2)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+- id: AT-3(3)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization includes practical exercises in security training that reinforce training objectives.
+
+    Supplemental Guidance:  Practical exercises may include, for example, security training for software developers that includes simulated cyber attacks exploiting common software vulnerabilities (e.g., buffer overflows), or spear/whale phishing attacks targeted at senior leaders/executives. These types of practical exercises help developers better understand the effects of such vulnerabilities and appreciate the need for security coding standards and processes.
+  title: >-
+    AT-3(3) - SECURITY TRAINING | PRACTICAL EXERCISES
+  levels:
+  - high
+- id: AT-3(4)
+  status: not applicable
+  notes: |-
+    This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization provides training to its personnel on [Assignment: organization-defined indicators of malicious code] to recognize suspicious communications and anomalous behavior in organizational information systems.
+
+    Supplemental Guidance:  A well-trained workforce provides another organizational safeguard that can be employed as part of a defense-in-depth strategy to protect organizations against malicious code coming in to organizations via email or the web applications. Personnel are trained to look for indications of potentially suspicious email (e.g., receiving an unexpected email, receiving an email containing strange or poor grammar, or receiving an email from an unfamiliar sender but who appears to be from a known sponsor or contractor). Personnel are also trained on how to respond to such suspicious email or web communications (e.g., not opening attachments, not clicking on embedded web links, and checking the source of email addresses). For this process to work effectively, all organizational personnel are trained and made aware of what constitutes suspicious communications. Training personnel on how to recognize anomalous behaviors in organizational information systems can potentially provide early warning for the presence of malicious code. Recognition of such anomalous behavior by organizational personnel can supplement automated malicious code detection and protection tools and systems employed by organizations.
+    AT-3 (4) [malicious code indicators as defined by organization  incident policy/capability]
+  title: >-
+    AT-3(4) - SECURITY TRAINING | SUSPICIOUS COMMUNICATIONS AND ANOMALOUS SYSTEM BEHAVIOR
+  levels:
+  - high
+- id: AT-4
+  status: not applicable
+  notes: |-
+    Section a: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+
+    Section b: This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Documents and monitors individual information system security training activities including basic security awareness training and specific information system security training; and
+     b. Retains individual training records for [Assignment: organization-defined time period].
+
+    Supplemental Guidance:  Documentation for specialized training may be maintained by individual supervisors at the option of the organization. Related controls: AT-2, AT-3, PM-14.
+
+    Control Enhancements:  None.
+
+    References:  None.
+
+    AT-4 (b) [five (5) years or 5 years after completion of a specific training program]
+  title: >-
+    AT-4 - SECURITY TRAINING RECORDS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AT-5
+  status: not applicable
+  notes: |-
+    As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PM-15.
+  rules: []
+- id: AU-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. An audit and accountability policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2.  Procedures to facilitate the implementation of the audit and accountability policy and associated audit and accountability controls; and
+     b. Reviews and updates the current:
+       1. Audit and accountability policy [Assignment: organization-defined frequency]; and
+       2. Audit and accountability procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the AU family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    AU-1 (b) (1) [at least annually]
+    AU-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    AU-1 - AUDIT AND ACCOUNTABILITY POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Determines that the information system is capable of auditing the following events: [Assignment: organization-defined auditable events];
+     b. Coordinates the security audit function with other organizational entities requiring audit- related information to enhance mutual support and to help guide the selection of auditable events;
+     c. Provides a rationale for why the auditable events are deemed to be adequate to support after- the-fact investigations of security incidents; and
+     d. Determines that the following events are to be audited within the information system: [Assignment: organization-defined audited events (the subset of the auditable events defined in AU-2 a.) along with the frequency of (or situation requiring) auditing for each identified event].
+
+    Supplemental Guidance:  An event is any observable occurrence in an organizational information system. Organizations identify audit events as those events which are significant and relevant to the security of information systems and the environments in which those systems operate in order to meet specific and ongoing audit needs. Audit events can include, for example, password changes, failed logons, or failed accesses related to information systems, administrative privilege usage, PIV credential usage, or third-party credential usage. In determining the set of auditable events, organizations consider the auditing appropriate for each of the security controls to be implemented. To balance auditing requirements with other information system needs, this control also requires identifying that subset of auditable events that are audited at a given point in time. For example, organizations may determine that information systems must have the capability to log every file access both successful and unsuccessful, but not activate that capability except for specific circumstances due to the potential burden on system performance. Auditing requirements, including the need for auditable events, may be referenced in other security controls and control enhancements. Organizations also include auditable events that are required by applicable federal laws, Executive Orders, directives, policies, regulations, and standards. Audit records can be generated at various levels of abstraction, including at the packet level as information traverses the network. Selecting the appropriate level of abstraction is a critical aspect of an audit capability and can facilitate the identification of root causes to problems. Organizations consider in the definition of auditable events, the auditing necessary to cover related events such as the steps in distributed, transaction-based processes (e.g., processes that are distributed across multiple organizations) and actions that occur in service-oriented architectures. Related controls: AC-6, AC-17, AU-3, AU-12, MA-4, MP-2, MP-4, SI-4.
+
+    References: NIST Special Publication 800-92; Web: http://idmanagement.gov.
+
+    AU-2 (a) [successful and unsuccessful account logon events, account management events, object access, policy change, privilege functions, process tracking, and system events. For Web applications: all administrator activity, authentication checks, authorization checks, data deletions, data access, data changes, and permission changes]
+    AU-2 (d) [organization-defined subset of the auditable events defined in AU-2a to be audited continually for each identified event].
+    AU-2 Requirement: Coordination between service provider and consumer shall be documented and accepted by the JAB/AO.
+  title: >-
+    AU-2 - AUDIT EVENTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-3
+  status: supported
+  notes: |-
+    'Red Hat Identity Management audit records contain this information
+    by default. No additional configuration is required.'
+  rules: []
+  description: |-
+    The information system generates audit records containing information that establishes what type of event occurred, when the event occurred, where the event occurred, the source of the event, the outcome of the event, and the identity of any individuals or subjects associated with the event.
+
+    Supplemental Guidance:  Audit record content that may be necessary to satisfy the requirement of this control, includes, for example, time stamps, source and destination addresses, user/process identifiers, event descriptions, success/fail indications, filenames involved, and access control or flow control rules invoked. Event outcomes can include indicators of event success or failure and event-specific results (e.g., the security state of the information system after the event occurred). Related controls: AU-2, AU-8, AU-12, SI-11.
+
+    References: None.
+  title: >-
+    AU-3 - CONTENT OF AUDIT RECORDS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-4
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization allocates audit record storage capacity in accordance with [Assignment:
+    organization-defined audit record storage requirements].
+
+    Supplemental Guidance:  Organizations consider the types of auditing to be performed and the audit processing requirements when allocating audit storage capacity. Allocating sufficient audit storage capacity reduces the likelihood of such capacity being exceeded and resulting in the potential loss or reduction of auditing capability. Related controls: AU-2, AU-5, AU-6, AU-7, AU-11, SI-4.
+
+    References: None.
+  title: >-
+    AU-4 - AUDIT STORAGE CAPACITY
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-5
+  status: pending
+  notes: |-
+    Section a: 'Red Hat Identity Management Administrators  are responsible for
+    alerting personnel or roles in the event of an audit processing
+    failure. A successful
+    control response will outline the process taken to alert personnel
+    when an auditing failure occurs.
+
+    Documentation/guidance on alerting administrators is being tracked
+    on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/19'
+
+    Section b: 'In the event of an audit processing failure, Red Hat Identity
+    Management Administrators
+    are responsible for: overwriting the oldest audit records for low
+    impact systems and shutting down moderate impact systems. A successful
+    control response will outline the actions taken when an auditing
+    failure occurs.
+
+    Documentation/guidance on achieving this control is being tracked
+    on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/20'
+  rules: []
+  description: |-
+    The information system:
+     a. Alerts [Assignment: organization-defined personnel or roles] in the event of an audit processing failure; and
+     b. Takes the following additional actions: [Assignment: organization-defined actions to be taken (e.g., shut down information system, overwrite oldest audit records, stop generating audit records)].
+
+    Supplemental Guidance:  Audit processing failures include, for example, software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded. Organizations may choose to define additional actions for different audit processing failures (e.g., by type, by location, by severity, or a combination of such factors). This control applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the total audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both. Related controls: AU-4, SI-12.
+
+    References: None.
+
+    AU-5 (b) [organization-defined actions to be taken (overwrite oldest record)
+  title: >-
+    AU-5 - RESPONSE TO AUDIT PROCESSING FAILURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-6
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Reviews and analyzes information system audit\
+    \ records [Assignment: organization-defined frequency] for indications of [Assignment:\
+    \ organization-defined inappropriate or unusual activity]; and\n b. Reports findings\
+    \ to [Assignment: organization-defined personnel or roles].\n\nSupplemental Guidance:\
+    \  Audit review, analysis, and reporting covers information security-related auditing\
+    \ performed by organizations including, for example, auditing that results from\
+    \ monitoring of account usage, remote access, wireless connectivity, mobile device\
+    \ connection, configuration settings, system component inventory, use of maintenance\
+    \ tools and nonlocal maintenance, physical access, temperature and humidity, equipment\
+    \ delivery and removal, communications at the information system boundaries, use\
+    \ of mobile code, and use of VoIP. Findings can be reported to organizational\
+    \ entities that include, for example, incident response team, help desk, information\
+    \ security group/department. If organizations are prohibited from reviewing and\
+    \ analyzing audit information or unable to conduct such activities (e.g., in certain\
+    \ national security applications or systems), the review/analysis may be carried\
+    \ out by other organizations granted such authority. Related controls: AC-2, AC-3,\
+    \ AC-6, AC-17, AT-3, AU-7, AU-16, CA-7, CM-5, CM-10, CM-11, IA-3, IA-5, IR-5,\
+    \ IR-6, MA-4, MP-4, PE-3, PE-6, PE-14, PE-16, RA-5, SC-7, SC-18, SC-19, SI-3,\
+    \ SI-4, SI-7.\n\nReferences: None.\n\nAU-6 (a)-1 [at least weekly] \nAU-6 Requirement:\
+    \ Coordination between service provider and consumer shall be documented and accepted\
+    \ by the JAB/AO. In multi-tennant environments, capability and means for providing\
+    \ review, analysis, and reporting to consumer for data pertaining to consumer\
+    \ shall be documented."
+  title: >-
+    AU-6 - AUDIT REVIEW, ANALYSIS, AND REPORTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-8
+  status: supported
+  notes: |-
+    Section a: 'Red Hat Identity Management time keeping relies on the time services
+    provided by the underlying operating system. This control is not
+    applicable to the configuration of Red Hat Identity Management.'
+
+    Section b: 'Red Hat Identity Management time keeping relies on the time
+    services provided by the
+    underlying operating system. This control is not applicable to the
+    configuration of Red Hat Identity Management.'
+  rules: []
+  description: |-
+    The information system:
+     a. Uses internal system clocks to generate time stamps for audit records; and
+     b. Records time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT) and meets [Assignment: organization-defined granularity of time measurement].
+
+    Supplemental Guidance:  Time stamps generated by the information system include date and time. Time is commonly expressed in Coordinated Universal Time (UTC), a modern continuation of Greenwich Mean Time (GMT), or local time with an offset from UTC. Granularity of time measurements refers to the degree of synchronization between information system clocks and reference clocks, for example, clocks synchronizing within hundreds of milliseconds or within tens of milliseconds. Organizations may define different time granularities for different system components. Time service can also be critical to other security capabilities such as access control and identification and authentication, depending on the nature of the mechanisms used to support those capabilities. Related controls: AU-3, AU-12.
+
+    References: None.
+
+    AU-8 (b) [one second granularity of time measurement]
+  title: >-
+    AU-8 - TIME STAMPS
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-9
+  status: pending
+  notes: |-
+    'Customers are required to protect the audit information and audit
+    tools from unauthorized access, modification, and deletion. A successful
+    control response will discuss the way that audit information and tools
+    are protected. This can include how access is controlled to audit
+    information and tools.
+
+    Documentation/instructions on protecting Red Hat
+    Identity Management audit information
+    is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/21'
+  rules: []
+  description: |-
+    The information system protects audit information and audit tools from unauthorized access, modification, and deletion.
+
+    Supplemental Guidance:  Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity. This control focuses on technical protection of audit information. Physical protection of audit information is addressed by media protection controls and physical and environmental protection controls. Related controls: AC-3, AC-6, MP-2, MP-4, PE-2, PE-3, PE-6.
+
+    References: None.
+  title: >-
+    AU-9 - PROTECTION OF AUDIT INFORMATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-11
+  status: pending
+  notes: |-
+    'Documentation/instructions on audit retention is being tracked
+    in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/22'
+  rules: []
+  description: "The organization retains audit records for [Assignment: organization-defined\
+    \ time period consistent with records retention policy] to provide support for\
+    \ after-the-fact investigations of security incidents and to meet regulatory and\
+    \ organizational information retention requirements.\n\nSupplemental Guidance:\
+    \  Organizations retain audit records until it is determined that they are no\
+    \ longer needed for administrative, legal, audit, or other operational purposes.\
+    \ This includes, for example, retention and availability of audit records relative\
+    \ to Freedom of Information Act (FOIA) requests, subpoenas, and law enforcement\
+    \ actions. Organizations develop standard categories of audit records relative\
+    \ to such types of actions and standard response processes for each type of action.\
+    \ The National Archives and Records Administration (NARA) General Records Schedules\
+    \ provide federal policy on record retention. Related controls: AU-4, AU-5, AU-9,\
+    \ MP-6.\n\nReferences: None.\n\nAU-11 [at least one (1) year] \nAU-11 Requirement:\
+    \ The service provider retains audit records on-line for at least ninety days\
+    \ and further preserves audit records off-line for a period that is in accordance\
+    \ with NARA requirements."
+  title: >-
+    AU-11 - AUDIT RECORD RETENTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: AU-12
+  status: pending
+  notes: |-
+    Section a: 'Customers are required to provide record generation capability for the
+    events defined in AU-2a at all information system components where audit
+    capability is available. A successful control response will discuss the
+    coniguration of all system components to capture the events that were
+    defined in AU-2.
+
+    Documentation/guidance on configuring auditable events is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/23'
+
+    Section b: '//*
+    Customers are required to allow defined personnel or roles to select
+    which auditable events are to be audited by specific components of the
+    information system. A successful control response will discuss how
+    audit generation is implemented, and who selects and configures
+    auditable events on the information system. Approved personnel or
+    roles are defined in AU-9(4).
+
+    Documentation/guidance on satisfying this control is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/24'
+
+    Section c: 'Customers are required to generate audit records for the events
+    defined in AU-2d with the content defined in AU-3. A successful control
+    response will discuss how audit records are generated, and how they meet
+    the requirements defined in AU-2 and AU-3.
+
+    Documentation/guidance on satisfying this control is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/25'
+  rules: []
+  description: "The information system:\n a. Provides audit record generation capability\
+    \ for the auditable events defined in AU-2 a. at [Assignment: organization-defined\
+    \ information system components];\n b. Allows [Assignment: organization-defined\
+    \ personnel or roles] to select which auditable events are to be audited by specific\
+    \ components of the information system; and\n c.    Generates audit records for\
+    \ the events defined in AU-2 d. with the content defined in AU-3. \n\nSupplemental\
+    \ Guidance:  Audit records can be generated from many different information system\
+    \ components. The list of audited events is the set of events for which audits\
+    \ are to be generated. These events are typically a subset of all events for which\
+    \ the information system is capable of generating audit records. Related controls:\
+    \ AC-3, AU-2, AU-3, AU-6, AU-7.\n\nReferences: None.\n\nAU-12 (a) [all information\
+    \ system and network components where audit capability is deployed/available]"
+  title: >-
+    AU-12 - AUDIT GENERATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A security assessment and authorization\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the security assessment and authorization\
+    \ policy and associated security assessment and authorization controls; and\n\
+    \ b. Reviews and updates the current:\n   1. Security assessment and authorization\
+    \ policy [Assignment: organization-defined frequency]; and\n   2. Security assessment\
+    \ and authorization procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance: This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the CA family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-37, 800-53A, 800-100.\n\n\
+    CA-1 (b) (1) [at least annually] \nCA-1 (b) (2) [at least annually or whenever\
+    \ a significant change occurs]"
+  title: >-
+    CA-1 - SECURITY ASSESSMENT AND AUTHORIZATION
+
+    POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops a security assessment plan that describes\
+    \ the scope of the assessment including:\n   1. Security controls and control\
+    \ enhancements under assessment;\n   2. Assessment procedures to be used to determine\
+    \ security control effectiveness; and\n   3. Assessment environment, assessment\
+    \ team, and assessment roles and responsibilities;\n b. Assesses the security\
+    \ controls in the information system and its environment of operation [Assignment:\
+    \ organization-defined frequency] to determine the extent to which the controls\
+    \ are implemented correctly, operating as intended, and producing the desired\
+    \ outcome with respect to meeting established security requirements;\n c. Produces\
+    \ a security assessment report that documents the results of the assessment; and\n\
+    \ d. Provides the results of the security control assessment to [Assignment: organization-defined\
+    \ individuals or roles].\n\nSupplemental Guidance:  Organizations assess security\
+    \ controls in organizational information systems and the environments in which\
+    \ those systems operate as part of: (i) initial and ongoing security authorizations;\
+    \ (ii) FISMA annual assessments; (iii) continuous monitoring; and (iv) system\
+    \ development life cycle activities. Security assessments: (i) ensure that information\
+    \ security is built into organizational information systems; (ii) identify weaknesses\
+    \ and deficiencies early in the development process; (iii) provide essential information\
+    \ needed to make risk-based decisions as part of security authorization processes;\
+    \ and (iv) ensure compliance to vulnerability mitigation procedures. Assessments\
+    \ are conducted on the implemented security controls from Appendix F (main catalog)\
+    \ and Appendix G (Program Management controls) as documented in System Security\
+    \ Plans and Information Security Program Plans. Organizations can use other types\
+    \ of assessment activities such as vulnerability scanning and system monitoring\
+    \ to maintain the security posture of information systems during the entire life\
+    \ cycle. Security assessment reports document assessment results in sufficient\
+    \ detail as deemed necessary by organizations, to determine the accuracy and completeness\
+    \ of the reports and whether the security controls are implemented correctly,\
+    \ operating as intended, and producing the desired outcome with respect to meeting\
+    \ security requirements. The FISMA requirement for assessing security controls\
+    \ at least annually does not require additional assessment activities to those\
+    \ activities already in place in organizational security authorization processes.\
+    \ Security assessment results are provided to the individuals or roles appropriate\
+    \ for the types of assessments being conducted. For example, assessments conducted\
+    \ in support of security authorization decisions are provided to authorizing officials\
+    \ or authorizing official designated representatives.\n\nTo satisfy annual assessment\
+    \ requirements, organizations can use assessment results from the following sources:\
+    \ (i) initial or ongoing information system authorizations; (ii) continuous monitoring;\
+    \ or (iii)  system development life cycle activities. Organizations ensure that\
+    \ security assessment results are current, relevant to the determination of security\
+    \ control effectiveness, and obtained with the appropriate level of assessor independence.\
+    \ Existing security control assessment results can be reused to the extent that\
+    \ the results are still valid and can also be supplemented with additional assessments\
+    \ as needed. Subsequent to initial authorizations and in accordance with OMB policy,\
+    \ organizations assess security controls during continuous monitoring. Organizations\
+    \ establish the frequency for ongoing security control assessments in accordance\
+    \ with organizational continuous monitoring strategies. Information Assurance\
+    \ Vulnerability Alerts provide useful examples of vulnerability mitigation procedures.\
+    \ External audits (e.g., audits by external entities such as regulatory agencies)\
+    \ are outside the scope of this control. Related controls: CA-5, CA-6, CA-7, PM-9,\
+    \ RA-5, SA-11, SA-12, SI-4.\n\nReferences: Executive Order 13587; FIPS Publication\
+    \ 199; NIST Special Publications 800-37, 800-39, 800-53A, 800-115, 800-137.\n\n\
+    CA-2 (b) [at least annually] \nCA-2 (d) [individuals or roles to include FedRAMP\
+    \ PMO]\nCA-2 Guidance: See the FedRAMP Documents page under Key Cloud Service\n\
+    Provider (CSP) Documents> Annual Assessment Guidance\nhttps://www.FedRAMP.gov/documents/"
+  title: >-
+    CA-2 - SECURITY ASSESSMENTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-2(1)
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization employs assessors or assessment teams with [Assignment:\
+    \ organization-defined level of independence] to conduct security control assessments.\n\
+    \nSupplemental Guidance:  Independent assessors or assessment teams are individuals\
+    \ or groups who conduct impartial assessments of organizational information systems.\
+    \ Impartiality implies that assessors are free from any perceived or actual conflicts\
+    \ of interest with regard to the development, operation, or management of the\
+    \ organizational information systems under assessment or to the determination\
+    \ of security control effectiveness. To achieve impartiality, assessors should\
+    \ not: (i) create a mutual or conflicting interest with the organizations where\
+    \ the assessments are being conducted; (ii) assess their own work; (iii) act as\
+    \ management or employees of the organizations they are serving; or (iv) place\
+    \ themselves in positions of advocacy for the organizations acquiring their services.\
+    \ Independent assessments can be obtained from elements within organizations or\
+    \ can be contracted to public or private sector entities outside of organizations.\
+    \ Authorizing officials determine the required level of independence based on\
+    \ the security categories of information systems and/or the ultimate risk to organizational\
+    \ operations, organizational assets, or individuals. Authorizing officials also\
+    \ determine if the level of assessor independence provides sufficient assurance\
+    \ that the results are sound and can be used to make credible, risk-based decisions.\
+    \ This includes determining whether contracted security assessment services have\
+    \ sufficient independence, for example, when information system owners are not\
+    \ directly involved in contracting processes or cannot unduly influence the impartiality\
+    \ of assessors conducting assessments. In special situations,\nfor example, when\
+    \ organizations that own the information systems are small or organizational structures\
+    \ require that assessments are conducted by individuals that are in the developmental,\
+    \ operational, or management chain of system owners, independence in assessment\
+    \ processes can be achieved by ensuring that assessment results are carefully\
+    \ reviewed and analyzed by independent teams of experts to validate the completeness,\
+    \ accuracy, integrity, and reliability of the results. Organizations recognize\
+    \ that assessments performed for purposes other than direct support to authorization\
+    \ decisions are, when performed by assessors with sufficient independence, more\
+    \ likely to be useable for such decisions, thereby reducing the need to\nrepeat\
+    \ assessments.\n \nCA-2 (1) Requirement: For JAB Authorization, must use an accredited\
+    \ 3PAO."
+  title: >-
+    CA-2(1) - SECURITY ASSESSMENTS | INDEPENDENT ASSESSORS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-3
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Authorizes connections from the information system to other information systems through the use of Interconnection Security Agreements;
+     b. Documents, for each interconnection, the interface characteristics, security requirements, and the nature of the information communicated; and
+     c. Reviews and updates Interconnection Security Agreements [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control applies to dedicated connections between information systems (i.e., system interconnections) and does not apply to transitory, user-controlled connections such as email and website browsing. Organizations carefully consider the risks that may be introduced when information systems are connected to other systems with different security requirements and security controls, both within organizations and external to organizations. Authorizing officials determine the risk associated with information system connections and the appropriate controls employed. If interconnecting systems have the same authorizing official, organizations do not need to develop Interconnection Security Agreements. Instead, organizations can describe the interface characteristics between those interconnecting systems in their respective security plans. If interconnecting systems have different authorizing officials within the same organization, organizations can either develop Interconnection Security Agreements or describe the interface characteristics between systems in the security plans for the respective systems. Organizations may also incorporate Interconnection Security Agreement information into formal contracts, especially for interconnections established between federal agencies and nonfederal (i.e., private sector) organizations. Risk considerations also include information systems sharing the same networks. For certain technologies (e.g., space, unmanned aerial vehicles, and medical devices), there may be specialized connections in place during preoperational testing. Such connections may require Interconnection Security Agreements and be subject to additional security controls.
+    Related controls: AC-3, AC-4, AC-20, AU-2, AU-12, AU-16, CA-7, IA-3, SA-9, SC-7, SI-4.
+
+    References: FIPS Publication 199; NIST Special Publication 800-47.
+
+    CA-3 (c) [at least annually and on input from FedRAMP]
+  title: >-
+    CA-3 - SYSTEM INTERCONNECTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-5
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops a plan of action and milestones for\
+    \ the information system to document the organization\u2019s planned remedial\
+    \ actions to correct weaknesses or deficiencies noted during\nthe assessment of\
+    \ the security controls and to reduce or eliminate known vulnerabilities in the\
+    \ system; and\n b. Updates existing plan of action and milestones [Assignment:\
+    \ organization-defined frequency] based on the findings from security controls\
+    \ assessments, security impact analyses, and continuous monitoring activities.\n\
+    \nSupplemental Guidance:  Plans of action and milestones are key documents in\
+    \ security authorization packages and are subject to federal reporting requirements\
+    \ established by OMB. Related controls: CA-2, CA-7, CM-4, PM-4.\n\nReferences:\
+    \  OMB Memorandum 02-01; NIST Special Publication 800-37.\n\nCA-5 (b) [at least\
+    \ monthly]\nCA-5 Requirement: POA&Ms must be provided at least monthly.\nCA-5\
+    \ Guidance: See the FedRAMP Documents page under Key Cloud Service\nProvider (CSP)\
+    \ Documents> Plan of Action and Milestones (POA&M) Template Completion Guide\n\
+    https://www.FedRAMP.gov/documents/"
+  title: >-
+    CA-5 - PLAN OF ACTION AND MILESTONES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-6
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Assigns a senior-level executive or manager\
+    \ as the authorizing official for the information system;\n b. Ensures that the\
+    \ authorizing official authorizes the information system for processing before\
+    \ commencing operations; and\n c. Updates the security authorization [Assignment:\
+    \ organization-defined frequency].\n\nSupplemental Guidance:  Security authorizations\
+    \ are official management decisions, conveyed through authorization decision documents,\
+    \ by senior organizational officials or executives (i.e., authorizing officials)\
+    \ to authorize operation of information systems and to explicitly accept the risk\
+    \ to organizational operations and assets, individuals, other organizations, and\
+    \ the Nation based on the implementation of agreed-upon security controls. Authorizing\
+    \ officials provide budgetary\noversight for organizational information systems\
+    \ or assume responsibility for the mission/business operations supported by those\
+    \ systems. The security authorization process is an inherently federal responsibility\
+    \ and therefore, authorizing officials must be federal employees. Through the\
+    \ security authorization process, authorizing officials assume responsibility\
+    \ and are accountable for security risks associated with the operation and use\
+    \ of organizational information systems. Accordingly, authorizing officials are\
+    \ in positions with levels of authority commensurate with understanding and accepting\
+    \ such information security-related risks. OMB policy requires that organizations\
+    \ conduct ongoing authorizations of information systems by implementing continuous\
+    \ monitoring programs. Continuous monitoring programs can satisfy three-year reauthorization\
+    \ requirements, so separate reauthorization processes are not necessary. Through\
+    \ the employment of comprehensive continuous monitoring processes, critical information\
+    \ contained in authorization packages (i.e., security plans, security assessment\
+    \ reports, and plans of action and milestones) is updated on an ongoing basis,\
+    \ providing authorizing officials and information system owners with an up-to-date\
+    \ status of the security state of organizational information systems and environments\
+    \ of operation. To reduce the administrative cost of security reauthorization,\
+    \ authorizing officials use the results of continuous monitoring processes to\
+    \ the maximum extent possible as the basis for rendering reauthorization decisions.\
+    \ Related controls: CA-2, CA-7, PM-9, PM-10.\n\nControl Enhancements:  None. \n\
+    \nReferences:  OMB Circular A-130; OMB Memorandum 11-33; NIST Special Publications\
+    \ 800-37, 800-137.\n\nCA-6 (c) [at least every three (3) years or when a significant\
+    \ change occurs] \nCA-6 (c) Guidance: Significant change is defined in NIST Special\
+    \ Publication 800-37 Revision 1, Appendix F. The service provider describes the\
+    \ types of changes to the information system or the environment of operations\
+    \ that would impact the risk posture. The types of changes are approved and accepted\
+    \ by the JAB/AO."
+  title: >-
+    CA-6 - SECURITY AUTHORIZATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-7
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization develops a continuous monitoring strategy and implements a continuous monitoring program that includes:
+     a. Establishment of [Assignment: organization-defined metrics] to be monitored;
+     b. Establishment of [Assignment: organization-defined frequencies] for monitoring and [Assignment: organization-defined frequencies] for assessments supporting such monitoring;
+     c. Ongoing security control assessments in accordance with the organizational continuous monitoring strategy;
+     d. Ongoing security status monitoring of organization-defined metrics in accordance with the organizational continuous monitoring strategy;
+     e. Correlation and analysis of security-related information generated by assessments and monitoring;
+     f. Response actions to address results of the analysis of security-related information; and
+     g. Reporting the security status of organization and the information system to [Assignment: organization-defined personnel or roles] [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Continuous monitoring programs facilitate ongoing awareness of threats, vulnerabilities, and information security to support organizational risk management decisions. The terms continuous and ongoing imply that organizations assess/analyze security controls and information security-related risks at a frequency sufficient to support organizational risk-based decisions. The results of continuous monitoring programs generate appropriate risk response actions by organizations. Continuous monitoring programs also allow organizations to maintain the security authorizations of information systems and common controls over time in highly dynamic environments of operation with changing mission/business needs, threats, vulnerabilities, and technologies. Having access to security-related information on a continuing basis through reports/dashboards gives organizational officials the capability to make more effective and timely risk management decisions, including ongoing security authorization decisions. Automation supports more frequent updates to security authorization packages, hardware/software/firmware inventories, and other system information. Effectiveness is further enhanced when continuous monitoring outputs are formatted to provide information that is specific, measurable, actionable, relevant, and timely. Continuous monitoring activities are scaled in accordance with the security categories of information systems. Related controls: CA-2, CA-5, CA-6, CM-3, CM-4, PM-6, PM-9, RA-5, SA-11, SA-12, SI-2, SI-4.
+
+    References: OMB Memorandum 11-33; NIST Special Publications 800-37, 800-39, 800-53A, 800-115, 800-137; US-CERT Technical Cyber Security Alerts; DoD Information Assurance Vulnerability Alerts.
+
+    CA-7 (g) [to meet Federal and FedRAMP requirements]
+    CA-7 Requirement: Operating System Scans: at least monthly. Database and Web Application Scans: at least monthly. All scans performed by Independent Assessor: at least annually
+    CA-7 Guidance: CSPs must provide evidence of closure and remediation of high vulnerabilities within the timeframe for standard POA&M updates.
+    CA-7 Guidance: See the FedRAMP Documents page under Key Cloud Service
+    Provider (CSP) Documents> Continuous Monitoring Strategy Guide
+    https://www.FedRAMP.gov/documents/
+  title: >-
+    CA-7 - CONTINUOUS MONITORING
+  levels:
+  - high
+  - moderate
+  - low
+- id: CA-9
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Authorizes internal connections of [Assignment: organization-defined information system components or classes of components] to the information system; and
+     b. Documents, for each internal connection, the interface characteristics, security requirements, and the nature of the information communicated.
+
+    Supplemental Guidance:  This control applies to connections between organizational information systems and (separate) constituent system components (i.e., intra-system connections) including, for example, system connections with mobile devices, notebook/desktop computers, printers, copiers, facsimile machines, scanners, sensors, and servers. Instead of authorizing each individual internal connection, organizations can authorize internal connections for a class of components with common characteristics and/or configurations, for example, all digital printers, scanners, and copiers with a specified processing, storage, and transmission capability or all smart phones with a specific baseline configuration. Related controls: AC-3, AC-4, AC-18, AC-19, AU-2, AU-12, CA-7, CM-2, IA-3, SC-7, SI-4.
+
+    References: None.
+  title: >-
+    CA-9 - INTERNAL SYSTEM CONNECTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A configuration management policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the configuration management policy and associated configuration management controls; and
+     b. Reviews and updates the current:
+       1. Configuration management policy [Assignment: organization-defined frequency]; and
+       2. Configuration management procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the CM family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    CM-1 (b) (1) [at least annually]
+    CM-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    CM-1 - CONFIGURATION MANAGEMENT POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization develops, documents, and maintains under configuration control, a current baseline configuration of the information system.
+
+    Supplemental Guidance:  This control establishes baseline configurations for information systems and system components including communications and connectivity-related aspects of systems. Baseline configurations are documented, formally reviewed and agreed-upon sets of specifications for information systems or configuration items within those systems. Baseline configurations serve as a basis for future builds, releases, and/or changes to information systems. Baseline configurations include information about information system components (e.g., standard software packages installed on workstations, notebook computers, servers, network components, or mobile devices; current version numbers and patch information on operating systems and applications; and configuration settings/parameters), network topology, and the logical placement of those components within the system architecture. Maintaining baseline configurations requires creating new baselines as organizational information systems change over time. Baseline configurations of information systems reflect the current enterprise architecture. Related controls: CM-3, CM-6, CM-8, CM-9, SA-10, PM-5, PM-7.
+
+    References: NIST Special Publication 800-128.
+  title: >-
+    CM-2 - BASELINE CONFIGURATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-4
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization analyzes changes to the information system to determine potential security impacts prior to change implementation.
+
+    Supplemental Guidance:  Organizational personnel with information security responsibilities (e.g., Information System Administrators, Information System Security Officers, Information System Security Managers, and Information System Security Engineers) conduct security impact analyses. Individuals conducting security impact analyses possess the necessary skills/technical expertise to analyze the changes to information systems and the associated security ramifications. Security impact analysis may include, for example, reviewing security plans to understand security control requirements and reviewing system design documentation to understand control implementation and how specific changes might affect the controls. Security impact analyses may also include assessments of risk to better understand the impact of the changes and to determine if additional security controls are required. Security impact analyses are scaled in accordance with the security categories of the information systems. Related controls: CA-2, CA-7, CM-3, CM-9, SA-4, SA-5, SA-10, SI-2.
+
+    References: NIST Special Publication 800-128.
+  title: >-
+    CM-4 - SECURITY IMPACT ANALYSIS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-6
+  status: pending
+  notes: |-
+    Section a: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management. Use of the NIST National Checklist
+    for Red Hat Identity Management is suggested as a supported,
+    US Government recognized, vendor supported, baseline.'
+
+    Section b: 'The customer will be responsible for implementing configuration
+    settings as defined in CM-6(a). A successful control response will
+    describe how mandatory configuration settings are implemented. This can
+    include the process or documentation followed.
+
+    Creation of a Red Hat Identity Management configuration baseline
+    is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/40'
+
+    Section c: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management.'
+
+    Section d: 'The customer will be responsible for monitoring and controlling
+    changes to the configuration settings in accordance with organization
+    policies and procedures. A successful control response will describe
+    how changes are controlled and monitored. This can include limitations
+    to privileges, how these changes are audited, and any tools in place to
+    track and approve changes.'
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes and documents configuration settings for information technology products employed within the information system using [Assignment: organization-defined security configuration checklists] that reflect the most restrictive mode consistent with operational requirements;
+     b. Implements the configuration settings;
+     c. Identifies, documents, and approves any deviations from established configuration settings for [Assignment: organization-defined information system components] based on [Assignment: organization-defined operational requirements]; and
+     d. Monitors and controls changes to the configuration settings in accordance with organizational policies and procedures.
+
+    Supplemental Guidance:  Configuration settings are the set of parameters that can be changed in hardware, software, or firmware components of the information system that affect the security posture and/or functionality of the system. Information technology products for which security- related configuration settings can be defined include, for example, mainframe computers, servers (e.g., database, electronic mail, authentication, web, proxy, file, domain name), workstations, input/output devices (e.g., scanners, copiers, and printers), network components (e.g., firewalls, routers, gateways, voice and data switches, wireless access points, network appliances, sensors), operating systems, middleware, and applications. Security-related parameters are those parameters impacting the security state of information systems including the parameters required to satisfy other security control requirements. Security-related parameters include, for example: (i) registry settings; (ii) account, file, directory permission settings; and (iii) settings for functions, ports, protocols, services, and remote connections. Organizations establish organization-wide configuration settings and subsequently derive specific settings for information systems. The established settings become part of the systems configuration baseline.
+
+    Common secure configurations (also referred to as security configuration checklists, lockdown
+    and hardening guides, security reference guides, security technical implementation guides) provide recognized, standardized, and established benchmarks that stipulate secure configuration settings for specific information technology platforms/products and instructions for configuring those information system components to meet operational requirements. Common secure configurations can be developed by a variety of organizations including, for example, information technology product developers, manufacturers, vendors, consortia, academia, industry, federal agencies, and other organizations in the public and private sectors. Common secure configurations include the United States Government Configuration Baseline (USGCB) which affects the implementation of CM-6 and other controls such as AC-19 and CM-7. The Security Content Automation Protocol (SCAP) and the defined standards within the protocol (e.g., Common Configuration Enumeration) provide an effective method to uniquely identify, track, and control configuration settings. OMB establishes federal policy on configuration requirements for federal information systems. Related controls: AC-19, CM-2, CM-3, CM-7, SI-4.
+
+    References: OMB Memoranda 07-11, 07-18, 08-22; NIST Special Publications 800-70, 800-128; Web: http://nvd.nist.gov, http://checklists.nist.gov, http://www.nsa.gov.
+
+    CM-6 (a) [United States Government Configuration Baseline (USGCB)]
+    CM-6 (a) Requirement 1: The service provider shall use the Center for Internet Security guidelines (Level 1) to establish configuration settings or establishes its own configuration settings if USGCB is not available.
+    CM-6 (a) Requirement 2: The service provider shall ensure that checklists for configuration settings are Security Content Automation Protocol (SCAP) validated or SCAP compatible (if validated checklists are not available).
+    CM-6 (a) Guidance: Information on the USGCB checklists can be found at: http://usgcb.nist.gov/usgcb_faq.html#usgcbfaq_usgcbfdcc
+  title: >-
+    CM-6 - CONFIGURATION SETTINGS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-7
+  status: pending
+  notes: |-
+    'Red Hat Identity Management provides many capabilities, including
+    user authentication, DNS integration, and several APIs. A successful
+    control response will outline which services are enabled
+    and their mission purpose.'
+  rules: []
+  description: "The organization:\n a. Configures the information system to provide\
+    \ only essential capabilities; and\n b. Prohibits or restricts the use of the\
+    \ following functions, ports, protocols, and/or services: [Assignment: organization-defined\
+    \ prohibited or restricted functions, ports, protocols, and/or services].\n\n\
+    Supplemental Guidance:  Information systems can provide a wide variety of functions\
+    \ and services. Some of the functions and services, provided by default, may not\
+    \ be necessary to support essential organizational operations (e.g., key missions,\
+    \ functions). Additionally, it is sometimes convenient to provide multiple services\
+    \ from single information system components, but doing so increases risk over\
+    \ limiting the services provided by any one component. Where feasible, organizations\
+    \ limit component functionality to a single function per device (e.g., email servers\
+    \ or web servers, but not both). Organizations review functions and services provided\
+    \ by information systems or individual components of information systems, to determine\
+    \ which functions and services are candidates for elimination (e.g., Voice Over\
+    \ Internet Protocol, Instant Messaging, auto-execute, and file sharing). Organizations\
+    \ consider disabling unused or unnecessary physical and logical ports/protocols\
+    \ (e.g., Universal Serial Bus, File Transfer Protocol, and Hyper Text Transfer\
+    \ Protocol) on information systems to prevent unauthorized connection of devices,\
+    \ unauthorized transfer of information, or unauthorized tunneling. Organizations\
+    \ can utilize network scanning tools, intrusion detection and prevention systems,\
+    \ and end-point protections such as firewalls and host-based intrusion detection\
+    \ systems to identify and prevent the use of prohibited functions, ports, protocols,\
+    \ and services. Related controls: AC-6, CM-2, RA-5, SA-5, SC-7.\n\nReferences:\
+    \ DoD Instruction 8551.01.\n\nCM-7 (b) [United States Government Configuration\
+    \ Baseline (USGCB)] \nCM-7 (b) Requirement: The service provider shall use the\
+    \ Center for Internet Security guidelines (Level 1) to establish list of prohibited\
+    \ or restricted functions, ports, protocols, and/or services or establishes its\
+    \ own list of prohibited or restricted functions, ports, protocols, and/or services\
+    \ if USGCB is not available.\nCM-7 Guidance: Information on the USGCB checklists\
+    \ can be found at: http://usgcb.nist.gov/usgcb_faq.html#usgcbfaq_usgcbfdcc.\n\
+    (Partially derived from AC-17(8).)"
+  title: >-
+    CM-7 - LEAST FUNCTIONALITY
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-8
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops and documents an inventory of information system components that:
+       1. Accurately reflects the current information system;
+       2. Includes all components within the authorization boundary of the information system;
+       3. Is at the level of granularity deemed necessary for tracking and reporting; and
+       4. Includes [Assignment: organization-defined information deemed necessary to achieve effective information system component accountability]; and
+     b. Reviews and updates the information system component inventory [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Organizations may choose to implement centralized information system component inventories that include components from all organizational information systems. In such situations, organizations ensure that the resulting inventories include system-specific information required for proper component accountability (e.g., information system association, information system owner). Information deemed necessary for effective accountability of information system components includes, for example, hardware inventory specifications, software license information, software version numbers, component owners, and for networked components or devices, machine names and network addresses. Inventory specifications include, for example, manufacturer, device type, model, serial number, and physical location. Related controls: CM-2, CM-6, PM-5.
+
+    References: NIST Special Publication 800-128.
+
+    CM-8 (b) [at least monthly]
+    CM-8 Requirement: must be provided at least monthly or when there is a change.
+  title: >-
+    CM-8 - INFORMATION SYSTEM COMPONENT INVENTORY
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-10
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+    a. Uses software and associated documentation in accordance with contract agreements and copyright laws;
+    b. Tracks the use of software and associated documentation protected by quantity licenses to control copying and distribution; and
+    c. Controls and documents the use of peer-to-peer file sharing technology to ensure that this capability is not used for the unauthorized distribution, display, performance, or reproduction of copyrighted work.
+
+    Supplemental Guidance:  Software license tracking can be accomplished by manual methods (e.g., simple spreadsheets) or automated methods (e.g., specialized tracking applications) depending on organizational needs. Related controls: AC-17, CM-8, SC-7.
+
+    References:  None.
+  title: >-
+    CM-10 - SOFTWARE USAGE RESTRICTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: CM-11
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Establishes [Assignment: organization-defined\
+    \ policies] governing the installation of software by users;\n b. Enforces software\
+    \ installation policies through [Assignment: organization-defined methods]; and\n\
+    \ c. Monitors policy compliance at [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  If provided the necessary privileges, users have the\
+    \ ability to install software in organizational information systems. To maintain\
+    \ control over the types of software installed, organizations identify permitted\
+    \ and prohibited actions regarding software installation. Permitted software installations\
+    \ may include, for example, updates and security patches to existing software\
+    \ and downloading applications from organization-approved \u201Capp stores.\u201D\
+    \ Prohibited software installations may include, for example, software with unknown\
+    \ or suspect pedigrees or software that organizations consider potentially malicious.\
+    \ The policies organizations select governing user-installed software may be organization-developed\
+    \ or provided by some external entity. Policy enforcement methods include procedural\
+    \ methods (e.g., periodic examination of user accounts), automated methods (e.g.,\
+    \ configuration settings implemented on organizational information systems), or\
+    \ both. Related controls: AC-3, CM-2, CM-3, CM-5, CM-6, CM-7, PL-4.\n\nReferences:\
+    \ None.\n\nCM-11 (c) [Continuously (via CM-7 (5))]"
+  title: >-
+    CM-11 - USER-INSTALLED SOFTWARE
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A contingency planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the contingency planning policy and associated contingency planning controls; and
+     b. Reviews and updates the current:
+       1. Contingency planning policy [Assignment: organization-defined frequency]; and
+       2. Contingency planning procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the CP family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  Federal Continuity Directive 1; NIST Special Publications 800-12, 800-34, 800-100.
+
+    CP-1 (b) (1) [at least annually]
+    CP-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    CP-1 - CONTINGENCY PLANNING POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops a contingency plan for the information system that:
+       1. Identifies essential missions and business functions and associated contingency requirements;
+       2. Provides recovery objectives, restoration priorities, and metrics;
+       3. Addresses contingency roles, responsibilities, assigned individuals with contact information;
+       4. Addresses maintaining essential missions and business functions despite an information system disruption, compromise, or failure;
+       5. Addresses eventual, full information system restoration without deterioration of the security safeguards originally planned and implemented; and
+       6. Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+     b. Distributes copies of the contingency plan to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements];
+     c. Coordinates contingency planning activities with incident handling activities;
+     d. Reviews the contingency plan for the information system [Assignment: organization-defined frequency];
+     e. Updates the contingency plan to address changes to the organization, information system, or environment of operation and problems encountered during contingency plan implementation, execution, or testing;
+     f. Communicates contingency plan changes to [Assignment: organization-defined key contingency personnel (identified by name and/or by role) and organizational elements]; and
+     g. Protects the contingency plan from unauthorized disclosure and modification.
+
+    Supplemental Guidance:  Contingency planning for information systems is part of an overall organizational program for achieving continuity of operations for mission/business functions. Contingency planning addresses both information system restoration and implementation of alternative mission/business processes when systems are compromised. The effectiveness of contingency planning is maximized by considering such planning throughout the phases of the system development life cycle. Performing contingency planning on hardware, software, and firmware development can be an effective means of achieving information system resiliency. Contingency plans reflect the degree of restoration required for organizational information systems since not all systems may need to fully recover to achieve the level of continuity of operations desired. Information system recovery objectives reflect applicable laws, Executive Orders, directives, policies, standards, regulations, and guidelines. In addition to information system availability, contingency plans also address other security-related events resulting in a reduction in mission and/or business effectiveness, such as malicious attacks compromising the confidentiality or integrity of information systems. Actions addressed in contingency plans include, for example, orderly/graceful degradation, information system shutdown, fallback to a manual mode, alternate information flows, and operating in modes reserved for when systems are under attack. By closely coordinating contingency planning with incident handling activities, organizations can ensure that the necessary contingency planning activities are in place and activated in the event of a security incident. Related controls: AC-14, CP-6, CP-7, CP-8, CP-9, CP-10, IR-4, IR-8, MP-2, MP-4, MP-5, PM-8, PM-11.
+
+    References: Federal Continuity Directive 1; NIST Special Publication 800-34.
+
+    CP-2 (d) [at least annually]
+    CP-2 Requirement: For JAB authorizations the contingency lists include designated FedRAMP personnel.
+  title: >-
+    CP-2 - CONTINGENCY PLAN
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-3
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization provides contingency training to information system\
+    \ users consistent with assigned roles and responsibilities:\n a. Within [Assignment:\
+    \ organization-defined time period] of assuming a contingency role or responsibility;\n\
+    \ b. When required by information system changes; and\n c. [Assignment: organization-defined\
+    \ frequency] thereafter.\n\nSupplemental Guidance:  Contingency training provided\
+    \ by organizations is linked to the assigned roles and responsibilities of organizational\
+    \ personnel to ensure that the appropriate content and level of detail is included\
+    \ in such training. For example, regular users may only need to know\nwhen and\
+    \ where to report for duty during contingency operations and if normal duties\
+    \ are affected; system administrators may require additional training on how to\
+    \ set up information systems at alternate processing and storage sites; and managers/senior\
+    \ leaders may receive more specific training on how to conduct mission-essential\
+    \ functions in designated off-site locations and how to establish communications\
+    \ with other governmental entities for purposes of coordination on\ncontingency-related\
+    \ activities. Training for contingency roles/responsibilities reflects the specific\
+    \ continuity requirements in the contingency plan. Related controls: AT-2, AT-3,\
+    \ CP-2, IR-2. \n\nReferences: Federal Continuity Directive 1; NIST Special Publications\
+    \ 800-16, 800-50.\n\nCP-3 (a) [ten (10) days]\nCP-3 (c) [at least annually]"
+  title: >-
+    CP-3 - CONTINGENCY TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-4
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Tests the contingency plan for the information\
+    \ system [Assignment: organization-defined frequency] using [Assignment: organization-defined\
+    \ tests] to determine the effectiveness of the plan and the organizational readiness\
+    \ to execute the plan;\n b. Reviews the contingency plan test results; and\n c.\
+    \ Initiates corrective actions, if needed.\n\nSupplemental Guidance:  Methods\
+    \ for testing contingency plans to determine the effectiveness of the plans and\
+    \ to identify potential weaknesses in the plans include, for example, walk-through\
+    \ and tabletop exercises, checklists, simulations (parallel, full interrupt),\
+    \ and comprehensive exercises. Organizations conduct testing based on the continuity\
+    \ requirements in contingency plans and include a determination of the effects\
+    \ on organizational operations, assets, and individuals arising due to contingency\
+    \ operations. Organizations have flexibility and discretion in the breadth, depth,\
+    \ and timelines of corrective actions. Related controls: CP-2, CP-3, IR-3.\n\n\
+    References: Federal Continuity Directive 1; FIPS Publication 199; NIST Special\
+    \ Publications 800-34, 800-84.\n\nCP-4 (a)-1 [at least annually] \nCP-4 (a)-2\
+    \ [functional exercises]\nCP-4 (a) Requirement: The service provider develops\
+    \ test plans in accordance with NIST Special Publication 800-34 (as amended);\
+    \ plans are approved by the JAB/AO prior to initiating testing."
+  title: >-
+    CP-4 - CONTINGENCY PLAN TESTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-9
+  status: pending
+  notes: |-
+    Section a: 'The customer will be responsible for conducting daily incremental and
+    weekly full backups of user-level information contained in the
+    information system. Additional FedRAMP requirements and guidance include
+    maintaining at least three backup copies of user-level information (at
+    least one of which is available online) or provides an equivalent
+    alternative. A successful control response will detail how backups of
+    user-level information occurs, and how three backup copies are
+    maintained.
+
+    Guidance on establishing such backups is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/51'
+
+    Section b: 'The customer will be responsible for conducting daily incremental and
+    weekly full backups of system-level information contained in the
+    information system. Additional FedRAMP requirements and guidance include
+    maintaining at least three backup copies of user-level information (at
+    least one of which is available online) or provides an equivalent
+    alternative. A successful control response will detail how backups of
+    user-level information occurs, and how three backup copies are
+    maintained.
+
+    Guidance on establishing such backups is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/52'
+
+    Section c: 'The customer will be responsible for conducting daily incremental and
+    weekly full backups of information system documentation including
+    security-related documentation. Additional FedRAMP requirements and
+    guidance include maintaining at least three backup copies of user-level
+    information (at least one of which is available online) or provides an
+    equivalent alternative. A successful control response will detail how
+    backups of user-level information occurs, and how three backup copies
+    are maintained.
+
+    Guidance on establishing such backups is being tracked in GitHub:
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/53'
+
+    Section d: 'The customer will be responsible for protecting the confidentiality,
+    integrity, and available of backup information at storage locations.
+    Additional FedRAMP requirements and guidance include determining
+    what elements of the cloud environment require the Information System
+    Backup control. The customer will determine how Information System
+    Backup is going to be verified and appropriate periodicity of the
+    check.
+
+    Guidance on establishing such backups is being tracked in GitHub:
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/54'
+  rules: []
+  description: |-
+    The organization:
+    a. Conducts backups of user-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+    b. Conducts backups of system-level information contained in the information system [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives];
+    c. Conducts backups of information system documentation including security-related documentation [Assignment: organization-defined frequency consistent with recovery time and recovery point objectives]; and
+    d. Protects the confidentiality, integrity, and availability of backup information at storage locations.
+
+    Supplemental Guidance:  System-level information includes, for example, system-state information, operating system and application software, and licenses. User-level information includes any information other than system-level information. Mechanisms employed by organizations to protect the integrity of information system backups include, for example, digital signatures and cryptographic hashes. Protection of system backup information while in transit is beyond the
+    scope of this control. Information system backups reflect the requirements in contingency plans as well as other organizational requirements for backing up information. Related controls: CP-2, CP-6, MP-4, MP-5, SC-13.
+
+    References: NIST Special Publication 800-34.
+
+    CP-9 (a) [daily incremental; weekly full]
+    CP-9 (b) [daily incremental; weekly full]
+    CP-9 (c) [daily incremental; weekly full]
+    CP-9 Requirement: The service provider shall determine what elements of the cloud environment require the Information System Backup control. The service provider shall determine how Information System Backup is going to be verified and appropriate periodicity of the check.
+    CP-9 (a) Requirement: The service provider maintains at least three backup copies of user-level information (at least one of which is available online) or provides an equivalent alternative.
+    CP-9 (b) Requirement: The service provider maintains at least three backup copies of system-level information (at least one of which is available online) or provides an equivalent alternative.
+    CP-9 (c) Requirement: The service provider maintains at least three backup copies of information system documentation including security information (at least one of which is available online) or provides an equivalent alternative.
+  title: >-
+    CP-9 - INFORMATION SYSTEM BACKUP
+  levels:
+  - high
+  - moderate
+  - low
+- id: CP-10
+  status: pending
+  notes: |-
+    'The customer will be responsible for documenting how to reconstitute
+    their Red Hat Identity Management environment. A successful control
+    response will detail
+    processes used to fully recover/restore the Red Hat Identity
+    Management environment.'
+  rules: []
+  description: |-
+    The organization provides for the recovery and reconstitution of the information system to a known state after a disruption, compromise, or failure.
+
+    Supplemental Guidance:  Recovery is executing information system contingency plan activities to restore organizational missions/business functions. Reconstitution takes place following recovery and includes activities for returning organizational information systems to fully operational states. Recovery and reconstitution operations reflect mission and business priorities, recovery point/time and reconstitution objectives, and established organizational metrics consistent with contingency plan requirements. Reconstitution includes the deactivation of any interim information system capabilities that may have been needed during recovery operations. Reconstitution also includes assessments of fully restored information system capabilities, reestablishment of continuous monitoring activities, potential information system reauthorizations, and activities to prepare the systems against future disruptions, compromises, or failures. Recovery/reconstitution capabilities employed by organizations can include both automated mechanisms and manual procedures. Related controls: CA-2, CA-6, CA-7, CP-2, CP-6, CP-7, CP-9, SC-24.
+
+    References: Federal Continuity Directive 1; NIST Special Publication 800-34.
+  title: >-
+    CP-10 - INFORMATION SYSTEM RECOVERY AND
+
+    RECONSTITUTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An identification and authentication\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the identification and authentication policy\
+    \ and associated identification and authentication controls; and\n b. Reviews\
+    \ and updates the current:\n   1. Identification and authentication policy [Assignment:\
+    \ organization-defined frequency]; and\n   2. Identification and authentication\
+    \ procedures [Assignment: organization-defined frequency].\n\nSupplemental Guidance:\
+    \  This control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ IA family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  FIPS\
+    \ Publication 201; NIST Special Publications 800-12, 800-63, 800-73, 800-76, 800-78,\
+    \ 800-100.\n\nIA-1 (b) (1) [at least annually] \nIA-1 (b) (2) [at least annually\
+    \ or whenever a significant change occurs]"
+  title: >-
+    IA-1 - IDENTIFICATION AND AUTHENTICATION POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2
+  status: pending
+  notes: |-
+    'Documentation/guidance on configuring Red Hat
+    Identity Management against
+    this requirement is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/61'
+  rules: []
+  description: |-
+    The information system uniquely identifies and authenticates organizational users (or processes acting on behalf of organizational users).
+
+    Supplemental Guidance:  Organizational users include employees or individuals that organizations deem to have equivalent status of employees (e.g., contractors, guest researchers). This control applies to all accesses other than: (i) accesses that are explicitly identified and documented in AC-14; and (ii) accesses that occur through authorized use of group authenticators without individual authentication. Organizations may require unique identification of individuals in group accounts (e.g., shared privilege accounts) or for detailed accountability of individual activity. Organizations employ passwords, tokens, or biometrics to authenticate user identities, or in the case multifactor authentication, or some combination thereof. Access to organizational information systems is defined as either local access or network access. Local access is any access to organizational information systems by users (or processes acting on behalf of users) where such access is
+    obtained by direct connections without the use of networks. Network access is access to organizational information systems by users (or processes acting on behalf of users) where such access is obtained through network connections (i.e., nonlocal accesses). Remote access is a type of network access that involves communication through external networks (e.g., the Internet). Internal networks include local area networks and wide area networks. In addition, the use of encrypted virtual private networks (VPNs) for network connections between organization- controlled endpoints and non-organization controlled endpoints may be treated as internal networks from the perspective of protecting the confidentiality and integrity of information traversing the network.
+
+    Organizations can satisfy the identification and authentication requirements in this control by complying with the requirements in Homeland Security Presidential Directive 12 consistent with the specific organizational implementation plans. Multifactor authentication requires the use of two or more different factors to achieve authentication. The factors are defined as: (i) something you know (e.g., password, personal identification number [PIN]); (ii) something you have (e.g.,
+    cryptographic identification device, token); or (iii) something you are (e.g., biometric). Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD common access card. In addition to identifying and authenticating users at the information system level
+    (i.e., at logon), organizations also employ identification and authentication mechanisms at the application level, when necessary, to provide increased information security. Identification and authentication requirements for other than organizational users are described in IA-8. Related controls: AC-2, AC-3, AC-14, AC-17, AC-18, IA-4, IA-5, IA-8.
+
+    References: HSPD-12; OMB Memoranda 04-04, 06-16, 11-11; FIPS Publication 201; NIST Special Publications 800-63, 800-73, 800-76, 800-78; FICAM Roadmap and Implementation Guidance; Web: http://idmanagement.gov.
+  title: >-
+    IA-2 - IDENTIFICATION AND AUTHENTICATION
+
+    (ORGANIZATIONAL USERS)
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2(1)
+  status: pending
+  notes: |-
+    'The customer will be responsible for implementing multifactor
+    authentication for network access to privileged accounts.
+
+    A successful control response will need to address all network-
+    accessible privileged account types and the means by which
+    multifactor authentication is enforced for each.
+
+    Documentation/guidance is being tracked through GitHub:
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/62
+
+    NOTE:
+    Many customers are accepting password-enabled SSH keys as multi-
+    factor authentication. The SSH key (something they have) and the
+    decryption password (something they know). Prior to enabling CAC
+    and PIV cards, it is recommended to seek guidance from the
+    Information Security Officer responsible for authorization of
+    Red Hat Identity Management.'
+  rules: []
+  description: |-
+    The information system implements multifactor authentication for network access to privileged accounts.
+
+    Supplemental Guidance:  Related control: AC-6.
+  title: >-
+    IA-2(1) - IDENTIFICATION AND AUTHENTICATION | NETWORK ACCESS TO PRIVILEGED ACCOUNTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-2(12)
+  status: pending
+  notes: |-
+    'Personal Identity Verification (PIV) credentials are those credentials
+    issued by federal agencies that conform to FIPS Publication 201 and
+    supporting guidance documents. Customers will not be expected to perform
+    this credential verification for government agencies. A mechanism for
+    allowing government agencies to perform credential verification in a way
+    that can be trusted by the customer system is through Active Directory
+    Federation Services (ADFS).
+
+    Documentation/guidance for this control is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/63'
+  rules: []
+  description: |-
+    The information system accepts and electronically verifies Personal Identity Verification (PIV)
+    credentials.
+
+    Supplemental Guidance:  This control enhancement applies to organizations implementing logical access control systems (LACS) and physical access control systems (PACS). Personal Identity Verification (PIV) credentials are those credentials issued by federal agencies that conform to FIPS Publication 201 and supporting guidance documents. OMB Memorandum 11-11 requires federal agencies to continue implementing the requirements specified in HSPD-12 to enable agency-wide use of PIV credentials. Related controls: AU-2, PE-3, SA-4.
+
+    IA-2 (12) Guidance: Include Common Access Card (CAC), i.e., the DoD technical implementation of PIV/FIPS 201/HSPD-12.
+  title: >-
+    IA-2(12) - IDENTIFICATION AND AUTHENTICATION | ACCEPTANCE OF PIV CREDENTIALS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-4
+  status: pending
+  notes: |-
+    Section a: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management.'
+
+    Section b: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management.'
+
+    Section c: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management.'
+
+    Section d: 'Documentation/guidance on preventing the reuse of identifiers is
+    being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/64'
+
+    Section e: 'Documentation/guidance on disabling idle accounts is being tracked
+    on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/65'
+  rules: []
+  description: "The organization manages information system identifiers by:\n a. Receiving\
+    \ authorization from [Assignment: organization-defined personnel or roles] to\
+    \ assign an individual, group, role, or device identifier;\n b. Selecting an identifier\
+    \ that identifies an individual, group, role, or device;\n c. Assigning the identifier\
+    \ to the intended individual, group, role, or device;\n d. Preventing reuse of\
+    \ identifiers for [Assignment: organization-defined time period]; and\n e. Disabling\
+    \ the identifier after [Assignment: organization-defined time period of inactivity].\n\
+    \nSupplemental Guidance:  Common device identifiers include, for example, media\
+    \ access control (MAC), Internet protocol (IP) addresses, or device-unique token\
+    \ identifiers. Management of individual identifiers is not applicable to shared\
+    \ information system accounts (e.g., guest and anonymous accounts). Typically,\
+    \ individual identifiers are the user names of the information system accounts\
+    \ assigned to those individuals. In such instances, the account management activities\
+    \ of AC-2 use account names provided by IA-4. This control also addresses individual\
+    \ identifiers not necessarily associated with information system accounts (e.g.,\
+    \ identifiers used in physical security control databases accessed by badge reader\
+    \ systems for access to information systems). Preventing reuse of identifiers\
+    \ implies preventing the assignment of previously used individual, group, role,\
+    \ or device identifiers to different individuals, groups, roles, or devices. Related\
+    \ controls: AC-2, IA-2, IA-3, IA-5, IA-8, SC-37.\n\nReferences: FIPS Publication\
+    \ 201; NIST Special Publications 800-73, 800-76, 800-78.\nIA-4(a) [at a minimum,\
+    \ the ISSO (or similar role within the organization)]  \nIA-4 (d) [at least two\
+    \ (2) years]\nIA-4 (e) [thirty-five (35) days] (See additional requirements and\
+    \ guidance.)\nIA-4 (e) Requirement: The service provider defines the time period\
+    \ of inactivity for device identifiers.\nGuidance: For DoD clouds, see DoD cloud\
+    \ website for specific DoD requirements that go above and beyond FedRAMP http://iase.disa.mil/cloud_security/Pages/index.aspx."
+  title: >-
+    IA-4 - IDENTIFIER MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-5
+  status: pending
+  notes: |-
+    Section a: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management.'
+
+    Section b: 'Documentation/guidance on how to configure initial authenticator
+    metadata is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/66'
+
+    Section c: 'Documentation/guidance on ensuring authenticators have sufficient
+    strenth of mechanism for their purpose is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/67'
+
+    Section d: 'Documentation/guidance for this control is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/68'
+
+    Section e: 'Documentation/guidance for this control is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/69'
+
+    Section f: 'Guidance/documentation for establishing minimum/maximum lifetime
+    restrictions and reuse conditions for authenticators is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/70'
+
+    Section g: 'Guidance on changing/refreshing authenticators after an
+    organizationally-defined time period is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/71'
+
+    Section h: 'Documentation/guidance for this control is being tracked on
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/72'
+
+    Section i: 'Documentation/guidance for this control is being tracked on
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/73'
+
+    Section j: 'This is an organizational control outside the scope of configuring
+    Red Hat Identity Management.'
+  rules: []
+  description: |-
+    The organization manages information system authenticators by:
+      a. Verifying, as part of the initial authenticator distribution, the identity of the individual, group, role, or device receiving the authenticator;
+      b. Establishing initial authenticator content for authenticators defined by the organization;
+      c. Ensuring that authenticators have sufficient strength of mechanism for their intended use;
+      d. Establishing and implementing administrative procedures for initial authenticator distribution, for lost/compromised or damaged authenticators, and for revoking authenticators;
+      e. Changing default content of authenticators prior to information system installation;
+      f. Establishing minimum and maximum lifetime restrictions and reuse conditions for authenticators;
+      g. Changing/refreshing authenticators [Assignment: organization-defined time period by authenticator type];
+      h. Protecting authenticator content from unauthorized disclosure and modification;
+      i. Requiring individuals to take, and having devices implement, specific security safeguards to protect authenticators; and
+      j. Changing authenticators for group/role accounts when membership to those accounts changes.
+
+    Supplemental Guidance: Individual authenticators include, for example, passwords, tokens, biometrics, PKI certificates, and key cards. Initial authenticator content is the actual content (e.g., the initial password) as opposed to requirements about authenticator content (e.g., minimum password length). In many cases, developers ship information system components with factory default authentication credentials to allow for initial installation and configuration. Default authentication credentials are often well known, easily discoverable, and present a significant security risk. The requirement to protect individual authenticators may be implemented via control PL-4 or PS-6 for authenticators in the possession of individuals and by controls AC-3, AC-6, and SC-28 for authenticators stored within organizational information systems (e.g., passwords stored in hashed or encrypted formats, files containing encrypted or hashed passwords accessible with administrator privileges). Information systems support individual authenticator management by organization-defined settings and restrictions for various authenticator characteristics including, for example, minimum password length, password composition, validation time window for time synchronous one-time tokens, and number of allowed rejections during the verification stage of biometric authentication. Specific actions that can be taken to safeguard authenticators include, for example, maintaining possession of individual authenticators, not loaning or sharing individual authenticators with others, and reporting lost, stolen, or compromised authenticators immediately. Authenticator management includes issuing and revoking, when no longer needed, authenticators for temporary access such as that required for remote maintenance. Device authenticators include, for example, certificates and passwords. Related controls: AC-2, AC-3, AC-6, CM-6, IA-2, IA-4, IA-8, PL-4, PS-5, PS-6, SC-12, SC-13, SC-17, SC-28.
+
+    References: OMB Memoranda 04-04, 11-11; FIPS Publication 201; NIST Special Publications 800-73, 800-63, 800-76, 800-78; FICAM Roadmap and Implementation Guidance
+
+
+
+    IA-5 Requirement: Authenticators must be compliant with NIST SP 800-63-3 Digital Identity Guidelines IAL, AAL, FAL level 3. Link https://pages.nist.gov/800-63-3
+  title: >-
+    IA-5 - AUTHENTICATOR MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-5(1)
+  status: pending
+  notes: |-
+    Section a: 'Documentation/guidance on implementing password complexity
+    is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/74'
+
+    Section b: 'Documentation/guidance on implementing changed characters during
+    password creation is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/75'
+
+    Section c: 'Documentation/guidance on storing and transmitting only
+    cryptographically-protected passwords is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/76'
+
+    Section d: 'Documentation/guidance on enforcing password minimum and maximum
+    lifetime restrictions is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/77'
+
+    Section e: 'Documentation/guidance on enforcing password minimum and maximum
+    lifetime restrictions is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/78'
+
+    Section f: 'Documentation/guidance on enforcing an immediate change to temporary
+    passwords is being tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/79'
+  rules: []
+  description: |-
+    The information system, for password-based authentication:
+     (a)   Enforces minimum password complexity of [Assignment: organization-defined requirements for case sensitivity, number of characters, mix of upper-case letters, lower-case letters, numbers, and special characters, including minimum requirements for each type];
+     (b)   Enforces at least the following number of changed characters when new passwords are created: [Assignment: organization-defined number];
+     (c)   Stores and transmits only encrypted representations of passwords;
+     (d)   Enforces password minimum and maximum lifetime restrictions of [Assignment: organization- defined numbers for lifetime minimum, lifetime maximum];
+     (e)   Prohibits password reuse for [Assignment: organization-defined number] generations; and
+     (f) Allows the use of a temporary password for system logons with an immediate change to a permanent password.
+
+    Supplemental Guidance:  This control enhancement applies to single-factor authentication of individuals using passwords as individual or group authenticators, and in a similar manner, when passwords are part of multifactor authenticators. This control enhancement does not apply when passwords are used to unlock hardware authenticators (e.g., Personal Identity Verification cards). The implementation of such password mechanisms may not meet all of the requirements in the enhancement. Encrypted representations of passwords include, for example, encrypted versions of passwords and one-way cryptographic hashes of passwords. The number of changed characters refers to the number of changes required with respect to the total number of positions in the current password. Password lifetime restrictions do not apply to temporary passwords. Related control: IA-6.
+
+    IA-5 (1) (b) [at least fifty percent (50%)]
+    IA-5 (1) (e) [twenty four (24)]
+    IA-5 (1) (a), and (d) Additional FedRAMP Requirements and Guidance:
+    Guidance: If password policies are compliant with NIST SP 800-63B Memorized Secret (Section 5.1.1) Guidance, the control may be considered compliant
+  title: >-
+    IA-5(1) - AUTHENTICATOR MANAGEMENT | PASSWORD-BASED AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-5(11)
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The information system, for hardware token-based authentication, employs mechanisms that satisfy [Assignment: organization-defined token quality requirements].
+
+    Supplemental Guidance:  Hardware token-based authentication typically refers to the use of PKI-based tokens, such as the U.S. Government Personal Identity Verification (PIV) card. Organizations define specific requirements for tokens, such as working with a particular PKI.
+  title: >-
+    IA-5(11) - AUTHENTICATOR MANAGEMENT | HARDWARE TOKEN-BASED AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-6
+  status: supported
+  notes: |-
+    'Red Hat Identity Management natively obscures such information.
+    Red Hat Identity Management cannot be
+    configured to be out of compliance with this requirement.'
+  rules: []
+  description: |-
+    The information system obscures feedback of authentication information during the authentication process to protect the information from possible exploitation/use by unauthorized individuals.
+
+    Supplemental Guidance:  The feedback from information systems does not provide information that would allow unauthorized individuals to compromise authentication mechanisms. For some types of information systems or system components, for example, desktops/notebooks with relatively large monitors, the threat (often referred to as shoulder surfing) may be significant. For other types of systems or components, for example, mobile devices with 2-4 inch screens, this threat may be less significant, and may need to be balanced against the increased likelihood of typographic input errors due to the small keyboards. Therefore, the means for obscuring the authenticator feedback is selected accordingly. Obscuring the feedback of authentication information includes, for example, displaying asterisks when users type passwords into input devices, or displaying feedback for a very limited time before fully obscuring it. Related control: PE-18.
+
+    Control Enhancements:  None.
+
+    References:  None.
+  title: >-
+    IA-6 - AUTHENTICATOR FEEDBACK
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-7
+  status: pending
+  notes: |-
+    'The customer will be responsible for configuring Red Hat Identity
+    Management to use
+    appropriate cryptographic modules. A successful control response will
+    document what modules are in use, how to attest the configuration is
+    in place, and references to supporing documentation outlining the
+    FIPS 140-2 certification for enabled modules.
+
+    Documentation to satisfy this control is being tracked on GitHub:
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/81'
+  rules: []
+  description: |-
+    The information system implements mechanisms for authentication to a cryptographic module that meet the requirements of applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance for such authentication.
+
+    Supplemental Guidance:  Authentication mechanisms may be required within a cryptographic module to authenticate an operator accessing the module and to verify that the operator is authorized to assume the requested role and perform services within that role. Related controls: SC-12, SC-13.
+
+    Control Enhancements:  None.
+
+    References:  FIPS Publication 140; Web: csrc.nist.gov/groups/STM/cmvp/index.html.
+  title: >-
+    IA-7 - CRYPTOGRAPHIC MODULE AUTHENTICATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8
+  status: pending
+  notes: |-
+    'The customer will be responsible for identifying and authenticating
+    non-organizational users accessing the customer application. A
+    successful control response will need to address how non-organizational
+    users are defined and the process by which identification
+    and authentication takes place, including any differences from
+    identification and authentication for organizational users.
+
+    Documentation on how to satisfy this control is being
+    tracked on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
+  rules: []
+  description: |-
+    The information system uniquely identifies and authenticates non-organizational users (or processes acting on behalf of non-organizational users).
+
+    Supplemental Guidance:  Non-organizational users include information system users other than organizational users explicitly covered by IA-2. These individuals are uniquely identified and authenticated for accesses other than those accesses explicitly identified and documented in AC-14. In accordance with the E-Authentication E-Government initiative, authentication of non- organizational users accessing federal information systems may be required to protect federal, proprietary, or privacy-related information (with exceptions noted for national security systems). Organizations use risk assessments to determine authentication needs and consider scalability, practicality, and security in balancing the need to ensure ease of use for access to federal information and information systems with the need to protect and adequately mitigate risk. IA-2 addresses identification and authentication requirements for access to information systems by organizational users. Related controls: AC-2, AC-14, AC-17, AC-18, IA-2, IA-4, IA-5, MA-4, RA-3, SA-12, SC-8.
+
+    References: OMB Memoranda 04-04, 11-11, 10-06-2011; FICAM Roadmap and Implementation Guidance; FIPS Publication 201; NIST Special Publications 800-63, 800-116; National Strategy for Trusted Identities in Cyberspace; Web: http://idmanagement.gov.
+  title: >-
+    IA-8 - IDENTIFICATION AND AUTHENTICATION (NON- ORGANIZATIONAL USERS)
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(1)
+  status: pending
+  notes: |-
+    'Personal Identity Verification (PIV) credentials are those
+    credentials issued by federal agencies that conform to FIPS Publication
+    201 and supporting guidance documents. Customers will not be expected
+    to perform this credential verification for government agencies. A
+    mechanism for allowing government agencies to perform credential
+    verification in a way that can be trusted by the customer system is
+    through Active Directory Federation Services (ADFS) or Red Hat IdM.
+
+    Documentation on satisfying this control is being tracked on
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/82'
+  rules: []
+  description: |-
+    The information system accepts and electronically verifies Personal Identity Verification (PIV) credentials from other federal agencies.
+
+    Supplemental Guidance:  This control enhancement applies to logical access control systems (LACS) and physical access control systems (PACS). Personal Identity Verification (PIV) credentials are those credentials issued by federal agencies that conform to FIPS Publication 201 and supporting guidance documents. OMB Memorandum 11-11 requires federal agencies to continue implementing the requirements specified in HSPD-12 to enable agency-wide use of PIV credentials. Related controls: AU-2, PE-3, SA-4.
+  title: >-
+    IA-8(1) - IDENTIFICATION AND AUTHENTICATION | ACCEPTANCE OF PIV CREDENTIALS FROM
+    OTHER AGENCIES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(2)
+  status: pending
+  notes: |-
+    'FICAM approved credentials are those credentials issued by nonfederal
+    government entities approved by the Federal Identity, Credential, and
+    Access Management (FICAM) Trust Framework Solutions Initiative.
+    Customers will not be expected to perform credential verification for
+    government agencies. A mechanism for allowing government agencies to
+    perform credential verification in a way that can be trusted by the
+    customer system is through Active Directory Federation Services
+    (ADFS) or Red Hat IdM.
+
+    Documentation/guidance for this control is being tracked
+    on GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/84'
+  rules: []
+  description: |-
+    The information system accepts only FICAM-approved third-party credentials.
+
+    Supplemental Guidance:  This control enhancement typically applies to organizational information systems that are accessible to the general public, for example, public-facing websites. Third-party credentials are those credentials issued by nonfederal government entities approved by the Federal Identity, Credential, and Access Management (FICAM) Trust Framework Solutions initiative. Approved third-party credentials meet or exceed the set of minimum federal government-wide technical, security, privacy, and organizational maturity requirements. This allows federal government relying parties to trust such credentials at their approved assurance levels. Related control: AU-2.
+  title: >-
+    IA-8(2) - IDENTIFICATION AND AUTHENTICATION | ACCEPTANCE OF THIRD-PARTY CREDENTIALS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(3)
+  status: pending
+  notes: |-
+    'FICAM approved credentials are those credentials issued by nonfederal
+    government entities approved by the Federal Identity, Credential, and
+    Access Management (FICAM) Trust Framework Solutions Initiative.
+    Customers will not be expected to perform credential verification for
+    government agencies. A mechanism for allowing government agencies to
+    perform credential verification in a way that can be trusted by the
+    customer system is through Active Directory Federation Services
+    (ADFS) or Red Hat IdM.
+
+    Documentation/guidance for this control is being tracked via
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/85'
+  rules: []
+  description: |-
+    The organization employs only FICAM-approved information system components in [Assignment:
+    organization-defined information systems] to accept third-party credentials.
+
+    Supplemental Guidance:  This control enhancement typically applies to information systems that are accessible to the general public, for example, public-facing websites. FICAM-approved information system components include, for example, information technology products and software libraries that have been approved by the Federal Identity, Credential, and Access Management conformance program. Related control: SA-4.
+  title: >-
+    IA-8(3) - IDENTIFICATION AND AUTHENTICATION | USE OF FICAM-APPROVED PRODUCTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: IA-8(4)
+  status: pending
+  notes: |-
+    'FICAM approved credentials are those credentials issued by nonfederal
+    government entities approved by the Federal Identity, Credential, and
+    Access Management (FICAM) Trust Framework Solutions Initiative.
+    Customers will not be expected to perform credential verification for
+    government agencies. A mechanism for allowing government agencies to
+    perform credential verification in a way that can be trusted by the
+    customer system is through Active Directory Federation Services
+    (ADFS) or Red Hat IdM.
+
+    Documentation/guidance for this control is being developed on
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/86'
+  rules: []
+  description: |-
+    The information system conforms to FICAM-issued profiles.
+
+    Supplemental Guidance:  This control enhancement addresses open identity management standards. To ensure that these standards are viable, robust, reliable, sustainable (e.g., available in commercial information technology products), and interoperable as documented, the United States Government assesses and scopes identity management standards and technology implementations against applicable federal legislation, directives, policies, and requirements. The result is FICAM-issued implementation profiles of approved protocols (e.g., FICAM authentication protocols such as SAML 2.0 and OpenID 2.0, as well as other protocols such as the FICAM Backend Attribute Exchange). Related control: SA-4.
+  title: >-
+    IA-8(4) - IDENTIFICATION AND AUTHENTICATION | USE OF FICAM-ISSUED PROFILES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-1
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. An incident response policy\
+    \ that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the incident response policy and associated\
+    \ incident response controls; and\n b. Reviews and updates the current:\n   1.\
+    \ Incident response policy [Assignment: organization-defined frequency]; and\n\
+    \   2. Incident response procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the IR family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-61, 800-83, 800-100.\n\n\
+    IR-1 (b) (1) [at least annually] \nIR-1 (b) (2) [at least annually or whenever\
+    \ a significant change occurs]"
+  title: >-
+    IR-1 - INCIDENT RESPONSE POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-2
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization provides incident response training to information system users consistent with assigned roles and responsibilities:
+     a. Within [Assignment: organization-defined time period] of assuming an incident response role or responsibility;
+     b. When required by information system changes; and
+     c. [Assignment: organization-defined frequency] thereafter.
+
+    Supplemental Guidance:  Incident response training provided by organizations is linked to the assigned roles and responsibilities of organizational personnel to ensure the appropriate content and level of detail is included in such training. For example, regular users may only need to know who to call or how to recognize an incident on the information system; system administrators may require additional training on how to handle/remediate incidents; and incident responders may receive more specific training on forensics, reporting, system recovery, and restoration. Incident response training includes user training in the identification and reporting of suspicious activities, both from external and internal sources. Related controls: AT-3, CP-3, IR-8.
+
+    References: NIST Special Publications 800-16, 800-50.
+
+    IR-2 (a) [within ten (10) days]
+    IR-2 (c) [at least annually]
+  title: >-
+    IR-2 - INCIDENT RESPONSE TRAINING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-2(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization incorporates simulated events into incident response training to facilitate effective response by personnel in crisis situations.
+  title: >-
+    IR-2(1) - INCIDENT RESPONSE TRAINING | SIMULATED EVENTS
+  levels:
+  - high
+- id: IR-2(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to provide a more thorough and realistic incident response training environment.
+  title: >-
+    IR-2(2) - INCIDENT RESPONSE TRAINING | AUTOMATED TRAINING ENVIRONMENTS
+  levels:
+  - high
+- id: IR-3
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization tests the incident response capability for the information system [Assignment: organization-defined frequency] using [Assignment: organization-defined tests] to determine the incident response effectiveness and documents the results.
+
+    Supplemental Guidance:  Organizations test incident response capabilities to determine the overall effectiveness of the capabilities and to identify potential weaknesses or deficiencies. Incident response testing includes, for example, the use of checklists, walk-through or tabletop exercises, simulations (parallel/full interrupt), and comprehensive exercises. Incident response testing can also include a determination of the effects on organizational operations (e.g., reduction in mission capabilities), organizational assets, and individuals due to incident response. Related controls: CP-4, IR-8.
+
+    References:  NIST Special Publications 800-84, 800-115.
+
+    IR-3-1 [at least every six (6) months, including functional at least annually]
+    IR-3-2 Requirement: The service provider defines tests and/or exercises in accordance with NIST Special Publication 800-61 (as amended). Functional Testing must occur prior to testing for initial authorization. Annual functional testing may be concurrent with required penetration tests (see CA-8). The service provider provides test plans to the JAB/AO annually. Test plans are approved and accepted by the JAB/AO prior to test commencing.
+  title: >-
+    IR-3 - INCIDENT RESPONSE TESTING
+  levels:
+  - high
+  - moderate
+- id: IR-3(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-3(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization coordinates incident response testing with organizational elements responsible for related plans.
+
+    Supplemental Guidance:  Organizational plans related to incident response testing include, for example, Business Continuity Plans, Contingency Plans, Disaster Recovery Plans, Continuity of Operations Plans, Crisis Communications Plans, Critical Infrastructure Plans, and
+    Occupant Emergency Plans.
+  title: >-
+    IR-3(2) - INCIDENT RESPONSE TESTING | COORDINATION WITH RELATED PLANS
+  levels:
+  - high
+  - moderate
+- id: IR-4
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization:\na. Implements an incident handling capability for\
+    \ security incidents that includes preparation, detection and analysis, containment,\
+    \ eradication, and recovery;\nb. Coordinates incident handling activities with\
+    \ contingency planning activities; and\nc. Incorporates lessons learned from ongoing\
+    \ incident handling activities into incident response procedures, training, and\
+    \ testing/exercises, and implements the resulting changes accordingly.\n\nSupplemental\
+    \ Guidance:  Organizations recognize that incident response capability is dependent\
+    \ on the capabilities of organizational information systems and the mission/business\
+    \ processes being supported by those systems. Therefore, organizations consider\
+    \ incident response as part of the definition, design, and development of mission/business\
+    \ processes and information systems. Incident-related information can be obtained\
+    \ from a variety of sources including, for example, audit monitoring, network\
+    \ monitoring, physical access monitoring, user/administrator reports, and reported\
+    \ supply chain events. Effective incident handling capability includes coordination\
+    \ among many organizational entities including, for example, mission/business\
+    \ owners, information system owners, authorizing officials, human resources offices,\
+    \ physical and personnel security offices, legal departments, operations personnel,\
+    \ procurement offices, and the risk executive (function). Related controls: AU-6,\
+    \ CM-6, CP-2, CP-4, IR-2, IR-3, IR-8, PE-6, SC-5, SC-7, SI-3, SI-4, SI-7.\n\n\
+    References: Executive Order 13587; NIST Special Publication 800-61.\n\n \nIR-4\
+    \ Requirement: The service provider ensures that individuals conducting incident\
+    \ handling meet personnel security requirements commensurate with the criticality/sensitivity\
+    \ of the information being processed, stored, and transmitted by the information\
+    \ system."
+  title: >-
+    IR-4 - INCIDENT HANDLING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-4(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to support the incident handling process.
+
+    Supplemental Guidance:  Automated mechanisms supporting incident handling processes include, for example, online incident management systems.
+  title: >-
+    IR-4(1) - INCIDENT HANDLING | AUTOMATED INCIDENT HANDLING PROCESSES
+  levels:
+  - high
+  - moderate
+- id: IR-4(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization includes dynamic reconfiguration of [Assignment: organization-defined information system components] as part of the incident response capability.
+
+    Supplemental Guidance:  Dynamic reconfiguration includes, for example, changes to router rules, access control lists, intrusion detection/prevention system parameters, and filter rules for firewalls and gateways. Organizations perform dynamic reconfiguration of information systems, for example, to stop attacks, to misdirect attackers, and to isolate components of systems, thus limiting the extent of the damage from breaches or compromises. Organizations include time frames for achieving the reconfiguration of information systems in the definition of the reconfiguration capability, considering the potential need for rapid response in order to effectively address sophisticated cyber threats. Related controls: AC-2, AC-4, AC-16, CM-2, CM-3, CM-4.
+
+    IR-4 (2) [all network, data storage, and computing devices]
+  title: >-
+    IR-4(2) - INCIDENT HANDLING | DYNAMIC RECONFIGURATION
+  levels:
+  - high
+- id: IR-4(3)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization identifies [Assignment: organization-defined classes of incidents] and [Assignment: organization-defined actions to take in response to classes of incidents] to ensure continuation of organizational missions and business functions.
+
+    Supplemental Guidance:  Classes of incidents include, for example, malfunctions due to design/implementation errors and omissions, targeted malicious attacks, and untargeted malicious attacks. Appropriate incident response actions include, for example, graceful degradation, information system shutdown, fall back to manual mode/alternative technology whereby the system operates differently, employing deceptive measures, alternate information flows, or operating in a mode that is reserved solely for when systems are under attack.
+  title: >-
+    IR-4(3) - INCIDENT HANDLING | CONTINUITY OF OPERATIONS
+  levels:
+  - high
+- id: IR-4(4)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization correlates incident information and individual incident responses to achieve an organization-wide perspective on incident awareness and response.
+
+    Supplemental Guidance:  Sometimes the nature of a threat event, for example, a hostile cyber attack, is such that it can only be observed by bringing together information from different sources including various reports and reporting procedures established by organizations.
+  title: >-
+    IR-4(4) - INCIDENT HANDLING | INFORMATION CORRELATION
+  levels:
+  - high
+- id: IR-4(5)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-4(6)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization implements incident handling capability for insider threats.
+
+    Supplemental Guidance:  While many organizations address insider threat incidents as an inherent part of their organizational incident response capability, this control enhancement provides additional emphasis on this type of threat and the need for specific incident handling capabilities (as defined within organizations) to provide appropriate and timely responses.
+  title: >-
+    IR-4(6) - INCIDENT HANDLING | INSIDER THREATS - SPECIFIC CAPABILITIES
+  levels:
+  - high
+- id: IR-4(7)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-4(8)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization coordinates with [Assignment: organization-defined\
+    \ external organizations] to correlate and share [Assignment: organization-defined\
+    \ incident information] to achieve a cross- organization perspective on incident\
+    \ awareness and more effective incident responses.\n\nSupplemental Guidance: \
+    \ The coordination of incident information with external organizations including,\
+    \ for example, mission/business partners, military/coalition partners, customers,\
+    \ and multitiered developers, can provide significant benefits. Cross-organizational\
+    \ coordination with respect to incident handling can serve as an important risk\
+    \ management capability. This capability allows organizations to leverage critical\
+    \ information from a variety of sources to effectively respond to information\
+    \ security-related incidents potentially affecting the organization\u2019s operations,\
+    \ assets, and individuals.\n\nIR-4 (8) [external organizations including consumer\
+    \ incident responders and network defenders and the appropriate CIRT/CERT (such\
+    \ as US-CERT, DOD CERT, IC CERT)]"
+  title: >-
+    IR-4(8) - INCIDENT HANDLING | CORRELATION WITH EXTERNAL ORGANIZATIONS
+  levels:
+  - high
+- id: IR-4(9)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-4(10)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-5
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization tracks and documents information system security incidents.
+
+    Supplemental Guidance:  Documenting information system security incidents includes, for example, maintaining records about each incident, the status of the incident, and other pertinent information necessary for forensics, evaluating incident details, trends, and handling. Incident information can be obtained from  a variety of sources including, for example, incident reports, incident response teams, audit monitoring, network monitoring, physical access monitoring, and user/administrator reports. Related controls: AU-6, IR-8, PE-6, SC-5, SC-7, SI-3, SI-4, SI-7.
+
+    References: NIST Special Publication 800-61.
+  title: >-
+    IR-5 - INCIDENT MONITORING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-5(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to assist in the tracking of security incidents and in the collection and analysis of incident information.
+
+    Supplemental Guidance:  Automated mechanisms for tracking security incidents and collecting/analyzing incident information include, for example, the Einstein network monitoring device and monitoring online Computer Incident Response Centers (CIRCs) or other electronic databases of incidents. Related controls: AU-7, IR-4.
+  title: >-
+    IR-5(1) - INCIDENT MONITORING | AUTOMATED TRACKING / DATA COLLECTION / ANALYSIS
+  levels:
+  - high
+- id: IR-6
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Requires personnel to report suspected security incidents to the organizational incident response capability within [Assignment: organization-defined time period]; and
+     b. Reports security incident information to [Assignment: organization-defined authorities].
+
+    Supplemental Guidance:  The intent of this control is to address both specific incident reporting requirements within an organization and the formal incident reporting requirements for federal agencies and their subordinate organizations. Suspected security incidents include, for example, the receipt of suspicious email communications that can potentially contain malicious code. The types of security incidents reported, the content and timeliness of the reports, and the designated reporting authorities reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Current federal policy requires that all federal agencies (unless specifically exempted from such requirements) report security incidents to the United States Computer Emergency Readiness Team (US-CERT) within specified time frames designated in the US-CERT Concept of Operations for Federal Cyber Security Incident Handling. Related controls: IR-4, IR-5, IR-8.
+
+    References: NIST Special Publication 800-61; Web: http://www.us-cert.gov.
+
+    IR-6 (a) [US-CERT incident reporting timelines as specified in NIST Special Publication 800-61 (as amended)]
+    IR-6 Requirement: Reports security incident information according to FedRAMP Incident Communications Procedure.
+  title: >-
+    IR-6 - INCIDENT REPORTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-6(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to assist in the reporting of security incidents.
+
+    Supplemental Guidance:  Related control: IR-7.
+  title: >-
+    IR-6(1) - INCIDENT REPORTING | AUTOMATED REPORTING
+  levels:
+  - high
+  - moderate
+- id: IR-6(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-6(3)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: IR-7
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization provides an incident response support resource, integral to the organizational incident response capability that offers advice and assistance to users of the information system for the handling and reporting of security incidents.
+
+    Supplemental Guidance:  Incident response support resources provided by organizations include, for example, help desks, assistance groups, and access to forensics services, when required. Related controls: AT-2, IR-4, IR-6, IR-8, SA-9.
+  title: >-
+    IR-7 - INCIDENT RESPONSE ASSISTANCE
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-7(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to increase the availability of incident response- related information and support.
+
+    Supplemental Guidance:  Automated mechanisms can provide a push and/or pull capability for users to obtain incident response assistance. For example, individuals might have access to a website to query the assistance capability, or conversely, the assistance capability may have the ability to proactively send information to users (general distribution or targeted) as part of increasing understanding of current response capabilities and support.
+  title: >-
+    IR-7(1) - INCIDENT RESPONSE ASSISTANCE | AUTOMATION SUPPORT FOR AVAILABILITY OF
+    INFORMATION / SUPPORT
+  levels:
+  - high
+  - moderate
+- id: IR-7(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     (a)   Establishes a direct, cooperative relationship between its incident response capability and external providers of information system protection capability; and
+     (b)   Identifies organizational incident response team members to the external providers.
+
+    Supplemental Guidance:  External providers of information system protection capability include, for example, the Computer Network Defense program within the U.S. Department of Defense. External providers help to protect, monitor, analyze, detect, and respond to unauthorized activity within organizational information systems and networks.
+  title: >-
+    IR-7(2) - INCIDENT RESPONSE ASSISTANCE | COORDINATION WITH EXTERNAL PROVIDERS
+  levels:
+  - high
+  - moderate
+- id: IR-8
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Develops an incident response plan that:
+       1. Provides the organization with a roadmap for implementing its incident response capability;
+       2. Describes the structure and organization of the incident response capability;
+       3. Provides a high-level approach for how the incident response capability fits into the overall organization;
+       4. Meets the unique requirements of the organization, which relate to mission, size, structure, and functions;
+       5. Defines reportable incidents;
+       6. Provides metrics for measuring the incident response capability within the organization;
+       7. Defines the resources and management support needed to effectively maintain and mature an incident response capability; and
+       8. Is reviewed and approved by [Assignment: organization-defined personnel or roles];
+     b. Distributes copies of the incident response plan to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements];
+     c. Reviews the incident response plan [Assignment: organization-defined frequency];
+     d. Updates the incident response plan to address system/organizational changes or problems encountered during plan implementation, execution, or testing;
+      e. Communicates incident response plan changes to [Assignment: organization-defined incident response personnel (identified by name and/or by role) and organizational elements]; and
+    f. Protects the incident response plan from unauthorized disclosure and modification.
+
+    Supplemental Guidance:  It is important that organizations develop and implement a coordinated approach to incident response. Organizational missions, business functions, strategies, goals, and objectives for incident response help to determine the structure of incident response capabilities. As part of a comprehensive incident response capability, organizations consider the coordination and sharing of information with external organizations, including, for example, external service providers and organizations involved in the supply chain for organizational information systems. Related controls: MP-2, MP-4, MP-5.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publication 800-61.
+
+    IR-8 (b) [see additional FedRAMP Requirements and Guidance]
+    IR-8 (c) [at least annually]
+    IR-8 (e) [see additional FedRAMP Requirements and Guidance]
+    IR-8 (b) Requirement: The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.
+    IR-8 (e) Requirement: The service provider defines a list of incident response personnel (identified by name and/or by role) and organizational elements. The incident response list includes designated FedRAMP personnel.
+  title: >-
+    IR-8 - INCIDENT RESPONSE PLAN
+  levels:
+  - high
+  - moderate
+  - low
+- id: IR-9
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization responds to information spills by:
+     a. Identifying the specific information involved in the information system contamination;
+     b. Alerting [Assignment: organization-defined personnel or roles] of the information spill using a method of communication not associated with the spill;
+     c. Isolating the contaminated information system or system component;
+     d. Eradicating the information from the contaminated information system or component;
+     e. Identifying other information systems or system components that may have been subsequently contaminated; and
+     f. Performing other [Assignment: organization-defined actions].
+    Supplemental Guidance: Information spillage refers to instances where either classified or sensitive information is inadvertently placed on information systems that are not authorized to process such information. Such information spills often occur when information that is initially thought to be of lower sensitivity is transmitted to an information system and then is subsequently determined to be of higher sensitivity. At that point, corrective action is required. The nature of the organizational response is generally based upon the degree of sensitivity of the spilled information (e.g., security category or classification level), the security capabilities of the information system, the specific nature of contaminated storage media, and the access authorizations (e.g., security clearances) of individuals with authorized access to the contaminated system. The methods used to communicate information about the spill after the fact do not involve methods directly associated with the actual spill to minimize the risk of further spreading the contamination before such contamination is isolated and eradicated.
+
+    References: None.
+  title: >-
+    IR-9 - INFORMATION SPILLAGE RESPONSE
+  levels:
+  - high
+  - moderate
+- id: IR-9(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization assigns [Assignment: organization-defined personnel or roles] with responsibility for responding to information spills.
+  title: >-
+    IR-9(1) - INFORMATION SPILLAGE RESPONSE | RESPONSIBLE PERSONNEL
+  levels:
+  - high
+  - moderate
+- id: IR-9(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization provides information spillage response training [Assignment: organization- defined frequency].
+
+    IR-9 (2) [at least annually]
+  title: >-
+    IR-9(2) - INFORMATION SPILLAGE RESPONSE | TRAINING
+  levels:
+  - high
+  - moderate
+- id: IR-9(3)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization implements [Assignment: organization-defined procedures] to ensure that organizational personnel impacted by information spills can continue to carry out assigned tasks while contaminated systems are undergoing corrective actions.
+
+    Supplemental Guidance:  Correction actions for information systems contaminated due to information spillages may be very time-consuming. During those periods, personnel may not have access to the contaminated systems, which may potentially affect their ability to conduct organizational business.
+  title: >-
+    IR-9(3) - INFORMATION SPILLAGE RESPONSE | POST-SPILL OPERATIONS
+  levels:
+  - high
+  - moderate
+- id: IR-9(4)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs [Assignment: organization-defined security safeguards] for personnel exposed to information not within assigned access authorizations.
+
+    Supplemental Guidance:  Security safeguards include, for example, making personnel exposed to spilled information aware of the federal laws, directives, policies, and/or regulations regarding the information and the restrictions imposed based on exposure to such information.
+  title: >-
+    IR-9(4) - INFORMATION SPILLAGE RESPONSE | EXPOSURE TO UNAUTHORIZED PERSONNEL
+  levels:
+  - high
+  - moderate
+- id: IR-10
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: MA-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A system maintenance policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the system maintenance policy and associated system maintenance controls; and
+     b. Reviews and updates the current:
+       1. System maintenance policy [Assignment: organization-defined frequency]; and
+       2. System maintenance procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the MA family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    MA-1 (b) (1) [at least annually]
+    MA-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    MA-1 - SYSTEM MAINTENANCE POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Schedules, performs, documents, and reviews records of maintenance and repairs on information system components in accordance with manufacturer or vendor specifications and/or organizational requirements;
+     b. Approves and monitors all maintenance activities, whether performed on site or remotely and whether the equipment is serviced on site or removed to another location;
+     c. Requires that [Assignment: organization-defined personnel or roles] explicitly approve the removal of the information system or system components from organizational facilities for off-site maintenance or repairs;
+     d. Sanitizes equipment to remove all information from associated media prior to removal from organizational facilities for off-site maintenance or repairs;
+     e. Checks all potentially impacted security controls to verify that the controls are still functioning properly following maintenance or repair actions; and
+     f. Includes [Assignment: organization-defined maintenance-related information] in organizational maintenance records.
+
+    Supplemental Guidance:  This control addresses the information security aspects of the information system maintenance program and applies to all types of maintenance to any system component (including applications) conducted by any local or nonlocal entity (e.g., in-contract, warranty, in- house, software maintenance agreement). System maintenance also includes those components not directly associated with information processing and/or data/information retention such as scanners, copiers, and printers. Information necessary for creating effective maintenance records includes, for example: (i) date and time of maintenance; (ii) name of individuals or group performing the maintenance; (iii) name of escort, if necessary; (iv) a description of the maintenance performed; and (v) information system components/equipment removed or replaced (including identification numbers, if applicable). The level of detail included in maintenance records can be informed by
+    the security categories of organizational information systems. Organizations consider supply chain issues associated with replacement components for information systems. Related controls: CM-3, CM-4, MA-4, MP-6, PE-16, SA-12, SI-2.
+
+    References: None.
+  title: >-
+    MA-2 - CONTROLLED MAINTENANCE
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-4
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Approves and monitors nonlocal maintenance and diagnostic activities;
+     b. Allows the use of nonlocal maintenance and diagnostic tools only as consistent with organizational policy and documented in the security plan for the information system;
+     c. Employs strong authenticators in the establishment of nonlocal maintenance and diagnostic sessions;
+     d. Maintains records for nonlocal maintenance and diagnostic activities; and
+     e. Terminates session and network connections when nonlocal maintenance is completed.
+
+    Supplemental Guidance:  Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the Internet) or an internal network. Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection. Authentication techniques used in the establishment of nonlocal maintenance and diagnostic sessions reflect the network access requirements in IA-2. Typically, strong authentication requires authenticators that are resistant to replay attacks and employ multifactor authentication. Strong authenticators include, for example, PKI where certificates are stored on a token protected by a password, passphrase, or biometric.  Enforcing requirements in MA-4 is accomplished in part by other controls. Related controls: AC-2, AC-3, AC-6, AC-17, AU-2, AU-3, IA-2, IA-4, IA-5, IA-8, MA-2, MA-5, MP-6, PL-2, SC-7, SC-10, SC-17.
+
+    References: FIPS Publications 140-2, 197, 201; NIST Special Publications 800-63, 800-88; CNSS Policy 15.
+  title: >-
+    MA-4 - NONLOCAL MAINTENANCE
+  levels:
+  - high
+  - moderate
+  - low
+- id: MA-5
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes a process for maintenance personnel authorization and maintains a list of authorized maintenance organizations or personnel;
+     b. Ensures that non-escorted personnel performing maintenance on the information system have required access authorizations; and
+     c. Designates organizational personnel with required access authorizations and technical competence to supervise the maintenance activities of personnel who do not possess the required access authorizations.
+
+    Supplemental Guidance:  This control applies to individuals performing hardware or software maintenance on organizational information systems, while PE-2 addresses physical access for individuals whose maintenance duties place them within the physical protection perimeter of the systems (e.g., custodial staff, physical plant maintenance personnel). Technical competence of supervising individuals relates to the maintenance performed on the information systems while having required access authorizations refers to maintenance on and near the systems. Individuals not previously identified as authorized maintenance personnel, such as information technology manufacturers, vendors, systems integrators, and consultants, may require privileged access to organizational information systems, for example, when required to conduct maintenance activities with little or no notice. Based on organizational assessments of risk, organizations may issue temporary credentials to these individuals. Temporary credentials may be for one-time use or for very limited time periods. Related controls: AC-2, IA-8, MP-2, PE-2, PE-3, PE-4, RA-3.
+
+    References: None.
+  title: >-
+    MA-5 - MAINTENANCE PERSONNEL
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A media protection policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the media protection policy and associated media protection controls; and
+     b. Reviews and updates the current:
+       1. Media protection policy [Assignment: organization-defined frequency]; and
+       2. Media protection procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the MP family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    MP-1 (b) (1) [at least annually]
+    MP-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    MP-1 - MEDIA PROTECTION POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization restricts access to [Assignment: organization-defined types of digital and/or non-digital media] to [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:   Information system media includes both digital and non-digital media. Digital media includes, for example, diskettes, magnetic tapes, external/removable hard disk drives, flash drives, compact disks, and digital video disks. Non-digital media includes, for example, paper and microfilm. Restricting non-digital media access includes, for example, denying access to patient medical records in a community hospital unless the individuals seeking access to such records are authorized healthcare providers. Restricting access to digital media includes, for example, limiting access to design specifications stored on compact disks in the media library to the project leader and the individuals on the development team. Related controls: AC-3, IA-2, MP-4, PE-2, PE-3, PL-2.
+
+    MP-2-1 [any digital and non-digital media deemed sensitive]
+  title: >-
+    MP-2 - MEDIA ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-6
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Sanitizes [Assignment: organization-defined information system media] prior to disposal, release out of organizational control, or release for reuse using [Assignment: organization- defined sanitization techniques and procedures] in accordance with applicable federal and organizational standards and policies; and
+     b. Employs sanitization mechanisms with the strength and integrity commensurate with the security category or classification of the information.
+
+    Supplemental Guidance:   This control applies to all information system media, both digital and non- digital, subject to disposal or reuse, whether or not the media is considered removable. Examples include media found in scanners, copiers, printers, notebook computers, workstations, network components, and mobile devices. The sanitization process removes information from the media such that the information cannot be retrieved or reconstructed. Sanitization techniques, including clearing, purging, cryptographic erase, and destruction, prevent the disclosure of information to unauthorized individuals when such media is reused or released for disposal. Organizations determine the appropriate sanitization methods recognizing that destruction is sometimes necessary when other methods cannot be applied to media requiring sanitization. Organizations use discretion on the employment of approved sanitization techniques and procedures for media containing information deemed to be in the public domain or publicly releasable, or deemed to have no adverse impact on organizations or individuals if released for reuse or disposal. Sanitization of non-digital media includes, for example, removing a classified appendix from an otherwise unclassified document, or redacting selected sections or words from a document by obscuring the redacted sections/words in a manner equivalent in effectiveness to removing them from the document. NSA standards and policies control the sanitization process for media containing classified information. Related controls: MA-2, MA-4, RA-3, SC-4.
+
+    References: FIPS Publication 199; NIST Special Publications 800-60, 800-88; Web: http://www.nsa.gov/ia/mitigation_guidance/media_destruction_guidance/index.shtml.
+
+    MP-6(a)-2 [techniques and procedures IAW NIST SP 800-88 and Section 5.9: Reuse and Disposal of Storage Media and Hardware]
+  title: >-
+    MP-6 - MEDIA SANITIZATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: MP-7
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization [Selection: restricts; prohibits] the use of [Assignment: organization- defined types of information system media] on [Assignment: organization-defined information systems or system components] using [Assignment: organization-defined security safeguards].
+
+    Supplemental Guidance:  Information system media includes both digital and non-digital media. Digital media includes, for example, diskettes, magnetic tapes, external/removable hard disk drives, flash drives, compact disks, and digital video disks. Non-digital media includes, for example, paper and microfilm. This control also applies to mobile devices with information storage capability (e.g., smart phones, tablets, E-readers). In contrast to MP-2, which restricts user access to media, this control restricts the use of certain types of media on information systems, for example, restricting/prohibiting the use of flash drives or external hard disk drives. Organizations can employ technical and nontechnical safeguards (e.g., policies, procedures, rules of behavior) to restrict the use of information system media. Organizations may restrict the use of portable storage devices, for example, by using physical cages on workstations to prohibit access to certain external ports, or disabling/removing the ability to insert, read or write to such devices. Organizations may also limit the use of portable storage devices to only approved devices including, for example, devices provided by the organization, devices provided by other approved organizations, and devices that are not personally owned. Finally, organizations may restrict the use of portable storage devices based on the type of device, for example, prohibiting the use of writeable, portable storage devices, and implementing this restriction by disabling or removing the capability to write to such devices. Related controls: AC-19, PL-4.
+
+    References: None.
+  title: >-
+    MP-7 - MEDIA USE
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-1
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A physical and environmental\
+    \ protection policy that addresses purpose, scope, roles, responsibilities, management\
+    \ commitment, coordination among organizational entities, and compliance; and\n\
+    \   2. Procedures to facilitate the implementation of the physical and environmental\
+    \ protection policy and associated physical and environmental protection controls;\
+    \ and\n b. Reviews and updates the current:\n   1. Physical and environmental\
+    \ protection policy [Assignment: organization-defined frequency]; and\n   2. Physical\
+    \ and environmental protection procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the PE family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-100.\n\nPE-1 (b) (1) [at\
+    \ least annually] \nPE-1 (b) (2) [at least annually or whenever a significant\
+    \ change occurs]"
+  title: >-
+    PE-1 - PHYSICAL AND ENVIRONMENTAL PROTECTION
+
+    POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-2
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, approves, and maintains a list of individuals with authorized access to the facility where the information system resides;
+     b. Issues authorization credentials for facility access;
+     c. Reviews the access list detailing authorized facility access by individuals [Assignment: organization-defined frequency]; and
+     d. Removes individuals from the facility access list when access is no longer required.
+
+    Supplemental Guidance:  This control applies to organizational employees and visitors. Individuals (e.g., employees, contractors, and others) with permanent physical access authorization credentials are not considered visitors. Authorization credentials include, for example, badges, identification cards, and smart cards. Organizations determine the strength of authorization credentials needed (including level of forge-proof badges, smart cards, or identification cards) consistent with federal standards, policies, and procedures. This control only applies to areas within facilities that have not been designated as publicly accessible. Related controls: PE-3, PE-4, PS-3.
+
+    References: None
+
+
+    PE-2 (c) [at least every ninety (90) days]
+  title: >-
+    PE-2 - PHYSICAL ACCESS AUTHORIZATIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-2(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-2(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-2(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-3
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Enforces physical access authorizations at [Assignment: organization-defined entry/exit points to the facility where the information system resides] by;
+       1. Verifying individual access authorizations before granting access to the facility; and
+       2. Controlling ingress/egress to the facility using [Selection (one or more): [Assignment: organization-defined physical access control systems/devices]; guards];
+     b. Maintains physical access audit logs for [Assignment: organization-defined entry/exit points];
+     c. Provides [Assignment: organization-defined security safeguards] to control access to areas within the facility officially designated as publicly accessible;
+     d. Escorts visitors and monitors visitor activity [Assignment: organization-defined circumstances requiring visitor escorts and monitoring];
+     e. Secures keys, combinations, and other physical access devices;
+     f. Inventories [Assignment: organization-defined physical access devices] every [Assignment: organization-defined frequency]; and
+     g. Changes combinations and keys [Assignment: organization-defined frequency] and/or when keys are lost, combinations are compromised, or individuals are transferred or terminated.
+
+    Supplemental Guidance:  This control applies to organizational employees and visitors. Individuals (e.g., employees, contractors, and others) with permanent physical access authorization credentials are not considered visitors. Organizations determine the types of facility guards needed including, for example, professional physical security staff or other personnel such as administrative staff or information system users. Physical access devices include, for example, keys, locks, combinations, and card readers. Safeguards for publicly accessible areas within organizational facilities include, for example, cameras, monitoring by guards, and isolating selected information systems and/or system components in secured areas. Physical access control systems comply with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance. The Federal Identity, Credential, and Access Management Program provides implementation guidance for identity, credential, and access management capabilities for physical access control systems. Organizations have flexibility in the types of audit logs employed. Audit logs can be procedural (e.g., a written log of individuals accessing the facility and when such access occurred), automated (e.g., capturing ID provided by a PIV card), or some combination thereof. Physical access points can include facility access points, interior access points to information systems and/or components requiring supplemental access controls, or both. Components of organizational information systems (e.g., workstations, terminals) may be located in areas designated as publicly accessible with organizations safeguarding access to such devices. Related controls: AU-2, AU-6, MP-2, MP-4, PE-2, PE-4, PE-5, PS-3, RA-3.
+
+    Supplemental Guidance: Related controls: CA-2, CA-7.
+
+    PE-3 (a) (2) [CSP defined physical access control systems/devices AND guards]
+    PE-3 (d) [in all circumstances within restricted access area where the information system resides]
+    PE-3 (f) [at least annually]
+    PE-3 (g) [at least annually]
+  title: >-
+    PE-3 - PHYSICAL ACCESS CONTROL
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-3(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization enforces physical access authorizations to the information system in addition to the physical access controls for the facility at [Assignment: organization-defined physical spaces containing one or more components of the information system].
+
+    Supplemental Guidance:  This control enhancement provides additional physical security for those areas within facilities where there is a concentration of information system components (e.g., server rooms, media storage areas, data and communications centers). Related control: PS-2.
+  title: >-
+    PE-3(1) - PHYSICAL ACCESS CONTROL | INFORMATION SYSTEM ACCESS
+  levels:
+  - high
+- id: PE-3(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-3(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-3(4)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-3(5)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-3(6)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-4
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization controls physical access to [Assignment: organization-defined information system distribution and transmission lines] within organizational facilities using [Assignment: organization-defined security safeguards].
+
+    Supplemental Guidance:  Physical security safeguards applied to information system distribution and transmission lines help to prevent accidental damage, disruption, and physical tampering. In addition, physical safeguards may be necessary to help prevent eavesdropping or in transit modification of unencrypted transmissions. Security safeguards to control physical access to system distribution and transmission lines include, for example: (i) locked wiring closets; (ii) disconnected or locked spare jacks; and/or (iii) protection of cabling by conduit or cable trays. Related controls: MP-2, MP-4, PE-2, PE-3, PE-5, SC-7, SC-8.
+
+    Control Enhancements:  None.
+
+    References:  NSTISSI No. 7003.
+  title: >-
+    PE-4 - ACCESS CONTROL FOR TRANSMISSION MEDIUM
+  levels:
+  - high
+  - moderate
+- id: PE-5
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization controls physical access to information system output devices to prevent unauthorized individuals from obtaining the output.
+
+    Supplemental Guidance:  Controlling physical access to output devices includes, for example, placing output devices in locked rooms or other secured areas and allowing access to authorized individuals only, and placing output devices in locations that can be monitored by organizational personnel. Monitors, printers, copiers, scanners, facsimile machines, and audio devices are examples of information system output devices. Related controls: PE-2, PE-3, PE-4, PE-18.
+
+    References: None.
+  title: >-
+    PE-5 - ACCESS CONTROL FOR OUTPUT DEVICES
+  levels:
+  - high
+  - moderate
+- id: PE-5(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-5(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-5(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-6
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Monitors physical access to the facility where the information system resides to detect and respond to physical security incidents;
+     b. Reviews physical access logs [Assignment: organization-defined frequency] and upon occurrence of [Assignment: organization-defined events or potential indications of events]; and
+     c. Coordinates results of reviews and investigations with the organizational incident response capability.
+
+    Supplemental Guidance:  Organizational incident response capabilities include investigations of and responses to detected physical security incidents. Security incidents include, for example, apparent security violations or suspicious physical access activities. Suspicious physical access activities include, for example: (i) accesses outside of normal work hours; (ii) repeated accesses to areas not normally accessed; (iii) accesses for unusual lengths of time; and (iv) out-of-sequence accesses. Related controls: CA-7, IR-4, IR-8.
+
+    References: None.
+
+    PE-6 (b) [at least monthly]
+  title: >-
+    PE-6 - MONITORING PHYSICAL ACCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-6(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization monitors physical intrusion alarms and surveillance equipment.
+  title: >-
+    PE-6(1) - MONITORING PHYSICAL ACCESS | INTRUSION ALARMS / SURVEILLANCE EQUIPMENT
+  levels:
+  - high
+  - moderate
+- id: PE-6(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-6(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-6(4)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization monitors physical access to the information system in addition to the physical access monitoring of the facility as [Assignment: organization-defined physical spaces containing one or more components of the information system].
+
+    Supplemental Guidance:  This control enhancement provides additional monitoring for those areas within facilities where there is a concentration of information system components (e.g., server rooms, media storage areas, communications centers). Related controls: PS-2, PS-3.
+  title: >-
+    PE-6(4) - MONITORING PHYSICAL ACCESS | MONITORING PHYSICAL ACCESS TO INFORMATION
+    SYSTEMS
+  levels:
+  - high
+- id: PE-7
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-8
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Maintains visitor access records to the facility where the information system resides for [Assignment: organization-defined time period]; and
+     b. Reviews visitor access records [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Visitor access records include, for example, names and organizations of persons visiting, visitor signatures, forms of identification, dates of access, entry and departure times, purposes of visits, and names and organizations of persons visited. Visitor access records are not required for publicly accessible areas.
+
+    References: None.
+
+    PE-8 (a) [for a minimum of one (1) year]
+    PE-8 (b) [at least monthly]
+  title: >-
+    PE-8 - VISITOR ACCESS RECORDS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-8(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to facilitate the maintenance and review of visitor access records.
+  title: >-
+    PE-8(1) - VISITOR ACCESS RECORDS | AUTOMATED RECORDS MAINTENANCE / REVIEW
+  levels:
+  - high
+- id: PE-8(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-9
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization protects power equipment and power cabling for the information system from damage and destruction.
+
+    Supplemental Guidance:  Organizations determine the types of protection necessary for power equipment and cabling employed at different locations both internal and external to organizational facilities and environments of operation. This includes, for example, generators and power cabling outside of buildings, internal cabling and uninterruptable power sources within an office or data center, and power sources for self-contained entities such as vehicles and satellites. Related control: PE-4.
+
+    References: None.
+  title: >-
+    PE-9 - POWER EQUIPMENT AND CABLING
+  levels:
+  - high
+  - moderate
+- id: PE-9(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-9(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-10
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Provides the capability of shutting off power to the information system or individual system components in emergency situations;
+     b. Places emergency shutoff switches or devices in [Assignment: organization-defined location by information system or system component] to facilitate safe and easy access for personnel; and
+     c. Protects emergency power shutoff capability from unauthorized activation.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Related control: PE-15.
+
+    References: None.
+  title: >-
+    PE-10 - EMERGENCY SHUTOFF
+  levels:
+  - high
+  - moderate
+- id: PE-10(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-11
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization provides a short-term uninterruptible power supply to facilitate [Selection (one or more): an orderly shutdown of the information system; transition of the information system to long-term alternate power] in the event of a primary power source loss.
+
+    Supplemental Guidance:  Related controls: AT-3, CP-2, CP-7.
+
+    References: None.
+  title: >-
+    PE-11 - EMERGENCY POWER
+  levels:
+  - high
+  - moderate
+- id: PE-11(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization provides a long-term alternate power supply for the information system that is capable of maintaining minimally required operational capability in the event of an extended loss of the primary power source.
+
+    Supplemental Guidance:  This control enhancement can be satisfied, for example, by the use of a secondary commercial power supply or other external power supply. Long-term alternate power supplies for the information system can be either manually or automatically activated.
+  title: >-
+    PE-11(1) - EMERGENCY POWER | LONG-TERM ALTERNATE POWER SUPPLY - MINIMAL OPERATIONAL
+    CAPABILITY
+  levels:
+  - high
+- id: PE-11(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-12
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs and maintains automatic emergency lighting for the information system that activates in the event of a power outage or disruption and that covers emergency exits and evacuation routes within the facility.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Related controls: CP-2, CP-7.
+
+    References: None.
+  title: >-
+    PE-12 - EMERGENCY LIGHTING
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-12(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-13
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs and maintains fire suppression and detection devices/systems for the information system that are supported by an independent energy source.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Fire suppression and detection devices/systems include, for example, sprinkler systems, handheld fire extinguishers, fixed fire hoses, and smoke detectors.
+
+    References: None.
+  title: >-
+    PE-13 - FIRE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-13(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs fire detection devices/systems for the information system that activate automatically and notify [Assignment: organization-defined personnel or roles] and [Assignment: organization-defined emergency responders] in the event of a fire.
+
+    Supplemental Guidance:  Organizations can identify specific personnel, roles, and emergency responders in the event that individuals on the notification list must have appropriate access authorizations and/or clearances, for example, to obtain access to facilities where classified operations are taking place or where there are information systems containing classified information.
+
+    PE-13 (1) -1 [service provider building maintenance/physical security personnel]
+    PE-13 (1) -2 [service provider emergency responders with incident response responsibilities]
+  title: >-
+    PE-13(1) - FIRE PROTECTION | DETECTION DEVICES / SYSTEMS
+  levels:
+  - high
+- id: PE-13(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs fire suppression devices/systems for the information system that provide automatic notification of any activation to Assignment: organization-defined personnel or roles] and [Assignment: organization-defined emergency responders].
+
+    Supplemental Guidance:  Organizations can identify specific personnel, roles, and emergency responders in the event that individuals on the notification list must have appropriate access authorizations and/or clearances, for example, to obtain access to facilities where classified operations are taking place or where there are information systems containing classified information.
+  title: >-
+    PE-13(2) - FIRE PROTECTION | SUPPRESSION DEVICES / SYSTEMS
+  levels:
+  - high
+  - moderate
+- id: PE-13(3)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs an automatic fire suppression capability for the information system when the facility is not staffed on a continuous basis.
+  title: >-
+    PE-13(3) - FIRE PROTECTION | AUTOMATIC FIRE SUPPRESSION
+  levels:
+  - high
+  - moderate
+- id: PE-13(4)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-14
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Maintains temperature and humidity levels within the facility where the information system resides at [Assignment: organization-defined acceptable levels]; and
+     b. Monitors temperature and humidity levels [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources, for example, data centers, server rooms, and mainframe computer rooms. Related control: AT-3.
+
+    References: None.
+
+    PE-14 (a) [consistent with American Society of Heating, Refrigerating and Air-conditioning Engineers (ASHRAE) document entitled Thermal Guidelines for Data Processing Environments]
+
+    PE-14 (b) [continuously]
+    PE-14 (a) Requirements:  The service provider measures temperature at server inlets and humidity levels by dew point.
+  title: >-
+    PE-14 - TEMPERATURE AND HUMIDITY CONTROLS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-14(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-14(2)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs temperature and humidity monitoring that provides an alarm or notification of changes potentially harmful to personnel or equipment.
+  title: >-
+    PE-14(2) - TEMPERATURE AND HUMIDITY CONTROLS | MONITORING WITH ALARMS / NOTIFICATIONS
+  levels:
+  - high
+  - moderate
+- id: PE-15
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization protects the information system from damage resulting from water leakage by providing master shutoff or isolation valves that are accessible, working properly, and known to key personnel.
+
+    Supplemental Guidance:  This control applies primarily to facilities containing concentrations of information system resources including, for example, data centers, server rooms, and mainframe computer rooms. Isolation valves can be employed in addition to or in lieu of master shutoff valves to shut off water supplies in specific areas of concern, without affecting entire organizations. Related control: AT-3.
+
+    References: None.
+  title: >-
+    PE-15 - WATER DAMAGE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-15(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization employs automated mechanisms to detect the presence of water in the vicinity of the information system and alerts [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:  Automated mechanisms can include, for example, water detection sensors, alarms, and notification systems.
+
+    PE-15 (1) [service provider building maintenance/physical security personnel]
+  title: >-
+    PE-15(1) - WATER DAMAGE PROTECTION | AUTOMATION SUPPORT
+  levels:
+  - high
+- id: PE-16
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization authorizes, monitors, and controls [Assignment: organization-defined types of information system components] entering and exiting the facility and maintains records of those items.
+
+    Supplemental Guidance:  Effectively enforcing authorizations for entry and exit of information system components may require restricting access to delivery areas and possibly isolating the areas from the information system and media libraries. Related controls: CM-3, MA-2, MA-3, MP-5, SA-12.
+
+    References: None.
+
+    PE-16 [all information system components]
+  title: >-
+    PE-16 - DELIVERY AND REMOVAL
+  levels:
+  - high
+  - moderate
+  - low
+- id: PE-17
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization:
+     a. Employs [Assignment: organization-defined security controls] at alternate work sites;
+     b. Assesses as feasible, the effectiveness of security controls at alternate work sites; and
+     c. Provides a means for employees to communicate with information security personnel in case of security incidents or problems.
+
+    Supplemental Guidance:  Alternate work sites may include, for example, government facilities or private residences of employees. While commonly distinct from alternative processing sites, alternate work sites may provide readily available alternate locations as part of contingency operations. Organizations may define different sets of security controls for specific alternate work sites or types of sites depending on the work-related activities conducted at those sites. This control supports the contingency planning activities of organizations and the federal telework initiative. Related controls: AC-17, CP-7.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publication 800-46.
+  title: >-
+    PE-17 - ALTERNATE WORK SITE
+  levels:
+  - high
+  - moderate
+- id: PE-18
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+  description: |-
+    The organization positions information system components within the facility to minimize potential damage from [Assignment: organization-defined physical and environmental hazards] and to minimize the opportunity for unauthorized access.
+
+    Supplemental Guidance:  Physical and environmental hazards include, for example, flooding, fire, tornados, earthquakes, hurricanes, acts of terrorism, vandalism, electromagnetic pulse, electrical interference, and other forms of incoming electromagnetic radiation. In addition, organizations consider the location of physical entry points where unauthorized individuals, while not being granted access, might nonetheless be in close proximity to information systems and therefore increase the potential for unauthorized access to organizational communications (e.g., through the use of wireless sniffers or microphones). Related controls: CP-2, PE-19, RA-3.
+
+    References: None.
+
+    PE-18 [physical and environmental hazards identified during threat assessment]
+  title: >-
+    PE-18 - LOCATION OF INFORMATION SYSTEM COMPONENTS
+  levels:
+  - high
+- id: PE-18(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-19
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-19(1)
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PE-20
+  status: not applicable
+  notes: |-
+    This control is outside the scope of Red Hat IdM configuration.
+  rules: []
+- id: PL-1
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A security planning policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the security planning policy and associated security planning controls; and
+     b. Reviews and updates the current:
+       1. Security planning policy [Assignment: organization-defined frequency]; and
+       2. Security planning procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the PL family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-18, 800-100.
+
+    PL-1 (b) (1) [at least annually]
+    PL-1 (b) (2) [at least annually or whenever a significant change occurs]
+  title: >-
+    PL-1 - SECURITY PLANNING POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: PL-2
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization:\n a. Develops a security plan for the information\
+    \ system that:\n   1. Is consistent with the organization\u2019s enterprise architecture;\n\
+    \   2. Explicitly defines the authorization boundary for the system;\n   3. Describes\
+    \ the operational context of the information system in terms of missions and business\
+    \ processes;\n   4. Provides the security categorization of the information system\
+    \ including supporting rationale;\n   5. Describes the operational environment\
+    \ for the information system and relationships with or connections to other information\
+    \ systems;\n   6. Provides an overview of the security requirements for the system;\n\
+    \   7. Identifies any relevant overlays, if applicable;\n   8. Describes the security\
+    \ controls in place or planned for meeting those requirements including a rationale\
+    \ for the tailoring and supplementation decisions; and\n   9. Is reviewed and\
+    \ approved by the authorizing official or designated representative prior to plan\
+    \ implementation;\n b. Distributes copies of the security plan and communicates\
+    \ subsequent changes to the plan to [Assignment: organization-defined personnel\
+    \ or roles];\n c. Reviews the security plan for the information system [Assignment:\
+    \ organization-defined frequency];\n d. Updates the plan to address changes to\
+    \ the information system/environment of operation or problems identified during\
+    \ plan implementation or security control assessments; and\n e. Protects the security\
+    \ plan from unauthorized disclosure and modification.\n\nSupplemental Guidance:\
+    \  Security plans relate security requirements to a set of security controls and\
+    \ control enhancements. Security plans also describe, at a high level, how the\
+    \ security controls and control enhancements meet those security requirements,\
+    \ but do not provide detailed, technical descriptions of the specific design or\
+    \ implementation of the controls/enhancements. Security plans contain sufficient\
+    \ information (including the specification of parameter values for assignment\
+    \ and selection statements either explicitly or by reference) to enable a design\
+    \ and implementation that is unambiguously compliant with the intent of the plans\
+    \ and subsequent determinations of risk to organizational operations and assets,\
+    \ individuals, other organizations, and the Nation if the plan is implemented\
+    \ as intended. Organizations can also apply tailoring guidance to the security\
+    \ control baselines in Appendix D and CNSS Instruction 1253 to develop overlays\
+    \ for community-wide use or to address specialized requirements, technologies,\
+    \ or missions/environments of operation (e.g., DoD-tactical, Federal Public Key\
+    \ Infrastructure, or Federal Identity, Credential, and Access Management, space\
+    \ operations). Appendix I provides guidance on developing overlays.\n\nSecurity\
+    \ plans need not be single documents; the plans can be a collection of various\
+    \ documents including documents that already exist. Effective security plans make\
+    \ extensive use of references to policies, procedures, and additional documents\
+    \ (e.g., design and implementation specifications) where more detailed information\
+    \ can be obtained. This reduces the documentation requirements associated with\
+    \ security programs and maintains security-related information in other established\
+    \ management/operational areas related to enterprise architecture, system development\
+    \ life cycle, systems engineering, and acquisition. For example, security plans\
+    \ do not contain detailed contingency plan or incident response plan information\
+    \ but instead provide explicitly or by reference, sufficient information to define\
+    \ what needs to be accomplished by those plans. Related controls: AC-2, AC-6,\
+    \ AC-14, AC-17, AC-20, CA-2, CA-3, CA-7, CM-9, CP-2, IR-8, MA-4, MA-5, MP-2, MP-4,\
+    \ MP-5, PL-7, PM-1, PM-7, PM-8, PM-9, PM-11, SA-5, SA-17.\n\nReferences: NIST\
+    \ Special Publication 800-18.\n\nPL-2 (c) [at least annually]"
+  title: >-
+    PL-2 - SYSTEM SECURITY PLAN
+  levels:
+  - high
+  - moderate
+  - low
+- id: PL-2(1)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-7.'
+  rules: []
+- id: PL-2(2)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-8.'
+  rules: []
+- id: PL-2(3)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization plans and coordinates security-related activities affecting the information system with [Assignment: organization-defined individuals or groups] before conducting such activities in order to reduce the impact on other organizational entities.
+
+    Supplemental Guidance:  Security-related activities include, for example, security assessments, audits, hardware and software maintenance, patch management, and contingency plan testing. Advance planning and coordination includes emergency and nonemergency (i.e., planned or nonurgent unplanned) situations. The process defined by organizations to plan and coordinate security-related activities can be included in security plans for information systems or other documents, as appropriate. Related controls: CP-4, IR-4.
+  title: >-
+    PL-2(3) - SYSTEM SECURITY PLAN | PLAN / COORDINATE WITH OTHER ORGANIZATIONAL ENTITIES
+  levels:
+  - high
+  - moderate
+- id: PL-3
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-2.'
+  rules: []
+- id: PL-4
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Establishes and makes readily available to individuals requiring access to the information system, the rules that describe their responsibilities and expected behavior with regard to information and information system usage;
+     b. Receives a signed acknowledgment from such individuals, indicating that they have read, understand, and agree to abide by the rules of behavior, before authorizing access to information and the information system;
+     c. Reviews and updates the rules of behavior [Assignment: organization-defined frequency]; and d. Requires individuals who have signed a previous version of the rules of behavior to read and
+    resign when the rules of behavior are revised/updated.
+
+    Supplemental Guidance: This control enhancement applies to organizational users. Organizations consider rules of behavior based on individual user roles and responsibilities, differentiating, for example, between rules that apply to privileged users and rules that apply to general users. Establishing rules of behavior for some types of non-organizational users including, for example, individuals who simply receive data/information from federal information systems, is often not feasible given the large number of such users and the limited nature of their interactions with the systems. Rules of behavior for both organizational and non-organizational users can also be established in AC-8, System Use Notification. PL-4 b. (the signed acknowledgment portion of this control) may be satisfied by the security awareness training and role-based security training programs conducted by organizations if such training includes rules of behavior. Organizations can use electronic signatures for acknowledging rules of behavior. Related controls: AC-2, AC-6, AC-8, AC-9, AC-17, AC-18, AC-19, AC-20, AT-2, AT-3, CM-11, IA-2, IA-4, IA-5, MP-7, PS-6, PS-8, SA-5.
+
+    References: NIST Special Publication 800-18.
+
+    PL-4 (c) [annually]
+  title: >-
+    PL-4 - RULES OF BEHAVIOR
+  levels:
+  - high
+  - moderate
+  - low
+- id: PL-4(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization includes in the rules of behavior, explicit restrictions on the use of social media/networking sites and posting organizational information on public websites.
+
+    Supplemental Guidance:  This control enhancement addresses rules of behavior related to the use of social media/networking sites: (i) when organizational personnel are using such sites for official duties or in the conduct of official business; (ii) when organizational information is involved in social media/networking transactions; and (iii) when personnel are accessing social media/networking sites from organizational information systems. Organizations also address specific rules that prevent unauthorized entities from obtaining and/or inferring non- public organizational information (e.g., system account information, personally identifiable information) from social media/networking sites.
+  title: >-
+    PL-4(1) - RULES OF BEHAVIOR | SOCIAL MEDIA AND NETWORKING RESTRICTIONS
+  levels:
+  - high
+  - moderate
+- id: PL-5
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into Appendix J, AR-2.'
+  rules: []
+- id: PL-6
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into PL-2.'
+  rules: []
+- id: PL-7
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: PL-8
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization:\n a. Develops an information security architecture\
+    \ for the information system that:\n   1. Describes the overall philosophy, requirements,\
+    \ and approach to be taken with regard to protecting the confidentiality, integrity,\
+    \ and availability of organizational information;\n   2. Describes how the information\
+    \ security architecture is integrated into and supports the enterprise architecture;\
+    \ and\n   3. Describes any information security assumptions about, and dependencies\
+    \ on, external services;\n b. Reviews and updates the information security architecture\
+    \ [Assignment: organization-defined frequency] to reflect updates in the enterprise\
+    \ architecture; and\n c. Ensures that planned information security architecture\
+    \ changes are reflected in the security plan, the security Concept of Operations\
+    \ (CONOPS), and organizational procurements/acquisitions.\n\nSupplemental Guidance:\
+    \  This control addresses actions taken by organizations in the design and development\
+    \ of information systems. The information security architecture at the individual\
+    \ information system level is consistent with and complements the more global,\
+    \ organization-wide information security architecture described in PM-7 that is\
+    \ integral to and developed as part of the enterprise architecture. The information\
+    \ security architecture includes an architectural description, the placement/allocation\
+    \ of security functionality (including security controls), security-related information\
+    \ for external interfaces, information being exchanged across the interfaces,\
+    \ and the protection mechanisms associated with each interface. In addition, the\
+    \ security architecture can include other important security-related information,\
+    \ for example, user roles and access privileges assigned to each role, unique\
+    \ security requirements, the types of information processed, stored, and transmitted\
+    \ by the information system, restoration priorities of information and information\
+    \ system services, and any other specific protection needs.\n\nIn today\u2019\
+    s modern architecture, it is becoming less common for organizations to control\
+    \ all information resources. There are going to be key dependencies on external\
+    \ information services and service providers. Describing such dependencies in\
+    \ the information security architecture is important to developing a comprehensive\
+    \ mission/business protection strategy. Establishing, developing, documenting,\
+    \ and maintaining under configuration control, a baseline configuration for organizational\
+    \ information systems is critical to implementing and maintaining an effective\
+    \ information security architecture. The development of the information security\
+    \ architecture is coordinated with the Senior Agency Official for Privacy (SAOP)/Chief\
+    \ Privacy Officer (CPO) to ensure that security controls needed to support privacy\
+    \ requirements are identified and effectively implemented. PL-8 is primarily directed\
+    \ at organizations (i.e., internally focused) to help ensure that organizations\
+    \ develop an information security architecture for the information system, and\
+    \ that the security architecture is integrated with or tightly coupled to the\
+    \ enterprise architecture through the organization-wide information security architecture.\
+    \ In contrast, SA-17 is primarily directed at external information technology\
+    \ product/system developers and integrators (although SA-17 could be used internally\
+    \ within organizations for in-house system development). SA-17, which is complementary\
+    \ to PL-8, is selected when organizations outsource the development of information\
+    \ systems or information system components to external entities, and there is\
+    \ a need to demonstrate/show consistency with the organization\u2019s enterprise\
+    \ architecture and information security architecture. Related controls: CM-2,\
+    \ CM-6, PL-2, PM-7, SA-5, SA-17, Appendix J.\n\nReferences: None.\n\nPL-8 (b)\
+    \ [at least annually or when a significant change occurs]\nPL-8 (b) Guidance:\
+    \ Significant change is defined in NIST Special Publication 800-37 Revision 1,\
+    \ Appendix F, page F-7."
+  title: >-
+    PL-8 - INFORMATION SECURITY ARCHITECTURE
+  levels:
+  - high
+  - moderate
+- id: PL-8(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: PL-8(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: PL-9
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: PS-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A personnel security policy\
+    \ that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the personnel security policy and associated\
+    \ personnel security controls; and\n b. Reviews and updates the current:\n   1.\
+    \ Personnel security policy [Assignment: organization-defined frequency]; and\n\
+    \   2. Personnel security procedures [Assignment: organization-defined frequency].\n\
+    \nSupplemental Guidance:  This control addresses the establishment of policy and\
+    \ procedures for the effective implementation of selected security controls and\
+    \ control enhancements in the PS family. Policy and procedures reflect applicable\
+    \ federal laws, Executive Orders, directives, regulations, policies, standards,\
+    \ and guidance. Security program policies and procedures at the organization level\
+    \ may make the need for system-specific policies and procedures unnecessary. The\
+    \ policy can be included as part of the general information security policy for\
+    \ organizations or conversely, can be represented by multiple policies reflecting\
+    \ the complex nature of certain organizations. The procedures can be established\
+    \ for the security program in general and for particular information systems,\
+    \ if needed. The organizational risk management strategy is a key factor in establishing\
+    \ policy and procedures. Related control: PM-9.\n\nControl Enhancements:  None.\n\
+    \nReferences:  NIST Special Publications 800-12, 800-100.\n\nPS-1 (b) (1) [at\
+    \ least annually] \nPS-1 (b) (2) [at least annually or whenever a significant\
+    \ change occurs]"
+  title: >-
+    PS-1 - PERSONNEL SECURITY POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Assigns a risk designation to all organizational positions;
+     b. Establishes screening criteria for individuals filling those positions; and
+     c. Reviews and updates position risk designations [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  Position risk designations reflect Office of Personnel Management policy and guidance. Risk designations can guide and inform the types of authorizations individuals receive when accessing organizational information and information systems. Position screening criteria include explicit information security role appointment requirements (e.g., training, security clearances). Related controls: AT-3, PL-2, PS-3.
+
+    Control Enhancements:  None.
+
+    References:  5 C.F.R. 731.106(a).
+
+    PS-2 (c) [at least annually]
+  title: >-
+    PS-2 - POSITION RISK DESIGNATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-3
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Screens individuals prior to authorizing access to the information system; and
+     b. Rescreens individuals according to [Assignment: organization-defined conditions requiring rescreening and, where rescreening is so indicated, the frequency of such rescreening].
+
+    Supplemental Guidance:  Personnel screening and rescreening activities reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, guidance, and specific criteria established for the risk designations of assigned positions. Organizations may define different rescreening conditions and frequencies for personnel accessing information systems based on types of information processed, stored, or transmitted by the systems. Related controls: AC-2, IA-4, PE-2, PS-2.
+
+    References: 5 C.F.R. 731.106; FIPS Publications 199, 201; NIST Special Publications 800-60, 800-73, 800-76, 800-78; ICD 704.
+
+    PS-3 (b) [for national security clearances; a reinvestigation is required during the fifth (5th) year for top secret security clearance, the tenth (10th) year for secret security clearance, and fifteenth (15th) year for confidential security clearance.
+
+    For moderate risk law enforcement and high impact public trust level, a reinvestigation is required during the fifth (5th) year.  There is no reinvestigation for other moderate risk positions or any low risk positions]
+  title: >-
+    PS-3 - PERSONNEL SCREENING
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-4
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization, upon termination of individual employment:
+     a. Disables information system access within [Assignment: organization-defined time period];
+     b. Terminates/revokes any authenticators/credentials associated with the individual;
+     c. Conducts exit interviews that include a discussion of [Assignment: organization-defined information security topics];
+     d. Retrieves all security-related organizational information system-related property;
+     e. Retains access to organizational information and information systems formerly controlled by terminated individual; and
+     f. Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period].
+
+    Supplemental Guidance:  Information system-related property includes, for example, hardware authentication tokens, system administration technical manuals, keys, identification cards, and building passes. Exit interviews ensure that terminated individuals understand the security constraints imposed by being former employees and that proper accountability is achieved for information system-related property. Security topics of interest at exit interviews can include, for example, reminding terminated individuals of nondisclosure agreements and potential limitations on future employment. Exit interviews may not be possible for some terminated individuals, for example, in cases related to job abandonment, illnesses, and nonavailability of supervisors. Exit interviews are important for individuals with security clearances. Timely execution of termination actions is essential for individuals terminated for cause. In certain situations, organizations consider disabling the information system accounts of individuals that are being terminated prior to the individuals being notified. Related controls: AC-2, IA-4, PE-2, PS-5, PS-6.
+
+    References: None.
+
+    PS-4 (a) [eight (8) hours]
+  title: >-
+    PS-4 - PERSONNEL TERMINATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-5
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Reviews and confirms ongoing operational need\
+    \ for current logical and physical access authorizations to information systems/facilities\
+    \ when individuals are reassigned or transferred to other positions within the\
+    \ organization;\n b. Initiates [Assignment: organization-defined transfer or reassignment\
+    \ actions] within [Assignment: organization-defined time period following the\
+    \ formal transfer action];\n c. Modifies access authorization as needed to correspond\
+    \ with any changes in operational need due to reassignment or transfer; and\n\
+    \ d. Notifies [Assignment: organization-defined personnel or roles] within [Assignment:\
+    \ organization-defined time period].\n\nSupplemental Guidance:  This control applies\
+    \ when reassignments or transfers of individuals are permanent or of such extended\
+    \ durations as to make the actions warranted. Organizations define actions appropriate\
+    \ for the types of reassignments or transfers, whether permanent or extended.\
+    \ Actions that may be required for personnel transfers or reassignments to other\
+    \ positions within organizations include, for example: (i) returning old and issuing\
+    \ new keys, identification cards, and building passes; (ii) closing information\
+    \ system accounts and establishing new accounts; (iii) changing information system\
+    \ access authorizations (i.e., privileges); and (iv) providing for access to official\
+    \ records to which individuals had access at previous work locations and in previous\
+    \ information system accounts. Related controls: AC-2, IA-4, PE-2, PS-4.\n\nControl\
+    \ Enhancements:  None.\n\nReferences:  None.\n\nPS-5 (b)-2 [twenty-four (24) hours]\
+    \ \nPS-5 (d)-2 [twenty-four (24) hours]"
+  title: >-
+    PS-5 - PERSONNEL TRANSFER
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-6
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Develops and documents access agreements for organizational information systems;
+     b. Reviews and updates the access agreements [Assignment: organization-defined frequency]; and
+     c. Ensures that individuals requiring access to organizational information and information systems:
+       1. Sign appropriate access agreements prior to being granted access; and
+       2. Re-sign access agreements to maintain access to organizational information systems when access agreements have been updated or [Assignment: organization-defined frequency].
+
+    Supplemental Guidance: Access agreements include, for example, nondisclosure agreements, acceptable use agreements, rules of behavior, and conflict-of-interest agreements. Signed access agreements include an acknowledgement that individuals have read, understand, and agree to abide by the constraints associated with organizational information systems to which access is authorized. Organizations can use electronic signatures to acknowledge access agreements unless specifically prohibited by organizational policy. Related control: PL-4, PS-2, PS-3, PS-4, PS-8.
+
+    References: None.
+
+    PS-6 (b) [at least annually]
+    PS-6 (c) (2) [at least annually and any time there is a change to the user's level of access]
+  title: >-
+    PS-6 - ACCESS AGREEMENTS
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-7
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Establishes personnel security requirements\
+    \ including security roles and responsibilities for third-party providers;\n b.\
+    \ Requires third-party providers to comply with personnel security policies and\
+    \ procedures established by the organization;\n c. Documents personnel security\
+    \ requirements;\n d. Requires third-party providers to notify [Assignment: organization-defined\
+    \ personnel or roles] of any personnel transfers or terminations of third-party\
+    \ personnel who possess organizational credentials and/or badges, or who have\
+    \ information system privileges within [Assignment: organization-defined time\
+    \ period]; and\n e. Monitors provider compliance.\n\nSupplemental Guidance: Third-party\
+    \ providers include, for example, service bureaus, contractors, and other organizations\
+    \ providing information system development, information technology services, outsourced\
+    \ applications, and network and security management. Organizations explicitly\
+    \ include personnel security requirements in acquisition-related documents. Third-party\
+    \ providers may have personnel working at organizational facilities with credentials,\
+    \ badges, or information system privileges issued by organizations. Notifications\
+    \ of third-party personnel changes ensure appropriate termination of privileges\
+    \ and credentials. Organizations define the transfers and terminations deemed\
+    \ reportable by security-related characteristics that include, for example, functions,\
+    \ roles, and nature of credentials/privileges associated with individuals transferred\
+    \ or terminated. \n\nRelated controls: PS-2, PS-3, PS-4, PS-5, PS-6, SA-9, SA-21.\n\
+    \nControl Enhancements:  None.\n\nReferences:  NIST Special Publication 800-35.\n\
+    \nPS-7 (d)-2 [terminations: immediately; transfers: within twenty-four (24) hours]"
+  title: >-
+    PS-7 - THIRD-PARTY PERSONNEL SECURITY
+  levels:
+  - high
+  - moderate
+  - low
+- id: PS-8
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Employs a formal sanctions process for individuals failing to comply with established information security policies and procedures; and
+     b. Notifies [Assignment: organization-defined personnel or roles] within [Assignment: organization-defined time period] when a formal employee sanctions process is initiated, identifying the individual sanctioned and the reason for the sanction.
+
+    Supplemental Guidance: Organizational sanctions processes reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Sanctions processes are described in access agreements and can be included as part of general personnel policies and procedures for organizations. Organizations consult with the Office of the General Counsel regarding matters of employee sanctions. Related controls: PL-4, PS-6.
+
+    Control Enhancements:  None.
+
+    References:  None.
+
+    PS-8(b)-1 [at a minimum, the ISSO and/or similar role within the organization]
+  title: >-
+    PS-8 - PERSONNEL SANCTIONS
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A risk assessment policy that\
+    \ addresses purpose, scope, roles, responsibilities, management commitment, coordination\
+    \ among organizational entities, and compliance; and\n   2. Procedures to facilitate\
+    \ the implementation of the risk assessment policy and associated risk assessment\
+    \ controls; and\n b. Reviews and updates the current:\n   1. Risk assessment policy\
+    \ [Assignment: organization-defined frequency]; and\n   2. Risk assessment procedures\
+    \ [Assignment: organization-defined frequency].\n\nSupplemental Guidance:  This\
+    \ control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ RA family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-30, 800-100.\n\nRA-1 (b) (1) [at least annually]\
+    \ \nRA-1 (b) (2) [at least annually or whenever a significant change occurs]"
+  title: >-
+    RA-1 - RISK ASSESSMENT POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-2
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Categorizes information and the information system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+     b. Documents the security categorization results (including supporting rationale) in the security plan for the information system; and
+     c. Ensures that the security categorization decision is reviewed and approved by the authorizing official or authorizing official designated representative.
+
+    Supplemental Guidance:  Clearly defined authorization boundaries are a prerequisite for effective security categorization decisions. Security categories describe the potential adverse impacts to organizational operations, organizational assets, and individuals if organizational information and information systems are comprised through a loss of confidentiality, integrity, or availability. Organizations conduct the security categorization process as an organization-wide activity with the involvement of chief information officers, senior information security officers, information system owners, mission/business owners, and information owners/stewards. Organizations also consider the potential adverse impacts to other organizations and, in accordance with the USA PATRIOT Act of 2001 and Homeland Security Presidential Directives, potential national-level adverse impacts. Security categorization processes carried out by organizations facilitate the development of inventories of information assets, and along with CM-8, mappings to specific information system components where information is processed, stored, or transmitted. Related controls: CM-8, MP-4, RA-3, SC-7.
+
+    Control Enhancements:  None.
+
+    References:  FIPS Publication 199; NIST Special Publications 800-30, 800-39, 800-60.
+  title: >-
+    RA-2 - SECURITY CATEGORIZATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-3
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Conducts an assessment of risk, including the\
+    \ likelihood and magnitude of harm, from the unauthorized access, use, disclosure,\
+    \ disruption, modification, or destruction of the information system and the information\
+    \ it processes, stores, or transmits;\n b. Documents risk assessment results in\
+    \ [Selection: security plan; risk assessment report; [Assignment: organization-defined\
+    \ document]];\n c. Reviews risk assessment results [Assignment: organization-defined\
+    \ frequency];\n d. Disseminates risk assessment results to [Assignment: organization-defined\
+    \ personnel or roles]; and\n e. Updates the risk assessment [Assignment: organization-defined\
+    \ frequency] or whenever there are significant changes to the information system\
+    \ or environment of operation (including the identification of new threats and\
+    \ vulnerabilities), or other conditions that may impact the security state of\
+    \ the system.\n\nSupplemental Guidance:  Clearly defined authorization boundaries\
+    \ are a prerequisite for effective risk assessments. Risk assessments take into\
+    \ account threats, vulnerabilities, likelihood, and impact to organizational operations\
+    \ and assets, individuals, other organizations, and the Nation based on the operation\
+    \ and use of information systems. Risk assessments also take into account risk\
+    \ from external parties (e.g., service providers, contractors operating information\
+    \ systems on behalf of the organization, individuals accessing organizational\
+    \ information systems, outsourcing\nentities). In accordance with OMB policy and\
+    \ related E-authentication initiatives, authentication of public users accessing\
+    \ federal information systems may also be required to protect nonpublic or privacy-related\
+    \ information. As such, organizational assessments of risk also address public\
+    \ access to federal information systems.\n\nRisk assessments (either formal or\
+    \ informal) can be conducted at all three tiers in the risk management hierarchy\
+    \ (i.e., organization level, mission/business process level, or information system\
+    \ level) and at any phase in the system development life cycle. Risk assessments\
+    \ can also be conducted at various steps in the Risk Management Framework, including\
+    \ categorization, security control selection, security control implementation,\
+    \ security control assessment, information\nsystem authorization, and security\
+    \ control monitoring. RA-3 is noteworthy in that the control must be partially\
+    \ implemented prior to the implementation of other controls in order to complete\
+    \ the\nfirst two steps in the Risk Management Framework. Risk assessments can\
+    \ play an important role in security control selection processes, particularly\
+    \ during the application of tailoring guidance, which includes security control\
+    \ supplementation. Related controls: RA-2, PM-9.\n\nControl Enhancements: None.\n\
+    \nReferences:  OMB Memorandum 04-04; NIST Special Publication 800-30, 800-39;\
+    \ Web:idmanagement.gov.\n\nRA-3 (b) [security assessment report]\n \nRA-3 (c)\
+    \ [at least annually or whenever a significant change occurs]\n \nRA-3 (e) [annually]\
+    \  \nRA-3 Guidance: Significant change is defined in NIST Special Publication\
+    \ 800-37 Revision 1, Appendix F.\nRA-3 (d) Requirement: Include all Authorizing\
+    \ Officials; for JAB authorizations to include FedRAMP."
+  title: >-
+    RA-3 - RISK ASSESSMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: RA-5
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Scans for vulnerabilities in the information\
+    \ system and hosted applications [Assignment: organization-defined frequency and/or\
+    \ randomly in accordance with organization-defined process] and when new vulnerabilities\
+    \ potentially affecting the system/applications are identified and reported;\n\
+    \ b. Employs vulnerability scanning tools and techniques that facilitate interoperability\
+    \ among tools and automate parts of the vulnerability management process by using\
+    \ standards for:\n   1. Enumerating platforms, software flaws, and improper configurations;\n\
+    \   2. Formatting checklists and test procedures; and\n   3. Measuring vulnerability\
+    \ impact;\n c. Analyzes vulnerability scan reports and results from security control\
+    \ assessments;\n d. Remediates legitimate vulnerabilities [Assignment: organization-defined\
+    \ response times], in accordance with an organizational assessment of risk; and\n\
+    \ e. Shares information obtained from the vulnerability scanning process and security\
+    \ control assessments with [Assignment: organization-defined personnel or roles]\
+    \ to help eliminate similar vulnerabilities in other information systems (i.e.,\
+    \ systemic weaknesses or deficiencies).\n\nSupplemental Guidance:  Security categorization\
+    \ of information systems guides the frequency and comprehensiveness of vulnerability\
+    \ scans. Organizations determine the required vulnerability scanning for all information\
+    \ system components, ensuring that potential sources of vulnerabilities such as\
+    \ networked printers, scanners, and copiers are not overlooked. Vulnerability\
+    \ analyses for custom software applications may require additional approaches\
+    \ such as static analysis, dynamic analysis, binary analysis, or a hybrid of the\
+    \ three approaches. Organizations can employ these analysis approaches in a variety\
+    \ of tools (e.g., web-based application scanners, static analysis tools, binary\
+    \ analyzers) and in source code reviews. Vulnerability scanning includes, for\
+    \ example: (i) scanning for patch levels; (ii) scanning for functions, ports,\
+    \ protocols, and services that should not be accessible to users or devices; and\
+    \ (iii) scanning for improperly configured or incorrectly operating information\
+    \ flow control mechanisms. Organizations consider using tools that express vulnerabilities\
+    \ in the Common Vulnerabilities and Exposures (CVE) naming convention and that\
+    \ use the Open Vulnerability Assessment Language (OVAL) to determine/test for\
+    \ the presence of vulnerabilities. Suggested sources for vulnerability information\
+    \ include the Common Weakness Enumeration (CWE) listing and the National Vulnerability\
+    \ Database (NVD). In addition, security control assessments such as red team exercises\
+    \ provide other sources of potential vulnerabilities for which to scan. Organizations\
+    \ also consider using tools that express vulnerability impact by the\n\nCommon\
+    \ Vulnerability Scoring System (CVSS). Related controls: CA-2, CA-7, CM-4, CM-6,\
+    \ RA-2, RA-3, SA-11, SI-2.\n\nReferences: NIST Special Publications 800-40, 800-70,\
+    \ 800-115; Web: http://cwe.mitre.org, http://nvd.nist.gov.\n\nRA-5 (a) [monthly\
+    \ operating system/infrastructure; monthly web applications and databases]\nRA-5\
+    \ (d) [high-risk vulnerabilities mitigated within thirty (30) days from date of\
+    \ discovery; moderate-risk vulnerabilities mitigated within ninety (90) days from\
+    \ date of discovery; low risk vulnerabilities mitigated within one hundred and\
+    \ eighty (180) days from date of discovery]\nRA-5 Guidance: See the FedRAMP Documents\
+    \ page under Key Cloud Service Provider (CSP) Documents> Vulnerability Scanning\
+    \ Requirements \nhttps://www.FedRAMP.gov/documents/\nRA-5 (a) Requirement: an\
+    \ accredited independent assessor scans operating systems/infrastructure, web\
+    \ applications, and databases once annually.\nRA-5 (e) Requirement: to include\
+    \ all Authorizing Officials; for JAB authorizations to include FedRAMP"
+  title: >-
+    RA-5 - VULNERABILITY SCANNING
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-1
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Develops, documents, and disseminates to [Assignment: organization-defined personnel or roles]:
+       1. A system and services acquisition policy that addresses purpose, scope, roles, responsibilities, management commitment, coordination among organizational entities, and compliance; and
+       2. Procedures to facilitate the implementation of the system and services acquisition policy and associated system and services acquisition controls; and
+     b. Reviews and updates the current:
+       1. System and services acquisition policy [Assignment: organization-defined frequency]; and
+       2.  System and services acquisition procedures [Assignment: organization-defined frequency].
+
+    Supplemental Guidance:  This control addresses the establishment of policy and procedures for the effective implementation of selected security controls and control enhancements in the SA family. Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance. Security program policies and procedures at the organization level may make the need for system-specific policies and procedures unnecessary. The policy can be included as part of the general information security policy for organizations or conversely, can be represented by multiple policies reflecting the complex nature of certain organizations. The procedures can be established for the security program in general and for particular information systems, if needed. The organizational risk management strategy is a key factor in establishing policy and procedures. Related control: PM-9.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-12, 800-100.
+
+    SA-1 (b) (1)  [at least annually]
+    SA-1 (b) (2)  [at least annually or whenever a significant change occurs]
+  title: >-
+    SA-1 - SYSTEM AND SERVICES ACQUISITION POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-2
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization:\n a. Determines information security requirements\
+    \ for the information system or information system service in mission/business\
+    \ process planning;\n b. Determines, documents, and allocates the resources required\
+    \ to protect the information system or information system service as part of its\
+    \ capital planning and investment control process; and\n c. Establishes a discrete\
+    \ line item for information security in organizational programming and budgeting\
+    \ documentation.\n\nSupplemental Guidance:  Resource allocation for information\
+    \ security includes funding for the initial information system or information\
+    \ system service acquisition and funding for the sustainment of the system/service.\
+    \ Related controls: PM-3, PM-11.\n\nControl Enhancements:  None.\n \nReferences:\
+    \  NIST Special Publication 800-65."
+  title: >-
+    SA-2 - ALLOCATION OF RESOURCES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-3
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Manages the information system using [Assignment: organization-defined system development life cycle] that incorporates information security considerations;
+     b. Defines and documents information security roles and responsibilities throughout the system development life cycle;
+     c. Identifies individuals having information security roles and responsibilities; and
+     d. Integrates the organizational information security risk management process into system development life cycle activities.
+
+    Supplemental Guidance:  A well-defined system development life cycle provides the foundation for the successful development, implementation, and operation of organizational information systems. To apply the required security controls within the system development life cycle requires a basic understanding of information security, threats, vulnerabilities, adverse impacts, and risk to critical missions/business functions. The security engineering principles in SA-8 cannot be properly applied if individuals that design, code, and test information systems and system components (including information technology products) do not understand security. Therefore, organizations include qualified personnel, for example, chief information security officers, security architects, security engineers, and information system security officers in system development life cycle activities to ensure that security requirements are incorporated into organizational information systems. It is equally important that developers include individuals on the development team that possess the requisite security expertise and skills to ensure that needed security capabilities are effectively integrated into the information system. Security awareness and training programs can help ensure that individuals having key security roles and responsibilities have the appropriate experience, skills, and expertise to conduct assigned system development life cycle activities. The effective integration of security requirements into enterprise architecture also helps to ensure that important security considerations are addressed early in the system development life cycle and that those considerations are directly related to the organizational mission/business processes. This process also facilitates the integration of the information security architecture into the enterprise architecture, consistent with organizational risk management and information security strategies. Related controls: AT-3, PM-7, SA-8.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publications 800-37, 800-64.
+  title: >-
+    SA-3 - SYSTEM DEVELOPMENT LIFE CYCLE
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-4
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization includes the following requirements, descriptions, and criteria, explicitly or by reference, in the acquisition contract for the information system, system component, or information system service in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, guidelines, and organizational mission/business needs:
+      a. Security functional requirements;
+     b. Security strength requirements;
+     c. Security assurance requirements;
+     d. Security-related documentation requirements;
+     e. Requirements for protecting security-related documentation;
+     f. Description of the information system development environment and environment in which the system is intended to operate; and
+     g. Acceptance criteria.
+
+    Supplemental Guidance:  Information system components are discrete, identifiable information technology assets (e.g., hardware, software, or firmware) that represent the building blocks of an information system. Information system components include commercial information technology products. Security functional requirements include security capabilities, security functions, and security mechanisms. Security strength requirements associated with such capabilities, functions, and mechanisms include degree of correctness, completeness, resistance to direct attack, and resistance to tampering or bypass. Security assurance requirements include: (i) development processes, procedures, practices, and methodologies; and (ii) evidence from development and assessment activities providing grounds for confidence that the required security functionality has been implemented and the required security strength has been achieved. Security documentation requirements address all phases of the system development life cycle.
+
+    Security functionality, assurance, and documentation requirements are expressed in terms of security controls and control enhancements that have been selected through the tailoring process. The security control tailoring process includes, for example, the specification of parameter values through the use of assignment and selection statements and the specification of platform dependencies and implementation information. Security documentation provides user and administrator guidance regarding the implementation and operation of security controls. The level of detail required in security documentation is based on the security category or classification level of the information system and the degree to which organizations depend on the stated security capability, functions, or mechanisms to meet overall risk response expectations (as defined in the organizational risk management strategy). Security requirements can also include organizationally mandated configuration settings specifying allowed functions, ports, protocols, and services. Acceptance criteria for information systems, information system components, and information system services are defined in the same manner as such criteria for any organizational acquisition or procurement. The Federal Acquisition Regulation (FAR) Section 7.103 contains information security requirements from FISMA. Related controls: CM-6, PL-2, PS-7, SA-3, SA-5, SA-8, SA-11, SA-12.
+
+    References: HSPD-12; ISO/IEC 15408; FIPS Publications 140-2, 201; NIST Special Publications 800-23, 800-35, 800-36, 800-37, 800-64, 800-70, 800-137; Federal Acquisition Regulation; Web: http://www.niap-ccevs.org, http://fips201ep.cio.gov, http://www.acquisition.gov/far.
+
+    SA-4 Requirement: The service provider must comply with Federal Acquisition Regulation (FAR) Subpart 7.103, and Section 889 of the John S. McCain National Defense Authorization Act (NDAA) for Fiscal Year 2019 (Pub. L. 115-232), and FAR Subpart 4.21, which implements Section 889 (as well as any added updates related to FISMA to address security concerns in the system acquisitions process).
+
+    SA-4 Guidance: The use of Common Criteria (ISO/IEC 15408) evaluated products is strongly preferred.
+    See https://www.niap-ccevs.org/Product/
+  title: >-
+    SA-4 - ACQUISITION PROCESS
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-4(1)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (1) is planned.'
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to provide a description of the functional properties of the security controls to be employed.
+
+    Supplemental Guidance:  Functional properties of security controls describe the functionality (i.e., security capability, functions, or mechanisms) visible at the interfaces of the controls and specifically exclude functionality and data structures internal to the operation of the controls. Related control: SA-5.
+  title: >-
+    SA-4(1) - ACQUISITION PROCESS | FUNCTIONAL PROPERTIES OF SECURITY CONTROLS
+  levels:
+  - high
+  - moderate
+- id: SA-4(2)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (2) is planned.'
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to provide design and implementation information for the security controls to be employed that includes: [Selection (one or more): security-relevant external system interfaces; high-level design; low-level design; source code or hardware schematics; [Assignment: organization-defined design/implementation information]] at [Assignment: organization-defined level of detail].
+
+    Supplemental Guidance:  Organizations may require different levels of detail in design and implementation documentation for security controls employed in organizational information systems, system components, or information system services based on mission/business requirements, requirements for trustworthiness/resiliency, and requirements for analysis and testing. Information systems can be partitioned into multiple subsystems. Each subsystem within the system can contain one or more modules. The high-level design for the system is expressed in terms of multiple subsystems and the interfaces between subsystems providing security-relevant functionality. The low-level design for the system is expressed in terms of modules with particular emphasis on software and firmware (but not excluding hardware) and the interfaces between modules providing security-relevant functionality. Source code and hardware schematics are typically referred to as the implementation representation of the information system. Related control: SA-5.
+
+    SA-4 (2)-1 [at a minimum to include security-relevant external system interfaces; high-level design; low-level design; source code or network and data flow diagram; [organization-defined design/implementation information]]
+  title: >-
+    SA-4(2) - ACQUISITION PROCESS | DESIGN / IMPLEMENTATION INFORMATION FOR SECURITY
+    CONTROLS
+  levels:
+  - high
+  - moderate
+- id: SA-4(3)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (3) is planned.'
+  rules: []
+- id: SA-4(4)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into CM-8 (9).'
+  rules: []
+- id: SA-4(5)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (5) is planned.'
+  rules: []
+- id: SA-4(6)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (6) is planned.'
+  rules: []
+- id: SA-4(7)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (7) is planned.'
+  rules: []
+- id: SA-4(8)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (8) is planned.'
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to produce a plan for the continuous monitoring of security control effectiveness that contains [Assignment: organization-defined level of detail].
+
+    Supplemental Guidance:  The objective of continuous monitoring plans is to determine if the complete set of planned, required, and deployed security controls within the information system, system component, or information system service continue to be effective over time based on the inevitable changes that occur. Developer continuous monitoring plans include a sufficient level of detail such that the information can be incorporated into the continuous monitoring strategies and programs implemented by organizations. Related control: CA-7.
+
+    SA-4 (8) [at least the minimum requirement as defined in control CA-7]
+    SA-4 (8) Guidance: CSP must use the same security standards regardless of where the system component or information system service is acquired.
+  title: >-
+    SA-4(8) - ACQUISITION PROCESS | CONTINUOUS MONITORING PLAN
+  levels:
+  - high
+  - moderate
+- id: SA-4(9)
+  status: pending
+  notes: |-
+    'A control response to SA-4 (9) is planned.'
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to identify early in the system development life cycle, the functions, ports, protocols, and services intended for organizational use.
+
+    Supplemental Guidance:  The identification of functions, ports, protocols, and services early in the system development life cycle (e.g., during the initial requirements definition and design phases) allows organizations to influence the design of the information system, information system component, or information system service. This early involvement in the life cycle helps organizations to avoid or minimize the use of functions, ports, protocols, or services that pose unnecessarily high risks and understand the trade-offs involved in blocking specific
+    ports, protocols, or services (or when requiring information system service providers to do so). Early identification of functions, ports, protocols, and services avoids costly retrofitting of security controls after the information system, system component, or information system service has been implemented. SA-9 describes requirements for external information system services with organizations identifying which functions, ports, protocols, and services are provided from external sources. Related controls: CM-7, SA-9.
+  title: >-
+    SA-4(9) - ACQUISITION PROCESS | FUNCTIONS / PORTS / PROTOCOLS / SERVICES IN USE
+  levels:
+  - high
+  - moderate
+- id: SA-4(10)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs only information technology products on the FIPS 201-approved products list for Personal Identity Verification (PIV) capability implemented within organizational information systems.
+
+    Supplemental Guidance:  Related controls: IA-2; IA-8.
+  title: >-
+    SA-4(10) - ACQUISITION PROCESS | USE OF APPROVED PIV PRODUCTS
+  levels:
+  - high
+  - moderate
+- id: SA-5
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: "The organization:\n a. Obtains administrator documentation for the\
+    \ information system, system component, or information system service that describes:\n\
+    \   1. Secure configuration, installation, and operation of the system, component,\
+    \ or service;\n   2. Effective use and maintenance of security functions/mechanisms;\
+    \ and\n   3. Known vulnerabilities regarding configuration and use of administrative\
+    \ (i.e., privileged) functions;\n b. Obtains user documentation for the information\
+    \ system, system component, or information system service that describes:\n  \
+    \ 1. User-accessible security functions/mechanisms and how to effectively use\
+    \ those security functions/mechanisms;\n   2. Methods for user interaction, which\
+    \ enables individuals to use the system, component, or service in a more secure\
+    \ manner; and\n   3. User responsibilities in maintaining the security of the\
+    \ system, component, or service;\n c. Documents attempts to obtain information\
+    \ system, system component, or information system service documentation when such\
+    \ documentation is either unavailable or nonexistent and [Assignment: organization-defined\
+    \ actions] in response;\n d. Protects documentation as required, in accordance\
+    \ with the risk management strategy; and e. Distributes documentation to [Assignment:\
+    \ organization-defined personnel or roles]. \n\nSupplemental Guidance:  This control\
+    \ helps organizational personnel understand the implementation and operation of\
+    \ security controls associated with information systems, system components, and\
+    \ information system services. Organizations consider establishing specific measures\
+    \ to determine the quality/completeness of the content provided. The inability\
+    \ to obtain needed documentation may occur, for example, due to the age of the\
+    \ information system/component or lack of support from developers and contractors.\
+    \ In those situations, organizations may need to recreate selected documentation\
+    \ if such documentation is essential to the effective implementation or operation\
+    \ of security controls. The level of protection provided for selected information\
+    \ system, component, or service documentation is commensurate with the security\
+    \ category or classification of the system. For example, documentation associated\
+    \ with a key DoD weapons system or command and control system would typically\
+    \ require a higher level of protection than a routine administrative system. Documentation\
+    \ that addresses information system vulnerabilities may also require an increased\
+    \ level of protection. Secure operation of the information system, includes, for\
+    \ example, initially starting the system and resuming secure system operation\
+    \ after any lapse in system operation. Related controls: CM-6, CM-8, PL-2, PL-4,\
+    \ PS-2, SA-3, SA-4.\n\nReferences: None.\n\nSA-5E [at a minimum, the ISSO (or\
+    \ similar role within the organization)]"
+  title: >-
+    SA-5 - INFORMATION SYSTEM DOCUMENTATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-5(1)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (1).'
+  rules: []
+- id: SA-5(2)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (2).'
+  rules: []
+- id: SA-5(3)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (3).'
+  rules: []
+- id: SA-5(4)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (4).'
+  rules: []
+- id: SA-5(5)
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into SA-4 (5).'
+  rules: []
+- id: SA-6
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into CM-10 and SI-7.'
+  rules: []
+- id: SA-7
+  status: not applicable
+  notes: |-
+    'As of NIST 800-53 rev4 this control was withdrawn
+    and incorporated into CM-11 and SI-7.'
+  rules: []
+- id: SA-8
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization applies information system security engineering principles in the specification, design, development, implementation, and modification of the information system.
+
+    Supplemental Guidance:  Organizations apply security engineering principles primarily to new development information systems or systems undergoing major upgrades. For legacy systems, organizations apply security engineering principles to system upgrades and modifications to the extent feasible, given the current state of hardware, software, and firmware within those systems. Security engineering principles include, for example: (i) developing layered protections; (ii) establishing sound security policy, architecture, and controls as the foundation for design; (iii) incorporating security requirements into the system development life cycle; (iv) delineating physical and logical security boundaries; (v) ensuring that system developers are trained on how to build secure software; (vi) tailoring security controls to meet organizational and operational needs; (vii) performing threat modeling to identify use cases, threat agents, attack vectors, and attack patterns as well as compensating controls and design patterns needed to mitigate risk; and (viii) reducing risk to acceptable levels, thus enabling informed risk management decisions. Related controls: PM-7, SA-3, SA-4, SA-17, SC-2, SC-3.
+
+    Control Enhancements:  None.
+
+    References:  NIST Special Publication 800-27.
+  title: >-
+    SA-8 - SECURITY ENGINEERING PRINCIPLES
+  levels:
+  - high
+  - moderate
+- id: SA-9
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     a. Requires that providers of external information system services comply with organizational information security requirements and employ [Assignment: organization-defined security controls] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance;
+     b. Defines and documents government oversight and user roles and responsibilities with regard to external information system services; and
+     c. Employs [Assignment: organization-defined processes, methods, and techniques] to monitor security control compliance by external service providers on an ongoing basis.
+
+    Supplemental Guidance:  External information system services are services that are implemented outside of the authorization boundaries of organizational information systems. This includes services that are used by, but not a part of, organizational information systems. FISMA and OMB policy require that organizations using external service providers that are processing, storing, or transmitting federal information or operating information systems on behalf of the federal government ensure that such providers meet the same security requirements that federal agencies are required to meet. Organizations establish relationships with external service providers in a variety of ways including, for example, through joint ventures, business partnerships, contracts, interagency agreements, lines of business arrangements, licensing agreements, and supply chain exchanges. The responsibility for managing risks from the use of external information system services remains with authorizing officials. For services external to organizations, a chain of trust requires that organizations establish and retain a level of confidence that each participating provider in the potentially complex consumer-provider relationship provides adequate protection for the services rendered. The extent and nature of this chain of trust varies based on the relationships between organizations and the external providers. Organizations document the basis for trust relationships so the relationships can be monitored over time. External information system services documentation includes government, service providers, end user security roles and responsibilities, and service-level agreements. Service-level agreements define expectations of performance for security controls, describe measurable outcomes, and identify remedies and response requirements for identified instances of noncompliance. Related controls: CA-3, IR-7, PS-7.
+
+    References: NIST Special Publication 800-35.
+
+    SA-9 (a) [FedRAMP Security Controls Baseline(s) if Federal information is processed or stored within the external system]
+    SA-9 (c) [Federal/FedRAMP Continuous Monitoring requirements must be met for external systems where Federal information is processed or stored]
+  title: >-
+    SA-9 - EXTERNAL INFORMATION SYSTEM SERVICES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SA-9(1)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization:
+     (a)   Conducts an organizational assessment of risk prior to the acquisition or outsourcing of dedicated information security services; and
+     (b)   Ensures that the acquisition or outsourcing of dedicated information security services is approved by [Assignment: organization-defined personnel or roles].
+
+    Supplemental Guidance:  Dedicated information security services include, for example, incident monitoring, analysis and response, operation of information security-related devices such as firewalls, or key management services. Related controls: CA-6, RA-3.
+  title: >-
+    SA-9(1) - EXTERNAL INFORMATION SYSTEMS | RISK ASSESSMENTS /
+
+    ORGANIZATIONAL APPROVALS
+  levels:
+  - high
+  - moderate
+- id: SA-9(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization requires providers of [Assignment: organization-defined external information system services] to identify the functions, ports, protocols, and other services required for the use of such services.
+
+    Supplemental Guidance:  Information from external service providers regarding the specific functions, ports, protocols, and services used in the provision of such services can be particularly useful when the need arises to understand the trade-offs involved in restricting certain functions/services or blocking certain ports/protocols. Related control: CM-7.
+
+    SA-9 (2) [all external systems where Federal information is processed or stored]
+  title: >-
+    SA-9(2) - EXTERNAL INFORMATION SYSTEMS | IDENTIFICATION OF FUNCTIONS / PORTS /
+    PROTOCOLS / SERVICES
+  levels:
+  - high
+  - moderate
+- id: SA-9(3)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: SA-9(4)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization employs [Assignment: organization-defined security safeguards] to ensure that the interests of [Assignment: organization-defined external service providers] are consistent with and reflect organizational interests.
+
+    Supplemental Guidance:  As organizations increasingly use external service providers, the possibility exists that the interests of the service providers may diverge from organizational interests. In such situations, simply having the correct technical, procedural, or operational safeguards in place may not be sufficient if the service providers that implement and control those safeguards are not operating in a manner consistent with the interests of the consuming organizations. Possible actions that organizations might take to address such concerns include, for example, requiring background checks for selected service provider personnel, examining ownership records, employing only trustworthy service providers (i.e., providers with which organizations have had positive experiences), and conducting periodic/unscheduled visits to service provider facilities.
+
+    SA-9 (4)-2 [all external systems where Federal information is processed or stored]
+  title: >-
+    SA-9(4) - EXTERNAL INFORMATION SYSTEMS | CONSISTENT INTERESTS OF CONSUMERS AND
+    PROVIDERS
+  levels:
+  - high
+  - moderate
+- id: SA-9(5)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+  description: |-
+    The organization restricts the location of [Selection (one or more): information processing; information/data; information system services] to [Assignment: organization-defined locations] based on [Assignment: organization-defined requirements or conditions].
+
+    Supplemental Guidance:  The location of information processing, information/data storage, or information system services that are critical to organizations can have a direct impact on the ability of those organizations to successfully execute their missions/business functions. This situation exists when external providers control the location of processing, storage or services. The criteria external providers use for the selection of processing, storage, or service locations may be different from organizational criteria. For example, organizations may want to ensure that data/information storage locations are restricted to certain locations to facilitate incident response activities (e.g., forensic analyses, after-the-fact investigations) in case of information security breaches/compromises. Such incident response activities may be adversely affected
+    by the governing laws or protocols in the locations where processing and storage occur and/or the locations from which information system services emanate.
+
+    SA-9 (5)-1 [information processing, information data, AND information services]
+    SA-9 (5)-2 [U.S./U.S. Territories or geographic locations where there is U.S. jurisdiction]
+    SA-9 (5)-3 [all High impact data, systems, or services]
+  title: >-
+    SA-9(5) - EXTERNAL INFORMATION SYSTEMS | PROCESSING, STORAGE, AND SERVICE LOCATION
+  levels:
+  - high
+  - moderate
+- id: SA-10
+  status: pending
+  notes: |-
+    Section a: 'A control response to SA-10 (a) is planned.'
+
+    Section b: 'A control response to SA-10 (b) is planned.'
+
+    Section c: 'A control response to SA-10 (c) is planned.'
+
+    Section d: 'A control response to SA-10 (d) is planned.'
+
+    Section e: 'A control response to SA-10 (e) is planned.'
+  rules: []
+  description: "The organization requires the developer of the information system,\
+    \ system component, or information system service to:\n a. Perform configuration\
+    \ management during system, component, or service [Selection (one or more): design;\
+    \ development; implementation; operation];\n b. Document, manage, and control\
+    \ the integrity of changes to [Assignment: organization-defined configuration\
+    \ items under configuration management];\n c. Implement only organization-approved\
+    \ changes to the system, component, or service;\n d. Document approved changes\
+    \ to the system, component, or service and the potential security impacts of such\
+    \ changes; and\n e. Track security flaws and flaw resolution within the system,\
+    \ component, or service and report findings to [Assignment: organization-defined\
+    \ personnel].\n \nSupplemental Guidance:  This control also applies to organizations\
+    \ conducting internal information systems development and integration. Organizations\
+    \ consider the quality and completeness of the configuration management activities\
+    \ conducted by developers as evidence of applying effective security safeguards.\
+    \ Safeguards include, for example, protecting from unauthorized modification or\
+    \ destruction, the master copies of all material used to generate security-relevant\
+    \ portions of the system hardware, software, and firmware. Maintaining the integrity\
+    \ of changes to the information system, information system component, or information\
+    \ system service requires configuration control throughout the system development\
+    \ life cycle to track authorized changes and prevent unauthorized changes. Configuration\
+    \ items that are placed under configuration management (if existence/use is required\
+    \ by other security controls) include: the formal model; the functional, high-level,\
+    \ and low-level design specifications; other design data; implementation documentation;\
+    \ source code and hardware schematics; the running version of the object code;\
+    \ tools for comparing new versions of security-relevant hardware descriptions\
+    \ and software/firmware source code with previous versions; and test fixtures\
+    \ and documentation. Depending on the mission/business needs of organizations\
+    \ and the nature of the contractual relationships in place, developers may provide\
+    \ configuration management support during the operations and maintenance phases\
+    \ of the life cycle. Related controls: CM-3, CM-4, CM-9, SA-12, SI-2.\n\nReferences:\
+    \ NIST Special Publication 800-128.\n\nSA-10 (a) [development, implementation,\
+    \ AND operation]\nSA-10 (e)  Requirement: for JAB authorizations, track security\
+    \ flaws and flaw resolution within the system, component, or service and report\
+    \ findings to organization-defined personnel, to include FedRAMP."
+  title: >-
+    SA-10 - DEVELOPER CONFIGURATION MANAGEMENT
+  levels:
+  - high
+  - moderate
+- id: SA-10(1)
+  status: pending
+  notes: |-
+    'A control response to SA-10 (1) is planned.'
+  rules: []
+  description: |-
+    The organization requires the developer of the information system, system component, or information system service to enable integrity verification of software and firmware components.
+
+    Supplemental Guidance:  This control enhancement allows organizations to detect unauthorized changes to software and firmware components through the use of tools, techniques, and/or mechanisms provided by developers. Integrity checking mechanisms can also address counterfeiting of software and firmware components. Organizations verify the integrity of software and firmware components, for example, through secure one-way hashes provided by developers. Delivered software and firmware components also include any updates to such components. Related control: SI-7.
+  title: >-
+    SA-10(1) - DEVELOPER CONFIGURATION MANAGEMENT | SOFTWARE /
+
+    FIRMWARE INTEGRITY VERIFICATION
+  levels:
+  - high
+  - moderate
+- id: SA-10(2)
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedure/policy and is not
+    applicable to component-level configuration.'
+  rules: []
+- id: SA-10(3)
+  status: pending
+  notes: |-
+    'A control response to SA-10 (1) is planned.'
+  rules: []
+- id: SA-10(4)
+  status: pending
+  notes: |-
+    'A control response to SA-10 (4) is planned.'
+  rules: []
+- id: SA-10(5)
+  status: pending
+  notes: |-
+    'A control response to SA-10 (5) is planned.'
+  rules: []
+- id: SA-10(6)
+  status: pending
+  notes: |-
+    'A control response to SA-10 (6) is planned.'
+  rules: []
+- id: SC-1
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A system and communications\
+    \ protection policy that addresses purpose, scope, roles, responsibilities, management\
+    \ commitment, coordination among organizational entities, and compliance; and\n\
+    \   2. Procedures to facilitate the implementation of the system and communications\
+    \ protection policy and associated system and communications protection controls;\
+    \ and\n b. Reviews and updates the current:\n   1. System and communications protection\
+    \ policy [Assignment: organization-defined frequency]; and\n   2. System and communications\
+    \ protection procedures [Assignment: organization-defined frequency].\n\nSupplemental\
+    \ Guidance:  This control addresses the establishment of policy and procedures\
+    \ for the effective implementation of selected security controls and control enhancements\
+    \ in the SC family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-100.\n\nSC-1 (b) (1) [at least annually]  \n\
+    SC-1 (b) (2) [at least annually or whenever a significant change occurs]"
+  title: >-
+    SC-1 - SYSTEM AND COMMUNICATIONS PROTECTION
+
+    POLICY AND PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-5
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The information system protects against or limits the effects of the following types of denial of service attacks: [Assignment: organization-defined types of denial of service attacks or reference to source for such information] by employing [Assignment: organization-defined security safeguards].
+
+    Supplemental Guidance:  A variety of technologies exist to limit, or in some cases, eliminate the effects of denial of service attacks. For example, boundary protection devices can filter certain types of packets to protect information system components on internal organizational networks from being directly affected by denial of service attacks. Employing increased capacity and bandwidth combined with service redundancy may also reduce the susceptibility to denial of service attacks. Related controls: SC-6, SC-7.
+
+    References: None.
+  title: >-
+    SC-5 - DENIAL OF SERVICE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-7
+  status: pending
+  notes: |-
+    Section a: 'Documentation on how communications at key internal boundaries of
+    Red Hat Identity Management can be monitored is forthcoming.
+    This activity is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/142'
+
+    Section b: 'Documentation regarding how Red Hat Identity Management can
+    implement subnetworks
+    for publicly accessible system components is forthcoming. This
+    activity is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/143'
+
+    Section c: 'Documentation regarding how Red Hat Identity Management can route
+    connections to external
+    systems through a managed interface is forthcoming. This
+    activity is being trackedin GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/144'
+  rules: []
+  description: |-
+    The information system:
+     a. Monitors and controls communications at the external boundary of the system and at key internal boundaries within the system;
+     b. Implements subnetworks for publicly accessible system components that are [Selection: physically; logically] separated from internal organizational networks; and
+     c. Connects to external networks or information systems only through managed interfaces consisting of boundary protection devices arranged in accordance with an organizational security architecture.
+
+    Supplemental Guidance:  Managed interfaces include, for example, gateways, routers, firewalls, guards, network-based malicious code analysis and virtualization systems, or encrypted tunnels implemented within a security architecture (e.g., routers protecting firewalls or application gateways residing on protected subnetworks). Subnetworks that are physically or logically separated from internal networks are referred to as demilitarized zones or DMZs. Restricting or prohibiting interfaces within organizational information systems includes, for example, restricting external web traffic to designated web servers within managed interfaces and prohibiting external traffic that appears to be spoofing internal addresses. Organizations consider the shared nature of commercial telecommunications services in the implementation of security controls associated with the use of such services. Commercial telecommunications services are commonly based on network components and consolidated management systems shared by all attached commercial customers, and may also include third party-provided access lines and other service elements. Such transmission services may represent sources of increased risk despite contract security provisions. Related controls: AC-4, AC-17, CA-3, CM-7, CP-8, IR-4, RA-3, SC-5, SC-13.
+
+    References: FIPS Publication 199; NIST Special Publications 800-41, 800-77.
+  title: >-
+    SC-7 - BOUNDARY PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-12
+  status: pending
+  notes: |-
+    'Documentation regarding how Red Hat Identity Management generates,
+    distributes, stores,
+    accesses, and destructs, cryptographic keys is forthcoming. This
+    activity is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/145'
+  rules: []
+  description: |-
+    The organization establishes and manages cryptographic keys for required cryptography employed within the information system in accordance with [Assignment: organization-defined requirements for key generation, distribution, storage, access, and destruction].
+
+    Supplemental Guidance:  Cryptographic key management and establishment can be performed using manual procedures or automated mechanisms with supporting manual procedures. Organizations define key management requirements in accordance with applicable federal laws, Executive Orders, directives, regulations, policies, standards, and guidance, specifying appropriate options, levels, and parameters. Organizations manage trust stores to ensure that only approved trust anchors are in such trust stores. This includes certificates with visibility external to organizational information systems and certificates related to the internal operations of systems. Related controls: SC-13, SC-17.
+
+    References: NIST Special Publications 800-56, 800-57.
+
+    SC-12 Guidance: Federally approved cryptography
+  title: >-
+    SC-12 - CRYPTOGRAPHIC KEY ESTABLISHMENT AND
+
+    MANAGEMENT
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-13
+  status: pending
+  notes: |-
+    'Documentation regarding Red Hat Identity Management's usage of
+    cryptography and applicability to Federal laws is forthcoming. This
+    activity is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/146'
+  rules: []
+  description: |-
+    The information system implements [Assignment: organization-defined cryptographic uses and type of cryptography required for each use] in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.
+
+    Supplemental Guidance:  Cryptography can be employed to support a variety of security solutions including, for example, the protection of classified and Controlled Unclassified Information, the provision of digital signatures, and the enforcement of information separation when authorized individuals have the necessary clearances for such information but lack the necessary formal access approvals. Cryptography can also be used to support random number generation and hash generation. Generally applicable cryptographic standards include FIPS-validated cryptography and NSA-approved cryptography. This control does not impose any requirements on organizations to use cryptography. However, if cryptography is required based on the selection of other security controls, organizations define each type of cryptographic use and the type of cryptography required (e.g., protection of classified information: NSA-approved cryptography; provision of digital signatures: FIPS-validated cryptography). Related controls: AC-2, AC-3, AC-7, AC-17, AC-18, AU-9, AU-10, CM-11, CP-9, IA-3, IA-7, MA-4, MP-2, MP-4, MP-5, SA-4, SC-8, SC-12, SC-28, SI-7.
+
+    References: FIPS Publication 140; Web: http://csrc.nist.gov/cryptval, http://www.cnss.gov.
+
+    SC-13 [FIPS-validated or NSA-approved cryptography]
+  title: >-
+    SC-13 - CRYPTOGRAPHIC PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-15
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The information system:
+     a. Prohibits remote activation of collaborative computing devices with the following exceptions: [Assignment: organization-defined exceptions where remote activation is to be allowed]; and
+     b. Provides an explicit indication of use to users physically present at the devices.
+
+    Supplemental Guidance:  Collaborative computing devices include, for example, networked white boards, cameras, and microphones. Explicit indication of use includes, for example, signals to users when collaborative computing devices are activated. Related control: AC-21.
+
+    References: None.
+
+    SC-15 (a) [no exceptions]
+    SC-15 Requirement: The information system provides disablement (instead of physical disconnect) of collaborative computing devices in a manner that supports ease of use.
+  title: >-
+    SC-15 - COLLABORATIVE COMPUTING DEVICES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-20
+  status: pending
+  notes: |-
+    Section a: 'Documentation on how to configure Red Hat Identity Management DNS services to provide
+    data origin authentication and integrity verification is forthcoming.
+    That activity is being tracked GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/147'
+
+    Section b: 'Documentation on how to configure this functionality within
+    Red Hat Identity Management is forthcoming. This activity is being tracked in
+    GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/148'
+  rules: []
+  description: "The information system:\n a. Provides additional data origin and integrity\
+    \ artifacts along with the authoritative name resolution data the system returns\
+    \ in response to external name/address resolution queries; and\n b. Provides the\
+    \ means to indicate the security status of child zones and (if the child supports\
+    \ secure resolution services) to enable verification of a chain of trust among\
+    \ parent and child domains, when operating as part of a distributed, hierarchical\
+    \ namespace.\n \nSupplemental Guidance:  This control enables external clients\
+    \ including, for example, remote Internet clients, to obtain origin authentication\
+    \ and integrity verification assurances for the host/service name to network address\
+    \ resolution information obtained through the service. Information systems that\
+    \ provide name and address resolution services include, for example, domain name\
+    \ system (DNS) servers. Additional artifacts include, for example, DNS Security\
+    \ (DNSSEC) digital signatures and cryptographic keys. DNS resource records are\
+    \ examples of authoritative data. The means to indicate the security status of\
+    \ child zones includes, for example, the use of delegation signer resource records\
+    \ in the DNS. The DNS security controls reflect (and are referenced from) OMB\
+    \ Memorandum 08-23. Information systems that use technologies other than the DNS\
+    \ to map between host/service names and network addresses provide other means\
+    \ to assure the authenticity and integrity of response data. Related controls:\
+    \ AU-10, SC-8, SC-12, SC-13, SC-21, SC-22.    \n\nReferences: OMB Memorandum 08-23;\
+    \ NIST Special Publication 800-81."
+  title: >-
+    SC-20 - SECURE NAME /ADDRESS RESOLUTION SERVICE
+
+    (AUTHORITATIVE SOURCE)
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-21
+  status: pending
+  notes: |-
+    'Documentation on enabling DNSSEC within Red Hat Identity Management is forthcoming. This
+    activity is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/149'
+  rules: []
+  description: |-
+    The information system requests and performs data origin authentication and data integrity verification on the name/address resolution responses the system receives from authoritative sources.
+
+    Supplemental Guidance:  Each client of name resolution services either performs this validation on its own, or has authenticated channels to trusted validation providers. Information systems that provide name and address resolution services for local clients include, for example, recursive resolving or caching domain name system (DNS) servers. DNS client resolvers either perform validation of DNSSEC signatures, or clients use authenticated channels to recursive resolvers that perform such validations. Information systems that use technologies other than the DNS to map between host/service names and network addresses provide other means to enable clients to verify the authenticity and integrity of response data. Related controls: SC-20, SC-22.
+
+    References: NIST Special Publication 800-81.
+  title: >-
+    SC-21 - SECURE NAME /ADDRESS RESOLUTION SERVICE
+
+    (RECURSIVE OR CACHING RESOLVER)
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-22
+  status: pending
+  notes: |-
+    'Documentation on creating fault-tolerant DNS configurations within
+    Red Hat Identity Management is forthcoming. This activity is being
+    tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/150'
+  rules: []
+  description: "The information systems that collectively provide name/address resolution\
+    \ service for an organization are fault-tolerant and implement internal/external\
+    \ role separation.\n \nSupplemental Guidance:  Information systems that provide\
+    \ name and address resolution services include, for example, domain name system\
+    \ (DNS) servers. To eliminate single points of failure and to enhance redundancy,\
+    \ organizations employ at least two authoritative domain name system servers,\
+    \ one configured as the primary server and the other configured as the secondary\
+    \ server. Additionally, organizations typically deploy the servers in two geographically\
+    \ separated network subnetworks (i.e., not located in the same physical facility).\
+    \ For role separation, DNS servers with internal roles only process name and address\
+    \ resolution requests from within organizations (i.e., from internal clients).\
+    \ DNS servers with external roles only process name and address resolution information\
+    \ requests from clients external to organizations (i.e., on external networks\
+    \ including\nthe Internet). Organizations specify clients that can access authoritative\
+    \ DNS servers in particular roles (e.g., by address ranges, explicit lists). Related\
+    \ controls: SC-2, SC-20, SC-21, SC-24.\n\nControl Enhancements:  None.\n\nReferences:\
+    \  NIST Special Publication 800-81."
+  title: >-
+    SC-22 - ARCHITECTURE AND PROVISIONING FOR
+
+    NAME/ADDRESS RESOLUTION SERVICE
+  levels:
+  - high
+  - moderate
+  - low
+- id: SC-39
+  status: pending
+  notes: |-
+    'When Red Hat Identity Management runs on Red Hat Enterprise Linux,
+    Red Hat Identity Management maintains separate execution domains for
+    each executing process by
+    assigning a private virtual address space to each process.
+
+    Documentation on ensuring this functionality is configured is forthcoming.
+    This activity is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/151'
+  rules: []
+  description: |-
+    The information system maintains a separate execution domain for each executing process.
+
+    Supplemental Guidance:  Information systems can maintain separate execution domains for each executing process by assigning each process a separate address space. Each information system process has a distinct address space so that communication between processes is performed in a manner controlled through the security functions, and one process cannot modify the executing code of another process. Maintaining separate execution domains for executing processes can be achieved, for example, by implementing separate address spaces. This capability is available in most commercial operating systems that employ multi-state processor technologies. Related controls: AC-3, AC-4, AC-6, SA-4, SA-5, SA-8, SC-2, SC-3.
+
+    References: None.
+  title: >-
+    SC-39 - PROCESS ISOLATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-1
+  status: not applicable
+  notes: |-
+    'This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Identity Management.'
+  rules: []
+  description: "The organization:\n a. Develops, documents, and disseminates to [Assignment:\
+    \ organization-defined personnel or roles]:\n   1. A system and information integrity\
+    \ policy that addresses purpose, scope, roles, responsibilities, management commitment,\
+    \ coordination among organizational entities, and compliance; and\n   2. Procedures\
+    \ to facilitate the implementation of the system and information integrity policy\
+    \ and associated system and information integrity controls; and\n b. Reviews and\
+    \ updates the current:\n   1. System and information integrity policy [Assignment:\
+    \ organization-defined frequency]; and\n   2.  System and information integrity\
+    \ procedures [Assignment: organization-defined frequency].\n\nSupplemental Guidance:\
+    \  This control addresses the establishment of policy and procedures for the effective\
+    \ implementation of selected security controls and control enhancements in the\
+    \ SI family. Policy and procedures reflect applicable federal laws, Executive\
+    \ Orders, directives, regulations, policies, standards, and guidance. Security\
+    \ program policies and procedures at the organization level may make the need\
+    \ for system-specific policies and procedures unnecessary. The policy can be included\
+    \ as part of the general information security policy for organizations or conversely,\
+    \ can be represented by multiple policies reflecting the complex nature of certain\
+    \ organizations. The procedures can be established for the security program in\
+    \ general and for particular information systems, if needed. The organizational\
+    \ risk management strategy is a key factor in establishing policy and procedures.\
+    \ Related control: PM-9.\n\nControl Enhancements:  None.\n\nReferences:  NIST\
+    \ Special Publications 800-12, 800-100.\n\nSI-1 (b) (1) [at least annually] \n\
+    SI-1 (b) (2) [at least annually or whenever a significant change occurs]"
+  title: >-
+    SI-1 - SYSTEM AND INFORMATION INTEGRITY POLICY AND
+
+    PROCEDURES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-2
+  status: pending
+  notes: |-
+    Section a: 'The customer will be responsible for analyzing their
+    Red Hat Identity Management deployment for
+    flaws, reporting on those flaws, and correcting them. A successful
+    control response will include a discussion of the process by which
+    flaws are discovered and remediated, as well as tools that are used to
+    assist in detection and remediation.
+
+    Documentation of the overall process of vulnerability identification to
+    patching is forthcoming. This work is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/155'
+
+    Section b: 'The customer will be responsible for testing
+    Red Hat Identity Management updates
+    related to flaw remediation prior to installation. A successful
+    control response will discuss the testing process (e.g. the
+    nature of the test environment, the types of testing performed,
+    the tools in testing, etc.).
+
+    Documentation regarding suggested testing procedures is forthcoming.
+    This work is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/156'
+
+    Section c: 'This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Identity Management.'
+
+    Section d: 'This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Identity Management.'
+  rules: []
+  description: |-
+    The organization:
+    a. Identifies, reports, and corrects information system flaws;
+    b. Tests software and firmware updates related to flaw remediation for effectiveness and potential side effects before installation;
+    c. Installs security-relevant software and firmware updates within [Assignment: organization- defined time period] of the release of the updates; and
+    d. Incorporates flaw remediation into the organizational configuration management process.
+    Supplemental Guidance:  Organizations identify information systems affected by announced software flaws including potential vulnerabilities resulting from those flaws, and report this information to designated organizational personnel with information security responsibilities. Security-relevant software updates include, for example, patches, service packs, hot fixes, and anti-virus signatures. Organizations also address flaws discovered during security assessments, continuous monitoring, incident response activities, and system error handling. Organizations take advantage of available resources such as the Common Weakness Enumeration (CWE) or Common Vulnerabilities and Exposures (CVE) databases in remediating flaws discovered in organizational information systems. By incorporating flaw remediation into ongoing configuration management processes, required/anticipated remediation actions can be tracked and verified. Flaw remediation actions that can be tracked and verified include, for example, determining whether organizations follow US-CERT guidance and Information Assurance Vulnerability Alerts. Organization-defined time periods for updating security-relevant software and firmware may vary based on a variety of factors including, for example, the security category of the information system or the criticality of the update (i.e., severity of the vulnerability related to the discovered flaw). Some types of flaw remediation may require more testing than other types. Organizations determine the degree and type of testing needed for the specific type of flaw remediation activity under consideration and also the types of changes that are to be configuration-managed. In some situations, organizations may determine that the testing of software and/or firmware updates is not necessary or practical,
+    for example, when implementing simple anti-virus signature updates. Organizations may also consider in testing decisions, whether security-relevant software or firmware updates are obtained from authorized sources with appropriate digital signatures. Related controls: CA-2, CA-7, CM-3, CM-5, CM-8, MA-2, IR-4, RA-5, SA-10, SA-11, SI-11.
+    SI-2 (c) [thirty (30) days of release of updates]
+  title: >-
+    SI-2 - FLAW REMEDIATION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-3
+  status: pending
+  notes: |-
+    Section a: 'The customer is responsible for ensuring that they employ malicious
+    code protection at information system entry, and exit points to detect
+    and eradicate malicious code. A successful control response will need
+    to address use of code protection mechanisms to protect assets from
+    malicious software (i.e. Viruses, malware, rootkits, worms, and
+    scripts). In regards to Red Hat Identity Management,
+    this is generally through
+    integrating third party tools into CI/CD pipelines.
+
+    Documentation and suggested integration procedures are forthcoming.
+    This work is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/158'
+
+    Section b: 'This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Identity Management.'
+
+    Section c: 'In the scope of Red Hat Identity Management, this control is
+    duplicative of SI-3(a).'
+
+    Section d: 'This control reflects organizational procedures/policies, and is not
+    applicable to the configuration of Red Hat Identity Management.'
+  rules: []
+  description: "The organization:\n a. Employs malicious code protection mechanisms\
+    \ at information system entry and exit points to detect and eradicate malicious\
+    \ code;\n b. Updates malicious code protection mechanisms whenever new releases\
+    \ are available in accordance with organizational configuration management policy\
+    \ and procedures;\n c. Configures malicious code protection mechanisms to:\n \
+    \  1. Perform periodic scans of the information system [Assignment: organization-defined\
+    \ frequency] and real-time scans of files from external sources at [Selection\
+    \ (one or more); endpoint; network entry/exit points] as the files are downloaded,\
+    \ opened, or executed in accordance with organizational security policy; and\n\
+    \   2. [Selection (one or more): block malicious code; quarantine malicious code;\
+    \ send alert to administrator; [Assignment: organization-defined action]] in response\
+    \ to malicious code detection; and\n d. Addresses the receipt of false positives\
+    \ during malicious code detection and eradication and the resulting potential\
+    \ impact on the availability of the information system.\n\nSupplemental Guidance:\
+    \  Information system entry and exit points include, for example, firewalls, electronic\
+    \ mail servers, web servers, proxy servers, remote-access servers, workstations,\
+    \ notebook computers, and mobile devices. Malicious code includes, for example,\
+    \ viruses, worms, Trojan horses, and spyware. Malicious code can also be encoded\
+    \ in various formats (e.g., UUENCODE, Unicode), contained within compressed or\
+    \ hidden files, or hidden in files using steganography. Malicious code can be\
+    \ transported by different means including, for example, web accesses, electronic\
+    \ mail, electronic mail attachments, and portable storage devices. Malicious code\
+    \ insertions occur through the exploitation of information system vulnerabilities.\
+    \ Malicious code protection mechanisms include, for example, anti-virus signature\
+    \ definitions and reputation-based technologies. A variety of technologies and\
+    \ methods exist to limit or eliminate the effects of malicious code. Pervasive\
+    \ configuration management and comprehensive software integrity controls may be\
+    \ effective in preventing execution of unauthorized code. In addition to commercial\
+    \ off-the-shelf software, malicious code may also be present in custom-built software.\
+    \ This could include, for example, logic bombs, back doors, and other types of\
+    \ cyber attacks that could affect organizational missions/business functions.\
+    \ Traditional malicious code protection mechanisms cannot always detect such code.\
+    \ In these situations, organizations rely instead on other safeguards including,\
+    \ for example, secure coding practices, configuration management and control,\
+    \ trusted procurement processes, and monitoring practices to help ensure that\
+    \ software does not perform functions other than the functions intended. Organizations\
+    \ may determine that in response to the detection of malicious code, different\
+    \ actions may be warranted. For example, organizations can define actions in response\
+    \ to malicious code detection during periodic scans, actions in response to detection\
+    \ of malicious downloads, and/or actions in response to detection of maliciousness\
+    \ when attempting to open or execute files. Related controls: CM-3, MP-2, SA-4,\
+    \ SA-8, SA-12, SA-13,\nSC-7, SC-26, SC-44, SI-2, SI-4, SI-7.\n\nReferences: NIST\
+    \ Special Publication 800-83. \n\nSI-3 (c) (1)-1 [at least weekly] \nSI-3 (c)\
+    \ (1)-2 [to include endpoints]\nSI-3 (c) (2) [to include blocking and quarantining\
+    \ malicious code and alerting administrator or defined security personnel near-realtime]"
+  title: >-
+    SI-3 - MALICIOUS CODE PROTECTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-4
+  status: not applicable
+  notes: ""
+  rules: []
+  description: "The organization:\n a. Monitors the information system to detect:\n\
+    \   1. Attacks and indicators of potential attacks in accordance with [Assignment:\
+    \ organization- defined monitoring objectives]; and\n   2. Unauthorized local,\
+    \ network, and remote connections;\n b. Identifies unauthorized use of the information\
+    \ system through [Assignment: organization- defined techniques and methods];\n\
+    \ c. Deploys monitoring devices: (i) strategically within the information system\
+    \ to collect organization-determined essential information; and (ii) at ad hoc\
+    \ locations within the system to track specific types of transactions of interest\
+    \ to the organization;\n d. Protects information obtained from intrusion-monitoring\
+    \ tools from unauthorized access, modification, and deletion;\n e. Heightens the\
+    \ level of information system monitoring activity whenever there is an indication\
+    \ of increased risk to organizational operations and assets, individuals, other\
+    \ organizations, or the Nation based on law enforcement information, intelligence\
+    \ information, or other credible sources of information;\n f. Obtains legal opinion\
+    \ with regard to information system monitoring activities in accordance with applicable\
+    \ federal laws, Executive Orders, directives, policies, or regulations; and\n\
+    \ g. Provides [Assignment: or ganization-defined information system monitoring\
+    \ information] to [Assignment: organization-defined personnel or roles] [Selection\
+    \ (one or more): as needed; [Assignment: organization-defined frequency]].\n\n\
+    Supplemental Guidance:  Information system monitoring includes external and internal\
+    \ monitoring. External monitoring includes the observation of events occurring\
+    \ at the information system boundary (i.e., part of perimeter defense and boundary\
+    \ protection). Internal monitoring includes the observation of events occurring\
+    \ within the information system. Organizations can monitor information systems,\
+    \ for example, by observing audit activities in real time or by observing other\
+    \ system aspects such as access patterns, characteristics of access, and other\
+    \ actions. The monitoring objectives may guide determination of the events. Information\
+    \ system monitoring capability is achieved through a variety of tools and techniques\
+    \ (e.g., intrusion detection systems, intrusion prevention systems, malicious\
+    \ code protection software, scanning tools, audit record monitoring software,\
+    \ network monitoring software). Strategic locations for monitoring devices include,\
+    \ for example, selected perimeter locations and near server farms supporting critical\
+    \ applications, with such devices typically being employed at the managed interfaces\
+    \ associated with controls SC-7 and AC-17. Einstein network monitoring devices\
+    \ from the Department of Homeland Security can also be included as monitoring\
+    \ devices. The granularity of monitoring information collected is based on organizational\
+    \ monitoring objectives and the capability of information systems to support such\
+    \ objectives. Specific types of transactions of interest include, for example,\
+    \ Hyper Text Transfer Protocol (HTTP) traffic that bypasses HTTP proxies. Information\
+    \ system monitoring is an integral part of organizational continuous monitoring\
+    \ and incident response programs. Output from system monitoring serves as input\
+    \ to continuous monitoring and incident response programs. A network connection\
+    \ is any connection with a device that communicates through a network (e.g., local\
+    \ area network, Internet). A remote connection is any connection with a device\
+    \ communicating through an external network (e.g., the Internet). Local, network,\
+    \ and remote connections can be either wired or wireless. Related controls: AC-3,\
+    \ AC-4, AC-8, AC-17, AU-2, AU-6, AU-7, AU-9, AU-12, CA-7, IR-4, PE-3, RA-5, SC-7,\
+    \ SC-26, SC-35, SI-3, SI-7.\n\nReferences: NIST Special Publications 800-61, 800-83,\
+    \ 800-92, 800-94, 800-137.\n\n \nSI-4 Guidance: See US-CERT Incident Response\
+    \ Reporting Guidelines."
+  title: >-
+    SI-4 - INFORMATION SYSTEM MONITORING
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-5
+  status: not applicable
+  notes: ""
+  rules: []
+  description: |-
+    The organization:
+     a. Receives information system security alerts, advisories, and directives from [Assignment: organization-defined external organizations] on an ongoing basis;
+     b. Generates internal security alerts, advisories, and directives as deemed necessary;
+     c. Disseminates security alerts, advisories, and directives to: [Selection (one or more): [Assignment: organization-defined personnel or roles]; [Assignment: organization-defined elements within the organization]; [Assignment: organization-defined external organizations]]; and
+     d. Implements security directives in accordance with established time frames, or notifies the issuing organization of the degree of noncompliance.
+
+    Supplemental Guidance:  The United States Computer Emergency Readiness Team (US-CERT) generates security alerts and advisories to maintain situational awareness across the federal government. Security directives are issued by OMB or other designated organizations with the responsibility and authority to issue such directives. Compliance to security directives is essential due to the critical nature of many of these directives and the potential immediate adverse effects
+    on organizational operations and assets, individuals, other organizations, and the Nation should the directives not be implemented in a timely manner. External organizations include, for example, external mission/business partners, supply chain partners, external service providers, and other peer/supporting organizations. Related control: SI-2.
+
+    References: NIST Special Publication 800-40.
+
+    SI-5 (a) [to include US-CERT]
+    SI-5 (c) [to include system security personnel and administrators with configuration/patch-management responsibilities]
+  title: >-
+    SI-5 - SECURITY ALERTS, ADVISORIES, AND DIRECTIVES
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-12
+  status: pending
+  notes: |-
+    'The customer will be responsible for handling and retaining
+    information within, or hosted by, Red Hat Identity Management in
+    accordance with applicable federal laws, Executive Orders,
+    directives, policies, regulations, standards, and operational
+    requirements. A successful control response will need to outline
+    the specific requirements applicable to customer information
+    handling and retention, and the means by which those requirements
+    are met.
+
+    Documentation and suggestions on protecting customer information
+    hosted within the Red Hat Identity Management environment
+    is forthcoming. This activity
+    is being tracked in GitHub:
+
+    https://github.com/ComplianceAsCode/redhat-identity-management/issues/159'
+  rules: []
+  description: |-
+    The organization handles and retains information within the information system and information output from the system in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and operational requirements.
+
+    Supplemental Guidance:  Information handling and retention requirements cover the full life cycle of information, in some cases extending beyond the disposal of information systems. The National Archives and Records Administration provides guidance on records retention. Related controls: AC-16, AU-5, AU-11, MP-2, MP-4.
+
+    Control Enhancements: None.
+
+    References: None.
+  title: >-
+    SI-12 - INFORMATION HANDLING AND RETENTION
+  levels:
+  - high
+  - moderate
+  - low
+- id: SI-16
+  status: not applicable
+  notes: |-
+    'Red Hat Red Hat Identity Management Container Platform
+    inherits memory protections
+    provided by the underlying operating system. This control is not
+    applicable to Red Hat Red Hat Identity Management Container Platform.'
+  rules: []
+  description: |-
+    The information system implements [Assignment: organization-defined security safeguards] to protect its memory from unauthorized code execution.
+
+    Supplemental Guidance:  Some adversaries launch attacks with the intent of executing code in non- executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced with hardware providing the greater strength of mechanism. Related controls: AC-25, SC-3.
+
+    Control Enhancements:  None.
+
+    References:  None.
+  title: >-
+    SI-16 - MEMORY PROTECTION
+  levels:
+  - high
+  - moderate
+  - low


### PR DESCRIPTION
This migrates the contents of OpenControl towards the control structure.
Currently there are no rules enabled for this, but this facilitates
that.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>