### PR TITLE
Remove product option definition from SSGTS GH integration.

### DIFF
--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -118,7 +118,7 @@ jobs:
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_bash --remediate-using bash --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
         env:
-          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora --product fedora"
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
       - name: Check for ERROR in logs
         if: ${{steps.bash.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_bash/test_suite.log
@@ -139,7 +139,7 @@ jobs:
         if: ${{ steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: tests/test_rule_in_container.sh --dontclean --logdir logs_ansible --remediate-using ansible --name ssg_test_suite --datastream ssg-${{steps.product.outputs.prop}}-ds.xml ${{join(steps.rules.outputs.prop)}}
         env:
-          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora --product fedora"
+          ADDITIONAL_SSGTS_OPTIONS: "--duplicate-templates --add-product-to-fips-certified fedora"
       - name: Check for ERROR in logs
         if: ${{steps.ansible.outputs.prop == 'True' && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: grep -q "^ERROR" logs_ansible/test_suite.log


### PR DESCRIPTION

#### Description:

- Remove product option definition from SSGTS GH integration.
  - This options can make tests to not be discoverable if the rule to be
tested doesn't contain prodtype: fedora. Which was the case of #7770.


#### Rationale:

- Fixes a problem with tests not being run at: #7770 
