### PR TITLE
Add references to OL8 profiles

### DIFF
--- a/products/ol8/profiles/anssi_bp28_enhanced.profile
+++ b/products/ol8/profiles/anssi_bp28_enhanced.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (enhanced)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the enhanced hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the enhanced hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/ol8/profiles/anssi_bp28_high.profile
+++ b/products/ol8/profiles/anssi_bp28_high.profile
@@ -1,9 +1,9 @@
 documentation_complete: true
 
-title: 'DRAFT - ANSSI-BP-028 (high)'
+title: 'ANSSI-BP-028 (high)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the high hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the high hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/ol8/profiles/anssi_bp28_intermediary.profile
+++ b/products/ol8/profiles/anssi_bp28_intermediary.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (intermediary)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the intermediary hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the intermediary hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/ol8/profiles/anssi_bp28_minimal.profile
+++ b/products/ol8/profiles/anssi_bp28_minimal.profile
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'ANSSI-BP-028 (minimal)'
 
 description: |-
-    This profile contains configurations that align to ANSSI-BP-028 at the minimal hardening level.
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the minimal hardening level.
 
     ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
     ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.

--- a/products/ol8/profiles/ospp.profile
+++ b/products/ol8/profiles/ospp.profile
@@ -1,5 +1,10 @@
 documentation_complete: true
 
+metadata:
+    version: 4.2.1
+
+reference: https://www.niap-ccevs.org/Profile/PP.cfm
+
 title: '[DRAFT] Protection Profile for General Purpose Operating Systems'
 
 description: |-

--- a/products/ol8/profiles/pci-dss.profile
+++ b/products/ol8/profiles/pci-dss.profile
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+reference: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+
 title: 'PCI-DSS v3.2.1 Control Baseline Draft for Oracle Linux 8'
 
 description: 'Ensures PCI-DSS v3.2.1 related security configuration settings are applied.'


### PR DESCRIPTION
#### Description:

- Add reference entry to OL8 ospp and pci-dss profiles
- Also update OL8 anssi profiles version on profiles title and remove the "draft" status from the OL8 anssi bp28 high profile

#### Rationale:

- OL8 profiles efforts
