### PR TITLE
Update templated service disabled/enabled test scenarios

### DIFF
--- a/shared/templates/service_disabled/tests/service_disabled.pass.sh
+++ b/shared/templates/service_disabled/tests/service_disabled.pass.sh
@@ -1,8 +1,16 @@
 #!/bin/bash
 # packages = {{{ PACKAGENAME }}}
 
-systemctl stop {{{ DAEMONNAME }}}
-systemctl disable {{{ DAEMONNAME }}}
-{{% if MASK_SERVICE %}}
-systemctl mask {{{ DAEMONNAME }}}
-{{% endif %}}
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+# Disable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
+    "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
+fi
+# The service may not be running because it has been started and failed,
+# so let's reset the state so OVAL checks pass.
+# Service should be 'inactive', not 'failed' after reboot though.
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true

--- a/shared/templates/service_disabled/tests/service_enabled.fail.sh
+++ b/shared/templates/service_disabled/tests/service_enabled.fail.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 # packages = {{{ PACKAGENAME }}}
 
-systemctl start {{{ DAEMONNAME }}}
-systemctl enable {{{ DAEMONNAME }}}
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+
+# The service may not be running because it has been started and failed,
+# so let's reset the state so OVAL checks pass.
+# Service should be 'inactive', not 'failed' after reboot though.
+"$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true

--- a/shared/templates/service_enabled/tests/service_disabled.fail.sh
+++ b/shared/templates/service_enabled/tests/service_disabled.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = {{{ PACKAGENAME }}}
 
-systemctl stop {{{ DAEMONNAME }}}
-systemctl disable {{{ DAEMONNAME }}}
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'

--- a/shared/templates/service_enabled/tests/service_enabled.pass.sh
+++ b/shared/templates/service_enabled/tests/service_enabled.pass.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # packages = {{{ PACKAGENAME }}}
 
-systemctl start {{{ DAEMONNAME }}}
-systemctl enable {{{ DAEMONNAME }}}
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'


### PR DESCRIPTION
Some `service_disabled` templated rules also need to
disable systemd socket units (e.g.
`service_systemd-coredump_disabled` rule). This commit
updates templated test scenarios to handle such cases.