### PR TITLE
Use common ancestor commit in Compare DS job

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -13,10 +13,20 @@ jobs:
         run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 git python3-deepdiff python3-requests jq python3-pip
       - name: Install deps python
         run: pip install gitpython xmldiff
-      - name: Checkout master
+      - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: master
+          fetch-depth: 0
+      - name: Find forking point
+        env:
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: echo "::set-output name=FORK_POINT::$(git merge-base --fork-point origin/$BASE_BRANCH)"
+        id: fork_point
+      - name: Checkout fork point
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.fork_point.outputs.FORK_POINT }}
+          fetch-depth: 0
       - name: Checkout (CTF)
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
#### Description:

- Use the common ancestor commit of a branch as the basis for compare ds datastream. If the branch is not up to date with latest main branch it can happens that newer changes introduced in master will appear in the diff because it's comparing with outdated branch.

#### Rationale:

- Mitigates: https://github.com/ComplianceAsCode/content/pull/7910#issuecomment-975681893
