### PR TITLE
Make sure files have newline during bash lineinfile remediation

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -964,6 +964,9 @@ LC_ALL=C sed -i "/{{{ regex }}}/{{{ modifier }}}" "{{{ dirname }}}"/{{{ filename
     {{%- else -%}}
         {{%- set grep_args="-q -m 1" -%}}
     {{%- endif -%}}
+# make sure file has newline at the end
+sed -i -e '$a\' "{{{ path }}}"
+
 cp "{{{ path }}}" "{{{ path }}}.bak"
     {{%- if not (insert_after or insert_before)  or insert_after == "EOF" %}}
 # Insert at the end of the file


### PR DESCRIPTION
#### Description:
- Make sure files have newline during bash lineinfile remediation.
  - If a configuration file has no newline at the end, the remediation
generated by bash jinja lineinfile macros would append the configuration
in the last line not appending a new one because of the missing newline.

#### Rationale:

- Prevents remediation to insert a parameter in the last line instead in a new one.
