### PR TITLE
OCP/RHCOS: Mark SC-7(18) as `not applicable`

### DIFF
--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -13576,14 +13576,12 @@ controls:
     https://issues.redhat.com/browse/CMP-487
   rules: []
 - id: SC-7(18)
-  status: automated
+  status: not applicable
   notes: |-
-    A complete control response is planned. Engineering progress can be
-    tracked via:
-
-    https://issues.redhat.com/browse/CMP-488
-  rules:
-  - configure_network_policies_namespaces
+    The focus of this control specifically speaks to the operational failure of
+    a boundary protection device and is therefore not applicable to the
+    OpenShift Platform
+  rules: []
   description: "The information system fails securely in the event of an operational\
     \ failure of a boundary protection device.\n \nSupplemental Guidance:  Fail secure\
     \ is a condition achieved by employing information system mechanisms to ensure\

--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -13001,12 +13001,11 @@ controls:
     https://issues.redhat.com/browse/CMP-487
   rules: []
 - id: SC-7(18)
-  status: pending
+  status: not applicable
   notes: |-
-    A complete control response is planned. Engineering progress can be
-    tracked via:
-
-    https://issues.redhat.com/browse/CMP-488
+    The focus of this control specifically speaks to the operational failure of
+    a boundary protection device and is therefore not applicable to Red Hat
+    CoreOS.
   rules: []
   description: "The information system fails securely in the event of an operational\
     \ failure of a boundary protection device.\n \nSupplemental Guidance:  Fail secure\


### PR DESCRIPTION
This control refers to a boundary protection device, and thus is not
applicable to neither Openshift nor RHCOS. These devices are typically
installed on the cloud these are running and should be checked
separately.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>