### PR TITLE
Add a split option to `utils/build_stig_control.py`

### DIFF
--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -44,19 +44,23 @@ profile pointed by the `--profile1` option.
 If you want a control file for product from DISA's XCCDF files you can run the following command:
 It supports the following arguments:
 
-- `-r`, `--root` - Path to SSG root directory
-- `-o`, `--output` - File to write yaml output to. The name of this file will the name of the directory the files are placed in with `--split`. Must only contain lowercase letters, underscores, and numbers.
-  - Defaults to `build/stig_control.yml`
-- `-p`, `--product` - What product to produce the tailoring file for (required)
-- `-m`, `--manual` - Path to the XCCDF XML file of the SCAP content (required)
-- `-j`, `--json` - Path to the `rules_dir.json ` file.
-  - Defaults to `build/stig_control.json`
-- `-c`, `--build-config-yaml` - YAML file with information about the build configuration.
-  - Defaults to `build/build_config.yml`
-- `-ref`, `--reference` - Reference system to check for
-  - Defaults to `stigid`
-- `-s`, `--spilt` - Splits the each ID into its own file. Files are output in directory with the same name as the YAML file.
-  - Default path for files `build/stig_control`
+```
+options:
+  -h, --help            show this help message and exit
+  -r ROOT, --root ROOT  Path to SSG root directory (defaults to the root of the repository)
+  -o OUTPUT, --output OUTPUT
+                        File to write yaml output to (defaults to build/stig_control.yml)
+  -p PRODUCT, --product PRODUCT
+                        What product to get STIGs for
+  -m MANUAL, --manual MANUAL
+                        Path to XML XCCDF manual file to use as the source of the STIGs
+  -j JSON, --json JSON  Path to the rules_dir.json (defaults to build/rule_dirs.json)
+  -c BUILD_CONFIG_YAML, --build-config-yaml BUILD_CONFIG_YAML
+                        YAML file with information about the build configuration.
+  -ref REFERENCE, --reference REFERENCE
+                        Reference system to check for, defaults to stigid
+  -s, --split           Splits the each ID into its own file.
+```
 
 Example
 

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -55,6 +55,8 @@ It supports the following arguments:
   - Defaults to `build/build_config.yml`
 - `-ref`, `--reference` - Reference system to check for
   - Defaults to `stigid`
+- `-s`, `--spilt` - Splits the each ID into its own file. Files are output in directory with the same name as the YAML file.
+  - Default path for files `build/stig_control`
 
 Example
 

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -42,11 +42,24 @@ profile pointed by the `--profile1` option.
 
 ## Generating Controls from DISA's XCCDF Files
 If you want a control file for product from DISA's XCCDF files you can run the following command:
+It supports the following arguments:
+
+- `-r`, `--root` - Path to SSG root directory
+- `-o`, `--output` - File to write yaml output to. The name of this file will the name of the directory the files are placed in with `--split`. Must only contain lowercase letters, underscores, and numbers.
+  - Defaults to `build/stig_control.yml`
+- `-p`, `--product` - What product to produce the tailoring file for (required)
+- `-m`, `--manual` - Path to the XCCDF XML file of the SCAP content (required)
+- `-j`, `--json` - Path to the `rules_dir.json ` file.
+  - Defaults to `build/stig_control.json`
+- `-c`, `--build-config-yaml` - YAML file with information about the build configuration.
+  - Defaults to `build/build_config.yml`
+- `-ref`, `--reference` - Reference system to check for
+  - Defaults to `stigid`
+
+Example
 
     $ ./utils/build_stig_control.py -p rhel8 -m shared/references/disa-stig-rhel8-v1r3-xccdf-manual.xml
 
-Where `-p` is the id the comes after `stigid@` in the `references` section of a rule and `-m` is the path to the
-XCCDF Manual file from DISA.
 
 ## Generating login banner regular expressions
 

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -26,7 +26,8 @@ BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")
 def check_output(output: str) -> None:
     pat = re.compile(r'.*\/?[a-z_0-9]+\.yml')
     if not pat.match(output):
-        sys.stderr.write('Output must only contain lowercase letters, underscores, and numbers.\n')
+        sys.stderr.write('Output must only contain lowercase letters, underscores, and numbers.'
+                         ' The file must also end with .yml\n')
         exit(1)
 
 
