### PR TITLE
Fix `utils/fix_rules.py` exit codes

### DIFF
--- a/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
+++ b/linux_os/guide/services/apt/apt_conf_disallow_unauthenticated/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,ubuntu1604,ubuntu1804,ubuntu2004
+prodtype: debian10,debian11,debian9,ubuntu1604,ubuntu1804,ubuntu2004
 
 title: 'Disable unauthenticated repositories in APT configuration'
 

--- a/linux_os/guide/services/apt/apt_sources_list_official/rule.yml
+++ b/linux_os/guide/services/apt/apt_sources_list_official/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9
+prodtype: debian10,debian11,debian9
 
 title: 'Ensure that official distribution repositories are used'
 

--- a/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/rule.yml
@@ -24,10 +24,10 @@ identifiers:
 
 references:
     disa: CCI-000381
+    nist: AU-8(1)
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000095-GPOS-00049
     stigid@rhel8: RHEL-08-030741
-    nist: AU-8(1)
 
 ocil_clause: 'it does not exist or port is set to non-zero value'
 

--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Uninstall net-snmp Package'
 

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,rhel7,rhel8,rhel9,sle15
+prodtype: debian10,debian11,debian9,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable snmpd Service'
 

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhel7,rhel8,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhel7,rhel8,wrlinux1019
 
 title: 'Ensure Default SNMP Password Is Not Used'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/rule.yml
@@ -20,8 +20,8 @@ identifiers:
     cce@rhel9: CCE-90810-3
 
 references:
-    cis@debian9: 9.3.5
     cis@debian11: 9.3.5
+    cis@debian9: 9.3.5
     cis@rhel7: 5.3.7
     cis@rhel8: 5.2.7
     cis@sle12: 5.3.8

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
@@ -23,10 +23,10 @@ identifiers:
 
 references:
     disa: CCI-000169
+    nist: AU-2,CM-8(3),IA-3
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000062-GPOS-00031
     stigid@rhel8: RHEL-08-030603
-    nist: AU-2,CM-8(3),IA-3
 
 ocil_clause: 'AuditBackend is not set to LinuxAudit'
 

--- a/linux_os/guide/services/usbguard/package_usbguard_installed/rule.yml
+++ b/linux_os/guide/services/usbguard/package_usbguard_installed/rule.yml
@@ -47,9 +47,9 @@ identifiers:
 references:
     disa: CCI-001958
     ism: "1418"
+    nist: CM-8(3),IA-3
     srg: SRG-OS-000378-GPOS-00163
     stigid@rhel8: RHEL-08-040139
-    nist: CM-8(3),IA-3
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/rule.yml
@@ -28,9 +28,9 @@ identifiers:
     cce@rhel9: CCE-84210-4
 
 references:
+    nist: CM-8(3),IA-3
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000114-GPOS-00059
-    nist: CM-8(3),IA-3
 
 ocil_clause: 'USB devices of class 3 and 9:00 are not authorized'
 

--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
@@ -32,10 +32,10 @@ references:
     cui: 3.4.5
     disa: CCI-000366
     hipaa: 164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)
