### PR TITLE
Revert PR #7842 and improve deregexify

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1181,7 +1181,7 @@ EOF
 
 {{# Strips newline or newline escape sequence regex #}}
 {{% macro bash_deregexify_banner_newline(banner_var_name, newline) -%}}
-{{{ banner_var_name }}}=$(echo "${{{ banner_var_name }}}" | sed 's/(?:\[\\n\]+|(?:\\n)+)/{{{ newline }}}/g')
+{{{ banner_var_name }}}=$(echo "${{{ banner_var_name }}}" | sed 's/(?:\[\\n\]+|(?:\\\\n)+)/{{{ newline }}}/g')
 {{%- endmacro %}}
 
 {{# Strips newline token for a newline escape sequence regex #}}

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -284,7 +284,7 @@ def banner_regexify(banner_text):
     return escape_regex(banner_text) \
         .replace("\n", "BFLMPSVZ") \
         .replace(" ", "[\\s\\n]+") \
-        .replace("BFLMPSVZ", "(?:[\\n]+|(?:\\n)+)")
+        .replace("BFLMPSVZ", "(?:[\\n]+|(?:\\\\n)+)")
 
 
 def banner_anchor_wrap(banner_text):


### PR DESCRIPTION
#### Description:

- Even though PR #7842 fixed the etc_banner_issue(_net) rules, it seems that dconf_gnome_login_banner_text was still having issues. So I've reverted that fix and instead made a fix in the deregexify function. This should fix the issue for both rules.