@@ -35,7 +36,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("-r", "--root", type=str, action="store", default=SSG_ROOT,
                         help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
     parser.add_argument("-o", "--output", type=str, action="store", default=BUILD_OUTPUT,
-                        help=f"File to write yaml output to (defaults to {BUILD_OUTPUT})")
+                        help=f"File to write yaml output to (defaults to {BUILD_OUTPUT}). "
+                             f"Must end in '.yml' and only contain "
+                             f"lowercase letters, underscores, and numbers.")
     parser.add_argument("-p", "--product", type=str, action="store", required=True,
                         help="What product to get STIGs for")
     parser.add_argument("-m", "--manual", type=str, action="store", required=True,
@@ -43,7 +46,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("-j", "--json", type=str, action="store", default=RULES_JSON,
                         help=f"Path to the rules_dir.json (defaults to {RULES_JSON})")
     parser.add_argument("-c", "--build-config-yaml", default=BUILD_CONFIG,
-                        help="YAML file with information about the build configuration. ")
+                        help="YAML file with information about the build configuration")
     parser.add_argument("-ref", "--reference", type=str, default="stigid",
                         help="Reference system to check for, defaults to stigid")
     parser.add_argument('-s', '--split', action='store_true',
@@ -158,6 +161,7 @@ def main():
     if args.split:
         with open(args.output, 'w') as f:
             f.write(yaml.dump(output, sort_keys=False))
+        print(f'Wrote main control file to {args.output}')
         output_path = Path(args.output)
         output_dir_name = output_path.stem
         output_root = output_path.parent
@@ -171,7 +175,6 @@ def main():
             output_filename = os.path.join(output_dir, filename)
             with open(output_filename, 'w') as f:
                 f.write(yaml.dump(out, sort_keys=False))
-        print(f'Wrote main control file to {args.output}')
         print(f'Wrote SRG files to {output_dir}')
         exit(0)
     else:

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -27,13 +27,13 @@ def parse_args():
     parser.add_argument("-r", "--root", type=str, action="store", default=SSG_ROOT,
                         help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
     parser.add_argument("-o", "--output", type=str, action="store", default=BUILD_OUTPUT,
-                        help="File to write yaml output to (defaults to build/stig_control.yml)")
+                        help=f"File to write yaml output to (defaults to {BUILD_OUTPUT})")
     parser.add_argument("-p", "--product", type=str, action="store", required=True,
                         help="What product to get STIGs for")
     parser.add_argument("-m", "--manual", type=str, action="store", required=True,
                         help="Path to XML XCCDF manual file to use as the source of the STIGs")
     parser.add_argument("-j", "--json", type=str, action="store", default=RULES_JSON,
-                        help="Path to the rules_dir.json (defaults to build/stig_control.json)")
+                        help=f"Path to the rules_dir.json (defaults to {RULES_JSON})")
     parser.add_argument("-c", "--build-config-yaml", default=BUILD_CONFIG,
                         help="YAML file with information about the build configuration. ")
     parser.add_argument("-ref", "--reference", type=str, default="stigid",

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -5,8 +5,9 @@ from __future__ import print_function
 import argparse
 import json
 import os
+import re
+from pathlib import Path
 import sys
-
 import xml.etree.ElementTree as ET
 import yaml
 
@@ -22,7 +23,14 @@ RULES_JSON = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
 BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")
 
 
-def parse_args():
+def check_output(output: str) -> None:
+    pat = re.compile(r'.*\/?[a-z_0-9]+\.yml')
+    if not pat.match(output):
+        sys.stderr.write('Output must only contain lowercase letters, underscores, and numbers.\n')
+        exit(1)
+
+
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument("-r", "--root", type=str, action="store", default=SSG_ROOT,
                         help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
@@ -38,8 +46,12 @@ def parse_args():
                         help="YAML file with information about the build configuration. ")
     parser.add_argument("-ref", "--reference", type=str, default="stigid",
                         help="Reference system to check for, defaults to stigid")
+    parser.add_argument('-s', '--split', action='store_true',
+                        help='Splits the each ID into its own file.')
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    check_output(args.output)
+    return args
 
 
 def handle_rule_yaml(args, rule_id, rule_dir, guide_dir, env_yaml):
@@ -141,9 +153,32 @@ def main():
     output['levels'] = list()
     for level in ['high', 'medium', 'low']:
         output['levels'].append({'id': level})
-    output['controls'] = get_controls(known_rules, ns, root)
-    with open(args.output, 'w') as f:
-        f.write(yaml.dump(output, sort_keys=False))
+    controls = get_controls(known_rules, ns, root)
+
+    if args.split:
+        with open(args.output, 'w') as f:
+            f.write(yaml.dump(output, sort_keys=False))
+        output_path = Path(args.output)
+        output_dir_name = output_path.stem
+        output_root = output_path.parent
+        output_dir = os.path.join(output_root, output_dir_name)
+        if not os.path.exists(output_dir):
+            os.mkdir(output_dir)
+        for control in controls:
+            out = dict()
+            out['controls'] = control
+            filename = f"{control['id']}.yml"
+            output_filename = os.path.join(output_dir, filename)
+            with open(output_filename, 'w') as f:
+                f.write(yaml.dump(out, sort_keys=False))
+        print(f'Wrote main control file to {args.output}')
+        print(f'Wrote SRG files to {output_dir}')
+        exit(0)
+    else:
+        output['controls'] = controls
+        with open(args.output, 'w') as f:
+            f.write(yaml.dump(output, sort_keys=False))
+        print(f'Wrote all SRGs out to {args.output}')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Description:

Adds `--split` to `utils/build_stig_control.py` to split control created by the script.

#### Rationale:

Allow for smaller files for easier collaboration. 