+    nist: CM-6
     ospp: FIA_UAU.1
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-040180
-    nist: CM-6
 
 ocil: |-
     {{{ ocil_service_disabled(service="debug-shell") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects File Deletion Events by User'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Unauthorized Access Attempts to Files (unsuccessful)'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - creat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - ftruncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open_by_handle_at'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - openat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - truncate'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading and Unloading - finit_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading - init_module'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - faillock'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - lastlog'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - tallylog'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
@@ -21,9 +21,9 @@ identifiers:
     cce@rhel9: CCE-83704-7
 
 references:
+    nist: CM-6
     ospp: FAU_GEN.1
     srg: SRG-OS-000051-GPOS-00024
-    nist: CM-6
 
 ocil_clause: freq isn't set to 50
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/rule.yml
@@ -21,10 +21,10 @@ identifiers:
 
 references:
     disa: CCI-000366
+    nist: CM-6
     ospp: FAU_GEN.1.1.c
     srg: SRG-OS-000062-GPOS-00031,SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-030061
-    nist: CM-6
 
 ocil_clause: local_events isn't set to yes
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/rule.yml
@@ -22,10 +22,10 @@ identifiers:
 
 references:
     disa: CCI-000366
+    nist: CM-6,AU-3
     ospp: FAU_GEN.1
     srg: SRG-OS-000255-GPOS-00096,SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-030063
-    nist: CM-6,AU-3
 
 ocil_clause: log_format isn't set to ENRICHED
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
@@ -23,12 +23,12 @@ identifiers:
 
 references:
     disa: CCI-001851
+    nist: CM-6,AU-3
     ospp: FAU_GEN.1
     srg: SRG-OS-000039-GPOS-00017,SRG-OS-000342-GPOS-00133,SRG-OS-000479-GPOS-00224
     stigid@ol7: OL07-00-030211
     stigid@rhel7: RHEL-07-030211
     stigid@rhel8: RHEL-08-030062
-    nist: CM-6,AU-3
 
 ocil_clause: name_format isn't set to hostname
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/rule.yml
@@ -20,9 +20,9 @@ identifiers:
     cce@rhel9: CCE-83705-4
 
 references:
+    nist: CM-6
     ospp: FAU_GEN.1.1.c
     srg: SRG-OS-000480-GPOS-00227
-    nist: CM-6
 
 ocil_clause: write_logs isn't set to yes
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/rule.yml
@@ -24,10 +24,10 @@ identifiers:
 
 references:
     disa: CCI-000381
+    nist: AC-18
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000095-GPOS-00049
     stigid@rhel8: RHEL-08-040021
-    nist: AC-18
 
 {{{ complete_ocil_entry_module_disable(module="atm") }}}
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/rule.yml
@@ -24,10 +24,10 @@ identifiers:
 
 references:
     disa: CCI-000381
+    nist: AC-18
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000095-GPOS-00049
     stigid@rhel8: RHEL-08-040022
-    nist: AC-18
 
 {{{ complete_ocil_entry_module_disable(module="can") }}}
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/rule.yml
@@ -23,10 +23,10 @@ identifiers:
 
 references:
     disa: CCI-000381
+    nist: AC-18
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000095-GPOS-00049
     stigid@rhel8: RHEL-08-040026
-    nist: AC-18
 
 {{{ complete_ocil_entry_module_disable(module="firewire-core") }}}
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/rule.yml
@@ -34,10 +34,10 @@ references:
     cis@sle12: 1.5.1
     cis@sle15: 1.6.1
     disa: CCI-000366
+    nist: CM-6
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-010675
-    nist: CM-6
 
 ocil_clause: ProcessSizeMax is not set to zero
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
@@ -30,10 +30,10 @@ references:
     cis@sle12: 1.5.1
     cis@sle15: 1.6.1
     disa: CCI-000366
+    nist: CM-6
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-010674
-    nist: CM-6
 
 ocil_clause: Storage is not set to none
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/rule.yml
@@ -34,10 +34,10 @@ references:
     disa: CCI-000366
     isa-62443-2013: 'SR 6.2,SR 7.1,SR 7.2'
     iso27001-2013: A.12.1.3,A.17.2.1
+    nist: CM-6,SC-7(10)
     nist-csf: DE.CM-1,PR.DS-4
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-010673
-    nist: CM-6,SC-7(10)
 
 ocil_clause: 'it is not'
 

--- a/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/service_systemd-coredump_disabled/rule.yml
@@ -25,10 +25,10 @@ identifiers:
 
 references:
     disa: CCI-000366
+    nist: SC-7(10)
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-010672
-    nist: SC-7(10)
 
 ocil_clause: unit systemd-coredump.socket is not masked or running
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -22,8 +22,8 @@ identifiers:
 
 references:
     anssi: BP28(R25)
-    nist: SC-7(10)
     disa: CCI-000366
+    nist: SC-7(10)
     srg: SRG-OS-000132-GPOS-00067,SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-040282
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -29,8 +29,8 @@ identifiers:
 references:
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-13,SC-12(2),SC-12(3)
-    stigid@rhel8: RHEL-08-010020
     srg: SRG-OS-000423-GPOS-00187,SRG-OS-000426-GPOS-00190
+    stigid@rhel8: RHEL-08-010020
 
 ocil_clause: |-
     BIND is installed and the BIND config file doesn't contain the

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml
@@ -65,8 +65,8 @@ references:
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1,CIP-007-3 R7.1
     nist: AC-17(a),AC-17(2),CM-6(a),MA-4(6),SC-13,SC-12(2),SC-12(3)
     ospp: FCS_COP.1(1),FCS_COP.1(2),FCS_COP.1(3),FCS_COP.1(4),FCS_CKM.1,FCS_CKM.2,FCS_TLSC_EXT.1
-    stigid@rhel8: RHEL-08-010020
     srg: SRG-OS-000396-GPOS-00176,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
+    stigid@rhel8: RHEL-08-010020
 
 ocil_clause: 'cryptographic policy is not configured or is configured incorrectly'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Build and Test AIDE Database'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian11,debian10,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Install AIDE'
 

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -596,7 +596,7 @@ def has_unsorted_prodtype(yaml_file, product_yaml=None):
 
 
 @command("empty_identifiers", "check and fix rules with empty identifiers")
-def fix_empty_identifiers(args, product_yaml):
+def fix_empty_identifiers(args, product_yaml) -> int:
     results = find_rules(args, has_empty_identifier)
     print("Number of rules with empty identifiers: %d" % len(results))
 
@@ -614,7 +614,7 @@ def fix_empty_identifiers(args, product_yaml):
 
         fix_file_prompt(rule_path, product_yaml, fix_empty_identifier, args)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("empty_references", "check and fix rules with empty references")
@@ -632,7 +632,7 @@ def fix_empty_references(args, product_yaml):
 
         fix_file_prompt(rule_path, product_yaml, fix_empty_reference)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("prefixed_identifiers", "check and fix rules with prefixed (CCE-) identifiers")
@@ -650,7 +650,7 @@ def find_prefix_cce(args):
 
         fix_file_prompt(rule_path, product_yaml, fix_prefix_cce)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("invalid_identifiers", "check and fix rules with invalid identifiers")
@@ -667,7 +667,7 @@ def find_invalid_cce(args, product_yamls):
             continue
 
         fix_file_prompt(rule_path, product_yaml, fix_invalid_cce)
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("int_identifiers", "check and fix rules with pseudo-integer identifiers")
@@ -685,7 +685,7 @@ def find_int_identifiers(args, product_yaml):
 
         fix_file_prompt(rule_path, product_yaml, fix_int_identifier)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("int_references", "check and fix rules with pseudo-integer references")
@@ -703,7 +703,7 @@ def find_int_references(args, product_yaml):
 
         fix_file_prompt(rule_path, product_yaml, fix_int_reference)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("duplicate_subkeys", "check for duplicated references and identifiers")
@@ -714,7 +714,7 @@ def duplicate_subkeys(args, product_yaml):
     for result in results:
         print(result[0] + " has one or more duplicated subkeys")
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("sort_subkeys", "sort references and identifiers")
@@ -732,7 +732,7 @@ def sort_subkeys(args, product_yaml):
 
         fix_file_prompt(rule_path, product_yaml, sort_rule_subkeys, args)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 @command("sort_prodtypes", "sorts the products in the prodtype")
@@ -748,7 +748,7 @@ def sort_prodtypes(args, product_yaml):
 
         fix_file(rule_path, product_yaml, fix_prodtypes)
 
-    return int(len(results) > 0)
+    exit(int(len(results) > 0))
 
 
 def create_parser_from_functions(subparsers):


### PR DESCRIPTION
#### Description:

Fix utils/fix_rules so that exit codes are right and run `utils/fix_rule` to fix issues to back the tests pass again.

#### Rationale:

Make sure the tests fail when they should. Doing the exit in the command methods since it appears argparse does not pass return values back.
