### PR TITLE
Add oval-graph support for the test suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -345,6 +345,12 @@ UserKnownHostsFile /dev/null
 
 All logs of Test Suite are stored in `logs` directory. The specific diretory is shown at the beginning of each test run.
 
+If you want more verbose logs, pass the `--dontclean` argument that preserves result files, reports and verbose scanner output
+even in cases when the test result went according to the expectations.
+If your system has the [oval-graph](://github.com/OpenSCAP/oval-graph) package installed that provides the `arf-to-html` command,
+the test suite will use it to extract OVAL evaluation details from ARFs, and save those condensed reports to the `logs` directory
+even if the `--dontclean` argument has been specified.
+
 ## Rule-based testing
 
 ```
@@ -499,7 +505,6 @@ If you would like to test all profile's rules against their test scenarios:
 ```
 ./test_suite.py combined --libvirt qemu:///system ssg-test-suite-rhel8 --datastream ../build/ssg-rhel8-ds.xml ospp
 ```
-
 
 
 # Analysis of results

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import contextlib
 import sys
 import os
+import re
 import time
 import subprocess
 import json
@@ -68,6 +69,21 @@ class TestEnv(object):
         self.ssh_additional_options = []
 
         self.product = None
+
+        self.have_local_oval_graph = False
+        p = subprocess.run(['arf-to-graph', '--version'], capture_output=True)
+        if p.returncode == 0:
+            self.have_local_oval_graph = True
+
+    def arf_to_html(self, arf_filename):
+        if not self.have_local_oval_graph:
+            return
+
+        html_filename = re.sub(r"\barf\b", "graph", arf_filename)
+        html_filename = re.sub(r".xml", ".html", html_filename)
+
+        cmd = ['arf-to-graph', '--all-in-one', '--output', html_filename, arf_filename, '.']
+        p = subprocess.run(cmd, capture_output=True)
 
     def start(self):
         """


### PR DESCRIPTION
This PR flips the result format to ARF, and uses oval-graph to generate HTML graphs locally.

If `oval-graph` is available on the system that runs the tests, the test suite generates the interactive HTML visualization of the OVAL check based on the ARF. Generated HTML graphs are small, so they are currently not cleaned from the folder (in contrast to  reports).

It looks like that the ARF that oscap produces when called with `--remediate` refers to the state before the fix, so those graphs aren't useful.