### PR TITLE
Add var_sshd_set_keepalive to Ubuntu 20.04 STIG profile

### DIFF
--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -65,6 +65,7 @@ selections:
     - sshd_enable_pam
 
     # UBTU-20-010036 The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic after a period of inactivity.
+    - var_sshd_set_keepalive=1
     - sshd_set_keepalive
 
     # UBTU-20-010037 The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic at the end of the session or after 10 minutes of inactivity.


### PR DESCRIPTION
#### Description:

- Add var_sshd_set_keepalive to Ubuntu 20.04 STIG profile (as discussed in PR #7751)