### PR TITLE
Add stig_gui profile for ol7

### DIFF
--- a/products/ol7/CMakeLists.txt
+++ b/products/ol7/CMakeLists.txt
@@ -11,6 +11,8 @@ ssg_build_html_ref_tables("${PRODUCT}" "table-${PRODUCT}-{ref_id}refs" "anssi;cu
 
 ssg_build_html_profile_table("table-${PRODUCT}-nistrefs-standard" "${PRODUCT}" "standard" "nist")
 ssg_build_html_profile_table("table-${PRODUCT}-nistrefs-stig" "${PRODUCT}" "stig" "nist")
+ssg_build_html_profile_table("table-${PRODUCT}-nistrefs-stig_gui" "${PRODUCT}" "stig_gui" "nist")
 
 ssg_build_html_stig_tables(${PRODUCT})
 ssg_build_html_stig_tables_per_profile( ${PRODUCT} "stig")
+ssg_build_html_stig_tables_per_profile( ${PRODUCT} "stig_gui")

--- a/products/ol7/profiles/stig_gui.profile
+++ b/products/ol7/profiles/stig_gui.profile
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'DISA STIG with GUI for Oracle Linux 7'
+
+description: |-
+    This profile contains configuration checks that align to the
+    DISA STIG with GUI for Oracle Linux V2R5.
+
+    Warning: The installation and use of a Graphical User Interface (GUI)
+    increases your attack vector and decreases your overall security posture. If
+    your Information Systems Security Officer (ISSO) lacks a documented operational
+    requirement for a graphical user interface, please consider using the
+    standard DISA STIG for Oracle Linux 7 profile.
+
+extends: stig
+
+selections:
+    - '!xwindows_remove_packages'


### PR DESCRIPTION
#### Description:

- Add the stig_gui profile for ol7

#### Rationale:

- This profile is based on the stig profile so it can be used with a GUI installation. 

