### PR TITLE
Fix kubelet_enable_iptables_util_chains

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/kubernetes/shared.yml
@@ -1,0 +1,3 @@
+---
+# platform = multi_platform_ocp
+{{{ kubelet_config_fixed(path='kubeletConfig',parameter='makeIPTablesUtilChains', value='true') }}}

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -43,8 +43,6 @@ template:
     vars:
         filepath: /etc/kubernetes/kubelet.conf
         yamlpath: ".makeIPTablesUtilChains"
-        check_existence: "any_exist"
         values:
-         - value: "false"
-           operation: "not equal"
-
+         - value: "true"
+           operation: "equals"

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS


### PR DESCRIPTION
We have rules `kubelet_enable_iptables_util_chains`that checks Automatic Firewall Configuration, 
we couldn't detect if the cluster is compliant.

This PR fixed the check for the rule, also added auto-remediation. 
