### PR TITLE
implement parsing of logical expressions in platform definitions

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -70,8 +70,7 @@ rationale: |-
 severity: medium
 
 platforms:
-    - ntp
-    - chrony
+    - ntp or chrony
 
 identifiers:
     cce@rhcos4: CCE-82684-2

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -86,7 +86,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+platform: machine and (chrony or ntp)  # The check uses service_... extended definition, which doesnt support offline mode
 
 identifiers:
     cce@rhcos4: CCE-82683-4

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -179,11 +179,10 @@ class CPEALPlatformSpecification(object):
         self.platforms = []
         self.cpe_products = cpe_products
 
-
     def parse_platform(self, expression):
         """
-        parses the expression and returns a CPEALPlatform instance
-        It either creates a new one or if equal instance already exists, it returns the existing one.
+        parses the expression and returns a CPEALPlatform instance It either creates a
+        new one or if equal instance already exists, it returns the existing one.
         """
         platform = CPEALPlatform(expression, self.algebra, self.cpe_products)
         if platform not in self.platforms:
@@ -245,6 +244,7 @@ class CPEALPlatform(object):
         else:
             return self.test == other.test
 
+
 class CPEALLogicalTest(Function):
 
     prefix = "cpe-lang"
@@ -277,7 +277,7 @@ class CPEALFactRef (Symbol):
 
     def __init__(self, obj):
         super(CPEALFactRef, self).__init__(obj)
-        self.cpe_name = "" # we do not want to modify original name used for platforms
+        self.cpe_name = ""  # we do not want to modify original name used for platforms
 
     def to_xml_element(self):
         cpe_factref = ET.Element("{%s}fact-ref" % CPEALFactRef.ns)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -12,11 +12,10 @@ from .constants import PREFIX_TO_NS
 from .utils import merge_dicts, required_key
 from .xml import ElementTree as ET
 from .yaml import open_raw
-
+from .boolean_expression import Algebra, Symbol, Function
 
 class CPEDoesNotExist(Exception):
     pass
-
 
 class ProductCPEs(object):
     """
@@ -31,10 +30,10 @@ class ProductCPEs(object):
         self.cpes_by_name = {}
         self.product_cpes = {}
         self.cpe_platforms = {}
-        self.cpe_platform_specification = CPEALPlatformSpecification()
 
         self.load_product_cpes()
         self.load_content_cpes()
+        self.cpe_platform_specification = CPEALPlatformSpecification(self)
 
     def _load_cpes_list(self, map_, cpes_list):
         for cpe in cpes_list:
@@ -175,15 +174,25 @@ class CPEALPlatformSpecification(object):
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
 
-    def __init__(self):
+    def __init__(self, cpe_products):
+        self.algebra = Algebra(symbol_cls=CPEALFactRef, function_cls=CPEALLogicalTest)
         self.platforms = []
+        self.cpe_products = cpe_products
 
-    def add_platform(self, platform):
+
+    def parse_platform(self, expression):
         """
