### PR TITLE
Add unit test for kubelet_enable_iptables_util_chains

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/enable_iptables_util_chains.fail.sh
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/enable_iptables_util_chains.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remediation = none
+
+mkdir -p /etc/kubernetes
+
+cat << EOF > /etc/kubernetes/kubelet.conf
+{
+
+}
+EOF

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/enable_iptables_util_chains.pass.sh
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/enable_iptables_util_chains.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remediation = none
+
+mkdir -p /etc/kubernetes
+
+cat << EOF > /etc/kubernetes/kubelet.conf
+{
+  "makeIPTablesUtilChains": "true",
+}
+EOF

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/enable_iptables_util_chains_false_key.fail.sh
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/tests/enable_iptables_util_chains_false_key.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remediation = none
+
+mkdir -p /etc/kubernetes
+
+cat << EOF > /etc/kubernetes/kubelet.conf
+{
+  "makeIPTablesUtilChains": "false",
+}
+EOF


### PR DESCRIPTION
The unit test was missing for `kubelet_enable_iptables_util_chains`, this PR adds the unit test for it.

