### PR TITLE
Add CentOS Stream 9 derivative product from RHEL9

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -97,7 +97,8 @@ def main():
         raise RuntimeError("No Benchmark found!")
 
     for namespace, benchmark in benchmarks:
-        ssg.build_derivatives.profile_handling(benchmark, namespace)
+        if args[1] != "cs9":
+            ssg.build_derivatives.profile_handling(benchmark, namespace)
         if not ssg.build_derivatives.add_cpes(benchmark, namespace, mapping):
             raise RuntimeError(
                 "Could not add derivative OS CPEs to Benchmark '%s'."

--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -98,6 +98,8 @@ def main():
 
     for namespace, benchmark in benchmarks:
         if args[1] != "cs9":
+            # In CentOS Stream 9 profiles are kept because it is a system
+            # intended to test content that will get into RHEL
             ssg.build_derivatives.profile_handling(benchmark, namespace)
         if not ssg.build_derivatives.add_cpes(benchmark, namespace, mapping):
             raise RuntimeError(

--- a/products/rhel9/CMakeLists.txt
+++ b/products/rhel9/CMakeLists.txt
@@ -15,3 +15,7 @@ ssg_build_html_srgmap_tables(${PRODUCT} "stig" ${DISA_SRG_TYPE})
 # ssg_build_html_stig_tables(${PRODUCT} "stig")
 
 #ssg_build_html_stig_tables(${PRODUCT} "ospp")
+
+if (SSG_CENTOS_DERIVATIVES_ENABLED)
+    ssg_build_derivative_product(${PRODUCT} "centos" "cs9")
+endif()

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -42,3 +42,7 @@ platform_package_overrides:
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/red_hat_linux/'
+
+centos_pkg_release: "5ccc5b19"
+centos_pkg_version: "8483c65d"
+centos_major_version: "9"

--- a/shared/applicability/derivatives.yml
+++ b/shared/applicability/derivatives.yml
@@ -10,6 +10,11 @@ cpes:
       title: "CentOS 8"
       check_id: installed_OS_is_centos8
 
+  - cs9:
+      name: "cpe:/o:centos:centos:9"
+      title: "CentOS Stream 9"
+      check_id: installed_OS_is_centos9
+
   - sl7:
       name: "cpe:/o:scientificlinux:scientificlinux:7"
       title: "Scientific Linux 7"

--- a/shared/checks/oval/installed_OS_is_centos9.xml
+++ b/shared/checks/oval/installed_OS_is_centos9.xml
@@ -1,0 +1,47 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_OS_is_centos9" version="2">
+    <metadata>
+      <title>CentOS Stream 9</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:centos:centos:9"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      CentOS Stream 9</description>
+    </metadata>
+    <criteria operator="AND">
+      <extend_definition comment="Installed OS is part of the Unix family"
+      definition_ref="installed_OS_is_part_of_Unix_family" />
+      <criterion comment="OS is CentOS Stream" test_ref="test_centos9_name" />
+      <criterion comment="OS version is 9" test_ref="test_centos9_version" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="Check os-release ID" id="test_centos9_name" version="1">
+    <ind:object object_ref="obj_name_centos9" />
+    <ind:state state_ref="state_name_centos9" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_name_centos9" version="1" comment="Check os-release ID">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^ID=&quot;(\w+)&quot;$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_name_centos9" version="1">
+    <ind:subexpression>centos</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" comment="Check os-release VERSION_ID" id="test_centos9_version" version="1">
+    <ind:object object_ref="obj_version_centos9" />
+    <ind:state state_ref="state_version_centos9" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_version_centos9" version="1" comment="Check os-release VERSION_ID">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d)&quot;$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_version_centos9" version="1">
+    <ind:subexpression>9</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -282,6 +282,7 @@ RHEL_CENTOS_CPE_MAPPING = {
     "cpe:/o:redhat:enterprise_linux:6": "cpe:/o:centos:centos:6",
     "cpe:/o:redhat:enterprise_linux:7": "cpe:/o:centos:centos:7",
     "cpe:/o:redhat:enterprise_linux:8": "cpe:/o:centos:centos:8",
+    "cpe:/o:redhat:enterprise_linux:9": "cpe:/o:centos:centos:9",
 }
 
 RHEL_SL_CPE_MAPPING = {


### PR DESCRIPTION
#### Description:

- Add CentOS Stream 9 derivative product from RHEL9.

#### Rationale:

- Do not exclude RHEL9 profiles.
- Use `cs9` as product name since OSCAP-Anaconda-Addon expects in this format.

CentOS Linux 8:
```python
>>> from pyanaconda.core import constants
>>> constants.shortProductName
'cl'
```

CentOS Stream 9:
```python
>>> from pyanaconda.core import constants
>>> constants.shortProductName
'cs'
```

In OOA we use `shortProductName` to find the default datastream to be used

https://github.com/OpenSCAP/oscap-anaconda-addon/blob/8229ad19588665d858dbdc1796be3bcd1bc79079/org_fedora_oscap/common.py#L80

I believe that for CentOS it never worked as we name the CentOS datastream as `ssg-centos8-ds.xml` for example, and the one that OAA tries to find is `ssg-cl8-ds.xml` for CentOS Linux 8 and `ssg-cs9-ds.xml` for CentOS Stream 9.
