### PR TITLE
add hint about audit backlog configuration

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -59,6 +59,16 @@ ocil: |-
     The output has to be exactly as follows:
     <pre>{{{ file_contents_audit_base_config|indent }}}    </pre>
 
+warnings:
+    - performance:
+        It might happen that Audit buffer configured by this rule is not large
+        enough for certain use cases. If that is the case, the buffer size can
+        be overridden by placing <pre>-b larger_buffer_size</pre> into a file
+        within <tt>/etc/audit/rules.d</tt> directory, replacing
+        <tt>larger_file_size</tt> with the desired value. The file name should
+        start with a number higher than 10 and lower than 99.
+
+
 template:
     name: audit_file_contents
     vars:


### PR DESCRIPTION
#### Description:

- add warning (performance) section to the audit_basic_configuration rule

#### Rationale:

- it tries to document a case when the hardcoded backlog size is not large enough and an user wants to override it.