-        we check if semantically equal platform is not already in the list of platforms
+        parses the expression and returns a CPEALPlatform instance
+        It either creates a new one or if equal instance already exists, it returns the existing one.
         """
+        platform = CPEALPlatform(expression, self.algebra, self.cpe_products)
         if platform not in self.platforms:
             self.platforms.append(platform)
+            return platform
+        else:
+            platform_idx = self.platforms.index(platform)
+            return self.platforms[platform_idx]
+
 
     def to_xml_element(self):
         cpe_platform_spec = ET.Element(
@@ -198,9 +207,18 @@ class CPEALPlatform(object):
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
 
-    def __init__(self, id):
-        self.id = id
-        self.test = None
+    def __init__(self, expression, algebra, cpe_products):
+        self.test = algebra.parse(expression, simplify=True)
+        self.id = "cpe_platform_" + self.test.as_id()
+        self.cpe_products = cpe_products
+        self._replace_cpe_names(self.test)
+
+    def _replace_cpe_names(self, exp):
+        if isinstance(exp, CPEALFactRef):
+            exp.cpe_name = self.cpe_products.get_cpe_name(str(exp.obj))
+        else:
+            for arg in exp.args:
+                self._replace_cpe_names(arg)
 
     def add_test(self, test):
         self.test = test
@@ -208,7 +226,16 @@ class CPEALPlatform(object):
     def to_xml_element(self):
         cpe_platform = ET.Element("{%s}platform" % CPEALPlatform.ns)
         cpe_platform.set('id', self.id)
-        cpe_platform.append(self.test.to_xml_element())
+        # in case the platform contains only single CPE name, fake the logical test
+        # we have to athere to CPE specification
+        if isinstance(self.test, CPEALFactRef):
+            cpe_test = ET.Element("{%s}logical-test" % CPEALLogicalTest.ns)
+            cpe_test.set('operator', 'AND')
+            cpe_test.set('negate', 'false')
+            cpe_test.append(self.test.to_xml_element())
+            cpe_platform.append(cpe_test)
+        else:
+            cpe_platform.append(self.test.to_xml_element())
         return cpe_platform
 
 
@@ -218,36 +245,19 @@ class CPEALPlatform(object):
         else:
             return self.test == other.test
 
-
-class CPEALLogicalTest(object):
+class CPEALLogicalTest(Function):
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
 
-    def __init__(self, operator, negate):
-        self.operator = operator
-        self.negate = negate
-        self.objects = []
-
-    def __eq__(self, other):
-        if not isinstance(other, CPEALLogicalTest):
-            return False
-        else:
-            if self.operator == other.operator and self.negate == other.negate:
-                diff = [
-                    i for i in self.objects + other.objects
-                    if i not in self.objects or i not in other.objects]
-                return (not diff)
-            else:
-                return False
 
     def to_xml_element(self):
         cpe_test = ET.Element("{%s}logical-test" % CPEALLogicalTest.ns)
-        cpe_test.set('operator', self.operator)
-        cpe_test.set('negate', self.negate)
-        # logical tests must go first, therefore we spearate tests and factrefs
-        tests = [t for t in self.objects if isinstance(t, CPEALLogicalTest)]
-        factrefs = [f for f in self.objects if isinstance(f, CPEALFactRef)]
+        cpe_test.set('operator', ('OR' if self.is_or() else 'AND'))
+        cpe_test.set('negate', ('true' if self.is_not() else 'false'))
+        # logical tests must go first, therefore we separate tests and factrefs
+        tests = [t for t in self.args if isinstance(t, CPEALLogicalTest)]
+        factrefs = [f for f in self.args if isinstance(f, CPEALFactRef)]
         for obj in tests + factrefs:
             cpe_test.append(obj.to_xml_element())
 
@@ -260,23 +270,18 @@ class CPEALLogicalTest(object):
         return self.objects
 
 
-class CPEALFactRef (object):
+class CPEALFactRef (Symbol):
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
 
-    def __init__(self, name):
-        self.name = name
-
-    def __eq__(self, other):
-        if not isinstance(other, CPEALFactRef):
-            return False
-        else:
-            return self.name == other.name
+    def __init__(self, obj):
+        super(CPEALFactRef, self).__init__(obj)
+        self.cpe_name = "" # we do not want to modify original name used for platforms
 
     def to_xml_element(self):
         cpe_factref = ET.Element("{%s}fact-ref" % CPEALFactRef.ns)
-        cpe_factref.set('name', self.name)
+        cpe_factref.set('name', self.cpe_name)
 
         return cpe_factref
 
@@ -357,32 +362,3 @@ def extract_referred_nodes(tree_with_refs, tree_with_ids, attrname):
             elementlist.append(element)
 
     return elementlist
-
-def parse_platform_line(platform_line, product_cpe):
-    # remove spaces
-    platform_line = platform_line.replace(" ", "")
-    if "&" in platform_line:
-        raise (NotImplementedError("not implemented yet"))
-    elif "!" in platform_line:
-        raise (NotImplementedError("not implemented yet"))
-    else:
-        # the line should contain a CPEAL ref name
-        cpealfactref = CPEALFactRef(product_cpe.get_cpe_name(platform_line))
-        return cpealfactref
-
-def convert_platform_to_id(platform):
-    id = platform.replace(" ", "")
-    return id
-
-def parse_platform_definition(platform_line, product_cpes):
-    """
-    This function takes one line of platform definition from yaml file and returns a
-    CPE platform with appropriate tests and factrefs.
-    """
-    # let's construct the platform id
-    id = "cpe_platform_" + convert_platform_to_id(platform_line)
-    platform = CPEALPlatform(id)
-    initial_test = CPEALLogicalTest(operator="OR", negate="false")
-    platform.add_test(initial_test)
-    initial_test.add_object(parse_platform_line(platform_line, product_cpes))
-    return platform

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -14,7 +14,7 @@ import glob
 
 import yaml
 
-from .build_cpe import CPEDoesNotExist, parse_platform_definition
+from .build_cpe import CPEDoesNotExist, CPEALPlatform
 from .constants import (XCCDF_REFINABLE_PROPERTIES,
                         SCE_SYSTEM,
                         cce_uri,
@@ -1046,10 +1046,8 @@ class Group(XCCDFEntity):
         # parse platform definition and get CPEAL platform
         if data["platforms"]:
             for platform in data["platforms"]:
-                cpe_platform = parse_platform_definition(platform, env_yaml["product_cpes"])
+                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
                 data["cpe_platform_names"].add(cpe_platform.id)
-                # add platform to platform specification
-                env_yaml["product_cpes"].cpe_platform_specification.add_platform(cpe_platform)
         return data
 
     def load_entities(self, rules_by_id, values_by_id, groups_by_id):
@@ -1193,11 +1191,8 @@ class Group(XCCDFEntity):
         # Once the group has inherited properties, update cpe_names
         if env_yaml:
             for platform in group.platforms:
-                cpe_platform = parse_platform_definition(
-                    platform, env_yaml["product_cpes"])
+                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
                 group.cpe_platform_names.add(cpe_platform.id)
-                env_yaml["product_cpes"].cpe_platform_specification.add_platform(
-                    cpe_platform)
 
     def _pass_our_properties_on_to(self, obj):
         for attr in self.ATTRIBUTES_TO_PASS_ON:
@@ -1215,11 +1210,8 @@ class Group(XCCDFEntity):
         # Once the rule has inherited properties, update cpe_platform_names
         if env_yaml:
             for platform in rule.platforms:
-                cpe_platform = parse_platform_definition(
-                    platform, env_yaml["product_cpes"])
+                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
-                env_yaml["product_cpes"].cpe_platform_specification.add_platform(
-                    cpe_platform)
 
     def __str__(self):
         return self.id_
@@ -1318,12 +1310,8 @@ class Rule(XCCDFEntity):
                 or env_yaml and rule.prodtype == "all"):
             # parse platform definition and get CPEAL platform
             for platform in rule.platforms:
-                cpe_platform = parse_platform_definition(
-                    platform, env_yaml["product_cpes"])
+                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
-                # add platform to platform specification
-                env_yaml["product_cpes"].cpe_platform_specification.add_platform(
-                    cpe_platform)
 
 
         if sce_metadata and rule.id_ in sce_metadata:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1046,7 +1046,8 @@ class Group(XCCDFEntity):
         # parse platform definition and get CPEAL platform
         if data["platforms"]:
             for platform in data["platforms"]:
-                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
+                cpe_platform = env_yaml[
+                    "product_cpes"].cpe_platform_specification.parse_platform(platform)
                 data["cpe_platform_names"].add(cpe_platform.id)
         return data
 
@@ -1191,7 +1192,8 @@ class Group(XCCDFEntity):
         # Once the group has inherited properties, update cpe_names
         if env_yaml:
             for platform in group.platforms:
-                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
+                cpe_platform = env_yaml[
+                    "product_cpes"].cpe_platform_specification.parse_platform(platform)
                 group.cpe_platform_names.add(cpe_platform.id)
 
     def _pass_our_properties_on_to(self, obj):
@@ -1210,7 +1212,8 @@ class Group(XCCDFEntity):
         # Once the rule has inherited properties, update cpe_platform_names
         if env_yaml:
             for platform in rule.platforms:
-                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
+                cpe_platform = env_yaml[
+                    "product_cpes"].cpe_platform_specification.parse_platform(platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
 
     def __str__(self):
@@ -1310,7 +1313,8 @@ class Rule(XCCDFEntity):
                 or env_yaml and rule.prodtype == "all"):
             # parse platform definition and get CPEAL platform
             for platform in rule.platforms:
-                cpe_platform = env_yaml["product_cpes"].cpe_platform_specification.parse_platform(platform)
+                cpe_platform = env_yaml[
+                    "product_cpes"].cpe_platform_specification.parse_platform(platform)
                 rule.cpe_platform_names.add(cpe_platform.id)
 
 


### PR DESCRIPTION
#### Description:

- CPEALPlatformDefinition now subclasses Algebra class
    -  this is due to the fact that if you want to compare two boolean expressions, they have to be apparently created by the same Algebra class
-  CPEALLogicalTest now subclasses Function
- CPEALFactRef now subclasses Symbol
- build_yaml.py is modified to make use of these new features while parsing platforms

#### Rationale:

- this PR actually allows to use logical expressions within platform definitions. It converts them into CPE applicability language logical expressions which are then present in the resulting datastream.