### PR TITLE
OCP: Use Fedora 35 for base container images

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -1,5 +1,5 @@
 # This dockerfile builds the content in the current repo for OCP4
-FROM registry.fedoraproject.org/fedora-minimal:34 as builder
+FROM registry.fedoraproject.org/fedora-minimal:35 as builder
 
 WORKDIR /content
 

--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -1,4 +1,4 @@
-FROM fedora:33 as builder
+FROM fedora:35 as builder
 
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content


### PR DESCRIPTION
Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>