### PR TITLE
Fix OVAL comments so they can be parsed by CTF tool

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
@@ -4,13 +4,13 @@
 
     <criteria operator="OR">
       {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
-      <criterion comment="make sure a superuser is defined in {{{ grub2_uefi_boot_path + "/grub.cfg" }}}" test_ref="test_bootloader_uefi_unique_superuser"/>
+      <criterion comment="make sure a superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_bootloader_uefi_unique_superuser"/>
     </criteria>
   </definition>
 
   {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path + "/grub.cfg" }}}. Superuser is not root, admin, or administrator" id="test_bootloader_uefi_unique_superuser" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg. Superuser is not root, admin, or administrator" id="test_bootloader_uefi_unique_superuser" version="1">
     <ind:object object_ref="object_bootloader_uefi_unique_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_uefi_unique_superuser" version="1">

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
@@ -16,7 +16,7 @@
 
   {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path + "/grub.cfg" }}}." id="test_bootloader_uefi_superuser" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg." id="test_bootloader_uefi_superuser" version="2">
     <ind:object object_ref="object_bootloader_uefi_superuser" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_bootloader_uefi_superuser" version="2">

--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
@@ -2,13 +2,13 @@
   <definition class="compliance" id="uefi_no_removeable_media" version="1">
     {{{ oval_metadata("Ensure the system is not configured to use a boot loader on removable media.") }}}
     <criteria comment="The respective application or service is configured correctly or system boot mode is not UEFI" operator="OR">
-      <criterion comment="Check the set root in {{{ grub2_uefi_boot_path + "/grub.cfg" }}}" test_ref="test_uefi_no_removeable_media" />
+      <criterion comment="Check the set root in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_uefi_no_removeable_media" />
       {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="tests the value of set root setting in the {{{ grub2_uefi_boot_path + "/grub.cfg" }}} file"
+  comment="tests the value of set root setting in the {{{ grub2_uefi_boot_path }}}/grub.cfg file"
   id="test_uefi_no_removeable_media" version="1">
   <ind:object object_ref="obj_uefi_no_removeable_media" />
   <ind:state state_ref="state_uefi_no_removeable_media" />


### PR DESCRIPTION
#### Description:

- Fix OVAL comments so they can be parsed by CTF tool.

#### Rationale:

- CTF can parse the XML to find differences between content changes. Problem manifested here: https://github.com/ComplianceAsCode/content/pull/7913
