### PR TITLE
SELinux docs: fix RHEL7 link, add RHEL8 link

### DIFF
--- a/linux_os/guide/system/selinux/group.yml
+++ b/linux_os/guide/system/selinux/group.yml
@@ -25,7 +25,10 @@ description: |-
     appropriate.
     {{% if product == "rhel7" %}}
     <br /><br />
-    For more information on SELinux, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/SELinux_Users_and_Administrators_Guide") }}}</b>.
+    For more information on SELinux, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/selinux_users_and_administrators_guide") }}}</b>.
+    {{% elif product == "rhel8" %}}
+    <br /><br />
+    For more information on SELinux, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux") }}}</b>.
     {{% elif product == "ol7" %}}
     For more information on SELinux, see <b>{{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/selinux/") }}}</b>.
     {{% endif %}}


### PR DESCRIPTION
#### Description:

- Fixed incorrect link to SELinux documentation on RHEL7
- Added link to RHEL8 SELinux documentation