### PR TITLE
 Move to grubby for RHEL9 in the template `grub2_bootloader_argument`

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/arg_not_there_rhel8.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 8
 
 # Removes audit argument from kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/blank_grubenv_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/blank_grubenv_rhel8.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 8
 
 # Removes audit argument from kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 8
 
 # Break the audit argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel8.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 8
 
 # Break the audit argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/oval/shared.xml
@@ -29,11 +29,34 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-<ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_off"
-  comment="check forkernel command line parameters random.trust_cpu=off in {{{ grub2_boot_path }}}/grubenv for all kernels"
-  check="all" check_existence="all_exist" version="1">
-    <ind:object object_ref="object_trust_cpu_rng_boot_param" />
-    <ind:state state_ref="state_trust_cpu_rng_boot_param_off" />
+  {{% if product in ['rhel9'] %}}
+  <ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_off"
+                              comment="check kernel command line parameters for the argument for all boot entries."
+                              check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_grub2_kernel_trust_cpu_rng_entries"/>
+    <ind:state state_ref="state_trust_cpu_rng_boot_param_off"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_on"
+                              comment="check kernel command line parameters for the argument for all boot entries."
+                              check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="obj_grub2_kernel_trust_cpu_rng_entries"/>
+    <ind:state state_ref="state_trust_cpu_rng_boot_param_on"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_grub2_kernel_trust_cpu_rng_entries" version="1">
+    <ind:path>/boot/loader/entries/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% else %}}
+
+  <ind:textfilecontent54_test id="test_trust_cpu_rng_boot_param_off"
+                              comment="check for kernel command line parameters random.trust_cpu=off in {{{ grub2_boot_path }}}/grubenv for all kernels"
+                              check="all" check_existence="all_exist" version="1">
+    <ind:object object_ref="object_trust_cpu_rng_boot_param"/>
+    <ind:state state_ref="state_trust_cpu_rng_boot_param_off"/>
   </ind:textfilecontent54_test>
 
 
