### PR TITLE
Fix banner regex to address change in PR #7784

### DIFF
--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -284,7 +284,7 @@ def banner_regexify(banner_text):
     return escape_regex(banner_text) \
         .replace("\n", "BFLMPSVZ") \
         .replace(" ", "[\\s\\n]+") \
-        .replace("BFLMPSVZ", "(?:[\\n]+|(?:\\\\n)+)")
+        .replace("BFLMPSVZ", "(?:[\\n]+|(?:\\n)+)")
 
 
 def banner_anchor_wrap(banner_text):


### PR DESCRIPTION
#### Description:

- The change introduced in PR #7784 broke the rule banner_etc_issue_net, and probably banner_etc_issue (if any distro that uses this rule could confirm, it would be great). After deregexify the banner text resulted in:
`You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only. By using this IS (which includes any device attached to this IS), you consent to the following conditions:(?:[n]+|(?:n)+)-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.(?:[n]+|(?:n)+)-At any time, the USG may inspect and seize data stored on this IS.(?:[n]+|(?:n)+)-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.(?:[n]+|(?:n)+)-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.(?:[n]+|(?:n)+)-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.`