### PR TITLE
remove ABRT related rules from RHEL9

### DIFF
--- a/linux_os/guide/services/base/package_abrt_removed/rule.yml
+++ b/linux_os/guide/services/base/package_abrt_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall Automatic Bug Reporting Tool (abrt)'
 

--- a/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
+++ b/linux_os/guide/services/base/service_abrtd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9
+prodtype: ol7,ol8,rhel7,rhel8
 
 title: 'Disable Automatic Bug Reporting Tool (abrtd)'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: rhel7,rhel8,rhv4
 
 title: 'Disable the abrt_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_handle_event/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_handle_event/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: rhel7,rhel8,rhv4
 
 title: 'Disable the abrt_handle_event SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_upload_watch_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_upload_watch_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: rhel7,rhel8,rhv4
 
 title: 'Disable the abrt_upload_watch_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-ccpp_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-ccpp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall abrt-addon-ccpp Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall abrt-addon-kerneloops Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-cli_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-cli_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall abrt-cli Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall abrt-plugin-logger Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall abrt-plugin-rhtsupport Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall abrt-plugin-sosreport Package'
 

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -199,13 +199,6 @@ selections:
     - package_gssproxy_removed
     - package_nfs-utils_removed
     - package_krb5-workstation_removed
-    - package_abrt-addon-kerneloops_removed
-    - package_abrt-addon-ccpp_removed
-    - package_abrt-plugin-rhtsupport_removed
-    - package_abrt-plugin-logger_removed
-    - package_abrt-plugin-sosreport_removed
-    - package_abrt-cli_removed
-    - package_abrt_removed
 
     ### Login
     - disable_users_coredumps

--- a/products/rhel9/profiles/rht-ccp.profile
+++ b/products/rhel9/profiles/rht-ccp.profile
@@ -82,7 +82,6 @@ selections:
     - service_firewalld_enabled
     - set_firewalld_default_zone
     - firewalld_sshd_port_enabled
-    - service_abrtd_disabled
     - service_telnet_disabled
     - package_telnet-server_removed
     - package_telnet_removed

--- a/products/rhel9/profiles/standard.profile
+++ b/products/rhel9/profiles/standard.profile
@@ -52,7 +52,6 @@ selections:
     - audit_rules_file_deletion_events
     - audit_rules_sysadmin_actions
     - audit_rules_kernel_module_loading
-    - service_abrtd_disabled
     - service_atd_disabled
     - service_autofs_disabled
     - service_ntpdate_disabled

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -827,15 +827,6 @@ selections:
     # RHEL-08-040000
     - package_telnet-server_removed
 
-    # RHEL-08-040001
-    - package_abrt_removed
-    - package_abrt-addon-ccpp_removed
-    - package_abrt-addon-kerneloops_removed
-    - package_abrt-cli_removed
-    - package_abrt-plugin-logger_removed
-    - package_abrt-plugin-rhtsupport_removed
-    - package_abrt-plugin-sosreport_removed
-
     # RHEL-08-040002
     - package_sendmail_removed
 


### PR DESCRIPTION
#### Description:

- remove abrt-related rules from RHEL9 profiles
- remove rhel9 prodtype from these rules as well

#### Rationale:

ABRT is not present in RHEL9.