### PR TITLE
Prevent Python 2 encoding error

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1687,10 +1687,8 @@ class Rule(XCCDFEntity):
         # The empty ocil_clause causing broken question is in line with the
         # legacy XSLT implementation.
         ocil_clause = self.ocil_clause if self.ocil_clause else ""
-        question_text.text = (
-            "{0}\n      Is it the case that {1}?\n      ".format(
-                question_text.text if question_text.text is not None else "",
-                ocil_clause))
+        x = question_text.text if question_text.text is not None else ""
+        question_text.text = x + "\n      Is it the case that " + ocil_clause + "?\n      "
         return (questionnaire, action, boolean_question)
 
     def __hash__(self):
@@ -1983,4 +1981,4 @@ class LinearLoader(object):
             questionnaires.append(questionnaire)
             test_actions.append(action)
             questions.append(boolean_question)
-        tree.write(filename)
+        tree.write(filename, encoding="UTF-8")


### PR DESCRIPTION
Addressing:

Traceback (most recent call last):
  File "/home/user/content/build-scripts/build_shorthand.py", line 65, in <module>
    main()
  File "/home/user/content/build-scripts/build_shorthand.py", line 61, in main
    loader.export_ocil_to_file(args.ocil)
  File "/home/user/content/ssg/build_yaml.py", line 1982, in export_ocil_to_file
    questionnaire, action, boolean_question = rule.to_ocil()
  File "/home/user/content/ssg/build_yaml.py", line 1693, in to_ocil
    ocil_clause))
UnicodeEncodeError: 'ascii' codec can't encode character u'\u25cf' in position 176: ordinal not in range(128)
