### PR TITLE
Fix CVE data URL

### DIFF
--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -19,7 +19,7 @@ aux_pkg_version: "2fa658e0"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "43A6E49C4A38F4BE9ABF2A5345689C882FA658E0"
-oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml"
+oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2"
 
 grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -19,7 +19,7 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
-oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml"
+oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2"
 
 grub2_boot_path: "/boot/grub2"
 grub2_uefi_boot_path: "/boot/efi/EFI/redhat"

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -27,7 +27,7 @@ aux_pkg_version: "d4082792"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
 auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
-oval_feed_url: "https://www.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml"
+oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml.bz2"
 
 cpes_root: "../../shared/applicability"
 cpes:


### PR DESCRIPTION
#### Description:

The CVE URL feed changed the location. It's still available also via
current URLs, but it's wise to use the new location:
* the uncompresesd XMLs are a redirect to compressed XMLs
* the files at www.redhat.com will redirect to access.redhat.com soon


#### Rationale:

Resolves: rhbz#2028428, rhbz#2028435

However, this changes means that we willl use bz2 files, which leads to a question on how we want to deal with warning "The OVAL feed of Red Hat Enterprise Linux 8 is not a XML file, which may not be understood by all scanners." That comes from https://github.com/ComplianceAsCode/content/blob/207eefd897a14e69e035846a99d22a792c284e07/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml#L77 
I propose to keep the warning. WDYT?