### PR TITLE
OCP4: Add CPEs for further versions

### DIFF
--- a/products/ocp4/product.yml
+++ b/products/ocp4/product.yml
@@ -47,5 +47,45 @@ cpes:
       title: "Red Hat OpenShift Container Platform 4.10"
       check_id: installed_app_is_ocp4_10
 
+  - ocp4.11:
+      name: "cpe:/a:redhat:openshift_container_platform:4.11"
+      title: "Red Hat OpenShift Container Platform 4.11"
+      check_id: installed_app_is_ocp4_11
+
+  - ocp4.12:
+      name: "cpe:/a:redhat:openshift_container_platform:4.12"
+      title: "Red Hat OpenShift Container Platform 4.12"
+      check_id: installed_app_is_ocp4_12
+
+  - ocp4.13:
+      name: "cpe:/a:redhat:openshift_container_platform:4.13"
+      title: "Red Hat OpenShift Container Platform 4.13"
+      check_id: installed_app_is_ocp4_13
+
+  - ocp4.14:
+      name: "cpe:/a:redhat:openshift_container_platform:4.14"
+      title: "Red Hat OpenShift Container Platform 4.14"
+      check_id: installed_app_is_ocp4_14
+
+  - ocp4.15:
+      name: "cpe:/a:redhat:openshift_container_platform:4.15"
+      title: "Red Hat OpenShift Container Platform 4.15"
+      check_id: installed_app_is_ocp4_15
+
+  - ocp4.16:
+      name: "cpe:/a:redhat:openshift_container_platform:4.16"
+      title: "Red Hat OpenShift Container Platform 4.16"
+      check_id: installed_app_is_ocp4_16
+
+  - ocp4.17:
+      name: "cpe:/a:redhat:openshift_container_platform:4.17"
+      title: "Red Hat OpenShift Container Platform 4.17"
+      check_id: installed_app_is_ocp4_17
+
+  - ocp4.18:
+      name: "cpe:/a:redhat:openshift_container_platform:4.18"
+      title: "Red Hat OpenShift Container Platform 4.18"
+      check_id: installed_app_is_ocp4_18
+
 # Requirement string, see: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing
 # requires: "openscap>=1.3.4"

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -43,7 +43,7 @@
       </ind:value>
   </ind:yamlfilecontent_state>
 
-{{% for minorversion in range(6, 11) %}}
+{{% for minorversion in range(6, 19) %}}
   <!-- Check for OpenShift Container Platform 4.{{{ minorversion }}} -->
   <definition class="inventory" id="installed_app_is_ocp4_{{{ minorversion }}}" version="1">
     <metadata>


### PR DESCRIPTION
We're currently working on version 4.10 (4.9 was just released). So...
it's time for us to add more CPEs to make sure our rules don't break in
the near future.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>