### PR TITLE
Add the ability to load controls from folder

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -982,6 +982,56 @@ Each of the values under the `rules` key maps onto a rule identifier in the
 project. In the future, we could automatically assign references to rules via
 this control file.
 
+To help control length of control files content authors can create a directory with same name as the control file (without `.yml`) and add YAML files to that folder.
+Then in the folder the author can crate `.yml` files for the controls.
+See the example below.
+
+```
+$ cat controls/abcd.yml
+ 
+id: abcd
+title: ABCD Benchmark for securing Linux systems
+version: 1.2.3
+source: https://www.abcd.com/linux.pdf
+```
+
+```
+$ cat controls/abcd/R1.yml
+ 
+controls:
+  - id: R1
+    title: User session timeout
+    description: |-
+      Remote user sessions must be closed after a certain
+      period of inactivity.
+    status: automated
+    rules:
+    - sshd_set_idle_timeout
+    - accounts_tmout
+    - var_accounts_tmout=10_min
+{{% if product == "rhel9" %}}
+    - cockpit_session_timeout
+{{% endif %}}
+```
+
+```
+$ cat controls/abcd/R2.yml
+ 
+controls:
+  - id: R2
+    title: Minimization of configuration
+    description: |-
+      The features configured at the level of launched services
+      should be limited to the strict minimum.
+    status: supported
+    note: |-
+      This is individual depending on the system workload
+      therefore needs to be audited manually.
+    related_rules:
+       - systemd_target_multi_user
+```
+
+
 ### Defining levels
 
 Some real world policies, e.g.,  ANSSI, have a concept of levels.

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -177,7 +177,10 @@ class Policy():
                 if file.endswith('.yml'):
                     full_path = os.path.join(self.controls_dir, file)
                     yaml_contents = ssg.yaml.open_and_expand(full_path, self.env_yaml)
-                    controls_tree.append(yaml_contents)
+                    for control in yaml_contents['controls']:
+                        controls_tree.append(control)
+                elif file.startswith('.'):
+                    continue
                 else:
                     raise RuntimeError("Found non yaml file in %s" % self.controls_dir)
         for c in self._parse_controls_tree(controls_tree):

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -130,6 +130,7 @@ class Policy():
         self.id = None
         self.env_yaml = env_yaml
         self.filepath = filepath
+        self.controls_dir = os.path.splitext(filepath)[0]
         self.controls = []
         self.controls_by_id = dict()
         self.levels = []
@@ -170,6 +171,15 @@ class Policy():
             self.levels_by_id[level.id] = level
 
         controls_tree = ssg.utils.required_key(yaml_contents, "controls")
+        if os.path.exists(self.controls_dir) and os.path.isdir(self.controls_dir):
+            files = os.listdir(self.controls_dir)
+            for file in files:
+                if file.endswith('.yml'):
+                    full_path = os.path.join(self.controls_dir, file)
+                    yaml_contents = ssg.yaml.open_and_expand(full_path, self.env_yaml)
+                    controls_tree.append(yaml_contents)
+                else:
+                    raise RuntimeError("Found non yaml file in %s" % self.controls_dir)
         for c in self._parse_controls_tree(controls_tree):
             self.controls.append(c)
             self.controls_by_id[c.id] = c

--- a/tests/unit/ssg-module/data/controls_dir/jklm.yml
+++ b/tests/unit/ssg-module/data/controls_dir/jklm.yml
@@ -1,0 +1,35 @@
+policy: JKLM Benchmark for securing Linux systems
+title: JKLM Benchmark for securing Linux systems
+id: jklm
+version: 1.2.3
+source: https://www.example.com/jklm/linux.pdf
+controls:
+  - id: R2
+    title: Minimization of configuration
+    description: >-
+      The features configured at the level of launched services
+      should be limited to the strict minimum.
+    automated: no
+    note: >-
+      This is individual depending on the system workload
+      therefore needs to be audited manually.
+    related_rules:
+       - systemd_target_multi_use
+  - id: R4
+    title: Configure authentication
+    description: >-
+      Ensure authentication methods are functional to prevent
+      unauthorized access to the system.
+    controls:
+      - id: R4.a
+        title: Disable administrator accounts
+        automated: yes
+        rules:
+          -  accounts_passwords_pam_faillock_deny_root
+      - id: R4.b
+        title: Enforce password quality standards
+        automated: yes
+        rules:
+          - accounts_password_pam_minlen
+          - accounts_password_pam_ocredit
+          - var_password_pam_ocredit=1

--- a/tests/unit/ssg-module/data/controls_dir/jklm/r1.yml
+++ b/tests/unit/ssg-module/data/controls_dir/jklm/r1.yml
@@ -1,0 +1,14 @@
+controls:
+  - id: R1
+    title: User session timeout
+    description: >-
+      Remote user sessions must be closed after a certain
+      period of inactivity.
+    automated: yes
+    rules:
+      - sshd_set_idle_timeout
+      - accounts_tmout
+      - var_accounts_tmout=10_min
+      - configure_crypto_policy
+    notes: >-
+      Certain period of inactivity is vague.

--- a/tests/unit/ssg-module/data/controls_dir/jklm/r3.yml
+++ b/tests/unit/ssg-module/data/controls_dir/jklm/r3.yml
@@ -1,0 +1,7 @@
+controls:
+    -   id: R3
+        title: Enabling SELinux targeted Policy
+        description: >-
+            It is recommended to enable SELinux in enforcing mode
+            and to use the targeted policy.
+        automated: yes


### PR DESCRIPTION
#### Description:

Loads controls from files matching `controls/control_file/*.yml`.

#### Rationale:

To help control the length of the control files.
