### PR TITLE
Enforce usage of product (fedora) option when running SSGTS on Github actions

### DIFF
--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -118,7 +118,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
         env:
-          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora --product fedora"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -139,7 +139,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
         env:
-          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora --product fedora"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log


### PR DESCRIPTION
#### Description:

-  Enforce usage of product (fedora) option when running SSGTS on Github actions



#### Rationale:

- When testing dpkg content on Fedora, we want to make sure that package installation uses dnf instead of apt-get.
