### PR TITLE
Ignore SSGTS slice option when running in profile mode

### DIFF
--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -250,13 +250,15 @@ def parse_args():
                                        "scenarios."))
 
     options = parser.parse_args()
-    options.slice_current, options.slice_total = options._slices
-    if options.slice_current < 1:
-        raise argparse.ArgumentTypeError('Current slice needs to be positive integer')
-    if options.slice_total < 1:
-        raise argparse.ArgumentTypeError('Number of slices needs to be positive integer')
-    if options.slice_current > options.slice_total:
-        raise argparse.ArgumentTypeError('Current slice cannot be greater than number of slices')
+    if options.subparser_name in ["rule", "combined"]:
+        options.slice_current, options.slice_total = options._slices
+        if options.slice_current < 1:
+            raise argparse.ArgumentTypeError('Current slice needs to be positive integer')
+        if options.slice_total < 1:
+            raise argparse.ArgumentTypeError('Number of slices needs to be positive integer')
+        if options.slice_current > options.slice_total:
+            raise argparse.ArgumentTypeError(
+                'Current slice cannot be greater than number of slices')
     return options
 
 


### PR DESCRIPTION
#### Description:

- Ignore SSGTS slice option when running in profile mode

#### Rationale:

- Fixes:

```
python3 tests/test_suite.py profile --container ssg_test_suite --datastream build/ssg-fedora-ds.xml standard
Traceback (most recent call last):
  File "tests/test_suite.py", line 461, in <module>
    main()
  File "tests/test_suite.py", line 420, in main
    options = parse_args()
  File "tests/test_suite.py", line 254, in parse_args
    options.slice_current, options.slice_total = options._slices
AttributeError: 'Namespace' object has no attribute '_slices'
```
