### PR TITLE
Fixed regex used in OVAL related to audit rules

### DIFF
--- a/shared/templates/audit_rules_login_events/oval.template
+++ b/shared/templates/audit_rules_login_events/oval.template
@@ -24,7 +24,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+{{{ PATH }}}\s+\-p\s+wa\s+(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -33,7 +33,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w\s+{{{ PATH }}}\s+\-p\s+wa\s+(-k[\s]+|-F[\s]+key=)[-\w]+\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
It was rightly caught by test scenarios where different variations
of valid permissions were used.