### PR TITLE
Update `chronyd_or_ntpd_set_maxpoll` to add maxpoll option to chrony pool directives

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -27,7 +27,7 @@
 - name: Update the maxpoll values in /etc/chrony.conf
   lineinfile:
     path: /etc/chrony.conf
-    regex: '^(server.*maxpoll) [0-9]+(\s+.*)$'
+    regex: '^((?:server|pool).*maxpoll) [0-9]+(\s+.*)$'
     line: '\1 {{ var_time_service_set_maxpoll }}\2'
     backrefs: yes
   when: chrony_conf_exist_result.stat.exists
@@ -43,7 +43,7 @@
 - name: Set the maxpoll values in /etc/chrony.conf
   lineinfile:
     path: /etc/chrony.conf
-    regex: '(^server\s+((?!maxpoll).)*)$'
+    regex: '(^(?:server|pool)\s+((?!maxpoll).)*)$'
     line: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
     backrefs: yes
   when: chrony_conf_exist_result.stat.exists

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -8,9 +8,9 @@ config_file="/etc/ntp.conf"
 
 
 # Set maxpoll values to var_time_service_set_maxpoll
-sed -i "s/^\(server.*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \2/" "$config_file"
+sed -i "s/^\(\(server\|pool\).*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \3/" "$config_file"
 
-# Add maxpoll to server entries without maxpoll
-grep "^server" "$config_file" | grep -v maxpoll | while read -r line ; do
+# Add maxpoll to server or pool entries without maxpoll
+grep "^\(server\|pool\)" "$config_file" | grep -v maxpoll | while read -r line ; do
         sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
 done

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -38,7 +38,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_chrony_set_maxpoll" version="1">
     <ind:filepath operation="pattern match">^/etc/chrony\.(conf|d/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^server[\s]+[\S]+.*maxpoll[\s]+(\d+)</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:server|pool)[\s]+[\S]+.*maxpoll[\s]+(\d+)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -69,7 +69,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_chrony_all_server_has_maxpoll" version="1">
     <ind:filepath operation="pattern match">^/etc/chrony\.(conf|d/.+\.conf)$</ind:filepath>
-    <ind:pattern operation="pattern match">^server[\s]+[\S]+[\s]+(.*)</ind:pattern>
+    <ind:pattern operation="pattern match">^(?:server|pool)[\s]+[\S]+[\s]+(.*)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -11,6 +11,8 @@ description: |-
     <tt>maxpoll</tt> in <tt>/etc/ntp.conf</tt> or <tt>/etc/chrony.conf</tt>
     add the following:
     <pre>maxpoll {{{ xccdf_value("var_time_service_set_maxpoll") }}}</pre>
+    to <pre>server</pre> direstives. If using chrony any <pre>pool</pre> directives
+    should be configured too.
     {{% if product == "rhcos4" %}}
     <p>
     Note that if the remediation shipping with this content is being used, the

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
@@ -5,6 +5,9 @@
 
 yum remove -y ntp
 
+# Remove all pool options
+sed -i "/^pool.*/d" /etc/chrony.conf
+
 if ! grep "^server" /etc/chrony.conf ; then
     echo "server foo.example.net iburst maxpoll 10" >> /etc/chrony.conf
 elif ! grep "^server.*maxpoll 10" /etc/chrony.conf; then

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_configured.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_configured.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = chrony
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+yum remove -y ntp
+
+# Remove all server or pool options
+sed -i "/^\(server\|pool\).*/d" /etc/chrony.conf
+
+echo "pool pool.ntp.org iburst maxpoll 16" >> /etc/chrony.conf
+
+systemctl enable chronyd.service
+

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_misconfigured.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = chrony
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+yum remove -y ntp
+
+# Remove all server or pool options
+sed -i "/^\(server\|pool\).*/d" /etc/chrony.conf
+
+echo "pool pool.ntp.org iburst maxpoll 18" >> /etc/chrony.conf
+
+systemctl enable chronyd.service
+

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_missing_parameter.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_missing_parameter.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = chrony
+#
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+yum remove -y ntp
+
+# Remove all server options
+sed -i "/^\(server\|pool\).*/d" /etc/chrony.conf
+
+echo "pool pool.ntp.org iburst" >> /etc/chrony.conf
+
+systemctl enable chronyd.service
+

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_server_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_server_misconfigured.fail.sh
@@ -5,6 +5,9 @@
 
 yum remove -y ntp
 
+# Remove all pool options
+sed -i "/^pool.*/d" /etc/chrony.conf
+
 if ! grep "^server.*maxpoll 10" /etc/chrony.conf; then
     sed -i "s/^server.*/& maxpoll 10/" /etc/chrony.conf
 fi


### PR DESCRIPTION
#### Description:

- This updates the rule to recognize and remediate `pool` directives with the appropriate `maxpoll` value.
- Enable and apply the same changes to Ansible remediation.

#### Rationale:

- The same option that apply to 'server' directive also applies to 'pool' directive.
  - https://chrony.tuxfamily.org/doc/3.4/chrony.conf.html#pool
- RHEL-8 chrony configuration defaults to using `pool`:
  - e.g.: `pool 2.rhel.pool.ntp.org iburst`