### PR TITLE
Improve ssgts gh action

### DIFF
--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -165,4 +165,7 @@ jobs:
           name: ssg-${{steps.product.outputs.prop}}-ds.xml
       - name: Fail in case of ERROR present in logs_bash/test_suite.log or logs_ansible/test_suite.log
         if: ${{ (steps.check_results_bash.outcome == 'success' || steps.check_results_ansible.outcome == 'success') && steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
-        run: exit 1
+        run: |
+          [[ -f logs_bash/test_suite.log ]] && echo "---------Bash Remediation Logs---------" && cat logs_bash/test_suite.log | grep -v "DEBUG - "
+          [[ -f logs_ansible/test_suite.log ]] && echo "---------Ansible Remediation Logs---------" && cat logs_ansible/test_suite.log | grep -v "DEBUG - "
+          exit 1

--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -21,7 +21,7 @@ jobs:
           repository: mildas/content-test-filtering
           path: ctf
       - name: Detect content changes in the PR
-        run: python3 ./ctf/content_test_filtering.py pr --rule --output json ${{ github.event.pull_request.number }} > output.json
+        run: python3 ./ctf/content_test_filtering.py pr --verbose --rule --output json ${{ github.event.pull_request.number }} > output.json
       - name: Test if there are no content changes
         run: echo "::set-output name=CTF_OUTPUT_SIZE::$(stat --printf="%s" output.json)"
         id: ctf

--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -25,6 +25,11 @@ jobs:
       - name: Test if there are no content changes
         run: echo "::set-output name=CTF_OUTPUT_SIZE::$(stat --printf="%s" output.json)"
         id: ctf
+      - uses: actions/upload-artifact@v2
+        if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
+        with:
+          name: output.json
+          path: output.json
       - name: Print changes to content detected if any
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         run: cat output.json
@@ -51,17 +56,19 @@ jobs:
       - name: Install Deps
         uses: mstksg/get-package@master
         with:
-          apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml ansible-lint python3-github podman git python3-deepdiff python3-git python3-requests xmldiff jq
+          apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml ansible-lint podman
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Checkout (CTF)
-        uses: actions/checkout@v2
+      - name: Get cached CTF output
+        uses: actions/download-artifact@v2
+        id: get_ctf_output
         with:
-          repository: mildas/content-test-filtering
-          path: ctf
-      - name: Detect content changes in the PR
-        run: python3 ./ctf/content_test_filtering.py pr --rule --output json ${{ github.event.pull_request.number }} > output.json
+          name: output.json
+        # continue even if the file is unavailable that
+        # means there are no changes detected by CTF in the previous job
+        continue-on-error: true
       - name: Test if there are no content changes
+        if: ${{ steps.get_ctf_output.outcome == 'success' }}
         run: echo "::set-output name=CTF_OUTPUT_SIZE::$(stat --printf="%s" output.json)"
         id: ctf
       - name: Print changes to content detected if any


### PR DESCRIPTION
#### Description:

- Enable verbose option in CTF to improve debugging.
- Cache CTF output to be used by different jobs.
- Print common logs in case of failure.

#### Rationale:

- Depends on https://github.com/mildas/content-test-filtering/pull/21 for `verbose` mode to work correctly.
