### PR TITLE
Fix bash remediation spurious variable substitution

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -8,7 +8,7 @@ echo "Setting=$varname1" >> config_file
 #}}
 {{%- macro bash_instantiate_variables() -%}}
 {{%- for name in varargs -%}}
-{{{ name }}}="(bash-populate {{{ name }}})"
+{{{ name }}}='(bash-populate {{{ name }}})'
 {{% endfor -%}}
 {{%- endmacro -%}}
 


### PR DESCRIPTION
#### Description:

If a variable value contains the char '$', the resulting fix in the
XCCDF file will generate the following pattern:

`<variable>="<value with a '$' char>"`

so when the bash engine executes the code, it erroneously finds a
new variable and substitutes its value. This leads to a variable
value which is different from the value set in the XCCDF or
tailoring file.

This fix only changes the double quotes enclosing the value by single
quotes, thus preventing the above behavior.

#### Rationale:
Macro `bash_instantiate_variables` uses double quotes instead of single quotes to set the homonymous bash variable, so if the value contains a `$`, the bash engine will interpret it as a variable and will substitute its value.

- Fixes #7783 
