### PR TITLE
Update tests for package_crypto-policies_installed

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/tests/package-installed-removed.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/tests/package-installed-removed.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# The crypto-policies package cannot be normally removed
+# from a system, therefore as a part of testing we only
+# remove the package without its dependencies.
+
+PKGNAME="crypto-policies"
+{{{ pkg_manager }}} install -y "$PKGNAME"
+rpm -e --nodeps "$PKGNAME"

--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/tests/package-removed.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/tests/package-removed.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# platform = multi_platform_rhel,multi_platform_fedora
+
+# The crypto-policies package cannot be normally removed
+# from a system, therefore as a part of testing we only
+# remove the package without its dependencies.
+
+PKGNAME="crypto-policies"
+rpm -e --nodeps "$PKGNAME"


### PR DESCRIPTION
The `crypto-policies` package cannot be normally removed
from a system, therefore as a part of testing we only
remove the package without its dependencies.

- Fixes issue from #7612
