### PR TITLE
Fix broken test scenario

### DIFF
--- a/linux_os/guide/system/selinux/selinux_state/tests/selinux_enforcing.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_state/tests/selinux_enforcing.pass.sh
@@ -2,6 +2,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_C2S, xccdf_org.ssgproject.content_profile_ospp
 
 SELINUX_FILE='/etc/selinux/config'
+touch "$SELINUX_FILE"
 
 if grep -s '^[[:space:]]*SELINUX' $SELINUX_FILE; then
 	sed -i 's/^\([[:space:]]*SELINUX[[:space:]]*=[[:space:]]*\).*/\1enforcing/' $SELINUX_FILE

--- a/linux_os/guide/system/selinux/selinux_state/tests/selinux_missing.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_state/tests/selinux_missing.fail.sh
@@ -3,4 +3,5 @@
 # remediation = none
 
 SELINUX_FILE='/etc/selinux/config'
+touch "$SELINUX_FILE"
 sed -i '/^[[:space:]]*SELINUX/d' $SELINUX_FILE

--- a/linux_os/guide/system/selinux/selinux_state/tests/selinux_permissive.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_state/tests/selinux_permissive.fail.sh
@@ -3,6 +3,7 @@
 # remediation = none
 
 SELINUX_FILE='/etc/selinux/config'
+touch "$SELINUX_FILE"
 
 if grep -s '^[[:space:]]*SELINUX' $SELINUX_FILE; then
 	sed -i 's/^\([[:space:]]*SELINUX[[:space:]]*=[[:space:]]*\).*/\1permissive/' $SELINUX_FILE

--- a/linux_os/guide/system/selinux/selinux_state/tests/selinux_permissive.fail.sh
+++ b/linux_os/guide/system/selinux/selinux_state/tests/selinux_permissive.fail.sh
@@ -5,7 +5,7 @@
 SELINUX_FILE='/etc/selinux/config'
 
 if grep -s '^[[:space:]]*SELINUX' $SELINUX_FILE; then
-	sed -i 's/^\([[:space:]]*SELINUX[[:space:]]*=[[:space:]]*\).*/\permissive/' $SELINUX_FILE
+	sed -i 's/^\([[:space:]]*SELINUX[[:space:]]*=[[:space:]]*\).*/\1permissive/' $SELINUX_FILE
 else
 	echo 'SELINUX=permissive' >> $SELINUX_FILE
 fi


### PR DESCRIPTION
During review of #7750 we have discovered that for this test scenario
the rule fails not because the `SELINUX=permissive` but because
no `SELINUX=` entry exists. The missing `SELINUX=` entry was caused
by a typo in the sed expression which effectively replaced
`SELINUX=enforcing` by just `permissive`. As a result, oscap didn't
find the OVAL object `oval:ssg-object_etc_selinux_config:obj:1`.

