### PR TITLE
OCP: Ensure `ebs_encryption_enabled_on_machinesets` on AWS only

### DIFF
--- a/applications/openshift/integrity/crypto/ebs_encryption_enabled_on_machinesets/rule.yml
+++ b/applications/openshift/integrity/crypto/ebs_encryption_enabled_on_machinesets/rule.yml
@@ -2,6 +2,9 @@ prodtype: ocp4
 
 title: Ensure that EBS volumes use by cluster nodes are encrypted
 
+platforms:
+  - ocp4-on-aws
+
 description: |-
   OpenShift MachineSets can be configured to enable EBS encryption on 
   EBS storage used by cluster nodes. By using EBS encryption, disk contents are 


### PR DESCRIPTION
Cloud-specific CPEs were recently introduced [1][2], and so, let's take
the AWS one into use so the aforementioned rule will only run on AWS.

As a result, if the rule is ran on Azure or another cloud, it'll be
marked as `NOT-APPLICABLE` in the result.

A subsequent commit will add the GCP and Azure rules to the disk
encryption catch-all rule `machine_volume_encrypted`.

[1] Commit 01b3ecdb84a92630c6f07fd9882a4a1eb4e7afe3
[2] Commit 12eb1bc8d1f3f6e21d45206bed21b185d74e9bb9

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>