### PR TITLE
Fix jinja issue on fedora rawhide

### DIFF
--- a/tests/unit/ssg-module/test_playbook_builder.py
+++ b/tests/unit/ssg-module/test_playbook_builder.py
@@ -34,9 +34,9 @@ def test_build_rule_playbook():
     assert os.path.exists(real_output_filepath)
 
     with open(real_output_filepath, "r") as real_output:
-        real_output_yaml = yaml.load(real_output)
+        real_output_yaml = yaml.load(real_output, Loader=yaml.Loader)
     with open(expected_output_filepath, "r") as expected_output:
-        expected_output_yaml = yaml.load(expected_output)
+        expected_output_yaml = yaml.load(expected_output, Loader=yaml.Loader)
 
     real_play = real_output_yaml.pop()
     expected_play = expected_output_yaml.pop()

--- a/utils/duplicated_prodtypes.py
+++ b/utils/duplicated_prodtypes.py
@@ -23,7 +23,7 @@ def _create_profile_cache(ssg_root):
             files.sort()
             for filename in files:
                 profile_path = os.path.join(prod_profiles_dir, filename)
-                parsed_profile = yaml.load(open(profile_path, 'r'))
+                parsed_profile = yaml.load(open(profile_path, 'r'), Loader=yaml.Loader)
                 for _obj in parsed_profile['selections']:
                     obj = _obj
                     if '=' in obj:
@@ -210,7 +210,7 @@ def find_profiles(ssg_root, path, obj_name):
 def parse_from_yaml(file_contents, lines):
     new_file_arr = file_contents[lines[0]:lines[1] + 1]
     new_file = "\n".join(new_file_arr)
-    return yaml.load(new_file)
+    return yaml.load(new_file, Loader=yaml.Loader)
 
 
 def print_file(file_contents):

--- a/utils/fix_file_ocilclause.py
+++ b/utils/fix_file_ocilclause.py
@@ -23,7 +23,7 @@ def _create_profile_cache(ssg_root):
             files.sort()
             for filename in files:
                 profile_path = os.path.join(prod_profiles_dir, filename)
-                parsed_profile = yaml.load(open(profile_path, 'r'))
+                parsed_profile = yaml.load(open(profile_path, 'r'), Loader=yaml.Loader)
                 for _obj in parsed_profile['selections']:
                     obj = _obj
                     if '=' in obj:
@@ -205,7 +205,7 @@ def fix_ocil_clause(ssg_root, path, obj_name):
 def parse_from_yaml(file_contents, lines):
     new_file_arr = file_contents[lines[0]:lines[1] + 1]
     new_file = "\n".join(new_file_arr)
-    return yaml.load(new_file)
+    return yaml.load(new_file, Loader=yaml.Loader)
 
 
 def print_file(file_contents):

--- a/utils/move_rules.py
+++ b/utils/move_rules.py
@@ -340,7 +340,7 @@ def fix_ocil_clause(ssg_root, path, obj_name):
 def parse_from_yaml(file_contents, lines):
     new_file_arr = file_contents[lines[0]:lines[1] + 1]
     new_file = "\n".join(new_file_arr)
-    return yaml.load(new_file)
+    return yaml.load(new_file, Loader=yaml.Loader)
 
 
 def print_file(file_contents):


### PR DESCRIPTION
#### Description:

- Newer versions of Jinja in Fedora rawhide require that loader in yaml.load function, so every function that was missing the parameter now has the default Loader used.
