### PR TITLE
sshd_set_idle_timeout: remove profile metadata from pass scenario

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value.pass.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
-# profiles = xccdf_org.ssgproject.content_profile_ospp
 SSHD_CONFIG="/etc/ssh/sshd_config"
 
 . "$SHARED/utilities.sh"
 
-# RHEL8 OSPP profile selects a timeout interval of 14_minutes
-# while RHEL7 OSPP has 10_minutes so we go with some lower value
-# to satisfy both profiles.
-assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 500"
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 200"
 assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "ClientAliveCountMax 0"


### PR DESCRIPTION
Workaround for https://github.com/OpenSCAP/openscap/issues/1814