### PR TITLE
OCP: Fix OCIL description of configure_network_policies_namespaces

### DIFF
--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -30,12 +30,15 @@ references:
 
 ocil_clause: 'Namespaced Network Policies needs review'
 
+# same as above except filters the names only. Used in OCIL only, not in the 'warnings attribute'
+{{% set non_ctlplane_namespaces_filter_names = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default") | .metadata.name ]' %}}
+
 ocil: |-
     Verify that the every non-control plane namespace has an appropriate
     NetworkPolicy.
 
     To get all the non-control plane namespaces, you can do the
-    following command <tt>{{{ ocil_oc_pipe_jq_filter('namespaces', non_ctlplane_namespaces_filter) }}}</tt>
+    following command <tt>{{{ ocil_oc_pipe_jq_filter('namespaces', non_ctlplane_namespaces_filter_names) }}}</tt>
 
     To get all the non-control plane namespaces with a NetworkPolicy, you can do the
     following command <tt>{{{ ocil_oc_pipe_jq_filter('networkpolicies', networkpolicies_for_non_ctlplane_namespaces_filter, all_namespaces=true) }}}</tt>


### PR DESCRIPTION
#### Description:
The JQ filter used in both the warnings for API collection purposes and
in OCIL was user-unfriendly as it was dumping the whole namespace
object. Because just changing the filter to look nicer would break the
API collection, I added a similar variable, just filtering the names
only and used that in OCIL only.

Jira: OCPBUGSM-35010
RHBZ: 2003170