### PR TITLE
OCP4/PCI-DSS: Add responses to Requirement 5

### DIFF
--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -925,28 +925,48 @@ controls:
     software (particularly personal computers and servers).
   levels:
   - base
-  notes: ''
-  status: pending
-  rules: []
+  notes: |-
+    Security techniques that are commonly used by traditional IT infrastructures
+    have limited functionality in containerized  infrastructures. A key aspect to
+    successful security of container environments is identifying and 
+    understanding the opportunities or gateways for detection. While this may
+    encompass several attack vectors, there are integrations and mechanisms in
+    OpenShift that allow for this.
+  status: automated
+  controls:
+    - id: Req-5.1.1
+      title: 5.1.1 Ensure that anti-virus programs are capable of detecting, removing,
+        and protecting against all known types of malicious software.
+      levels:
+      - base
+      notes: |-
+        OpenShift container platforms may install the OpenShift File 
+        Integrity Operator [1] which monitors file system integrity on the host.
+        This may allow for the detection of threats on the hosts which attempt
+        to modify the file system in malicious ways. Additionally, there exist
+        several solutions to scan for container vulnerabilities which are indispensible
+        from any deployment. One such example is Red Hat Quay [2] which supports
+        image verification and continuous security scanning of container images.
 
-- id: Req-5.1.1
-  title: 5.1.1 Ensure that anti-virus programs are capable of detecting, removing,
-    and protecting against all known types of malicious software.
-  levels:
-  - base
-  notes: ''
-  status: pending
-  rules: []
+        [1] https://docs.openshift.com/container-platform/latest/security/file_integrity_operator/file-integrity-operator-understanding.html
+        [2] https://docs.openshift.com/container-platform/latest/security/container_security/security-registries.html
+      status: automated
+      rules:
+      - file_integrity_exists
 
-- id: Req-5.1.2
-  title: 5.1.2 For systems considered to be not commonly affected by malicious software,
-    perform periodic evaluations to identify and evaluate evolving malware threats
-    in order to confirm whether such systems continue to not require anti-virus software.
-  levels:
-  - base
-  notes: ''
-  status: pending
-  rules: []
+    - id: Req-5.1.2
+      title: 5.1.2 For systems considered to be not commonly affected by malicious software,
+        perform periodic evaluations to identify and evaluate evolving malware threats
+        in order to confirm whether such systems continue to not require anti-virus software.
+      levels:
+      - base
+      notes: |-
+        Red Hat Product Security constantly tracks threats to the OpenShift Container
+        Platform to ensure they are addressed. Besides this they also perform
+        vulnerability assessments on the platform which aid in keeping up
+        with the constantly evolving threat landscape.
+      status: inherently met
+      rules: []
 
 - id: Req-5.2
   title: '5.2 Ensure that all anti-virus mechanisms are maintained as follows:'
@@ -956,9 +976,20 @@ controls:
     * Generate audit logs which are retained per PCI DSS Requirement 10.7.
   levels:
   - base
-  notes: ''
-  status: pending
-  rules: []
+  notes: |-
+    OpenShift container platforms may install the OpenShift File 
+    Integrity Operator [1] which monitors file system integrity on the host.
+    This may allow for the detection of threats on the hosts which attempt
+    to modify the file system in malicious ways. Additionally, there exist
+    several solutions to scan for container vulnerabilities which are indispensible
+    from any deployment. One such example is Red Hat Quay [2] which supports
+    image verification and continuous security scanning of container images.
+
+    [1] https://docs.openshift.com/container-platform/latest/security/file_integrity_operator/file-integrity-operator-understanding.html
+    [2] https://docs.openshift.com/container-platform/latest/security/container_security/security-registries.html
+  status: automated
+  rules:
+    - file_integrity_exists
 
 - id: Req-5.3
   title: 5.3 Ensure that anti-virus mechanisms are actively running and cannot be
@@ -971,17 +1002,32 @@ controls:
     for the period of time during which anti-virus protection is not active.'
   levels:
   - base
-  notes: ''
-  status: pending
-  rules: []
+  notes: |-
+    The OpenShift File Integrity Operator runs on a namespace prepended with
+    the `openshift-` prefix. Such namespaces are only accessible by system
+    administrators. Users require explicit roles to access the namespace. On
+    the other hand, given the usage of Custom Resource Definitions, users also
+    require explicit roles and permissions to access and modify the scan settings
+    of the operator.
+
+    Image registries such as Red Hat Quay also require special privileges in
+    order to modify and access them. Security scanning of images may not be
+    turned off.
+  status: automated
+  rules:
+    - file_integrity_exists
 
 - id: Req-5.4
   title: 5.4 Ensure that security policies and operational procedures for protecting
     systems against malware are documented, in use, and known to all affected parties.
   levels:
   - base
-  notes: ''
-  status: pending
+  notes: |-
+    This requirement is not applicable to the OpenShift Container Platform
+    as it instead pertains to the practices and documentation from the
+    payment entity. The platform may not generate the entity's policies
+    and security practices.
+  status: not applicable
   rules: []
 
 - id: Req-6.1


### PR DESCRIPTION
These mostly pertain to threat detection and malware. Our supported
solution is the File Integrity Operator. However, vulnerability scans
via image registries are also documeted, even if they're out of scope of
our automation.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>