### PR TITLE
Use different path to configure audit's `overflow_action` in RHEL7/OL7

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/ansible/shared.yml
@@ -4,9 +4,16 @@
 # complexity = low
 # disruption = low
 
-{{{ ansible_set_config_file(file="/etc/audit/auditd.conf",
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set auditd_conf_path="/etc/audisp/audispd.conf" %}}
+{{%- else %}}
+  {{%- set auditd_conf_path="/etc/audit/auditd.conf" %}}
+{{%- endif %}}
+
+{{{ ansible_set_config_file(file=auditd_conf_path,
                   parameter="overflow_action",
                   value="syslog",
+                  create=true,
                   separator=" = ",
                   separator_regex="\s*=\s*",
                   prefix_regex="(?i)^\s*") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/bash/shared.sh
@@ -4,9 +4,16 @@
 # complexity = low
 # disruption = low
 
-{{{set_config_file(path="/etc/audit/auditd.conf",
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set auditd_conf_path="/etc/audisp/audispd.conf" %}}
+{{%- else %}}
+  {{%- set auditd_conf_path="/etc/audit/auditd.conf" %}}
+{{%- endif %}}
+
+{{{set_config_file(path=auditd_conf_path,
                   parameter="overflow_action",
                   value="syslog",
+                  create=true,
                   insensitive=true,
                   separator=" = ",
                   separator_regex="\s*=\s*",

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/oval/shared.xml
@@ -1,5 +1,11 @@
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set auditd_conf_path="/etc/audisp/audispd.conf" %}}
+{{%- else %}}
+  {{%- set auditd_conf_path="/etc/audit/auditd.conf" %}}
+{{%- endif %}}
+
 {{{ oval_check_config_file(
-    path="/etc/audit/auditd.conf",
+    path=auditd_conf_path,
     prefix_regex="^[ \\t]*(?i)",
     parameter="overflow_action",
     value="(?i)(syslog|single|halt)(?-i)",

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/rule.yml
@@ -1,10 +1,16 @@
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set auditd_conf_path="/etc/audisp/audispd.conf" %}}
+{{%- else %}}
+  {{%- set auditd_conf_path="/etc/audit/auditd.conf" %}}
+{{%- endif %}}
+
 documentation_complete: true
 
 title: Appropriate Action Must be Setup When the Internal Audit Event Queue is Full
 
 description: |-
     The audit system should have an action setup in the event the internal event queue becomes full.
-    To setup an overflow action edit <tt>/etc/audit/auditd.conf</tt>. Set <tt>overflow_action</tt>
+    To setup an overflow action edit <tt>{{{ auditd_conf_path }}}</tt>. Set <tt>overflow_action</tt>
     to one of the following values: <tt>syslog</tt>, <tt>single</tt>, <tt>halt</tt>.
 
 
@@ -30,7 +36,7 @@ ocil_clause: 'auditd overflow action is not setup correctly'
 
 ocil: |-
     Verify the audit system is configured to take an appropriate action when the internal event queue is full:
-    <pre>$ sudo grep -i overflow_action /etc/audit/auditd.conf</pre>
+    <pre>$ sudo grep -i overflow_action {{{ auditd_conf_path }}}</pre>
 
     The output should contain be like <tt>overflow_action = syslog</tt>
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/commented_out.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/commented_out.fail.sh
@@ -2,4 +2,13 @@
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 
-echo "# overflow_action = syslog" >> /etc/audit/auditd.conf
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*overflow_action.*$//" $config_file
+# put commented out occurrence
+echo "# overflow_action = syslog" >> "$config_file"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/empty.fail.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 # Ensure test system has proper directories/files for test scenario
+
 bash -x setup.sh
 
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
 if [[ -f $config_file ]]; then
-    echo '' > $config_file
+    echo '' > ${config_file}
 fi

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/file_not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/file_not_present.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-config_file=/etc/audit/auditd.conf
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
 
 if [[ -f $config_file ]]; then
     rm -f $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/halt.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/halt.pass.sh
@@ -2,4 +2,12 @@
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 
-echo "overflow_action = halt" >> /etc/audit/auditd.conf
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*overflow_action.*$//" $config_file
+echo "overflow_action = halt" >> $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/ignore.fail.sh
@@ -2,4 +2,12 @@
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 
-echo "overflow_action = ignore" >> /etc/audit/auditd.conf
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*overflow_action.*$//" $config_file
+echo "overflow_action = ignore" >> $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/not_present.fail.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
-config_file=/etc/audit/auditd.conf
+
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
 sed -i "s/^.*overflow_action.*$//" $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/setup.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/setup.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 # Use this script to ensure the audit directory structure and audit conf file
 # exist in the test env.
-config_file=/etc/audit/auditd.conf
-
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+# Ensure directory structure exists (useful for container based testing)
+test -d /etc/audisp/ || mkdir -p /etc/audisp/
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
 # Ensure directory structure exists (useful for container based testing)
 test -d /etc/audit/ || mkdir -p /etc/audit/
+{{%- endif %}}
 
 test -f $config_file || touch $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/single.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/single.pass.sh
@@ -2,4 +2,12 @@
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 
-echo "overflow_action = single" >> /etc/audit/auditd.conf
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*overflow_action.*$//" $config_file
+echo "overflow_action = single" >> $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/syslog.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/syslog.pass.sh
@@ -2,4 +2,12 @@
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 
-echo "overflow_action = syslog" >> /etc/audit/auditd.conf
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*overflow_action.*$//" $config_file
+echo "overflow_action = syslog" >> $config_file


### PR DESCRIPTION
#### Description:
- Use different path to configure overflow_action in RHEL7/OL7
  - The correct path for this option in these OSes is
/etc/audisd/audispd.conf.

#### Rationale:

- Audit service can be started successfully.
