### PR TITLE
OCP: Add Azure and GCP disk encryption rules to `machine_volume_encrypted`

### DIFF
--- a/applications/openshift/integrity/crypto/machine_volume_encrypted/oval/shared.xml
+++ b/applications/openshift/integrity/crypto/machine_volume_encrypted/oval/shared.xml
@@ -1,8 +1,10 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="machine_volume_encrypted" version="1">
-    {{{ oval_metadata("Full disk encryption should be enabled, either through EBS (AWS case) or using FIPS") }}}
+    {{{ oval_metadata("Full disk encryption should be enabled, either through the cloud provider or using FIPS") }}}
 
     <criteria operator="OR">
+      <extend_definition comment="Azure disk encryption enabled" definition_ref="azure_disk_encryption_enabled" />
+      <extend_definition comment="GCP disk encryption enabled" definition_ref="gcp_disk_encryption_enabled" />
       <extend_definition comment="ebs encryption enabled" definition_ref="ebs_encryption_enabled_on_machinesets" />
       <criteria operator="AND">
         <extend_definition comment="fips mode enabled" definition_ref="fips_mode_enabled_on_all_nodes" />

--- a/applications/openshift/integrity/crypto/machine_volume_encrypted/rule.yml
+++ b/applications/openshift/integrity/crypto/machine_volume_encrypted/rule.yml
@@ -5,8 +5,11 @@ title: Ensure that full disk encryption is configured on cluster nodes
 description: |-
   When full disk encryption is chosen as a way to protect card data at rest, OpenShift can provide
   several solutions depending on the hosting environment. 
-  While LUKS (with TPM2 or Tang) can be used for bare metal use cases, EBS encryption can be used 
-  when the cluster is hosted on AWS.
+  While LUKS (with TPM2 or Tang) can be used for bare metal use cases, cloud-provider specific
+  disk encryption can be used as well. [1][2]
+
+  [1] https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-enabling-customer-managed-encryption-azure_creating-machineset-azure
+  [2] https://docs.openshift.com/container-platform/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-enabling-customer-managed-encryption_creating-machineset-gcp
   
 rationale: |-
   Use of weak or untested encryption algorithms undermines the purposes of utilizing encryption to
@@ -21,23 +24,45 @@ identifiers:
 references:
   pcidss: Req-3.4.1
 
+{{% set azurejqfilter = '[.items[] | select(.spec.template.spec.providerSpec.value.osDisk.managedDisk.diskEncryptionSet.id != null) | .metadata.name]' %}}
+{{% set ebsjqfilter = '[.items[] | .spec.template.spec.providerSpec.value.blockDevices[0].ebs.encrypted] | map(. == true)' %}}
+{{% set gcpjqfilter = '[.items[] | select(.spec.template.spec.providerSpec.value.disks[0].encryptionKey.kmsKey.name != null) | .metadata.name]' %}}
+
 ocil_clause: 'FIPS mode is not enabled on worker nodes'
 
 ocil: |-
     Run the following command to see if EBS encryption is enabled:
-    <pre>$ oc get machineset --all-namespaces -o json | jq '[.items[] | .spec.template.spec.providerSpec.value.blockDevices[0].ebs.encrypted] | map(. == true)'</pre>
+    <pre>$ oc get machineset --all-namespaces -o json | jq '{{{ ebsjqfilter }}}'</pre>
     Make sure that the result is an array of 'true' values.
