### PR TITLE
Set permissions of private SSH keys to 600 for all products

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -3,11 +3,7 @@ documentation_complete: true
 title: 'Verify Permissions on SSH Server Private *_key Key Files'
 
 description: |-
-    {{% if product in ['ubuntu1804','opensuse', 'sle12', 'sle15'] %}}
     {{{ describe_file_permissions(file="/etc/ssh/*_key", perms="0600") }}}
-    {{% else %}}
-    {{{ describe_file_permissions(file="/etc/ssh/*_key", perms="0640") }}}
-    {{% endif %}}
 
 rationale: |-
     If an unauthorized user obtains the private SSH host key file, the host could be
@@ -45,10 +41,10 @@ references:
     stigid@sle12: SLES-12-030220
     stigid@sle15: SLES-15-040250
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/ssh/*_key", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-r-----") }}}
+    {{{ ocil_file_permissions(file="/etc/ssh/*_key", perms="-rw-------") }}}
 
 template:
     name: file_permissions
@@ -56,9 +52,4 @@ template:
         filepath: /etc/ssh/
         missing_file_pass: 'true'
         file_regex: ^.*_key$
-        filemode: '0640'
-        filemode@sle12: '0600'
-        filemode@sle15: '0600'
-        filemode@ubuntu1604: '0600'
-        filemode@ubuntu1804: '0600'
-        filemode@ubuntu2004: '0600'
+        filemode: '0600'

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/correct_permissions.pass.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 #
 
-{{% if product in ("ubuntu1804", "opensuse", "sle12", "sle15") %}}
-    {{% set target_perms_octal="0600" %}}
-{{% else %}}
-    {{% set target_perms_octal="0640" %}}
-{{% endif %}}
-
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
-chmod {{{ target_perms_octal }}}  /etc/ssh/*_key
+chmod 0600 /etc/ssh/*_key

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing_file_test.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing_file_test.pass.sh
@@ -3,5 +3,6 @@
 
 mkdir -p /etc/ssh/keys
 mv /etc/ssh/*_key /etc/ssh/keys
-sed -i "s#HostKey /etc/ssh/#HostKey /etc/ssh/keys/#g" sshd_config
+sed -i "s#HostKey /etc/ssh/#HostKey /etc/ssh/keys/#g" /etc/ssh/sshd_config
 systemctl restart sshd
+rm -f /etc/ssh/*_key # systemctl restart sshd always regenerate keys in the /etc/ssh if they are not there

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/multiple_keys.fail.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/multiple_keys.fail.sh
@@ -4,4 +4,4 @@
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chmod 0777 $FAKE_KEY
 FAKE_KEY2=$(mktemp -p /etc/ssh/ XXXX_key)
-chmod 0640 $FAKE_KEY2
+chmod 0600 $FAKE_KEY2


### PR DESCRIPTION
#### Description:

- RHEL8 STIG is already using 600 (V1R3) and RHEL7 will start using from next release V3R5.
