### PR TITLE
OCP/PCI-DSS: Mark overall req 3.6 as `not applicable`

### DIFF
--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -838,7 +838,11 @@ controls:
     from various resources including NIST, which can be found at http://csrc.nist.gov.'
   levels:
   - base
-  notes: ''
+  notes: |-
+    Although some key management processes rely on OpenShift Container Platform and its underlying components
+    for Full Disk Encryption, the responsibility for documentation and implementation of key-management processes
+    and procedures for cryptographic keys used for encryption of cardholder data is still on the payment service and its 
+    operations team in order to cover all aspects of cardholder data protection.
   status: not applicable
   controls:
   - id: Req-3.6.1

--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -839,7 +839,7 @@ controls:
   levels:
   - base
   notes: ''
-  status: pending
+  status: not applicable
   controls:
   - id: Req-3.6.1
     title: 3.6.1 Generation of strong cryptographic keys


### PR DESCRIPTION
Key management documentation of the system in scope is not the task of
the platform overall but of the payment entity instead.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>