### PR TITLE
OCP4: Optimize `Dockerfiles/ocp4_content` for caching

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -3,9 +3,9 @@ FROM registry.fedoraproject.org/fedora-minimal:34 as builder
 
 WORKDIR /content
 
-COPY . .
-
 RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
+
+COPY . .
 
 RUN ./build_product --datastream-only --debug ocp4 rhel7 rhcos4
 


### PR DESCRIPTION
By moving the package installation before our copying of files, we can
allow the build engine to cache the packages so we don't need to fetch
them every time. This is useful for local development.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>