@@ -50,6 +73,7 @@
     <ind:pattern operation="pattern match">^kernelopts=(.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 
   <ind:textfilecontent54_state id="state_trust_cpu_rng_boot_param_on"
   version="1">
@@ -60,6 +84,5 @@
   version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?random\.trust_cpu=off(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
-
 
 </def-group>

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure IPv6 is disabled through kernel boot parameter'
 

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/arg_not_there_rhel9.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/arg_not_there_rhel9.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 9
+
+# Removes ipv6.disable argument from kernel command line in //boot/loader/entries/*.conf
+
+for file in /boot/loader/entries/*.conf ; do
+  if grep -q '^.*ipv6\.disable=.*'  "$file" ; then
+    sed -i 's/\(^.*\)ipv6\.disable=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
+  fi
+done

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/wrong_value_rhel9.fail.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/tests/wrong_value_rhel9.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 9
+
+# Break the ipv6.disable argument in kernel command line in /boot/loader/entries/*.conf
+
+for file in /boot/loader/entries/*.conf ; do
+  if grep -q '^.*ipv6\.disable=.*'  "$file" ; then
+    # modify the GRUB command-line if an ipv6.disable= arg already exists
+    sed -i 's/\(^.*\)ipv6\.disable=[^[:space:]]*\(.*\)/\1 ipv6\.disable=0 \2/'  "$file"
+  else
+    # no ipv6.disable=arg is present, append it
+    sed -i 's/\(^.*\(vmlinuz\|kernelopts|options\).*\)/\1 ipv6\.disable=0/'  "$file"
+  fi
+done

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1637,3 +1637,43 @@ if [ "$skip" -ne 0 ]; then
     fi
 fi
 {{%- endmacro %}}
+
+{{#
+
+    Remediation for grub2 bootloader arguments
+#}}
+{{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
+{{% if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product %}}
+{{% if '/' in ARG_NAME %}}
+{{{ raise("ARG_NAME (" + ARG_NAME + ") uses sed path separator (/) in " + rule_id) }}}
+{{% elif '/' in ARG_NAME_VALUE %}}
+{{{ raise("ARG_NAME_VALUE (" + ARG_NAME_VALUE + ") uses sed path separator (/) in " + rule_id) }}}
+{{% endif %}}
+# Correct the form of default kernel command line in GRUB
+if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
+	# modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
+else
+	# no {{{ ARG_NAME }}}=arg is present, append it
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'
+fi
+
+{{% if 'ubuntu' in product %}}
+update-grub
+{{% else %}}
+# Correct the form of kernel command line for each installed kernel in the bootloader
+grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
+{{% endif %}}
+{{% else %}}
+# Correct grub2 kernelopts value using grub2-editenv
+existing_kernelopts="$(grub2-editenv - list | grep kernelopts)"
+if ! printf '%s' "$existing_kernelopts" | grep -qE '^kernelopts=(.*\s)?{{{ ARG_NAME_VALUE }}}(\s.*)?$'; then
+  if test -n "$existing_kernelopts"; then
+    grub2-editenv - set "$existing_kernelopts {{{ ARG_NAME_VALUE }}}"
+  else
+    grub2-editenv - set "kernelopts={{{ ARG_NAME_VALUE }}}"
+  fi
+fi
+{{% endif %}}
+
+{{% endmacro %}}

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -1,6 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
 
-{{% if product in ["rhel7", "ol7"] or 'ubuntu' in product %}}
+{{% if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product %}}
 {{% if '/' in ARG_NAME %}}
 {{{ raise("ARG_NAME (" + ARG_NAME + ") uses sed path separator (/) in " + rule_id) }}}
 {{% elif '/' in ARG_NAME_VALUE %}}

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -5,7 +5,7 @@
       {{% if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product %}}
         {{% if product in ['rhel9'] %}}
           <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
-                     comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
+                     comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the /boot/loader/entries/*.conf" />
         {{% else %}}
           <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
           comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -67,7 +67,7 @@
     <ind:path>/boot/loader/entries/</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% else %}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -2,9 +2,14 @@
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
     {{{ oval_metadata("Ensure " + ARG_NAME_VALUE + " is configured in the kernel line in /etc/default/grub.") }}}
     <criteria operator="AND">
-      {{% if product in ["rhel7", "ol7"] or 'ubuntu' in product %}}
-        <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
-        comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
+      {{% if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product %}}
+        {{% if product in ['rhel9'] %}}
+          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
+                     comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
+        {{% else %}}
+          <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
+          comment="Check if {{{ ARG_NAME_VALUE }}} is present in the boot parameters in the {{{ grub2_boot_path }}}/grub.cfg for all kernels" />
+        {{% endif %}}
         <criteria operator="OR">
           <criterion test_ref="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
           comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX" />
@@ -22,7 +27,7 @@
     </criteria>
   </definition>
 
-{{% if product in ["rhel7", "ol7"] or 'ubuntu' in product %}}
+{{% if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product %}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   comment="check for {{{ ARG_NAME_VALUE }}} in /etc/default/grub via GRUB_CMDLINE_LINUX"
   check="all" check_existence="all_exist" version="1">
@@ -50,6 +55,21 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  {{% if product in ["rhel9"] %}}
+    <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_entries"
+                                comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} for all boot entries."
+                                check="all" check_existence="all_exist" version="1">
+      <ind:object object_ref="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" />
+      <ind:state state_ref="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument" />
+    </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_grub2_{{{ SANITIZED_ARG_NAME }}}_entries" version="1">
+    <ind:path>/boot/loader/entries/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% else %}}
   <ind:textfilecontent54_test id="test_grub2_{{{ SANITIZED_ARG_NAME }}}_argument_grub_cfg"
   comment="check kernel command line parameters for {{{ ARG_NAME_VALUE }}} in {{{ grub2_boot_path }}}/grub.cfg for all kernels"
   check="all" check_existence="all_exist" version="1">
@@ -67,6 +87,8 @@
     {{% endif %}}
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{% endif %}}
 
 {{% else %}}
 

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -6,6 +6,7 @@ def preprocess(data, lang):
     if lang == "oval":
         # escape dot, this is used in oval regex
         data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")
+        data["escaped_arg_name"] = data["arg_name"].replace(".", "\\.")
         # replace . with _, this is used in test / object / state ids
         data["sanitized_arg_name"] = ssg.utils.escape_id(data["arg_name"])
     return data

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_there.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_there.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# platform = Red Hat Enterprise Linux 8
+
+# Removes audit argument from kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*{{{ARG_NAME}}}=.*'  "$file" ; then
+	sed -i 's/\(^.*\){{{ARG_NAME}}}=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
+fi
+

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_there_etcdefaultgrub.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_there_etcdefaultgrub.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 9
+
+# Removes argument from kernel command line in /etc/default/grub
+if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ARG_NAME}}}=.*"'  '/etc/default/grub' ; then
+	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ARG_NAME}}}=[^[:space:]]*\(.*"\)/\1 \2/'  '/etc/default/grub'
+fi
+

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8
+
+# Break the argument in kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*{{{ARG_NAME}}}=.*'  "$file" ; then
+	# modify the GRUB command-line if the arg already exists
+	sed -i 's/\(^.*\){{{ARG_NAME}}}=[^[:space:]]*\(.*\)/\1 {{{ARG_NAME}}}=wrong \2/'  "$file"
+else
+	# no arg is present, append it
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME}}}=wrong/'  "$file"
+fi

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value_entries.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 9
+
+# Removes argument from kernel command line in /boot/loader/entries/*.conf
+
+for file in /boot/loader/entries/*.conf ; do
+  if grep -q '^.*{{{ ESCAPED_ARG_NAME }}}=.*'  "$file" ; then
+      # modify the GRUB command-line if an audit= arg already exists
+	    sed -i 's/\(^.*\){{{ARG_NAME}}}=[^[:space:]]*\(.*\)/\1 {{{ARG_NAME}}}=wrong \2/'  "$file"
+    else
+	    # no audit=arg is present, append it
+	    sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME}}}=wrong/'  "$file"
+  fi
+done


### PR DESCRIPTION
#### Description:

In the `grub2_bootloader_argument` template use the RHEL7 method for all of RHEL.

#### Rationale:

The RHEL8 STIG recommends this.

See https://github.com/ComplianceAsCode/content/pull/7736#pullrequestreview-817947083
