### PR TITLE
Make the table-generating code Python2-compatible

### DIFF
--- a/utils/gen_multiple_reference_tables.py
+++ b/utils/gen_multiple_reference_tables.py
@@ -41,5 +41,6 @@ if __name__ == "__main__":
         renderer.process_rules(reference)
         result = renderer.get_result()
         output = args.output_template.format(ref_id=reference.id)
-        with open(output, "w") as outfile:
-            outfile.write(result)
+        with open(output, "wb") as outfile:
+            result_for_output = result.encode('utf8', 'replace')
+            outfile.write(result_for_output)

--- a/utils/gen_profile_table.py
+++ b/utils/gen_profile_table.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from __future__ import print_function
+
 import os
 import sys
 

--- a/utils/gen_profile_table.py
+++ b/utils/gen_profile_table.py
@@ -17,7 +17,7 @@ class HtmlOutput(tables.table_renderer.TableHtmlOutput):
         profile_id = kwargs.pop("profile_id")
         super(HtmlOutput, self).__init__(* args, ** kwargs)
 
-        profile_path = str(self.built_content_path / "profiles" / (profile_id + ".profile"))
+        profile_path = os.path.join(self.built_content_path, "profiles", (profile_id + ".profile"))
         self.profile = ssg.build_yaml.Profile.from_yaml(profile_path, self.env_yaml)
         self.profile_variables = self.profile.variables
 

--- a/utils/render-rules.py
+++ b/utils/render-rules.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python3
 
+from __future__ import print_function
+
 from glob import glob
 import collections
 import os

--- a/utils/tables/table_renderer.py
+++ b/utils/tables/table_renderer.py
@@ -49,8 +49,8 @@ class TableHtmlOutput(template_renderer.Renderer):
     def __init__(self, * args, ** kwargs):
         super(TableHtmlOutput, self).__init__(* args, ** kwargs)
 
-        self.rules_root = str(self.built_content_path / "rules")
-        self.var_root = str(self.built_content_path / "values")
+        self.rules_root = os.path.join(self.built_content_path, "rules")
+        self.var_root = os.path.join(self.built_content_path, "values")
 
     def _get_var_value(self, varname):
         return self._get_var_value_from_default(varname)

--- a/utils/template_renderer.py
+++ b/utils/template_renderer.py
@@ -20,7 +20,7 @@ This is intended to be used when templates reference other templates.
 """
 class FlexibleLoader(ssg.jinja.AbsolutePathFileSystemLoader):
     def __init__(self, lookup_dirs=None, ** kwargs):
-        super().__init__(** kwargs)
+        super(FlexibleLoader, self).__init__(** kwargs)
         self.lookup_dirs = []
         if lookup_dirs:
             if isinstance(lookup_dirs, str):
@@ -39,7 +39,7 @@ class FlexibleLoader(ssg.jinja.AbsolutePathFileSystemLoader):
 
     def get_source(self, environment, template):
         template = self._find_absolute_path(template)
-        return super().get_source(environment, template)
+        return super(FlexibleLoader, self).get_source(environment, template)
 
 
 class Renderer(object):
@@ -104,8 +104,9 @@ class Renderer(object):
         if not args.output:
             print(result)
         else:
-            with open(args.output, "w") as outfile:
-                outfile.write(result)
+            with open(args.output, "wb") as outfile:
+                result_for_output = result.encode('utf8', 'replace')
+                outfile.write(result_for_output)
 
     @staticmethod
     def create_parser(description):


### PR DESCRIPTION
- Substitute the `pathlib` module usage with the legacy `os.path`.