### PR TITLE
Drop RHEL9 OSPP rule for chrony network management

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -72,7 +72,6 @@ selections:
 
     # Time Server
     - chronyd_client_only
-    - chronyd_no_chronyc_network
 
     ### Network Settings
     - sysctl_net_ipv6_conf_all_accept_ra


### PR DESCRIPTION
#### Description:
- Remove RHEL9 OSPP rule that set chrony network management port to 0

#### Rationale:

- By default chronyd listens on port 323 only on localhost and it is the way to run unauthenticated monitoring commands, for example chronyc sources.