### PR TITLE
Make datastream matching more strict when building man page 

### DIFF
--- a/build-scripts/generate_man_page.py
+++ b/build-scripts/generate_man_page.py
@@ -10,6 +10,7 @@ import ssg.constants
 import ssg.xml
 import ssg.jinja
 import os
+import re
 import io
 
 
@@ -31,7 +32,7 @@ def main():
 def get_all_products(input_dir):
     all_products = []
     for item in sorted(os.listdir(input_dir)):
-        if item.endswith("-ds.xml"):
+        if re.match(r"ssg-\w+-ds.xml", item):
             ds_filepath = os.path.join(input_dir, item)
             all_products.append(get_product_info(ds_filepath))
     return all_products


### PR DESCRIPTION

#### Description:
- Make pattern matching of data streams to include in the man page more strict.

#### Rationale:

- The search and collection of data streams to list in the man page was
being fooled by the dot files created by graphviz. Which can generate
dot files named "ssg.dot.generate-ssg-centos8-ds.xml".

Fixes:
```
[1/1] [man-page] generating man page                                                                                                                           
FAILED: scap-security-guide.8                                                                                                                                  
cd /home/wsato/git/content/build && env PYTHONPATH=/home/wsato/git/content /usr/bin/python3 /home/wsato/git/content/build-scripts/generate_man_page.py --template /home/wsato/git/content/docs/man_page_template.jinja --input_dir /home/wsato/git/content/build --output /home/wsato/git/content/build/scap-security-guide.8
Traceback (most recent call last):                                                                                                                             
  File "/home/wsato/git/content/build-scripts/generate_man_page.py", line 78, in <module>                                                                      
    main()                                                                                                                                                     
  File "/home/wsato/git/content/build-scripts/generate_man_page.py", line 24, in main                                                                          
    all_products = get_all_products(input_dir)                                                                                                                 
  File "/home/wsato/git/content/build-scripts/generate_man_page.py", line 36, in get_all_products                                                              
    all_products.append(get_product_info(ds_filepath))                                                                                                         
  File "/home/wsato/git/content/build-scripts/generate_man_page.py", line 41, in get_product_info                                                              
    tree = ssg.xml.ElementTree.parse(ds_filepath)                                                                                                              
  File "/usr/lib64/python3.9/xml/etree/ElementTree.py", line 1229, in parse                                                                                    
    tree.parse(source, parser)                                                                                                                                 
  File "/usr/lib64/python3.9/xml/etree/ElementTree.py", line 580, in parse                                                                                     
    self._root = parser._parse_whole(source)                                                                                                                   
xml.etree.ElementTree.ParseError: syntax error: line 1, column 0                                                                                               
ninja: build stopped: subcommand failed.   
```