### PR TITLE
OCP4: Allow cluster filtering macros to work accross rules

### DIFF
--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -28,11 +28,11 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
 <ul>
 {{% for path, filter in path_filter_pairs.items() %}}
   <li>
-    <code class="ocp-api-endpoint" id="{{{ (rule_id+path+filter)|sha256 }}}">{{{ path }}}</code>
+    <code class="ocp-api-endpoint" id="{{{ (path+filter)|sha256 }}}">{{{ path }}}</code>
     API endpoint, filter with with the <code>jq</code> utility using the following filter
-    <code class="ocp-api-filter" id="filter-{{{ (rule_id+path+filter)|sha256 }}}">{{{ filter }}}</code>
+    <code class="ocp-api-filter" id="filter-{{{ (path+filter)|sha256 }}}">{{{ filter }}}</code>
     and persist it to the local
-    <code class="ocp-dump-location" id="dump-{{{ (rule_id+path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (rule_id+path+filter)|sha256 }}}</code>
+    <code class="ocp-dump-location" id="dump-{{{ (path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (path+filter)|sha256 }}}</code>
     file.
   </li>
 {{% endfor %}}
@@ -48,7 +48,7 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
     - filter (String): A filtering directive
 #}}
 {{% macro openshift_filtered_path(path, filter) -%}}
-{{{ path }}}#{{{ (rule_id+path+filter)|sha256 }}}
+{{{ path }}}#{{{ (path+filter)|sha256 }}}
 {{%- endmacro %}}
 
 {{#


### PR DESCRIPTION
The Compliance Operator has a mechanism for allowing filtering of
resources through `jq` syntax. This is quite powerful, but has some
content caveats:

In order to ensure that folks can filter the same Kube resource in
different rules, we need to ensure that they don't stumble upon each
other. If we don't, they'll overwrite the same file, and we won't get
reliable results.

Thus, we introduces a mechanism in CaC through jinja to generate a hash
ID for the filtered files.

This mechanism relied on `rule_id + path + filter`, which was passed to
a hashing function to generate the ID.

This, unfortunately, breaks down when importing a check from another
rule. Since we need these hashes to match. It resulted in the rule not
evaluating as it should (the file wasn't being found as the hash didn't
match).

This removes the `rule_id` from the function. Thus allowing us to share
these checks between rules, while still having a unique ID based on the
kube API path and the filter.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>