### PR TITLE
sshd_set_idle_timeout: update pass scenario for both RHEL7 and RHEL8

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value.pass.sh
@@ -4,6 +4,8 @@ SSHD_CONFIG="/etc/ssh/sshd_config"
 
 . "$SHARED/utilities.sh"
 
-# OSPP profile selects a time out of 14_minutes
-assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 840"
+# RHEL8 OSPP profile selects a timeout interval of 14_minutes
+# while RHEL7 OSPP has 10_minutes so we go with some lower value
+# to satisfy both profiles.
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 500"
 assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "ClientAliveCountMax 0"


### PR DESCRIPTION
#### Description:

- pass scenario for `sshd_set_idle_timeout` updated to work on both RHEL7 and RHEL8