### PR TITLE
SLE15 Add selinux rules to HIPAA profile

### DIFF
--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable the selinuxuser_execheap SELinux Boolean'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-82312-0
     cce@rhel8: CCE-80949-1
     cce@rhel9: CCE-84084-3
+    cce@sle15: CCE-91424-2
 
 references:
     anssi: BP28(R67)

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable the selinuxuser_execmod SELinux Boolean'
 
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-82313-8
     cce@rhel8: CCE-80950-9
     cce@rhel9: CCE-84086-8
+    cce@sle15: CCE-91423-4
 
 references:
     hipaa: 164.308(a)(1)(ii)(D),164.308(a)(3),164.308(a)(4),164.310(b),164.310(c),164.312(a),164.312(e)

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'disable the selinuxuser_execstack SELinux Boolean'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-82314-6
     cce@rhel8: CCE-80951-7
     cce@rhel9: CCE-84089-2
+    cce@sle15: CCE-91422-6
 
 references:
     anssi: BP28(R67)

--- a/products/sle15/profiles/hipaa.profile
+++ b/products/sle15/profiles/hipaa.profile
@@ -147,4 +147,7 @@ selections:
     - libreswan_approved_tunnels
     - package_rsh-server_removed
     - package_talk-server_removed
+    - sebool_selinuxuser_execheap
+    - sebool_selinuxuser_execmod
+    - sebool_selinuxuser_execstack
 

--- a/shared/templates/sebool/ansible.template
+++ b/shared/templates/sebool/ansible.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,SUSE Linux Enterprise 15
 # reboot = false
 # strategy = enable
 # complexity = low
@@ -17,6 +17,11 @@
 - name: Ensure python3-libsemanage installed
   package:
     name: python3-libsemanage
+    state: present
+{{% elif product == "sle15" %}}
+- name: Ensure policycoreutils installed
+  package:
+    name: policycoreutils
     state: present
 {{% else %}}
 - name: Ensure libsemanage-python installed

--- a/shared/templates/sebool/bash.template
+++ b/shared/templates/sebool/bash.template
@@ -1,8 +1,12 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,SUSE Linux Enterprise 15
 # reboot = false
 # strategy = enable
 # complexity = low
 # disruption = low
+
+{{% if product == "sle15" %}}
+{{{ bash_package_install("policycoreutils") }}}
+{{% endif %}}
 
 {{% if SEBOOL_BOOL %}}
 setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}


### PR DESCRIPTION


#### Description:
Add selinux rules to SLE15 HIPAA profile

#### Rationale:

Add rules:
- sebool_selinuxuser_execheap
- sebool_selinuxuser_execmod
- sebool_selinuxuser_execstack

to HIPAA profile for SUSE Linux Enterprise 15 platform