### PR TITLE
accounts_no_uid_except_zero: Don't run `passwd` if `awk` returns nothing

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/bash/shared.sh
@@ -1,2 +1,2 @@
 # platform = multi_platform_all
-awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs --max-lines=1 passwd -l
+awk -F: '$3 == 0 && $1 != "root" { print $1 }' /etc/passwd | xargs --no-run-if-empty --max-lines=1 passwd -l


### PR DESCRIPTION
#### Description:

Adds `--no-run-if-empty` so that you don't a usage error if passing.

#### Rationale:

Fixes #7457
