### PR TITLE
fix enable_fips_mode remediations

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -13,3 +13,13 @@
   command: /usr/bin/fips-mode-setup --enable
   when:
     - is_fips_enabled.stdout.find('FIPS mode is enabled.') == -1
+
+- name: "{{{ rule_title }}}"
+  lineinfile:
+    path: /etc/crypto-policies/config
+    regexp: '^(?!#)(\S+)$'
+    line: "{{ var_system_crypto_policy }}"
+    create: yes
+
+- name: Verify that Crypto Policy is Set (runtime)
+  command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -3,6 +3,7 @@
 # strategy = restrict
 # complexity = medium
 # disruption = medium
+{{{ ansible_instantiate_variables("var_system_crypto_policy") }}}
 
 - name: Check to see the current status of FIPS mode
   command: /usr/bin/fips-mode-setup --check

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
@@ -1,3 +1,20 @@
 # platform = multi_platform_rhel,multi_platform_fedora,Oracle Linux 8,Red Hat Virtualization 4
+{{{ bash_instantiate_variables("var_system_crypto_policy") }}}
 
 fips-mode-setup --enable
+
+stderr_of_call=$(update-crypto-policies --set ${var_system_crypto_policy} 2>&1 > /dev/null)
+rc=$?
+
+if test "$rc" = 127; then
+	echo "$stderr_of_call" >&2
+	echo "Make sure that the script is installed on the remediated system." >&2
+	echo "See output of the 'dnf provides update-crypto-policies' command" >&2
+	echo "to see what package to (re)install" >&2
+
+	false  # end with an error code
+elif test "$rc" != 0; then
+	echo "Error invoking the update-crypto-policies script: $stderr_of_call" >&2
+	false  # end with an error code
+fi
+

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
     <pre>fips-mode-setup --check</pre>
     The output should contain the following:
     <pre>FIPS mode is enabled.</pre>
-    To verify that cryptography policy has been configured correctly, run the
+    To verify that the cryptographic policy has been configured correctly, run the
     following command:
     <pre>$ update-crypto-policies --show</pre>
     The output should return <pre>{{{ xccdf_value("var_system_crypto_policy") }}}</pre>.

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -16,6 +16,7 @@ description: |-
     <li>Setting the system crypto policy in <tt>/etc/crypto-policies/config</tt> to <tt>FIPS</tt></li>
     <li>Loading the Dracut <tt>fips</tt> module</li>
     </ul>
+    This rule also ensures that the system policy is set to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt>.
     Furthermore, the system running in FIPS mode should be FIPS certified by NIST.
 
 rationale: |-
@@ -50,6 +51,10 @@ ocil: |-
     <pre>fips-mode-setup --check</pre>
     The output should contain the following:
     <pre>FIPS mode is enabled.</pre>
+    To verify that cryptography policy has been configured correctly, run the
+    following command:
+    <pre>$ update-crypto-policies --show</pre>
+    The output should return <pre>{{{ xccdf_value("var_system_crypto_policy") }}}</pre>.
 
 warnings:
     - general: |-


### PR DESCRIPTION
#### Description:

- modify Bash and Ansible remediations of enable_fips_mode
- apart from running fips-mode-setup --enable, it now applies also the cryptopolicy configured in the profile.

#### Rationale:

- the previous implementation only used the fips-mode-setup utility to enable the FIPS mode. However, this utility always configures the "fips" cryptopolicy. However, some profiles (such as OSPP), uses a policy based on "fips" - "fips:ospp". This policy is based on "fips", it is even stricter. But due to hardcoded configuration of "fips" policy done by fips-mode-setup, the remediation always resulted in error.
- This implementation should not cause problems even if the profile for some reason tries to use FIPS mode and at the same time it tries to use policy not based on fips. In that case, the check test_system_crypto_policy_value will always make rule fail.