### PR TITLE
OCP4/PCI-DSS: Add rules for 2.3 requirement

### DIFF
--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -22,7 +22,7 @@ references:
     cis@ocp4: 1.2.20
     nerc-cip: CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>bindAddress</tt> allows unsecure connections'
 

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -34,7 +34,7 @@ references:
     cis@ocp4: 1.2.31
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 identifiers:
     cce@ocp4: CCE-84284-9

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -37,7 +37,7 @@ references:
     cis@ocp4: 1.2.32
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>etcd-cafile</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -35,7 +35,7 @@ references:
     cis@ocp4: 1.2.29
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>etcd-certfile</tt> does not exist or is not configured to valid certificates'
 

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -35,7 +35,7 @@ references:
     cis@ocp4: 1.2.29
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>keyFile</tt> does not exist or is not configured to valid certificates'
 

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -21,7 +21,7 @@ references:
     cis: 1.2.4
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2
+    pcidss: Req-2.2,Req-2.3
 
 ocil_clause: '<tt>kubelet-https</tt> is set to false'
 

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -37,7 +37,7 @@ references:
     cis@ocp4: 1.2.19
     nerc-cip: CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
-    pcidss: Req-2.2
+    pcidss: Req-2.2,Req-2.3
 
 ocil_clause: '<tt>insecure-port</tt> setting exists'
 

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -36,7 +36,7 @@ references:
     cis@ocp4: 1.2.6
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>kubelet-certificate-authority</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 

--- a/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
@@ -24,7 +24,7 @@ references:
     cis@ocp4: 1.2.4
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: |-
     The openshift-apiserver serving-cert is not set to type

--- a/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
@@ -24,7 +24,7 @@ references:
     cis@ocp4: 1.2.4
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: |-
     The openshift-apiserver serving-cert is not set to type

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -35,7 +35,7 @@ references:
     cis@ocp4: 1.2.28
     nerc-cip: CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'serviceAccountPublicKeyFiles is not configured correctly'
 

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -35,7 +35,7 @@ references:
     cis@ocp4: 1.2.30
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>tls-cert-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -33,7 +33,7 @@ severity: medium
 references:
     cis@ocp4: 1.2.35
     nist: CM-6
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>cipherSuites</tt> is not configured, or contains ciphers (possibly insecure) other than TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, or TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 in servingInfo'
 

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -35,7 +35,7 @@ references:
     cis@ocp4: 1.2.30
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>tls-private-key-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 

--- a/applications/openshift/authentication/ocp_no_ldap_insecure/rule.yml
+++ b/applications/openshift/authentication/ocp_no_ldap_insecure/rule.yml
@@ -43,6 +43,7 @@ identifiers:
 references:
   nerc-cip: CIP-003-3 R4.2,CIP-003-3 R5.1.1,CIP-003-3 R5.3,CIP-004-3 R2.2.3,CIP-004-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R5.1.2,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3 R5.3.2,CIP-007-3 R5.3.3
   nist: IA-2(8),SC-8
+  pcidss: Req-2.3
 
 severity: high
 

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -35,7 +35,7 @@ references:
     cis@ocp4: 1.3.4
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: '<tt>service-account-private-key-file</tt> does not exist or is configured properly'
 

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -27,7 +27,7 @@ references:
     cis@ocp4: '2.1'
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the etcd client certificate is not configured'
 

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -25,7 +25,7 @@ references:
     cis@ocp4: '2.2'
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the etcd client certificate authentication is not configured'
 

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -27,7 +27,7 @@ references:
     cis@ocp4: '2.1'
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the etcd client key file is not configured'
 

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -27,7 +27,7 @@ references:
     cis@ocp4: '2.4'
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the etcd peer client certificate is not configured'
 

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -25,7 +25,7 @@ references:
     cis@ocp4: '2.5'
     nerc-cip: CIP-003-3 R4.2,CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the etcd peer client certificate authentication is not configured'
 

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -27,7 +27,7 @@ references:
     cis@ocp4: '2.4'
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the etcd peer client key file is not configured'
 

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -23,7 +23,7 @@ references:
     cis@ocp4: 4.2.10
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the kubelet certificate is not configured'
 

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -23,7 +23,7 @@ references:
     cis@ocp4: 4.2.10
     nerc-cip: CIP-003-3 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
-    pcidss: Req-2.2,Req-2.2.3
+    pcidss: Req-2.2,Req-2.2.3,Req-2.3
 
 ocil_clause: 'the kubelet server key certificate is not configured'
 

--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -483,9 +483,32 @@ controls:
   levels:
   - base
   notes: ''
-  status: pending
+  status: automated
   rules:
-  - file_owner_worker_ca
+    - api_server_bind_address
+    - api_server_client_ca
+    - api_server_etcd_ca
+    - api_server_etcd_cert
+    - api_server_etcd_key
+    - api_server_https_for_kubelet_conn
+    - api_server_insecure_port
+    - api_server_kubelet_certificate_authority
+    - api_server_oauth_https_serving_cert
+    - api_server_openshift_https_serving_cert
+    - api_server_service_account_public_key
+    - api_server_tls_cert
+    - api_server_tls_cipher_suites
+    - api_server_tls_private_key
+    - controller_service_account_private_key
+    - etcd_cert_file
+    - etcd_client_cert_auth
+    - etcd_key_file
+    - etcd_peer_cert_file
+    - etcd_peer_client_cert_auth
+    - etcd_peer_key_file
+    - kubelet_configure_tls_cert
+    - kubelet_configure_tls_key
+    - ocp_no_ldap_insecure
 
 - id: Req-2.4
   title: 2.4 Maintain an inventory of system components that are in scope for PCI


### PR DESCRIPTION
TLS-related rules are relevant.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>