### PR TITLE
Sort CPEs before adding them to the datastream

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -47,6 +47,7 @@ jobs:
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           clean: false
       - name: Build product
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1535,7 +1535,7 @@ class Rule(XCCDFEntity):
 
         add_sub_element(rule, 'rationale', self.rationale)
 
-        for cpe_platform_name in self.cpe_platform_names:
+        for cpe_platform_name in sorted(self.cpe_platform_names):
             platform_el = ET.SubElement(rule, "platform")
             platform_el.set("idref", "#"+cpe_platform_name)
 

--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -233,7 +233,7 @@ def compare_checks(
                 "'%s' to '%s'." % (
                     system, rule_id, old_check_id, new_check_id)
             )
-        if show_diffs:
+        if show_diffs and rule_id != "xccdf_org.ssgproject.content_rule_security_patches_up_to_date":
             try:
                 old_check_doc = old_checks[old_check_file_name]
             except KeyError:


### PR DESCRIPTION
#### Description:

- Sort CPEs before adding them to the datastream.
- Do not show diff for rule security_patches_up_to_date.

#### Rationale

- Produce reproduceable builds and remove not useful information about security_patches_up_to_date in compare_ds.py tool