### PR TITLE
OCP4/e2e: Tolerate INCONSISTENT for file_permissions_var_log_kube_audit

### DIFF
--- a/applications/openshift/logging/file_permissions_var_log_kube_audit/tests/ocp4/e2e.yml
+++ b/applications/openshift/logging/file_permissions_var_log_kube_audit/tests/ocp4/e2e.yml
@@ -1,4 +1,6 @@
 ---
+# nodes get INCONSISTENT because of
+# https://bugzilla.redhat.com/show_bug.cgi?id=2001442
 default_result:
-  master: PASS
+  master: PASS or INCONSISTENT
   worker: NOT-APPLICABLE


### PR DESCRIPTION
e2e tests have been very flaky because of the file_permissions_var_log_kube_audit
rule. This is because there is a bug in the API-server [1] which is yet
to be addressed.

To make CI less flaky, let's work around this...

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2001442

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>