### PR TITLE
Add pam pwhistory remember rules to OL7 stig

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/bash/shared.sh
@@ -16,7 +16,7 @@ if grep -q "^password.*pam_pwhistory.so.*" $pamFile; then
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $pamFile)
 	if [[ -z $option ]]; then
 		# option is not set, append to module
-		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$var_password_pam_remember/"
+		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$var_password_pam_remember/" $pamFile
 	else
 		# option is set, replace value
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$var_password_pam_remember\3/" $pamFile
@@ -30,4 +30,3 @@ else
 	# no 'password required|requisite pam_pwhistory.so', add it
 	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $CONTROL pam_pwhistory.so use_authtok remember=$var_password_pam_remember" $pamFile
 fi
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/bash/shared.sh
@@ -16,7 +16,7 @@ if grep -q "^password.*pam_pwhistory.so.*" $pamFile; then
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $pamFile)
 	if [[ -z $option ]]; then
 		# option is not set, append to module
-		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$var_password_pam_remember/"
+		sed -i --follow-symlinks "/pam_pwhistory.so/ s/$/ remember=$var_password_pam_remember/" $pamFile
 	else
 		# option is set, replace value
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$var_password_pam_remember\3/" $pamFile
@@ -30,4 +30,3 @@ else
 	# no 'password required|requisite pam_pwhistory.so', add it
 	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $CONTROL pam_pwhistory.so use_authtok remember=$var_password_pam_remember" $pamFile
 fi
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -54,7 +54,6 @@ references:
     nist@sle15: IA-5(1)(e),IA-5(1).1(v)
     pcidss: Req-8.2.5
     srg: SRG-OS-000077-GPOS-00045
-    stigid@ol7: OL07-00-010270
     stigid@rhel7: RHEL-07-010270
     stigid@sle15: SLES-15-020250
     stigid@ubuntu2004: UBTU-20-010070

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -21,7 +21,6 @@ selections:
     - var_accounts_passwords_pam_faillock_unlock_time=never
     - var_accounts_passwords_pam_faillock_fail_interval=900
     - var_accounts_passwords_pam_faillock_deny=3
-    - var_password_pam_unix_remember=5
     - var_password_pam_maxclassrepeat=4
     - var_password_pam_difok=8
     - var_password_pam_dcredit=1
@@ -37,6 +36,8 @@ selections:
     - var_password_pam_retry=3
     - var_accounts_max_concurrent_login_sessions=10
     - var_accounts_tmout=15_min
+    - var_password_pam_remember=5
+    - var_password_pam_remember_control_flag=required
     - var_time_service_set_maxpoll=system_default
     - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
     - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
@@ -73,7 +74,6 @@ selections:
     - accounts_password_set_min_life_existing
     - accounts_maximum_age_login_defs
     - accounts_password_set_max_life_existing
-    - accounts_password_pam_unix_remember
     - accounts_password_pam_minlen
     - no_empty_passwords
     - sshd_disable_empty_passwords
@@ -310,3 +310,5 @@ selections:
     - accounts_authorized_local_users
     - grub2_password_legacy
     - grub2_uefi_password_legacy
+    - accounts_password_pam_pwhistory_remember_password_auth
+    - accounts_password_pam_pwhistory_remember_system_auth


### PR DESCRIPTION
#### Description:

- Remove `accounts_password_pam_unix_remember` from OL7 stig profile. Also remove the OL7 STIG ID from this rule.

- Add `accounts_password_pam_pwhistory_remember_system_auth` and `accounts_password_pam_pwhistory_remember_password_auth` to OL7 stig profile.

- Also fix bash remediation for the two above mentioned rules; A `sed` command was missing the input file.

#### Rationale:

- This is an effort to align OL7 stig profile with the OL7 DISA STIG.
- Bugfix for `accounts_password_pam_pwhistory_` rules' remediations
