### PR TITLE
Add CCE ids for SLE15 platform for some HIPAA related rules

### DIFF
--- a/linux_os/guide/services/cron_and_at/service_crond_enabled/rule.yml
+++ b/linux_os/guide/services/cron_and_at/service_crond_enabled/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-27323-5
     cce@rhel8: CCE-80875-8
     cce@rhel9: CCE-84163-5
+    cce@sle15: CCE-91437-4
 
 references:
     cis-csc: 11,14,3,9

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-27354-0
     cce@rhel8: CCE-80850-1
     cce@rhel9: CCE-84155-1
+    cce@sle15: CCE-91436-6
 
 references:
     anssi: BP28(R1)

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/service_xinetd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/service_xinetd_disabled/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-27443-1
     cce@rhel8: CCE-80888-1
     cce@rhel9: CCE-84156-9
+    cce@sle15: CCE-91438-2
 
 references:
     cis-csc: 11,12,14,15,3,8,9

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel7: CCE-27406-8
     cce@rhel8: CCE-80842-8
     cce@rhel9: CCE-84145-2
+    cce@sle15: CCE-91431-7
 
 references:
     cis-csc: 11,12,14,15,3,8,9

--- a/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-27210-4
     cce@rhel8: CCE-82180-1
     cce@rhel9: CCE-84158-5
+    cce@sle15: CCE-91433-3
 
 references:
     anssi: BP28(R1)

--- a/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel7: CCE-27432-4
     cce@rhel8: CCE-80848-5
     cce@rhel9: CCE-84157-7
+    cce@sle15: CCE-91432-5
 
 references:
     anssi: BP28(R1)

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-27305-2
     cce@rhel8: CCE-80849-3
     cce@rhel9: CCE-84146-0
+    cce@sle15: CCE-91434-1
 
 references:
     anssi: BP28(R1)

--- a/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
@@ -42,6 +42,7 @@ identifiers:
     cce@rhel7: CCE-27401-9
     cce@rhel8: CCE-80887-3
     cce@rhel9: CCE-84150-2
+    cce@sle15: CCE-91435-8
 
 references:
     cis-csc: 1,11,12,14,15,16,3,5,8,9

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel7: CCE-27413-4
     cce@rhel8: CCE-80786-7
     cce@rhel9: CCE-90816-0
+    cce@sle15: CCE-91439-0
 
 references:
     cis-csc: 11,12,14,15,16,18,3,5,9

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-27320-1
     cce@rhel8: CCE-80894-9
     cce@rhel9: CCE-90812-9
+    cce@sle15: CCE-91440-8
 
 references:
     anssi: NT007(R1)

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/rule.yml
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-80220-7
     cce@rhel8: CCE-80897-2
     cce@rhel9: CCE-90808-7
+    cce@sle15: CCE-91441-6
 
 references:
     cis-csc: 11,3,9

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_kerb_auth/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-80221-5
     cce@rhel8: CCE-80898-0
     cce@rhel9: CCE-90802-0
+    cce@sle15: CCE-91442-4
 
 references:
     cis-csc: 11,3,9

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -26,6 +26,7 @@ identifiers:
     cce@rhel7: CCE-27287-2
     cce@rhel8: CCE-80855-0
     cce@rhel9: CCE-83594-2
+    cce@sle15: CCE-91428-3
 
 references:
     cis-csc: 1,11,12,14,15,16,18,3,5

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -31,6 +31,7 @@ identifiers:
     cce@rhel7: CCE-27294-8
     cce@rhel8: CCE-80840-2
     cce@rhel9: CCE-83625-4
+    cce@sle15: CCE-91427-5
 
 references:
     anssi: BP28(R19)

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/restrict_serial_port_logins/rule.yml
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-27268-2
     cce@rhel8: CCE-80856-8
     cce@rhel9: CCE-83622-1
+    cce@sle15: CCE-91429-1
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/securetty_root_login_console_only/rule.yml
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-27318-5
     cce@rhel8: CCE-80864-2
     cce@rhel9: CCE-83626-2
+    cce@sle15: CCE-91430-9
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -29,6 +29,7 @@ identifiers:
     cce@rhel7: CCE-80383-3
     cce@rhel8: CCE-80718-0
     cce@rhel9: CCE-83783-1
+    cce@sle15: CCE-91449-9
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/rule.yml
@@ -40,6 +40,7 @@ identifiers:
     cce@rhel8: CCE-80739-6
     cce@rhel9: CCE-83762-5
     cce@sle12: CCE-83158-6
+    cce@sle15: CCE-91450-7
 
 references:
     cis-csc: 1,12,13,14,15,16,2,3,5,6,7,8,9

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel7: CCE-82039-9
     cce@rhel8: CCE-80814-7
     cce@rhel9: CCE-83846-6
+    cce@sle15: CCE-91426-7
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5

--- a/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-26900-1
     cce@rhel8: CCE-80912-9
     cce@rhel9: CCE-83981-1
+    cce@sle15: CCE-91447-3
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-27050-4
     cce@rhel8: CCE-80913-7
     cce@rhel9: CCE-83952-2
+    cce@sle15: CCE-91448-1
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel7: CCE-26961-3
     cce@rhel8: CCE-80827-9
     cce@rhel9: CCE-84078-5
+    cce@sle15: CCE-91443-2
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,3,4,5,6,8,9

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel7: CCE-27288-0
     cce@rhel8: CCE-80867-5
     cce@rhel9: CCE-84075-1
+    cce@sle15: CCE-91444-0
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,3,5,6,9

--- a/linux_os/guide/system/selinux/selinux_policytype/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/rule.yml
@@ -32,6 +32,7 @@ identifiers:
     cce@rhel7: CCE-27279-9
     cce@rhel8: CCE-80868-3
     cce@rhel9: CCE-84074-4
+    cce@sle15: CCE-91445-7
 
 references:
     anssi: BP28(R66)

--- a/linux_os/guide/system/selinux/selinux_state/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_state/rule.yml
@@ -24,6 +24,7 @@ identifiers:
     cce@rhel7: CCE-27334-2
     cce@rhel8: CCE-80869-1
     cce@rhel9: CCE-84079-3
+    cce@sle15: CCE-91446-5
 
 references:
     anssi: BP28(R4),BP28(R66)


### PR DESCRIPTION
#### Description:

- Add CCE ids to SLE15 HIPAA rules

#### Rationale:

-  Make sure all rules in SLE15 HIPAA profile have valid CCE sle15 ids