### PR TITLE
Implemented buildsystem profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ release_tools/artifacts
 
 # Ignore the test profile that utils/add_platform_rule.py creates
 ocp4/profiles/test.profile
+
+# Ignore the build profiling files
+.build_profiling/*

--- a/build_product
+++ b/build_product
@@ -10,6 +10,7 @@
 # ARG_OPTIONAL_BOOLEAN([ansible-playbooks],[],[Build Ansible Playbooks for every profile],[on])
 # ARG_OPTIONAL_BOOLEAN([bash-scripts],[],[Build Bash remediation scripts for every profile],[on])
 # ARG_OPTIONAL_BOOLEAN([datastream-only],[],[Build the datastream only. Do not build any of the guides, tables, etc],[off])
+# ARG_OPTIONAL_BOOLEAN([profiling],[p],[Use ninja and call the build_profiler.sh util],[off])
 # ARG_USE_ENV([ADDITIONAL_CMAKE_OPTIONS],[],[Whitespace-separated string of arguments to pass to CMake])
 # ARG_POSITIONAL_INF([product],[Products to build, ALL means all products],[0],[ALL])
 # ARG_DEFAULTS_POS([])
@@ -59,7 +60,7 @@ builder_type()
 
 begins_with_short_option()
 {
-	local first_option all_short_options='objh'
+	local first_option all_short_options='objph'
 	first_option="${1:0:1}"
 	test "$all_short_options" = "${all_short_options/$first_option/}" && return 1 || return 0
 }
@@ -82,7 +83,7 @@ _arg_profiling="off"
 print_help()
 {
 	printf '%s\n' "Wipes out contents of the 'build' directory and builds only and only the given products."
-	printf 'Usage: %s [-o|--oval <VERSION>] [-b|--builder <BUILDER>] [-j|--jobs <arg>] [--(no-)debug] [--(no-)derivatives] [--(no-)ansible-playbooks] [--(no-)bash-scripts] [--(no-)datastream-only] [-h|--help] [<product-1>] ... [<product-n>] ...\n' "$0"
+	printf 'Usage: %s [-o|--oval <VERSION>] [-b|--builder <BUILDER>] [-j|--jobs <arg>] [--(no-)debug] [--(no-)derivatives] [--(no-)ansible-playbooks] [--(no-)bash-scripts] [--(no-)datastream-only] [-p|--(no-)profiling] [-h|--help] [<product-1>] ... [<product-n>] ...\n' "$0"
 	printf '\t%s\n' "<product>: Products to build, ALL means all products (defaults for <product>: 'ALL')"
 	printf '\t%s\n' "-o, --oval: OVAL version. Can be one of: '5.10', '5.11' and 'auto' (default: 'auto')"
 	printf '\t%s\n' "-b, --builder: Builder engine. Can be one of: 'make', 'ninja' and 'auto' (default: 'auto')"
@@ -92,8 +93,8 @@ print_help()
 	printf '\t%s\n' "--ansible-playbooks, --no-ansible-playbooks: Build Ansible Playbooks for every profile (on by default)"
 	printf '\t%s\n' "--bash-scripts, --no-bash-scripts: Build Bash remediation scripts for every profile (on by default)"
 	printf '\t%s\n' "--datastream-only, --no-datastream-only: Build the datastream only. Do not build any of the guides, tables, etc (off by default)"
+	printf '\t%s\n' "-p, --profiling, --no-profiling: Use ninja and call the build_profiler.sh util (off by default)"
 	printf '\t%s\n' "-h, --help: Prints help"
-	printf '\t%s\n' "-p, --profiling: Use ninja and call the build_profiler.sh util"
 	printf '\nEnvironment variables that are supported:\n'
 	printf '\t%s\n' "ADDITIONAL_CMAKE_OPTIONS: Whitespace-separated string of arguments to pass to CMake."
 
@@ -160,6 +161,18 @@ parse_commandline()
 				_arg_datastream_only="on"
 				test "${1:0:5}" = "--no-" && _arg_datastream_only="off"
 				;;
+			-p|--no-profiling|--profiling)
+				_arg_profiling="on"
+				test "${1:0:5}" = "--no-" && _arg_profiling="off"
+				;;
+			-p*)
+				_arg_profiling="on"
+				_next="${_key##-p}"
+				if test -n "$_next" -a "$_next" != "$_key"
+				then
+					{ begins_with_short_option "$_next" && shift && set -- "-p" "-${_next}" "$@"; } || die "The short option '$_key' can't be decomposed to ${_key:0:2} and -${_key:2}, because ${_key:0:2} doesn't accept value and '-${_key:2:1}' doesn't correspond to a short option."
+				fi
+				;;
 			-h|--help)
 				print_help
 				exit 0
@@ -167,9 +180,6 @@ parse_commandline()
 			-h*)
 				print_help
 				exit 0
-				;;
-			-p|--profiling)
-				_arg_profiling="on"
 				;;
 			*)
 				_last_positional="$1"

--- a/build_product
+++ b/build_product
@@ -76,6 +76,7 @@ _arg_derivatives="off"
 _arg_ansible_playbooks="on"
 _arg_bash_scripts="on"
 _arg_datastream_only="off"
+_arg_profiling="off"
 
 
 print_help()
@@ -92,6 +93,7 @@ print_help()
 	printf '\t%s\n' "--bash-scripts, --no-bash-scripts: Build Bash remediation scripts for every profile (on by default)"
 	printf '\t%s\n' "--datastream-only, --no-datastream-only: Build the datastream only. Do not build any of the guides, tables, etc (off by default)"
 	printf '\t%s\n' "-h, --help: Prints help"
+	printf '\t%s\n' "-p, --profiling: Use ninja and call the build_profiler.sh util"
 	printf '\nEnvironment variables that are supported:\n'
 	printf '\t%s\n' "ADDITIONAL_CMAKE_OPTIONS: Whitespace-separated string of arguments to pass to CMake."
 
@@ -165,6 +167,9 @@ parse_commandline()
 			-h*)
 				print_help
 				exit 0
+				;;
+			-p|--profiling)
+				_arg_profiling="on"
 				;;
 			*)
 				_last_positional="$1"
@@ -336,10 +341,13 @@ test "$_arg_debug" = on && build_type_option="-DCMAKE_BUILD_TYPE=Debug"
 jobs="$_arg_jobs"
 test "$jobs" = auto && jobs=$cores
 
-if test "$_arg_builder" = make; then
-	build_with_make
+if test "$_arg_profiling" = on; then
+	build_with_ninja
+	jobs=1
 elif test "$_arg_builder" = ninja; then
 	build_with_ninja
+elif test "$_arg_builder" = make; then
+	build_with_make
 else
 	autodetect_builder
 fi
@@ -372,4 +380,11 @@ cd build
 cmake .. "${CMAKE_OPTIONS[@]}"
 $build_command "-j${jobs}" "${EXPLICIT_BUILD_TARGETS[@]}"
 
+if test "$_arg_profiling" = on; then
+	# remove cycles in ninja logs
+	ninja -t recompact
+	# go back to content dir
+	cd ..
+	utils/build_profiler.sh `echo "${_arg_product[@]}" | sed 's/ /_/g'`
+fi
 # ] <-- needed because of Argbash

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -448,11 +448,9 @@ Note: CTest does not run [SSG Test Suite](https://github.com/ComplianceAsCode/co
 
 ## Profiling the buildsystem
 
-To make sure your changes don't prolong the time that it takes to build products by using the `build_product` script too much,
-you can use the `-p|--profiling` switch to get a report containing build times of all build targets/files, and you can compare
-build times between a baseline profiling log and your current log to see exactly which targets/files are taking longer to
-build, what percentage of the total build time they take up, and even see what targets you have added/removed and how did that
-affect the build time. You also get an interactive HTML report that visualises how much time each target/file takes up.
+To make sure your changes don't prolong the time that it takes to build products by using the `build_product` script too much, you can use the `-p|--profiling` switch to get a report containing build times of all build targets/files.
+You can compare build times between a baseline profiling log and your current log to see exactly which targets/files are taking longer to build, what percentage of the total build time they take up, and even see what targets you have added/removed and how did that affect the build time.
+You also get an interactive HTML report that visualises how much time each target/file takes up.
 
 For details about how this works, see `section 5 - tools and utilities - Profiling the buildsystem`.
 

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -446,6 +446,16 @@ ctest -LE quick -j4
 
 Note: CTest does not run [SSG Test Suite](https://github.com/ComplianceAsCode/content/tree/master/tests) which provides simple system of test scenarios for testing profiles and rule remediations.
 
+## Profiling the buildsystem
+
+To make sure your changes don't prolong the time that it takes to build products by using the `build_product` script too much,
+you can use the `-p|--profiling` switch to get a report containing build times of all build targets/files, and you can compare
+build times between a baseline profiling log and your current log to see exactly which targets/files are taking longer to
+build, what percentage of the total build time they take up, and even see what targets you have added/removed and how did that
+affect the build time. You also get an interactive HTML report that visualises how much time each target/file takes up.
+
+For details about how this works, see `section 5 - tools and utilities - Profiling the buildsystem`.
+
 ## Installation
 
 System-wide installation:

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -348,3 +348,51 @@ Examples:
 To execute:
 
     $ ./utils/compare_results.py ssg_results.xml disa_results.xml
+
+## Profiling the buildsystem
+
+The goal of `utils/build_profiler.sh` and `utils/build_profiler_report.py` is to help developers measure and compare build times of a single product or a group of products and determine what impact their changes had on the speed of the buildsystem. Both of these tools shouldn't be invoked alone but rather through the build_product script by using the -p|--profiling switch.
+
+The intended usage is:
+
+    $ ./build_product <products> -p|--profiling
+
+### `utils/build_profiler.sh` -- Handle directory structure for profiling files and invokes other script
+The goal of this tool is to create the directory structure necessary for the profiling system and create a new numbered logfile, as well as invoking the `utils/build_profiler_report.py` and subsequently generating an interactive HTML file using webtreenode.
+
+It is invoked by the `build_product` script. When invoked for the first time, it creates the `.build_profiling` directory and then a directory inside it named `product_string`, which is passed from the build_product script. This is done so that each product combination being built has its own directory for log files, because different combinations may affect each other and have different build times.
+
+The script then moves the ninja log from the build folder to the product_string folder and numbers it. The baseline script is number 0 and if missing, the script will call the `utils/build_profiler_report.py` script with the `--baseline` switch.
+
+It then invokes the `utils/build_profiler_report.py` script with a logfile name, as well as the optional baseline switch. After that, it checks if the .webtreenode file was generated and then uses the webtreenode command to generate an interactive HTML report.
+
+It supports exactly one argument:
+
+- `"product_string"` - Contains all the product names that were built joined by underscores
+
+To execute:
+
+    $ ./build_profiler.sh <product_string>
+
+### `utils/build_profiler_report.py` -- Parse a ninja file and display report to user
+The goal of this tool is to generate a report about differences in build times, both a text version in the terminal and a webtreenode version that is later converted into an interactive HTML report.
+
+The script parses the data from `"logfile"` as the current logfile and the data from `0.ninja_log` as the baseline logfile (if the `--baseline` switch is used, the baseline log is not loaded). It then generates a `.webtreemap` file and prints the report:
+
+- `Target` - The target/outputfile that was built
+- `%`      - The percentage of the total build time that the target took
+- `D`      - The difference of the `%` percentage between baseline and current logfile (dimensionless value, not a percentage)
+              - This is the most important metric, as it signifies the ratio of this target to the other targets, therefore 
+                  it shouldn't be affected too much by the speed of the hardware
+- `T`      - The time that the target took to get built in an `h:m:s` format
+- `TD`     - The time difference between baseline and current logfile in an `h:m:s` format
+- `%TD`     - The percentage difference of build times between current and baseline logfile
+
+It supports up to two arguments:
+
+- `"logfile"`  - [mandatory] Name of the numbered ninja logfile, e.g. `0.ninja_log`
+- `--baseline` - [optional] If the switch is used, the values are not compared with a baseline log
+
+To execute:
+
+    $ ./build_profiler_report.py <logflie> [--baseline]

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -351,7 +351,8 @@ To execute:
 
 ## Profiling the buildsystem
 
-The goal of `utils/build_profiler.sh` and `utils/build_profiler_report.py` is to help developers measure and compare build times of a single product or a group of products and determine what impact their changes had on the speed of the buildsystem. Both of these tools shouldn't be invoked alone but rather through the build_product script by using the -p|--profiling switch.
+The goal of `utils/build_profiler.sh` and `utils/build_profiler_report.py` is to help developers measure and compare build times of a single product or a group of products and determine what impact their changes had on the speed of the buildsystem.
+Both of these tools shouldn't be invoked alone but rather through the build_product script by using the -p|--profiling switch.
 
 The intended usage is:
 
@@ -360,11 +361,14 @@ The intended usage is:
 ### `utils/build_profiler.sh` -- Handle directory structure for profiling files and invokes other script
 The goal of this tool is to create the directory structure necessary for the profiling system and create a new numbered logfile, as well as invoking the `utils/build_profiler_report.py` and subsequently generating an interactive HTML file using webtreenode.
 
-It is invoked by the `build_product` script. When invoked for the first time, it creates the `.build_profiling` directory and then a directory inside it named `product_string`, which is passed from the build_product script. This is done so that each product combination being built has its own directory for log files, because different combinations may affect each other and have different build times.
+It is invoked by the `build_product` script. When invoked for the first time, it creates the `.build_profiling` directory and then a directory inside it named `product_string`, which is passed from the build_product script.
+This is done so that each product combination being built has its own directory for log files, because different combinations may affect each other and have different build times.
 
-The script then moves the ninja log from the build folder to the product_string folder and numbers it. The baseline script is number 0 and if missing, the script will call the `utils/build_profiler_report.py` script with the `--baseline` switch.
+The script then moves the ninja log from the build folder to the product_string folder and numbers it.
+The baseline script is number 0 and if missing, the script will call the `utils/build_profiler_report.py` script with the `--baseline` switch.
 
-It then invokes the `utils/build_profiler_report.py` script with a logfile name, as well as the optional baseline switch. After that, it checks if the .webtreenode file was generated and then uses the webtreenode command to generate an interactive HTML report.
+It then invokes the `utils/build_profiler_report.py` script with a logfile name, as well as the optional baseline switch.
+After that, it checks if the .webtreenode file was generated and then uses the webtreenode command to generate an interactive HTML report.
 
 It supports exactly one argument:
 
@@ -377,13 +381,13 @@ To execute:
 ### `utils/build_profiler_report.py` -- Parse a ninja file and display report to user
 The goal of this tool is to generate a report about differences in build times, both a text version in the terminal and a webtreenode version that is later converted into an interactive HTML report.
 
-The script parses the data from `"logfile"` as the current logfile and the data from `0.ninja_log` as the baseline logfile (if the `--baseline` switch is used, the baseline log is not loaded). It then generates a `.webtreemap` file and prints the report:
+The script parses the data from `"logfile"` as the current logfile and the data from `0.ninja_log` as the baseline logfile (if the `--baseline` switch is used, the baseline log is not loaded).
+It then generates a `.webtreemap` file and prints the report:
 
 - `Target` - The target/outputfile that was built
 - `%`      - The percentage of the total build time that the target took
 - `D`      - The difference of the `%` percentage between baseline and current logfile (dimensionless value, not a percentage)
-              - This is the most important metric, as it signifies the ratio of this target to the other targets, therefore 
-                  it shouldn't be affected too much by the speed of the hardware
+              - This is the most important metric, as it signifies the ratio of this target to the other targets, therefore it shouldn't be affected too much by the speed of the hardware
 - `T`      - The time that the target took to get built in an `h:m:s` format
 - `TD`     - The time difference between baseline and current logfile in an `h:m:s` format
 - `%TD`     - The percentage difference of build times between current and baseline logfile

--- a/utils/build_profiler.sh
+++ b/utils/build_profiler.sh
@@ -1,70 +1,60 @@
 #!/bin/bash
 
+die()
+{
+	echo "$1" >&2
+	exit 1
+}
+
 if [ "$#" -ne 1 ]; then
-    echo "build_profiler.sh requires one argument - product_string"
-    exit 1
+    die "build_profiler.sh requires one argument - product_string"
 fi
 
 product_string="$1"
 
 # Create and change to .build_profiling dir 
-if [ ! -d ".build_profiling" ]; then
-    mkdir .build_profiling
-    if [ $? -ne 0 ]; then
-        >&2 echo "Creating the .build_profiling directory failed"
-        exit 1
-    fi
-fi
+[ ! -d ".build_profiling" ] && (mkdir .build_profiling || die \
+"Creating the .build_profiling directory failed")
 
-cd .build_profiling
-if [ $? -ne 0 ]; then
-    >&2 echo "Changing to the .build_profiling directory failed"
-    exit 1
-fi
+cd .build_profiling || die "Changing to the .build_profiling directory failed"
 
 # Create and change to product_string dir 
-if [ ! -d "$product_string" ]; then
-    mkdir "$product_string"
-    if [ $? -ne 0 ]; then
-        >&2 echo "Creating the $product_string directory failed"
-        exit 1
-    fi
-fi
+[ ! -d "$product_string" ] && (mkdir "$product_string" || die \
+"Creating the $product_string directory failed")
 
-cd "$product_string"
-if [ $? -ne 0 ]; then
-    >&2 echo "Changing to the $product_string directory failed"
-    exit 1
-fi
+cd "$product_string" || die "Changing to the $product_string directory failed"
 
-# Set log_number
+# Set log_number and mode switch for python script
+switch=''
 if [ -f "0.ninja_log" ]; then
     # set log number to the number of the latest log file and add 1
     log_number=$(ls *.ninja_log | cut -d'.' -f1 | sort -rn | head -n 1)
     ((log_number=log_number+1))
-    echo "-----\nComparing logfile $log_number to baseline 0..."
+    printf "_____\nComparing logfile $log_number to baseline 0...\n"
 else
-    echo "-----\nCreating new baseline 0..."
+    printf "_____\nCreating new baseline 0...\n"
     log_number=0
+    switch='--baseline'
 fi
 
 # create new numbered log file
-mv ../../build/.ninja_log "$log_number.ninja_log"
-if [ $? -ne 0 ]; then
-    >&2 echo "Creating a new numbered .ninja_log file failed"
-    exit 1
-fi
+mv ../../build/.ninja_log "$log_number.ninja_log" || die \
+"Creating a new numbered .ninja_log file failed"
 
 # parse and compare log files; show results to user
-../../utils/build_profiler_report.py "$log_number.ninja_log"
-if [ ! -f "$log_number.ninja_log.webtreemap" ]; then
-    >&2 echo "utils/build_profiler_report.py failed to create $log_number.ninja_log.webtreemap"
-    exit 1
-fi
+../../utils/build_profiler_report.py "$log_number.ninja_log" $switch
+[ -f "$log_number.ninja_log.webtreemap" ] || die \
+"utils/build_profiler_report.py failed to create $log_number.ninja_log.webtreemap"
+
+# check if webtreemap command is available
+[ -x "$(command -v webtreemap)" ] || die \
+"The webtreemap command is not installed. Please install it using 'sudo npm i webtreemap'. To create \
+the HTML from this session, use 'webtreemap -o .build_profiling/$product_string/$log_number.html \
+< .build_profiling/$product_string/$log_number.ninja_log.webtreemap'"
 
 # create HTML from .webtreemap file
 webtreemap -o "$log_number.html" < "$log_number.ninja_log.webtreemap"
-if [ ! -f "$log_number.html" ]; then
-    >&2 echo "utils/build_profiler.sh failed to create $log_number.html"
-    exit 1
-fi
+[ -f "$log_number.html" ] || die "utils/build_profiler.sh failed to create $log_number.html"
+
+echo -e "-----\nSee the html buildsystem profiling visualisation here: \
+.build_profiling/$product_string/$log_number.html"

--- a/utils/build_profiler.sh
+++ b/utils/build_profiler.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+    echo "build_profiler.sh requires one argument - product_string"
+    exit 1
+fi
+
+product_string="$1"
+
+# Create and change to .build_profiling dir 
+if [ ! -d ".build_profiling" ]; then
+    mkdir .build_profiling
+    if [ $? -ne 0 ]; then
+        >&2 echo "Creating the .build_profiling directory failed"
+        exit 1
+    fi
+fi
+
+cd .build_profiling
+if [ $? -ne 0 ]; then
+    >&2 echo "Changing to the .build_profiling directory failed"
+    exit 1
+fi
+
+# Create and change to product_string dir 
+if [ ! -d "$product_string" ]; then
+    mkdir "$product_string"
+    if [ $? -ne 0 ]; then
+        >&2 echo "Creating the $product_string directory failed"
+        exit 1
+    fi
+fi
+
+cd "$product_string"
+if [ $? -ne 0 ]; then
+    >&2 echo "Changing to the $product_string directory failed"
+    exit 1
+fi
+
+# Set log_number
+if [ -f "0.ninja_log" ]; then
+    # set log number to the number of the latest log file and add 1
+    log_number=$(ls *.ninja_log | cut -d'.' -f1 | sort -rn | head -n 1)
+    ((log_number=log_number+1))
+    echo "-----\nComparing logfile $log_number to baseline 0..."
+else
+    echo "-----\nCreating new baseline 0..."
+    log_number=0
+fi
+
+# create new numbered log file
+mv ../../build/.ninja_log "$log_number.ninja_log"
+if [ $? -ne 0 ]; then
+    >&2 echo "Creating a new numbered .ninja_log file failed"
+    exit 1
+fi
+
+# parse and compare log files; show results to user
+../../utils/build_profiler_report.py "$log_number.ninja_log"
+if [ ! -f "$log_number.ninja_log.webtreemap" ]; then
+    >&2 echo "utils/build_profiler_report.py failed to create $log_number.ninja_log.webtreemap"
+    exit 1
+fi
+
+# create HTML from .webtreemap file
+webtreemap -o "$log_number.html" < "$log_number.ninja_log.webtreemap"
+if [ ! -f "$log_number.html" ]; then
+    >&2 echo "utils/build_profiler.sh failed to create $log_number.html"
+    exit 1
+fi

--- a/utils/build_profiler_report.py
+++ b/utils/build_profiler_report.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python3
+import sys
+
+
+def LoadLogFile(file) -> dict:
+    """Loads Targets and their durations from ninja logfile `file` and returns them in a dict"""
+
+    with open(file, 'r') as fp:
+        lines = fp.read().splitlines()
+
+    # {Target: duration} dict
+    TargetDurationDict = {}
+    for line in lines:
+        line = line.split()
+
+        # ToDo - create better comment detection
+        if line[0][0] != '#':
+
+            # calculate target compilation duration and add it to dict
+            duration = int(line[1]) - int(line[0])
+            TargetDurationDict[line[3]] = duration
+
+    return TargetDurationDict
+
+
+def FormatTime(t):
+    """Converts a time into a human-readable format"""
+
+    t /= 1000
+    if t < 60:
+        return '%.1fs' % t
+    if t < 60 * 60:
+        return '%dm%.1fs' % (t / 60, t % 60)
+    return '%dh%dm%.1fs' % (t / (60 * 60), t % (60 * 60) / 60, t % 60)
+
+
+def GenerateWebTreeMap(CurrentDict: dict, BaselineDict: dict) -> None:
+    """Create file for webtreemap to generate an HTML from; if target is new, append _NEW"""
+    with open(sys.argv[1] + ".webtreemap", 'w') as fp:
+        for target in CurrentDict.keys():
+            new_tag = ''
+            if BaselineDict and target not in BaselineDict.keys():
+                new_tag = '_NEW'
+
+            fp.write(str(CurrentDict[target]) + ' ' + target
+                     + '_' + FormatTime(CurrentDict[target]) + new_tag + '\n')
+
+
+def GetTotalTime(TargetDurationDict: dict) -> int:
+    """Return sum of durations for all targets in dict"""
+    total_time = 0
+    for target in TargetDurationDict.keys():
+        total_time += TargetDurationDict[target]
+    return total_time
+
+
+def GetTotalTimeIntersect(TargetDurationDict_A: dict, TargetDurationDict_B: dict) -> int:
+    """Return sum of durations for targets in A that are also in B"""
+    total_time = 0
+    for target in TargetDurationDict_A.keys():
+        if target in TargetDurationDict_B.keys():
+            total_time += TargetDurationDict_A[target]
+    return total_time
+
+
+def PrintReport(CurrentDict: dict, BaselineDict: dict = None) -> None:
+    """Print report with results of profiling to stdout"""
+
+    # If the targets have changed between baseline and current, we are using total_time_intersect
+    # to calculate delta (ratio of durations of targets) instead of total_time
+    if BaselineDict and BaselineDict.keys() != CurrentDict.keys():
+        print("Warning: the targets in the current logfile differ from those in the baseline\
+             logfile; therefore the Δ delta is calculated without taking the added/removed\
+                  targets into consideration. If the added/removed targets modify the behavior of\
+                      targets in both logfiles, the Δ delta may not make sense.\n-----")
+        target_mismatch = True
+        total_time_current_intersect = GetTotalTimeIntersect(CurrentDict, BaselineDict)
+        total_time_baseline_intesect = GetTotalTimeIntersect(BaselineDict, CurrentDict)
+    else:
+        target_mismatch = False
+
+    header = [f'{"Target:":60}', f"{'%':4}", f"{'Δ':5}", f"{'T':8}", f"{'%Δ':5}", "Note"]
+    print(' | '.join(header))
+
+    total_time_current = GetTotalTime(CurrentDict)
+    if BaselineDict:
+        total_time_baseline = GetTotalTime(BaselineDict)
+
+    # sort targets by % taken of build time
+    temp = {k: v for k, v in sorted(CurrentDict.items(), key=lambda item: item[1], reverse=True)}
+    CurrentDict = temp
+
+    for target in CurrentDict.keys():
+        # percentage of build time that the target took
+        perc = CurrentDict[target]/total_time_current * 100
+
+        # difference between perc in current and in baseline
+        delta = 0
+        if BaselineDict:
+            if target_mismatch:
+                if target in BaselineDict.keys():
+                    delta = CurrentDict[target]/total_time_current_intersect * 100 - \
+                        BaselineDict[target]/total_time_baseline_intesect * 100
+
+            else:
+                delta = perc - (BaselineDict[target]/total_time_baseline * 100)
+
+        # time is the formatted build time of the target
+        time = FormatTime(CurrentDict[target])
+
+        # timeDelta a percentage difference of before and after build times 
+        if BaselineDict and target in BaselineDict.keys():
+            timeDelta = (CurrentDict[target]/BaselineDict[target]) * 100 - 100
+        else:
+            timeDelta = 0
+
+        line = [f'{target:60}', f"{perc:4.1f}", f"{delta:5.1f}", f"{time:8}", f"{timeDelta:+5.1f}"]
+        # if target was not in baseline, append note
+        if BaselineDict and target not in BaselineDict.keys():
+            line.append("Not in baseline")
+        print(' | '.join(line))
+
+    # Print time and % delta of the whole build time
+    if BaselineDict:
+        # totalDelta is the percentage change of build times between current and baseline
+        totalDelta = (total_time_current / total_time_baseline) * 100 - 100
+        line = ["-----\nTotal time:", FormatTime(total_time_current), "| %Δ", f'{totalDelta:+.1f}']
+        # if there are different targets in current and baseline log, add intersect delta, which
+        # compares build times while omitting conficting build targets
+        if target_mismatch:
+            intersectDelta = (total_time_current_intersect / total_time_baseline_intesect)\
+                 * 100 - 100
+            line.append(f'| intersect %Δ{intersectDelta:+5.1f}')
+        print(' '.join(line))
+    else:
+        print("-----\nTotal time:", FormatTime(total_time_current))
+
+    # Print targets which are present in baseline but not in current log
+    if BaselineDict:
+        removed = [target for target in BaselineDict.keys() if target not in CurrentDict.keys()]
+        print("-----\nTargets omitted from baseline:\n", '\n'.join(removed))
+
+
+def main() -> None:
+    # Dict key order used by PrintReport only specified in 3.7.0+
+    if sys.version_info < (3, 7, 0):
+        sys.stderr.write("You need python 3.7 or later to run this script\n")
+        exit(1)
+
+    if len(sys.argv) != 2:
+        print("Incorrect number of arguments")
+        sys.exit(99)
+
+    # skip loading baseline if we are creating it
+    if sys.argv[1] != "0.ninja_log":
+        BaselineDict = LoadLogFile("0.ninja_log")
+    else:
+        BaselineDict = None
+    CurrentDict = LoadLogFile(sys.argv[1])
+
+    GenerateWebTreeMap(CurrentDict, BaselineDict)
+    PrintReport(CurrentDict, BaselineDict)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/build_profiler_report.py
+++ b/utils/build_profiler_report.py
@@ -1,165 +1,198 @@
 #!/usr/bin/python3
+"""Compare and present build times to user and generate an HTML interactive graph"""
 import sys
+import argparse
 
 
-def LoadLogFile(file) -> dict:
+def load_log_file(file) -> dict:
     """Loads Targets and their durations from ninja logfile `file` and returns them in a dict"""
 
-    with open(file, 'r') as fp:
-        lines = fp.read().splitlines()
+    with open(file, 'r') as file_pointer:
+        lines = file_pointer.read().splitlines()
 
     # {Target: duration} dict
-    TargetDurationDict = {}
+    target_duration_dict = {}
     for line in lines:
-        line = line.split()
-
-        # ToDo - create better comment detection
-        if line[0][0] != '#':
-
+        line = line.strip()
+        if not line.startswith('#'):
             # calculate target compilation duration and add it to dict
+            line = line.split()
             duration = int(line[1]) - int(line[0])
-            TargetDurationDict[line[3]] = duration
+            target_duration_dict[line[3]] = duration
 
-    return TargetDurationDict
+    return target_duration_dict
 
 
-def FormatTime(t):
+def format_time(time):
     """Converts a time into a human-readable format"""
 
-    t /= 1000
-    if t < 60:
-        return '%.1fs' % t
-    if t < 60 * 60:
-        return '%dm%.1fs' % (t / 60, t % 60)
-    return '%dh%dm%.1fs' % (t / (60 * 60), t % (60 * 60) / 60, t % 60)
+    time /= 1000
+    if time < 60:
+        return '%.1fs' % time
+    if time < 60 * 60:
+        return '%dm%.1fs' % (time / 60, time % 60)
+    return '%dh%dm%.1fs' % (time / (60 * 60), time % (60 * 60) / 60, time % 60)
 
 
-def GenerateWebTreeMap(CurrentDict: dict, BaselineDict: dict) -> None:
+def generate_webtreemap(current_dict: dict, baseline_dict: dict, logfile: str) -> None:
     """Create file for webtreemap to generate an HTML from; if target is new, append _NEW"""
-    with open(sys.argv[1] + ".webtreemap", 'w') as fp:
-        for target in CurrentDict.keys():
+    with open(logfile + ".webtreemap", 'w') as file_pointer:
+        for target in current_dict.keys():
             new_tag = ''
-            if BaselineDict and target not in BaselineDict.keys():
+            if baseline_dict and target not in baseline_dict.keys():
                 new_tag = '_NEW'
 
-            fp.write(str(CurrentDict[target]) + ' ' + target
-                     + '_' + FormatTime(CurrentDict[target]) + new_tag + '\n')
+            file_pointer.write(str(current_dict[target]) + ' ' + target + '_'
+                               + format_time(current_dict[target]) + new_tag + '\n')
 
 
-def GetTotalTime(TargetDurationDict: dict) -> int:
+def get_total_time(target_duration_dict: dict) -> int:
     """Return sum of durations for all targets in dict"""
     total_time = 0
-    for target in TargetDurationDict.keys():
-        total_time += TargetDurationDict[target]
+    for target in target_duration_dict.keys():
+        total_time += target_duration_dict[target]
     return total_time
 
 
-def GetTotalTimeIntersect(TargetDurationDict_A: dict, TargetDurationDict_B: dict) -> int:
+def get_total_time_intersect(target_duration_dict_a: dict, target_duration_dict_b: dict) -> int:
     """Return sum of durations for targets in A that are also in B"""
     total_time = 0
-    for target in TargetDurationDict_A.keys():
-        if target in TargetDurationDict_B.keys():
-            total_time += TargetDurationDict_A[target]
+    for target in target_duration_dict_a.keys():
+        if target in target_duration_dict_b.keys():
+            total_time += target_duration_dict_a[target]
     return total_time
 
 
-def PrintReport(CurrentDict: dict, BaselineDict: dict = None) -> None:
+def print_report(current_dict: dict, baseline_dict: dict = None) -> None:
     """Print report with results of profiling to stdout"""
 
-    # If the targets have changed between baseline and current, we are using total_time_intersect
-    # to calculate delta (ratio of durations of targets) instead of total_time
-    if BaselineDict and BaselineDict.keys() != CurrentDict.keys():
-        print("Warning: the targets in the current logfile differ from those in the baseline\
-             logfile; therefore the Δ delta is calculated without taking the added/removed\
-                  targets into consideration. If the added/removed targets modify the behavior of\
-                      targets in both logfiles, the Δ delta may not make sense.\n-----")
+    # If the targets/outputfiles have changed between baseline and current, we are using
+    # total_time_intersect to calculate delta (ratio of durations of targets) instead of total_time
+    if baseline_dict and baseline_dict.keys() != current_dict.keys():
+        msg = ("Warning: the targets in the current logfile differ from those in the baseline"
+               "logfile; therefore the time and time percentage deltas TD and %TD for each target"
+               "as well as for the entire build are calculated without taking the added/removed"
+               "targets into account, but the total build time at the end does take them into"
+               "account. If the added/removed targets modify the behavior of targets in both"
+               "logfiles, the D delta may not make sense.\n-----\n")
+        print(msg)
         target_mismatch = True
-        total_time_current_intersect = GetTotalTimeIntersect(CurrentDict, BaselineDict)
-        total_time_baseline_intesect = GetTotalTimeIntersect(BaselineDict, CurrentDict)
+        total_time_current_intersect = get_total_time_intersect(current_dict, baseline_dict)
+        total_time_baseline_intesect = get_total_time_intersect(baseline_dict, current_dict)
     else:
         target_mismatch = False
 
-    header = [f'{"Target:":60}', f"{'%':4}", f"{'Δ':5}", f"{'T':8}", f"{'%Δ':5}", "Note"]
+    header = [f'{"Target:":60}', f"{'%':4}", f"{'D':5}", f"{'T':8}",
+              f"{'TD':8}", f"{'%TD':5}", "Note"]
     print(' | '.join(header))
 
-    total_time_current = GetTotalTime(CurrentDict)
-    if BaselineDict:
-        total_time_baseline = GetTotalTime(BaselineDict)
+    total_time_current = get_total_time(current_dict)
+    if baseline_dict:
+        total_time_baseline = get_total_time(baseline_dict)
 
-    # sort targets by % taken of build time
-    temp = {k: v for k, v in sorted(CurrentDict.items(), key=lambda item: item[1], reverse=True)}
-    CurrentDict = temp
+    # sort targets/outputfiles by % taken of build time
+    current_dict = dict(sorted(current_dict.items(), key=lambda item: item[1], reverse=True))
 
-    for target in CurrentDict.keys():
+    for target in current_dict.keys():
         # percentage of build time that the target took
-        perc = CurrentDict[target]/total_time_current * 100
+        perc = current_dict[target]/total_time_current * 100
 
         # difference between perc in current and in baseline
         delta = 0
-        if BaselineDict:
+        if baseline_dict:
             if target_mismatch:
-                if target in BaselineDict.keys():
-                    delta = CurrentDict[target]/total_time_current_intersect * 100 - \
-                        BaselineDict[target]/total_time_baseline_intesect * 100
-
+                if target in baseline_dict.keys():
+                    delta = current_dict[target]/total_time_current_intersect * 100 - \
+                        baseline_dict[target]/total_time_baseline_intesect * 100
             else:
-                delta = perc - (BaselineDict[target]/total_time_baseline * 100)
+                delta = perc - (baseline_dict[target]/total_time_baseline * 100)
+            if abs(delta) < 0.1:
+                delta = 0
 
         # time is the formatted build time of the target
-        time = FormatTime(CurrentDict[target])
+        time = format_time(current_dict[target])
 
-        # timeDelta a percentage difference of before and after build times 
-        if BaselineDict and target in BaselineDict.keys():
-            timeDelta = (CurrentDict[target]/BaselineDict[target]) * 100 - 100
+        # time_delta is the formatted time difference between current and baseline
+        if baseline_dict and target in baseline_dict.keys():
+            time_delta = current_dict[target] - baseline_dict[target]
+            if abs(time_delta) < 60:
+                time_delta = 0
+            time_delta = format_time(time_delta)
         else:
-            timeDelta = 0
+            time_delta = 0
 
-        line = [f'{target:60}', f"{perc:4.1f}", f"{delta:5.1f}", f"{time:8}", f"{timeDelta:+5.1f}"]
+        # perc_time_delta is a percentage difference of before and after build times
+        if baseline_dict and target in baseline_dict.keys():
+            perc_time_delta = (current_dict[target]/baseline_dict[target]) * 100 - 100
+        else:
+            perc_time_delta = 0
+
+        line = [f'{target:60}', f"{perc:4.1f}", f"{delta:5.1f}", f"{time:>8}",
+                f"{time_delta:>8}", f"{perc_time_delta:5.1f}"]
         # if target was not in baseline, append note
-        if BaselineDict and target not in BaselineDict.keys():
+        if baseline_dict and target not in baseline_dict.keys():
             line.append("Not in baseline")
         print(' | '.join(line))
 
     # Print time and % delta of the whole build time
-    if BaselineDict:
-        # totalDelta is the percentage change of build times between current and baseline
-        totalDelta = (total_time_current / total_time_baseline) * 100 - 100
-        line = ["-----\nTotal time:", FormatTime(total_time_current), "| %Δ", f'{totalDelta:+.1f}']
-        # if there are different targets in current and baseline log, add intersect delta, which
-        # compares build times while omitting conficting build targets
+    if baseline_dict:
+        # total_perc_time_delta is the percentage change of build times between current and baseline
+        total_time_delta = total_time_current - total_time_baseline
+        if abs(total_time_delta) < 60:
+            total_time_delta = 0
+        total_time_delta = format_time(total_time_delta)
+        total_perc_time_delta = (total_time_current / total_time_baseline) * 100 - 100
+        line = ["-----\nTotal time:", format_time(total_time_current),
+                "| TD", f'{total_time_delta:>8}', "| %TD", f'{total_perc_time_delta:+5.1f}']
+        # if there are different targets in current and baseline log, add intersect deltas,
+        # which compare build times while omitting conficting build targets
         if target_mismatch:
-            intersectDelta = (total_time_current_intersect / total_time_baseline_intesect)\
-                 * 100 - 100
-            line.append(f'| intersect %Δ{intersectDelta:+5.1f}')
+            intersect_time_delta = total_time_current_intersect - total_time_baseline_intesect
+            if abs(intersect_time_delta) < 60:
+                intersect_time_delta = 0
+            intersect_time_delta = format_time(intersect_time_delta)
+            line.append(f'| intersect TD {intersect_time_delta:>8}')
+            intersect_perc_time_delta = (total_time_current_intersect /
+                                         total_time_baseline_intesect) * 100 - 100
+            line.append(f'| intersect %TD {intersect_perc_time_delta:+5.1f}')
         print(' '.join(line))
     else:
-        print("-----\nTotal time:", FormatTime(total_time_current))
+        print("-----\nTotal time:", format_time(total_time_current))
 
     # Print targets which are present in baseline but not in current log
-    if BaselineDict:
-        removed = [target for target in BaselineDict.keys() if target not in CurrentDict.keys()]
+    if baseline_dict:
+        removed = [target for target in baseline_dict.keys() if target not in current_dict.keys()]
         print("-----\nTargets omitted from baseline:\n", '\n'.join(removed))
 
 
 def main() -> None:
-    # Dict key order used by PrintReport only specified in 3.7.0+
+    """Parse args, check for python version, then generate webtreemap HTML and print report"""
+
+    # Dict key order used by print_report only specified in 3.7.0+
     if sys.version_info < (3, 7, 0):
         sys.stderr.write("You need python 3.7 or later to run this script\n")
-        exit(1)
+        sys.exit(1)
 
-    if len(sys.argv) != 2:
-        print("Incorrect number of arguments")
-        sys.exit(99)
+    # Parse arguments
+    parser = argparse.ArgumentParser(description='Create .webtreemap and print profiling report',
+                                     usage='./build_profiler_report.py <logflie> [--baseline]')
+    parser.add_argument('logfile', type=str, help='Ninja logfile to compare against baseline')
+    parser.add_argument('--baseline', dest='skipBaseline', action='store_const',
+                        const=True, default=False, help='Do not compare logfile with baseline log \
+                        (default: compare baseline logfile with current logfile)')
 
-    # skip loading baseline if we are creating it
-    if sys.argv[1] != "0.ninja_log":
-        BaselineDict = LoadLogFile("0.ninja_log")
+    args = parser.parse_args()
+
+    if args.skipBaseline:
+        baseline_dict = None
     else:
-        BaselineDict = None
-    CurrentDict = LoadLogFile(sys.argv[1])
+        baseline_dict = load_log_file("0.ninja_log")
 
-    GenerateWebTreeMap(CurrentDict, BaselineDict)
-    PrintReport(CurrentDict, BaselineDict)
+    logfile = sys.argv[1]
+    current_dict = load_log_file(sys.argv[1])
+
+    generate_webtreemap(current_dict, baseline_dict, logfile)
+    print_report(current_dict, baseline_dict)
 
 
 if __name__ == "__main__":

--- a/utils/build_profiler_report.py
+++ b/utils/build_profiler_report.py
@@ -2,6 +2,7 @@
 """Compare and present build times to user and generate an HTML interactive graph"""
 import sys
 import argparse
+import re
 
 
 def load_log_file(file) -> dict:
@@ -14,7 +15,12 @@ def load_log_file(file) -> dict:
     target_duration_dict = {}
     for line in lines:
         line = line.strip()
-        if not line.startswith('#'):
+
+        # pattern to match target names that are an absolute path - these should be skipped
+        # --> an issue appeared with new versions of cmake where the targets are duplicated for some
+        # reason and therefore they must be filtered here
+        duplicate_pattern = re.compile("[0-9]+\s+[0-9]+\s+[0-9]+\s+/.*")
+        if not line.startswith('#') and not duplicate_pattern.match(line):
             # calculate target compilation duration and add it to dict
             line = line.split()
             duration = int(line[1]) - int(line[0])


### PR DESCRIPTION
#### Description:

- For developers to be able to see how their changes affect the speed of the buildsystem, we need some sort of a profiling tool. I created the build_profiler.sh and build_profiler_report.py scripts located in the utils folder to make this a simple process.
- These tools run automatically from the .build_product script located in the content folder simply by adding the '-p' or '--profiling' flag. The build is then done using ninja with jobs limited to 1 and the output is saved in a .ninja_log, which is then placed in the .build_profiling directory inside a directory named after the products that were built. The file is numbered starting from 0 (the baseline reading).
- After that, the .build_profiler_report.py script is called with the logfile name and it parses the data from it and prints it to the CLI. It also creates a .webtreemap file, which is then used to generate an HTML file with the same number as the logfile. This interactive HTML can be used to quickly see what are the biggest items prolonging the build time. 

#### Rationale:

- We need a way to
1. See what build targets take the most time to finish
2. What changes to the build time did our code cause
and this tool helps with that.
