### PR TITLE
OL8 stig prodtype and platform

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Mount Remote Filesystems with nodev'
 

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_fedora
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Certificate certificate status checking in SSSD'
 

--- a/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Enable Certmap in SSSD'
 

--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/ansible/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/bash/shared.sh
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'Generate USBGuard Policy'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Prevent the Use of Dictionary Words'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Assign Expiration Date to Emergency Accounts'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Assign Expiration Date to Temporary Accounts'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Verify All Account Password Hashes are Shadowed with SHA512'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Record Any Attempts to Run chacl'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Record Any Attempts to Run setfacl'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -8,7 +8,7 @@
 
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - kmod'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Record Any Attempts to Run ssh-agent'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,ubuntu2004
+prodtype: ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - unix_update'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - usermod'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'Ensure auditd Collects System Administrator Actions - /etc/sudoers'
 
@@ -37,4 +37,3 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/etc/sudoers\|-w /etc/sudoers\"</pre>
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'Ensure auditd Collects System Administrator Actions - /etc/sudoers.d/'
 
@@ -37,4 +37,3 @@ ocil_clause: 'there is not output'
 ocil: |-
     To verify that auditing is configured for system administrator actions, run the following command:
     <pre>$ sudo auditctl -l | grep "watch=/etc/sudoers.d\|-w /etc/sudoers.d"</pre>
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'System Audit Directories Must Be Group Owned By Root'
 
@@ -38,4 +38,3 @@ references:
 
 ocil: |-
     {{{ describe_file_group_owner(file="/var/log/audit", group="root") }}}
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'System Audit Directories Must Be Owned By Root'
 
@@ -36,4 +36,3 @@ references:
 
 ocil: |-
     {{{ describe_file_owner(file="/var/log/audit", owner="root") }}}
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
 
 if LC_ALL=C grep -iw ^log_file /etc/audit/auditd.conf; then
   DIR=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ' | rev | cut -d"/" -f2- | rev)

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,ubuntu2004
+prodtype: ol8,rhel8,rhel9,ubuntu2004
 
 title: 'System Audit Logs Must Be Group Owned By Root'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,ubuntu2004
+prodtype: ol8,rhel8,rhel9,ubuntu2004
 
 title: 'System Audit Logs Must Be Owned By Root'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Configure a Sufficiently Large Partition for Audit Logs'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
 
 {{{ bash_instantiate_variables("var_auditd_disk_error_action") }}}
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_auditd_disk_full_action") }}}
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,ubuntu2004
+prodtype: fedora,ol8,rhel7,rhel8,rhel9,ubuntu2004
 
 title: 'Configure auditd space_left on Low Disk Space'
 
@@ -47,4 +47,3 @@ ocil: |-
     Inspect <tt>/etc/audit/auditd.conf</tt> and locate the following line to
     determine if the system is configured correctly:
     <pre>space_left <i>PERCENTAGE</i>%</pre>
-

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Ensure remote access methods are monitored in Rsyslog'
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_rhel
+# platform = multi_platform_sle,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 df --local -P | awk '{if (NR!=1) print $6}' \
 | xargs -I '{}' find '{}' -xdev -type d \
 \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Verify Permissions on /etc/audit/auditd.conf'
 

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_rulesd/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_rulesd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,ubuntu2004
 
 title: 'Verify Permissions on /etc/audit/rules.d/*.rules'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Verify that Shared Library Directories Have Root Group Ownership'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_sle,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_sle,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 for SYSCMDFILES in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin
 do

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Verify that system commands files are group owned by root '
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_sle,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = false
 # strategy = restrict
 # complexity = high
@@ -24,4 +24,3 @@
   when:
     - library_files_not_group_owned_by_root.matched > 0
     - item.gid != 0
-

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = multi_platform_sle,Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 find /lib \
 /lib64 \

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,sle12,sle15
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15
 
 title: |-
     Verify the system-wide library files in directories

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Configure GnuTLS library to use DoD-approved TLS Encryption'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'Configure OpenSSL library to use TLS Encryption'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Configure SSH Client to Use FIPS 140-2 Validated Ciphers: openssh.config'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'Configure SSH Server to Use FIPS 140-2 Validated Ciphers: opensshserver.config'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,rhel8,rhel9
 
 title: 'Configure SSH Client to Use FIPS 140-2 Validated MACs: openssh.config'
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,rhel8,rhel9
 
 title: 'Configure SSH Server to Use FIPS 140-2 Validated MACs: opensshserver.config'
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_rhel
+# platform = multi_platform_sle,multi_platform_ol,multi_platform_rhel
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -23,7 +23,7 @@
 - name: Set audit_tools fact
   set_fact:
     audit_tools:
-      {{% if 'rhel' not in product %}}- /usr/sbin/audispd{{% endif %}}
+      {{% if 'rhel' not in product and product != 'ol8' %}}- /usr/sbin/audispd{{% endif %}}
       - /usr/sbin/auditctl
       - /usr/sbin/auditd
       - /usr/sbin/augenrules

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ubuntu,multi_platform_sle
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -14,7 +14,7 @@
       "/usr/sbin/autrace",
       "/usr/sbin/augenrules" ] %}}
 
-{{% if 'rhel' not in product %}}
+{{% if 'rhel' not in product and product != 'ol8' %}}
 {{% set auditfiles = auditfiles + ["/usr/sbin/audispd"] %}}
 {{% endif %}}
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Configure AIDE to Verify the Audit Tools'
 


### PR DESCRIPTION
#### Description:

- Add OL prodtype and platform to rules and remediation content part of the OL8 draft stig profile

#### Rationale:

- The OL8 DISA STIG v1r1 profile was released earlier this year and it has not been implemented in the scap-security-guide project.
