### PR TITLE
Interactive user initialization files

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -1,0 +1,10 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Ensure interactive local users are the group-owners of their respective initialization files
+  ansible.builtin.command:
+    cmd: |
+      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chgrp -f " $3" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chgrp -f " $3" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
@@ -1,0 +1,52 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("User Initialization Files Must Be Group-Owned By The Primary User") }}}
+    <criteria>
+      <criterion test_ref="test_accounts_user_dot_group_ownership"
+                 comment="User Initialization Files Must Be Group-Owned By The Primary User"/>
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_accounts_user_dot_group_ownership_objects" version="1">
+    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <filter action="include">state_accounts_user_dot_group_ownership_interactive_gids</filter>
+  </unix:password_object>
+
+  <unix:password_state id="state_accounts_user_dot_group_ownership_interactive_gids" version="1">
+    <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
+  </unix:password_state>
+
+  <local_variable id="var_accounts_user_dot_group_ownership_dirs" datatype="string" version="1"
+                  comment="Variable including all home dirs from interactive users">
+    <object_component item_field="home_dir"
+                      object_ref="object_accounts_user_dot_group_ownership_objects"/>
+  </local_variable>
+
+  <local_variable id="var_accounts_user_dot_group_ownership_gids" datatype="int" version="1"
+                  comment="List of interactive users gids">
+    <object_component item_field="group_id"
+                      object_ref="object_accounts_user_dot_group_ownership_objects"/>
+  </local_variable>
+
+  <!-- #### creation of object #### -->
+  <unix:file_object id="object_accounts_user_dot_group_ownership_init_files" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="1"
+                    recurse_file_system="local"/>
+    <unix:path var_ref="var_accounts_user_dot_group_ownership_dirs" var_check="at least one"/>
+    <unix:filename operation="pattern match">^\..*</unix:filename>
+  </unix:file_object>
+
+  <!-- #### creation of state #### -->
+  <unix:file_state id="state_accounts_user_dot_group_ownership_gids" version="1">
+    <unix:group_id datatype="int" var_check="only one"
+                  var_ref="var_accounts_user_dot_group_ownership_gids"/>
+  </unix:file_state>
+
+  <!-- #### creation of test #### -->
+  <unix:file_test id="test_accounts_user_dot_group_ownership" check="all"
+              check_existence="any_exist" version="1"
+              comment="All user initialization files are group-owned by a local interactive user">
+    <unix:object object_ref="object_accounts_user_dot_group_ownership_init_files"/>
+    <unix:state state_ref="state_accounts_user_dot_group_ownership_gids"/>
+  </unix:file_test>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/rule.yml
@@ -10,6 +10,9 @@ description: |-
     interactive user home directory, use the following command:
     <pre>$ sudo chgrp <i>USER_GROUP</i> /home/<i>USER</i>/.<i>INIT_FILE</i></pre>
 
+    This rule ensures every initialization file related to an interactive user
+    is group-owned by an interactive user.
+
 rationale: |-
     Local initialization files for interactive users are used to configure the
     user's shell environment upon logon. Malicious modification of these files could
@@ -35,3 +38,9 @@ ocil: |-
     users in <tt>/etc/passwd</tt> and verify all initialization files under the
     respective users home directory. Check the group owner of all local interactive users
     initialization files.
