### PR TITLE
Fix remediation for accounts_umask_interactive_users

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -8,5 +8,7 @@
   ansible.builtin.shell:
     cmd: |
       for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
-        sed -i 's/^\([\s]*umask\s*\)/#\1/g' $dir/.[^\.]?*
+        for file in $(find $dir -maxdepth 1 -type f -name ".*"); do
+          sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+        done
       done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -5,5 +5,7 @@
 # disruption = low
 
 for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
-    sed -i 's/^\([\s]*umask\s*\)/#\1/g' $dir/.[^\.]?*
+    for file in $(find $dir -maxdepth 1 -type f -name ".*"); do
+        sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+    done
 done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/hidden_folder_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/hidden_folder_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+mkdir /home/$USER/.hiddenfolder


### PR DESCRIPTION
Included logic to ensure `sed` command considers only hidden files,
ignoring possible hidden folders.

- Fixes #7893