### PR TITLE
Assess PCI-DSS:Req-1.3.5

### DIFF
--- a/controls/pcidss_ocp4.yml
+++ b/controls/pcidss_ocp4.yml
@@ -248,8 +248,9 @@ controls:
     title: 1.3.5 Permit only "established" connections into the network.
     levels:
     - base
-    notes: ''
-    status: pending
+    notes: |-
+      This will be met by a third-party stateful firewall, and it is external to OpenShift.
+    status: not applicable
     rules: []
 
   - id: Req-1.3.6


### PR DESCRIPTION
Assess PCI-DSS: Req-1.3.5, this control states 'permit only "established" connections into the network.`, which is out of OpenShift scope, hence not applicable.