### PR TITLE
Dockerfiles: Include EKS in Compliance Operator-related dockerfiles

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -7,10 +7,10 @@ RUN microdnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-j
 
 COPY . .
 
-RUN ./build_product --datastream-only --debug ocp4 rhel7 rhcos4
+RUN ./build_product --datastream-only --debug ocp4 rhcos4 eks
 
 FROM registry.access.redhat.com/ubi8/ubi-micro:latest
 WORKDIR /
 COPY --from=builder /content/build/ssg-ocp4-ds.xml .
-COPY --from=builder /content/build/ssg-rhel7-ds.xml .
 COPY --from=builder /content/build/ssg-rhcos4-ds.xml .
+COPY --from=builder /content/build/ssg-eks-ds.xml .

--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -3,10 +3,10 @@ FROM fedora:35 as builder
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content
 WORKDIR /content
-RUN ./build_product --datastream-only --debug ocp4 rhel7 rhcos4
+RUN ./build_product --datastream-only --debug ocp4 rhcos4 eks
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal
 WORKDIR /
 COPY --from=builder /content/build/ssg-ocp4-ds.xml .
-COPY --from=builder /content/build/ssg-rhel7-ds.xml .
 COPY --from=builder /content/build/ssg-rhcos4-ds.xml .
+COPY --from=builder /content/build/ssg-eks-ds.xml .


### PR DESCRIPTION
We never supported RHEL7 in the Compliance Operator, but EKS support is
on the works, so lets include that instead to make it easier for folks
to test it.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>