### PR TITLE
OCP4/PCI-DSS: Add response for Requirement 2.2.4

### DIFF
--- a/applications/openshift/risk-assessment/compliancesuite_exists/rule.yml
+++ b/applications/openshift/risk-assessment/compliancesuite_exists/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
   nerc-cip: CIP-003-3 R1.3,CIP-003-3 R4.3,CIP-003-3 R6,CIP-004-3 4.1,CIP-004-3 4.2,CIP-004-3 R3,CIP-004-3 R4,CIP-004-3 R4.2,CIP-005-3a R1,CIP-005-3a R1.1,CIP-005-3a R1.2,CIP-007-3 R3,CIP-007-3 R3.1,CIP-007-3 R6.1,CIP-007-3 R8.4
   nist: CM-6,CM-6(1),RA-5,RA-5(5),SA-4(8)
+  pcidss: Req-2.2.4
 
 ocil_clause: 'The proper audit profile is not set'
 

--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -453,9 +453,16 @@ controls:
     title: 2.2.4 Configure system security parameters to prevent misuse.
     levels:
     - base
-    notes: ''
-    status: pending
-    rules: []
+    notes: |-
+      While it's possible to manually configure the security settings
+      in the Openshift Container Platform, the Compliance Operator provides
+      an automated way of checking for a secure configuration and automatically
+      remediating issues according to known security standards. It's usage
+      is recommended to ensure appropriate configuration is set and prevent
+      drift.
+    status: automated
+    rules:
+    - compliancesuite_exists
 
   - id: Req-2.2.5
     title: 2.2.5 Remove all unnecessary functionality, such as scripts, drivers, features,


### PR DESCRIPTION
We recommend the usage of the Compliance Operator to both verify and
automate setting of secure configuration settings.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>