### PR TITLE
Correct the name of the package and service for syslog-ng

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/package_syslogng_installed/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/package_syslogng_installed/rule.yml
@@ -30,4 +30,4 @@ ocil: '{{{ ocil_package(package="syslog-ng-core") }}}'
 template:
     name: package_installed
     vars:
-        pkgname: syslogng
+        pkgname: syslog-ng

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/service_syslogng_enabled/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/service_syslogng_enabled/rule.yml
@@ -29,4 +29,4 @@ ocil: |-
 template:
     name: service_enabled
     vars:
-        servicename: syslogng
+        servicename: syslog-ng


### PR DESCRIPTION
#### Description:

- Correct the name of the `syslog-ng` package and service name

#### Rationale:

- The name is wrong, the check of the package installation and service enableing is not done correctly, even if the remediation is correct

Here is the result of the searches done with `dpkg` for the package:

```
mdedonno@debian9openscap:~$ dpkg -l syslogng
dpkg-query: no packages found matching syslogng

mdedonno@debian9openscap:~$ dpkg -l syslog-ng
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name                  Version         Architecture    Description
+++-=====================-===============-===============-================================================
ii  syslog-ng             3.8.1-10        all             Enhanced system logging daemon (metapackage)

mdedonno@debian9openscap:~$ cat /etc/*-release
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
VERSION_CODENAME=stretch
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

```
mdedonno@debian10openscap:~$ dpkg -l syslogng
dpkg-query: no packages found matching syslogng

mdedonno@debian10openscap:~$ dpkg -l syslog-ng
Desired=Unknown/Install/Remove/Purge/Hold
| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
||/ Name           Version      Architecture Description
+++-==============-============-============-============================================
ii  syslog-ng      3.19.1-5     all          Enhanced system logging daemon (metapackage)

mdedonno@debian10openscap:~$ cat /etc/*-release
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```