### PR TITLE
Add type hints to style guide

### DIFF
--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -35,6 +35,7 @@
 * Utilities may only support Python 3
 * Shall use the `.py` for the file extension
 * Shall use 4-space indentation
+* New Python 3 methods and scripts should have type hints
 
 ## YAML
 * All new YAML files shall use 4-space indentation


### PR DESCRIPTION
#### Description:

Add to the style guide that all new scripts need type hints.

#### Rationale:

Type hints can help us reduce errors.
