### PR TITLE
OCP4:include sc-5 and sc5(2) in routes_rate_limit

### DIFF
--- a/applications/openshift/networking/routes_rate_limit/rule.yml
+++ b/applications/openshift/networking/routes_rate_limit/rule.yml
@@ -17,7 +17,7 @@ identifiers:
   cce@ocp4: CCE-90779-0
 
 references:
-  nist: SC-5(1)
+  nist: SC-5,SC-5(1),SC-5(2)
 
 {{% set jqfilter = '[.items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select(.metadata.annotations["haproxy.router.openshift.io/rate-limit-connections"] == "true" | not) | .metadata.name]' %}}
 

--- a/applications/openshift/networking/routes_rate_limit/tests/ocp4/e2e.yml
+++ b/applications/openshift/networking/routes_rate_limit/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
 default_result: PASS
+result_after_remediation: FAIL

--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -13172,7 +13172,8 @@ controls:
     [6] https://kubernetes.io/docs/concepts/cluster-administration/flow-control/
 
     https://issues.redhat.com/browse/CMP-427
-  rules: []
+  rules: 
+  - routes_rate_limit
   description: |-
     The information system protects against or limits the effects of the following types of denial of service attacks: [Assignment: organization-defined types of denial of service attacks or reference to source for such information] by employing [Assignment: organization-defined security safeguards].
 
@@ -13221,7 +13222,8 @@ controls:
     [2] https://docs.openshift.com/container-platform/4.7/applications/quotas/quotas-setting-per-project.html
     [3] https://docs.openshift.com/container-platform/4.7/applications/quotas/quotas-setting-across-multiple-projects.html
     [4] https://docs.openshift.com/container-platform/4.7/nodes/pods/nodes-pods-priority.html
-  rules: []
+  rules: 
+  - routes_rate_limit
 - id: SC-5(3)
   status: not applicable
   notes: |-


### PR DESCRIPTION
Only SC5 is included in FedRAMP, and since `routes_rate_limit` is also relevant with SC5(1) and SC5, we included  SC5(1) and SC5 in the rule. 