### PR TITLE
Update Centos8 Dockerfile to enable powertools and ninja-build correctly

### DIFF
--- a/Dockerfiles/centos8
+++ b/Dockerfiles/centos8
@@ -7,8 +7,8 @@ ENV BUILD_JOBS 4
 RUN true \
   && dnf -y upgrade \
   && dnf -y install cmake openscap-utils python3-jinja2 \
-    python3-libs python3-pip python3-pyyaml \
-  && dnf -y --enablerepo=PowerTools install ninja-build \
+    python3-libs python3-pip python3-pyyaml dnf-plugins-core \
+  && dnf -y --enablerepo=powertools install ninja-build \
   && mkdir -p /home/$OSCAP_USERNAME \
   && dnf clean all \
   && rm -rf /usr/share/doc /usr/share/doc-base \


### PR DESCRIPTION
#### Description:

Properly enable the Centos8 PowerTools repo to install ninja-build

#### Rationale:

The current Centos8 Dockerfile fails to build. It exists with an error when attempting to install the ninja-build package because enabling the PowerTools repo fails. This commit resolves that problem by installing dnf-plugins-core and properly enabling the powertools repo.

