### PR TITLE
Re-introduce smartcard_configure_cert_checking to rhel8

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,sle12,sle15,ubuntu2004
+prodtype: ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004
 
 title: 'Configure Smart Card Certificate Status Checking'
 


### PR DESCRIPTION
The rule has been removed in #7365 - it probably fell out of a profile.
However, this is not a reason for removal from a benchmark.
Removals can break tailoring, and subsequently cause regressions.