+
+warnings:
+    - general: |-
+       Due to OVAL limitation, this rule can report a false negative in a
+       specific situation where two interactive users swap the group-ownership
+       of their respective initialization files.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/expected_groupowner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/expected_groupowner.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chgrp $USER /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_all_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_all_absent.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -M $USER
+# This make sure home dirs related to test environment users are also removed.
+rm -Rf /home/*

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_one_absent_group_ok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/home_dirs_one_absent_group_ok.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+USER1="cac_user1"
+USER2="cac_user2"
+
+useradd -m $USER1
+useradd -M $USER2
+
+touch /home/$USER1/.bashrc
+chgrp $USER1 /home/$USER1/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_users_absent.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# remove all interactive users (ID >= 1000) from /etc/passwd
+sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/no_dot_file_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/no_dot_file_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/nodotfile
+chgrp 2 /home/$USER/nodotfile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/unexpected_groupowner_system_gid.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/unexpected_groupowner_system_gid.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chgrp 2 /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/unexpected_groupowner_unknown_gid.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/unexpected_groupowner_unknown_gid.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chgrp 10005 /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/warning_swapped_groupowners.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/warning_swapped_groupowners.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+USER1="cac_user1"
+USER2="cac_user2"
+
+useradd -m $USER1
+useradd -m $USER2
+touch /home/$USER1/.bashrc
+touch /home/$USER2/.bashrc
+
+# Swap the ownership of files in two home directories
+# WARNING: This test scenario will report a false negative, as explained in the
+# warning section of this rule.
+chgrp -f $USER2 /home/$USER1/.bashrc
+chgrp -f $USER1 /home/$USER2/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/ansible/shared.yml
@@ -1,0 +1,10 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Ensure interactive local users are the group-owners of their respective initialization files
+  ansible.builtin.command:
+    cmd: |
+      awk -F':' '{ if ($3 >= {{{ gid_min }}} && $3 != 65534) system("chmod -f g-w,o-w "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+awk -F':' '{ if ($4 >= {{{ uid_min }}} && $4 != 65534) system("chmod -f g-w,o-w "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/oval/shared.xml
@@ -1,0 +1,52 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("User Initialization Files Must Not Run World-Writable Programs") }}}
+    <criteria>
+      <criterion test_ref="test_accounts_user_dot_no_world_writable_programs"
+                 comment="User Initialization Files Must Not Run World-Writable Programs"/>
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_accounts_user_dot_no_world_writable_programs_objects"
+                        version="1">
+    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <filter action="include">state_accounts_user_dot_no_world_writable_programs_interactive_uids</filter>
+  </unix:password_object>
+
+  <unix:password_state id="state_accounts_user_dot_no_world_writable_programs_interactive_uids"
+                       version="1">
+    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
+  </unix:password_state>
+
+  <local_variable id="var_accounts_user_dot_no_world_writable_programs_dirs"
+                  datatype="string" version="1"
+                  comment="Variable including all home dirs from interactive users">
+    <object_component item_field="home_dir"
+                      object_ref="object_accounts_user_dot_no_world_writable_programs_objects"/>
+  </local_variable>
+
+  <!-- #### creation of object #### -->
+  <unix:file_object id="object_accounts_user_dot_no_world_writable_programs_init_files"
+                    version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+                    recurse_file_system="local"/>
+    <unix:path var_ref="var_accounts_user_dot_no_world_writable_programs_dirs"
+               var_check="at least one"/>
+    <unix:filename operation="pattern match">^\..*</unix:filename>
+  </unix:file_object>
+
+  <!-- #### creation of state #### -->
+  <unix:file_state id="state_accounts_user_dot_no_world_writable_programs" version="1"
+                   operator='AND'>
+    <unix:gwrite datatype="boolean">false</unix:gwrite>
+    <unix:owrite datatype="boolean">false</unix:owrite>
+  </unix:file_state>
+
+  <!-- #### creation of test #### -->
+  <unix:file_test id="test_accounts_user_dot_no_world_writable_programs" check="all"
+                  check_existence="any_exist" version="1"
+                  comment="All home directories have proper permissions">
+    <unix:object object_ref="object_accounts_user_dot_no_world_writable_programs_init_files"/>
+    <unix:state state_ref="state_accounts_user_dot_no_world_writable_programs"/>
+  </unix:file_test>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/expected_permissions.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/expected_permissions.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "$USER" > /home/$USER/$USER.txt
+chmod -f 755 /home/$USER/.*

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/home_dirs_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/home_dirs_absent.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -M $USER
+# This make sure home dirs related to test environment users are also removed.
+rm -Rf /home/*

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/interactive_users_absent.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# remove all interactive users (ID >= 1000) from /etc/passwd
+sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/lenient_permission.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/lenient_permission.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chmod -f o+w /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/more_restrictive_permission.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/more_restrictive_permission.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "$USER" > /home/$USER/$USER.txt
+chmod -f 700 /home/$USER/.*

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/no_dot_file_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/no_dot_file_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "$USER" > /home/$USER/$USER.txt
+chmod -f o+w /home/$USER/$USER.txt

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -1,0 +1,10 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Ensure interactive local users are the owners of their respective initialization files
+  ansible.builtin.command:
+    cmd: |
+      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/oval/shared.xml
@@ -1,0 +1,52 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("User Initialization Files Must Be Owned By the Primary User") }}}
+    <criteria>
+      <criterion test_ref="test_accounts_user_dot_user_ownership"
+                 comment="User Initialization Files Must Be Owned By the Primary User"/>
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_accounts_user_dot_user_ownership_objects" version="1">
+    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <filter action="include">state_accounts_user_dot_user_ownership_interactive_uids</filter>
+  </unix:password_object>
+
+  <unix:password_state id="state_accounts_user_dot_user_ownership_interactive_uids" version="1">
+    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
+  </unix:password_state>
+
+  <local_variable id="var_accounts_user_dot_user_ownership_dirs" datatype="string" version="1"
+                  comment="Variable including all home dirs from interactive users">
+    <object_component item_field="home_dir"
+                      object_ref="object_accounts_user_dot_user_ownership_objects"/>
+  </local_variable>
+
+  <local_variable id="var_accounts_user_dot_user_ownership_uids" datatype="int" version="1"
+                  comment="List of interactive users uids">
+    <object_component item_field="user_id"
+                      object_ref="object_accounts_user_dot_user_ownership_objects"/>
+  </local_variable>
+
+  <!-- #### creation of object #### -->
+  <unix:file_object id="object_accounts_user_dot_user_ownership_init_files" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="1"
+                    recurse_file_system="local"/>
+    <unix:path var_ref="var_accounts_user_dot_user_ownership_dirs" var_check="at least one"/>
+    <unix:filename operation="pattern match">^\..*</unix:filename>
+  </unix:file_object>
+
+  <!-- #### creation of state #### -->
+  <unix:file_state id="state_accounts_user_dot_user_ownership_uids" version="1">
+    <unix:user_id datatype="int" var_check="only one"
+                  var_ref="var_accounts_user_dot_user_ownership_uids"/>
+  </unix:file_state>
+
+  <!-- #### creation of test #### -->
+  <unix:file_test id="test_accounts_user_dot_user_ownership" check="all"
+                  check_existence="any_exist" version="1"
+                  comment="All user initialization files are owned by a local interactive user">
+    <unix:object object_ref="object_accounts_user_dot_user_ownership_init_files"/>
+    <unix:state state_ref="state_accounts_user_dot_user_ownership_uids"/>
+  </unix:file_test>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/rule.yml
@@ -9,6 +9,9 @@ description: |-
     the primary owner with the following command:
     <pre>$ sudo chown <i>USER</i> /home/<i>USER</i>/.*</pre>
 
+    This rule ensures every initialization file related to an interactive user
+    is owned by an interactive user.
+
 rationale: |-
     Local initialization files are used to configure the user's shell environment
     upon logon. Malicious modification of these files could compromise accounts upon
@@ -33,3 +36,9 @@ ocil: |-
     primary user, run the following command:
     <pre>$ sudo ls -al /home/<i>USER</i>/.*</pre>
     The user initialization files should be owned by <i>USER</i>.
+
+warnings:
+    - general: |-
+       Due to OVAL limitation, this rule can report a false negative in a
+       specific situation where two interactive users swap the ownership of
+       their respective initialization files.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/expected_owner.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/expected_owner.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chown $USER /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/home_dirs_all_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/home_dirs_all_absent.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -M $USER
+# This make sure home dirs related to test environment users are also removed.
+rm -Rf /home/*

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/home_dirs_one_absent_owner_ok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/home_dirs_one_absent_owner_ok.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+USER1="cac_user1"
+USER2="cac_user2"
+
+useradd -m $USER1
+useradd -M $USER2
+
+touch /home/$USER1/.bashrc
+chown $USER1 /home/$USER1/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_users_absent.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# remove all interactive users (ID >= 1000) from /etc/passwd
+sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/no_dot_file_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/no_dot_file_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/nodotfile
+chown 2 /home/$USER/nodotfile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/unexpected_owner_system_uid.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/unexpected_owner_system_uid.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chown 2 /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/unexpected_owner_unknown_uid.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/unexpected_owner_unknown_uid.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+touch /home/$USER/.bashrc
+chown 10005 /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/warning_swapped_owners.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/warning_swapped_owners.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+USER1="cac_user1"
+USER2="cac_user2"
+
+useradd -m $USER1
+useradd -m $USER2
+touch /home/$USER1/.bashrc
+touch /home/$USER2/.bashrc
+
+# Swap the ownership of files in two home directories
+# WARNING: This test scenario will report a false negative, as explained in the
+# warning section of this rule.
+chown -f $USER2 /home/$USER1/.bashrc
+chown -f $USER1 /home/$USER2/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -1,0 +1,12 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+- name: Ensure interactive local users are the owners of their respective initialization files
+  ansible.builtin.shell:
+    cmd: |
+      for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
+        sed -i 's/^\([\s]*umask\s*\)/#\1/g' $dir/.[^\.]?*
+      done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
+    sed -i 's/^\([\s]*umask\s*\)/#\1/g' $dir/.[^\.]?*
+done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
@@ -1,0 +1,40 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure the Default Umask is Set Correctly For Interactive Users") }}}
+    <criteria>
+      <criterion test_ref="test_accounts_umask_interactive_users"
+                 comment="Ensure the Default Umask is Set Correctly For Interactive Users"/>
+    </criteria>
+  </definition>
+
+  <unix:password_object id="object_accounts_umask_interactive_users_objects" version="1">
+    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <filter action="include">state_accounts_umask_interactive_users_interactive_uids</filter>
+  </unix:password_object>
+
+  <unix:password_state id="state_accounts_umask_interactive_users_interactive_uids" version="1">
+    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
+  </unix:password_state>
+
+  <local_variable id="var_accounts_umask_interactive_users_dirs" datatype="string" version="1"
+                  comment="Variable including all home dirs from interactive users">
+    <object_component item_field="home_dir"
+                      object_ref="object_accounts_umask_interactive_users_objects"/>
+  </local_variable>
+
+  <!-- #### creation of object #### -->
+  <ind:textfilecontent54_object id="object_accounts_umask_interactive_users"
+                                comment="Umask value from initialization files" version="1">
+    <ind:path var_ref="var_accounts_umask_interactive_users_dirs" var_check="at least one"/>
+    <ind:filename operation="pattern match">^\..*</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*umask\s*</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- #### creation of test #### -->
+  <ind:textfilecontent54_test id="test_accounts_umask_interactive_users" check="all"
+                  check_existence="none_exist" version="1"
+                  comment="Umask must not be defined in user initialization files">
+    <ind:object object_ref="object_accounts_umask_interactive_users"/>
+  </ind:textfilecontent54_test>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/home_dirs_all_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/home_dirs_all_absent.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -M $USER
+# This make sure home dirs related to test environment users are also removed.
+rm -Rf /home/*

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/home_dirs_one_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/home_dirs_one_absent.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+USER1="cac_user1"
+USER2="cac_user2"
+
+useradd -m $USER1
+useradd -M $USER2
+
+# Make sure no umask definition exists in the startup files
+sed -i 's/^\([\s]*umask\s*\)/#\1/g' /home/$USER1/.[^\.]?*

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_users_absent.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# remove all interactive users (ID >= 1000) from /etc/passwd
+sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/no_dot_file_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/no_dot_file_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "umask 022" > /home/$USER/nodotfile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/umask_defined.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/umask_defined.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "umask 022" >> /home/$USER/.bashrc


### PR DESCRIPTION
#### Description:

This PR brings OVAL, tests and remediation for the following rules:

accounts_user_dot_user_ownership
accounts_user_dot_group_ownership
accounts_user_dot_no_world_writable_programs
accounts_umask_interactive_users

#### Rationale:

These rules are required by some standards, like STIG and CIS. Therefore, it is valuable to have them properly working.
This PR partially fix:

https://bugzilla.redhat.com/show_bug.cgi?id=1884687

This PR is also related to #7770, #7790 and #7824.
These PRs together close the gaps of all relevant rules related to files under interactive users home directories.
