### PR TITLE
OCP4/PCI-DSS: Mark Req-2.1.1 as not applicable

### DIFF
--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -355,8 +355,10 @@ controls:
     SNMP community strings.
   levels:
   - base
-  notes: ''
-  status: pending
+  notes: |-
+    The OpenShift Container Platform isn't used in a wireless environment and 
+    doesn't come with any hardcoded credentials or passwords.
+  status: not applicable
   rules: []
 
 - id: Req-2.2


### PR DESCRIPTION
Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>