### PR TITLE
update description of grub2_uefi_password

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -25,13 +25,14 @@ description: |-
     </pre>
     NOTE: the bootloader superuser account and password MUST differ from the
     root account and password.
-    {{% endif %}}
-    <br /><br />
-    {{% if product in ["sle12", "sle15"] %}}
     Once the superuser password has been added,
     update the
     <tt>grub.cfg</tt> file by running:
-    <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
+    {{% if "ubuntu" in product %}}
+    <pre>update-grub</pre>
+    {{% elif product in ["sle12", "sle15"] %}}
+    <pre>grub2-mkconfig -o {{{ grub2_uefi_boot_path }}}/grub.cfg</pre>
+    {{% endif %}}
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -27,10 +27,12 @@ description: |-
     root account and password.
     {{% endif %}}
     <br /><br />
+    {{% if product in ["sle12", "sle15"] %}}
     Once the superuser password has been added,
     update the
     <tt>grub.cfg</tt> file by running:
     <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
+    {{% endif %}}
 
 rationale: |-
     Password protection on the boot loader configuration ensures

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -26,13 +26,11 @@ description: |-
     NOTE: the bootloader superuser account and password MUST differ from the
     root account and password.
     {{% endif %}}
+    {{% if "ubuntu" in product %}}
     Once the superuser password has been added,
     update the
     <tt>grub.cfg</tt> file by running:
-    {{% if "ubuntu" in product %}}
     <pre>update-grub</pre>
-    {{% else %}}
-    <pre>grub2-mkconfig -o {{{ grub2_uefi_boot_path }}}/grub.cfg</pre>
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -25,12 +25,14 @@ description: |-
     </pre>
     NOTE: the bootloader superuser account and password MUST differ from the
     root account and password.
-    {{% endif %}}
-    {{% if "ubuntu" in product %}}
     Once the superuser password has been added,
     update the
     <tt>grub.cfg</tt> file by running:
+    {{% if "ubuntu" in product %}}
     <pre>update-grub</pre>
+    {{% elif product in ["sle12", "sle15"] %}}
+    <pre>grub2-mkconfig -o {{{ grub2_uefi_boot_path }}}/grub.cfg</pre>
+    {{% endif %}}
     {{% endif %}}
 
 rationale: |-


### PR DESCRIPTION
#### Description:

remove the part which talks about using grub2-mkconfig to update the documentation

#### Rationale:

according to documentation it is not needed

https://access.redhat.com/solutions/4575381