### PR TITLE
grub2_kernel_trust_cpu_rng was checking for wrong option

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
@@ -25,7 +25,7 @@
 
   <ind:textfilecontent54_object id="object_trust_cpu_rng_compiled_in" version="1">
     <ind:filepath operation="equals" var_ref="var_kernel_config_file" />
-    <ind:pattern operation="pattern match">^CONFIG_RANDOM_TRUST_CPU=Y$</ind:pattern>
+    <ind:pattern operation="pattern match">^CONFIG_RANDOM_TRUST_CPU=(y|Y)$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_but_overridden.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_but_overridden.fail.sh
@@ -4,7 +4,7 @@
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) random.trust_cpu=off"
 
 if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
-    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=Y\2/' /boot/config-`uname -r`
+    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=y\2/' /boot/config-`uname -r`
 else
-    echo "CONFIG_RANDOM_TRUST_CPU=Y" >> /boot/config-`uname -r`
+    echo "CONFIG_RANDOM_TRUST_CPU=y" >> /boot/config-`uname -r`
 fi

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
@@ -7,7 +7,7 @@ if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
 fi
 
 if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
-    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=y\2/' /boot/config-`uname -r`
+    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=Y\2/' /boot/config-`uname -r`
 else
-    echo "CONFIG_RANDOM_TRUST_CPU=y" >> /boot/config-`uname -r`
+    echo "CONFIG_RANDOM_TRUST_CPU=Y" >> /boot/config-`uname -r`
 fi


### PR DESCRIPTION
#### Description:

- modify OVAL to accept y as well as Y
- modify / add tests

#### Rationale:

- we are checking for kernel config option. Usually it is set to "y", but we were checking only for "Y". Now we check for both cases.