### PR TITLE
Fix issues with dividing a str by str in `utils/render-policy.py`

### DIFF
--- a/utils/render-policy.py
+++ b/utils/render-policy.py
@@ -18,7 +18,7 @@ class HtmlOutput(template_renderer.Renderer):
     TEMPLATE_NAME = "controls-template.html"
 
     def set_all_rules_with_metadata(self):
-        compiled_rules = self.built_content_path / "rules"
+        compiled_rules = os.path.join(self.built_content_path, 'rules')
         rule_files = glob("{compiled_rules}/*".format(compiled_rules=compiled_rules))
         if not rule_files:
             msg = (


### PR DESCRIPTION
#### Description:

Use `os.path.join` for path building in `utils/render-policy.py`.

#### Rationale:

Without this fix the script will not work. Errors on trying to divide a `str ` by `str`.
