### PR TITLE
Update reference to disa-os-srg file

### DIFF
--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -4,7 +4,7 @@
 <!-- this style sheet expects parameter $profile, which is the id of the Profile to be shown -->
 
 <xsl:variable name="cci_list" select="document('../references/disa-cci-list.xml')/cci:cci_list" />
-<xsl:variable name="os_srg" select="document('../references/disa-os-srg-v1r6.xml')/cdf:Benchmark" />
+<xsl:variable name="os_srg" select="document('../references/disa-os-srg-v2r1.xml')/cdf:Benchmark" />
 
 <xsl:param name="profile" select="''"/>
 <xsl:param name="testinfo" select="''" />


### PR DESCRIPTION
#### Description:

- Reference to disa-os-srg file in shared/transforms/shared_xccdf2table-profileccirefs.xslt is outdated

#### Rationale:

- This removes the warning:
`warning: failed to load external entity "/path-to-project/content/shared/references/disa-os-srg-v1r6.xml"`
