### PR TITLE
SLE15 add sysctl_kernel_exec_shield to HIPAA profile5 

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -35,7 +35,7 @@
     - { path: /etc/grub2.cfg }
     - { path: /etc/default/grub }
   with_items: "{{ stat_results.results }}"
-  when: ( kexec_arch == "b64" ) and ( item.stat.exists == False )
+  when: ( kexec_arch == "b64" ) and ( not item.stat.exists )
   register: dropped_noexec_cfg
 
 - name: make grub config

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -1,4 +1,8 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
 
 # What architecture are we on?
 - name: Set architecture for kernel exec-shield tasks

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
-# reboot = false
+# reboot = true 
 # strategy = restrict
 # complexity = low
 # disruption = low

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -13,7 +13,7 @@
     reload: yes
   when: kexec_arch == "b32"
 
-- name: Ensure existing of grub config
+- name: Ensure existence of grub config
   stat:
     path: "{{ item.path }}"
   register: stat_results

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -1,0 +1,39 @@
+# platform = multi_platform_all
+
+# What architecture are we on?
+- name: Set architecture for kernel exec-shield tasks
+  set_fact:
+    kexec_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+
+- name: Ensure sysctl kernel.exec-shield is set to 1
+  sysctl:
+    name: "kernel.exec-shield"
+    value: "1"
+    state: present
+    reload: yes
+  when: kexec_arch == "b32"
+
+- name: Ensure existing of grub config
+  stat:
+    path: "{{ item.path }}"
+  register: stat_results
+  with_items:
+    - { path: /etc/grub2.cfg }
+    - { path: /etc/default/grub }
+  ignore_errors: True
+
+- name: Ensure noexec is not present in grub config files
+  replace:
+    path: "{{ item.item }}"
+    regexp: 'noexec.*'
+    replace: ''
+  with_items:
+    - { path: /etc/grub2.cfg }
+    - { path: /etc/default/grub }
+  with_items: "{{ stat_results.results }}"
+  when: ( kexec_arch == "b64" ) and ( item.stat.exists == False )
+  register: dropped_noexec_cfg
+
+- name: make grub config
+  command: "grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg"
+  when: dropped_noexec_cfg.changed

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
-# reboot = true 
+# reboot = true
 # strategy = restrict
 # complexity = low
 # disruption = low

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
-# reboot = false
+# reboot = true 
 # strategy = restrict
 # complexity = low
 # disruption = low

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
-# reboot = true 
+# reboot = true
 # strategy = restrict
 # complexity = low
 # disruption = low

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -1,5 +1,9 @@
-
 # platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
 if [ "$(getconf LONG_BIT)" = "32" ] ; then
   #
   # Set runtime for kernel.exec-shield

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/oval/shared.xml
@@ -44,7 +44,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_nx_disabled_grub" version="1">
-    <ind:filepath>/boot/grub2/grub.cfg</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">[\s]*noexec[\s]*=[\s]*off</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -5,10 +5,10 @@ prodtype: fedora,rhel7,rhel8,rhel9,rhv4,sle15
 title: 'Enable ExecShield via sysctl'
 
 description: |-
-    By default on Red Hat Enterprise Linux 7 64-bit systems, ExecShield is
+    By default on {{{ full_name }}} 64-bit systems, ExecShield is
     enabled and can only be disabled if the hardware does not support
-    ExecShield or is disabled in <tt>/etc/default/grub</tt>. For Red Hat
-    Enterprise Linux 7 32-bit systems, <tt>sysctl</tt> can be used to enable
+    ExecShield or is disabled in <tt>/etc/default/grub</tt>. For
+    {{{ full_name }}}  32-bit systems, <tt>sysctl</tt> can be used to enable
     ExecShield.
 
 rationale: |-
@@ -47,7 +47,7 @@ references:
 ocil_clause: 'ExecShield is not supported by the hardware, is not enabled, or has been disabled by the kernel configuration.'
 
 ocil: |-
-    To verify ExecShield is enabled on 64-bit Red Hat Enterprise Linux 7 systems,
+    To verify ExecShield is enabled on 64-bit {{{ full_name }}} systems,
     run the following command:
     <pre>$ dmesg | grep '[NX|DX]*protection'</pre>
     The output should not contain <tt>'disabled by kernel command line option'</tt>.
@@ -55,7 +55,7 @@ ocil: |-
     run the following command:
     <pre>$ sudo grep noexec {{{ grub2_boot_path }}}/grub.cfg</pre>
     The output should not return <tt>noexec=off</tt>.
-    For 32-bit Red Hat Enterprise Linux 7 systems, run the following command:
+    For 32-bit {{{ full_name }}} systems, run the following command:
     <pre>$ sysctl kernel.exec-shield</pre>
     The output should be:
     {{{ describe_sysctl_option_value(sysctl="kernel.exec-shield", value="1") }}}

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,rhv4
+prodtype: fedora,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Enable ExecShield via sysctl'
 
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel7: CCE-27211-2
     cce@rhel8: CCE-80914-5
     cce@rhel9: CCE-83970-4
+    cce@sle15: CCE-91417-6
 
 references:
     anssi: BP28(R9)

--- a/products/sle15/profiles/hipaa.profile
+++ b/products/sle15/profiles/hipaa.profile
@@ -57,6 +57,7 @@ selections:
     - selinux_state
     - service_kdump_disabled
     - sysctl_fs_suid_dumpable
+    - sysctl_kernel_exec_shield
     - sysctl_kernel_dmesg_restrict
     - sysctl_kernel_randomize_va_space
     - rpm_verify_hashes


### PR DESCRIPTION
#### Description:

- Add sysctl_kernel_exec_shield to HIPAA profile

#### Rationale:

- Add sysctl_kernel_exec_shield rule to SLE15 HIPAA profile
- Add ansible remediation for the rule
- Use template variable for grub config path to improve portability of the OVAL rule

