### PR TITLE
utils/build_ds_container.sh: Add option to push to any image repository

### DIFF
--- a/Dockerfiles/compliance_operator_content.Dockerfile
+++ b/Dockerfiles/compliance_operator_content.Dockerfile
@@ -1,0 +1,5 @@
+# This dockerfile is used by the `utils/build_ds_container.sh` script in order
+# to persist the built content into a remote container image repository.
+FROM registry.access.redhat.com/ubi8/ubi-micro:latest
+WORKDIR /
+ADD ./build/* .


### PR DESCRIPTION
This adds the option to push to any given repository with the
aforementioned utility. This is useful for when developing content for
Kubernetes distros other than OpenShift.

A Dockerfile to take this into use was also created.

Co-Authored-By: Vincent Shen <wenshen@redhat.com>
Co-Authored-By: Lance Bragstad <lbragsta@redhat.com>
Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>