+
+    Run the following command to retrieve if the GCP disk encryption is enabled:
+    <pre>$ oc get machineset --all-namespaces -o json | jq {{{ gcpjqfilter }}}</pre>
+    Make sure that the result is an array MachineSet names. These MachineSets 
+    have references to the GCP's KMS key names, which can be inspected by going through them
+    with <pre>$ oc get machineset --all-namespaces -o yaml</pre>
+
+    Run the following command to retrieve if the Azure disk encryption is enabled:
+    <pre>$ oc get machineset --all-namespaces -o json | jq '{{{ azurejqfilter }}}}'</pre>
+    Make sure that the result is an array of machineset names where
+    disk encryption is enabled.
+    This can be inspected by going through them
+    with <pre>$ oc get machineset --all-namespaces -o yaml</pre>
+
     If not, run the following command to retrieve if the FIPS flag is enabled:
     <pre>$ oc get machineconfig -o json | jq '. | [select(.items[].metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|[.[].items[].spec.fips]'</pre>
     Make sure that the result is an array of 'true' values.
     Then, run this next command to retrieve if LUKS encryption is enabled:
     <pre>$ oc get machineconfig -o json | jq '. | [select(.items[].metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.config.storage.luks[0].clevis != null)'</pre>
     The result must also be an array of 'true' values.
+
 severity: high
+
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting(
-      {'/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.fips == true)',
+    {{{ openshift_filtered_cluster_setting({
+      '/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.fips == true)',
       '/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.config.storage.luks[0].clevis != null)',
-      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': '[.items[] | .spec.template.spec.providerSpec.value.blockDevices[0].ebs.encrypted] | map(. == true)'}
-    ) | indent(4) }}}
+      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': ebsjqfilter,
+      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': azurejqfilter,
+      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': gcpjqfilter,
+      }) | indent(4) }}}

--- a/applications/openshift/integrity/crypto/machine_volume_encrypted/rule.yml
+++ b/applications/openshift/integrity/crypto/machine_volume_encrypted/rule.yml
@@ -59,10 +59,10 @@ severity: high
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({
-      '/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.fips == true)',
-      '/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.config.storage.luks[0].clevis != null)',
-      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': ebsjqfilter,
-      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': azurejqfilter,
-      '/apis/machine.openshift.io/v1beta1/machinesets?limit=500': gcpjqfilter,
-      }) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting(
+        {'/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.fips == true)'},
+        {'/apis/machineconfiguration.openshift.io/v1/machineconfigs': '[.items[] | select(.metadata.name | test("^[0-9]{2}-worker$|^[0-9]{2}-master$"))]|map(.spec.config.storage.luks[0].clevis != null)'},
+        {'/apis/machine.openshift.io/v1beta1/machinesets?limit=500': ebsjqfilter},
+        {'/apis/machine.openshift.io/v1beta1/machinesets?limit=500': azurejqfilter},
+        {'/apis/machine.openshift.io/v1beta1/machinesets?limit=500': gcpjqfilter},
+      ) | indent(4) }}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -30,6 +30,8 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the {{% i
 
 :param path_filter_pairs: Kubernetes object path/filter directive pairs
 :type path_filter_pairs: dict
+:param varargs: A list of path_filter_pairs (in case repeated paths need to be used)
+:type path_filter_pairs: list
 
 #}}
 {{% macro openshift_filtered_cluster_setting(path_filter_pairs) -%}}
@@ -45,6 +47,18 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
     <code class="ocp-dump-location" id="dump-{{{ (path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (path+filter)|sha256 }}}</code>
     file.
   </li>
+{{% endfor %}}
+{{% for arg in varargs %}}
+{{% for path, filter in arg.items() %}}
+  <li>
+    <code class="ocp-api-endpoint" id="{{{ (path+filter)|sha256 }}}">{{{ path }}}</code>
+    API endpoint, filter with with the <code>jq</code> utility using the following filter
+    <code class="ocp-api-filter" id="filter-{{{ (path+filter)|sha256 }}}">{{{ filter }}}</code>
+    and persist it to the local
+    <code class="ocp-dump-location" id="dump-{{{ (path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (path+filter)|sha256 }}}</code>
+    file.
+  </li>
+{{% endfor %}}
 {{% endfor %}}
 </ul>
 {{%- endmacro %}}


### PR DESCRIPTION
The aforementioned rule is meant to encompass disk encryption for
several cloud providers. This makes sure it also checks Azure and GCP.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>