### PR TITLE
Filter out RHEL8 STIG rules on RHV hosts

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -56,13 +56,11 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="PermitRootLogin", value="no") }}}
 
-{{% if product == "rhel8" %}}
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV hosts require root access to be managed by RHV Manager") | indent(4) }}}
-{{% endif %}}
 
 template:
     name: sshd_lineinfile

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -61,9 +61,7 @@ platforms:
     - no_ovirt
 
 warnings:
-    - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
-        RHV hosts require root access to be managed by RHV Manager.
+{{{ ovirt_rule_notapplicable_warning("RHV hosts require root access to be managed by RHV Manager") | indent(4) }}}
 {{% endif %}}
 
 template:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -58,11 +58,11 @@ references:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - not_ovirt-host
+    - no_ovirt
 
 warnings:
     - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
         RHV hosts require root access to be managed by RHV Manager.
 {{% endif %}}
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -56,6 +56,11 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="PermitRootLogin", value="no") }}}
 
+{{% if product == "rhel8" %}}
+platforms:
+    - not_ovirt-host
+{{% endif %}}
+
 template:
     name: sshd_lineinfile
     vars:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -59,6 +59,11 @@ references:
 {{% if product == "rhel8" %}}
 platforms:
     - not_ovirt-host
+
+warnings:
+    - general: |-
+        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        RHV hosts require root access to be managed by RHV Manager.
 {{% endif %}}
 
 template:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -58,7 +58,7 @@ references:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - no_ovirt
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV hosts require root access to be managed by RHV Manager") | indent(4) }}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -64,10 +64,8 @@ ocil: |-
     For each <tt>package</tt> mentioned above you should receive following line:
     <pre>package &lt;package&gt; is not installed</pre>
 
-{{% if product == "rhel8" %}}
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
-{{% endif %}}
 
 warnings:
     - functionality: |-

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -66,7 +66,7 @@ ocil: |-
 
 {{% if product == "rhel8" %}}
 platforms:
-    - no_ovirt
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 {{% endif %}}
 
 warnings:

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -76,8 +76,4 @@ warnings:
         which might bring your system to an inconsistent state requiring additional configuration to access the system
         again. If a GUI is an operational requirement, a tailored profile that removes this rule should used before
         continuing installation.
-{{% if product == "rhel8" %}}
-    - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
-        X11 graphic libraries are dependency of OpenStack Cinderlib storage provider.
-{{% endif %}}
+{{{ ovirt_rule_notapplicable_warning("X11 graphic libraries are dependency of OpenStack Cinderlib storage provider") | indent(4) }}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -64,6 +64,11 @@ ocil: |-
     For each <tt>package</tt> mentioned above you should receive following line:
     <pre>package &lt;package&gt; is not installed</pre>
 
+{{% if product == "rhel8" %}}
+platforms:
+    - no_ovirt
+{{% endif %}}
+
 warnings:
     - functionality: |-
         The installation and use of a Graphical User Interface (GUI) increases your attack vector and decreases your
@@ -71,3 +76,8 @@ warnings:
         which might bring your system to an inconsistent state requiring additional configuration to access the system
         again. If a GUI is an operational requirement, a tailored profile that removes this rule should used before
         continuing installation.
+{{% if product == "rhel8" %}}
+    - general: |-
+        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
+        X11 graphic libraries are dependency of OpenStack Cinderlib storage provider.
+{{% endif %}}

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/group.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/group.yml
@@ -6,3 +6,5 @@ description: |-
     If the system is not going to be used as a router, then setting certain
     kernel parameters ensure that the host will not perform routing
     of network traffic.
+
+platform: machine

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
@@ -51,8 +51,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.send_redirects", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
@@ -51,8 +51,6 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.default.send_redirects", value="0") }}}
 
-platform: machine
-
 template:
     name: sysctl
     vars:

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -56,8 +56,16 @@ warnings:
         Certain technologies such as virtual machines, containers, etc. rely on IPv4 forwarding to enable and use networking.
         Disabling IPv4 forwarding would cause those technologies to stop working. Therefore, this rule should not be used in
         profiles or benchmarks that target usage of IPv4 forwarding.
+{{% if product == "rhel8" %}}
+    - general: |-
+        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
+        RHV host requires IPv4 forwarding for the Hosted Engine bootstrap VM to reach network outside of the initial host.
+{{% endif %}}
 
-platform: machine
+{{% if product == "rhel8" %}}
+platforms:
+    - no_ovirt
+{{% endif %}}
 
 template:
     name: sysctl

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -60,7 +60,7 @@ warnings:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - no_ovirt
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 {{% endif %}}
 
 template:

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -56,11 +56,7 @@ warnings:
         Certain technologies such as virtual machines, containers, etc. rely on IPv4 forwarding to enable and use networking.
         Disabling IPv4 forwarding would cause those technologies to stop working. Therefore, this rule should not be used in
         profiles or benchmarks that target usage of IPv4 forwarding.
-{{% if product == "rhel8" %}}
-    - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
-        RHV host requires IPv4 forwarding for the Hosted Engine bootstrap VM to reach network outside of the initial host.
-{{% endif %}}
+{{{ ovirt_rule_notapplicable_warning("RHV host requires IPv4 forwarding for the Hosted Engine bootstrap VM to reach network outside of the initial host") | indent(4) }}}
 
 {{% if product == "rhel8" %}}
 platforms:

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -58,10 +58,8 @@ warnings:
         profiles or benchmarks that target usage of IPv4 forwarding.
 {{{ ovirt_rule_notapplicable_warning("RHV host requires IPv4 forwarding for the Hosted Engine bootstrap VM to reach network outside of the initial host") | indent(4) }}}
 
-{{% if product == "rhel8" %}}
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
-{{% endif %}}
 
 template:
     name: sysctl

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -54,4 +54,9 @@ ocil: |-
 {{% if product == "rhel8" %}}
 platforms:
     - not_ovirt-host
+
+warnings:
+    - general: |-
+        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        RHV requires to perform operations as root without being asked for password.
 {{% endif %}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -50,3 +50,8 @@ ocil: |-
     To determine if <tt>NOPASSWD</tt> has been configured for sudo, run the following command:
     <pre>$ sudo grep -ri nopasswd /etc/sudoers /etc/sudoers.d/</pre>
     The command should return no output.
+
+{{% if product == "rhel8" %}}
+platforms:
+    - not_ovirt-host
+{{% endif %}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -56,7 +56,5 @@ platforms:
     - no_ovirt
 
 warnings:
-    - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
-        RHV requires to perform operations as root without being asked for password.
+{{{ ovirt_rule_notapplicable_warning("RHV requires to perform operations as root without being asked for password") | indent(4) }}}
 {{% endif %}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 {{% if product == "rhel8" %}}
 platforms:
-    - no_ovirt
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV requires to perform operations as root without being asked for password") | indent(4) }}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -51,10 +51,8 @@ ocil: |-
     <pre>$ sudo grep -ri nopasswd /etc/sudoers /etc/sudoers.d/</pre>
     The command should return no output.
 
-{{% if product == "rhel8" %}}
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV requires to perform operations as root without being asked for password") | indent(4) }}}
-{{% endif %}}

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/rule.yml
@@ -53,10 +53,10 @@ ocil: |-
 
 {{% if product == "rhel8" %}}
 platforms:
-    - not_ovirt-host
+    - no_ovirt
 
 warnings:
     - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
         RHV requires to perform operations as root without being asked for password.
 {{% endif %}}

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -27,7 +27,7 @@ references:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - no_ovirt
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV uses NFS storage, which has dependency on gssproxy") | indent(4) }}}

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -28,6 +28,11 @@ references:
 {{% if product == "rhel8" %}}
 platforms:
     - not_ovirt-host
+
+warnings:
+    - general: |-
+        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        RHV uses NFS storage, which has dependency on gssproxy.
 {{% endif %}}
 
 template:

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -30,9 +30,7 @@ platforms:
     - no_ovirt
 
 warnings:
-    - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
-        RHV uses NFS storage, which has dependency on gssproxy.
+{{{ ovirt_rule_notapplicable_warning("RHV uses NFS storage, which has dependency on gssproxy") | indent(4) }}}
 {{% endif %}}
 
 template:

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -25,13 +25,11 @@ references:
 
 {{{ complete_ocil_entry_package(package="gssproxy") }}}
 
-{{% if product == "rhel8" %}}
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV uses NFS storage, which has dependency on gssproxy") | indent(4) }}}
-{{% endif %}}
 
 template:
     name: package_removed

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -25,6 +25,11 @@ references:
 
 {{{ complete_ocil_entry_package(package="gssproxy") }}}
 
+{{% if product == "rhel8" %}}
+platforms:
+    - not_ovirt-host
+{{% endif %}}
+
 template:
     name: package_removed
     vars:

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -27,11 +27,11 @@ references:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - not_ovirt-host
+    - no_ovirt
 
 warnings:
     - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
         RHV uses NFS storage, which has dependency on gssproxy.
 {{% endif %}}
 

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -31,6 +31,11 @@ references:
 {{% if product == "rhel8" %}}
 platforms:
     - not_ovirt-host
+
+warnings:
+    - general: |-
+        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        RHV requires tuned package for tuning profiles that can enhance virtualization performance.
 {{% endif %}}
 
 template:

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -30,11 +30,11 @@ references:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - not_ovirt-host
+    - no_ovirt
 
 warnings:
     - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts, it will report not applicable.
+        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
         RHV requires tuned package for tuning profiles that can enhance virtualization performance.
 {{% endif %}}
 

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -28,13 +28,11 @@ references:
 
 {{{ complete_ocil_entry_package(package="tuned") }}}
 
-{{% if product == "rhel8" %}}
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV requires tuned package for tuning profiles that can enhance virtualization performance") | indent(4) }}}
-{{% endif %}}
 
 template:
     name: package_removed

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -28,6 +28,11 @@ references:
 
 {{{ complete_ocil_entry_package(package="tuned") }}}
 
+{{% if product == "rhel8" %}}
+platforms:
+    - not_ovirt-host
+{{% endif %}}
+
 template:
     name: package_removed
     vars:

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -30,7 +30,7 @@ references:
 
 {{% if product == "rhel8" %}}
 platforms:
-    - no_ovirt
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
 
 warnings:
 {{{ ovirt_rule_notapplicable_warning("RHV requires tuned package for tuning profiles that can enhance virtualization performance") | indent(4) }}}

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -33,9 +33,7 @@ platforms:
     - no_ovirt
 
 warnings:
-    - general: |-
-        This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
-        RHV requires tuned package for tuning profiles that can enhance virtualization performance.
+{{{ ovirt_rule_notapplicable_warning("RHV requires tuned package for tuning profiles that can enhance virtualization performance") | indent(4) }}}
 {{% endif %}}
 
 template:

--- a/shared/applicability/virtualization.yml
+++ b/shared/applicability/virtualization.yml
@@ -9,3 +9,13 @@ cpes:
       name: "cpe:/a:machine"
       title: "Bare-metal or Virtual Machine"
       check_id: installed_env_is_a_machine
+
+  - not_ovirt-host:
+      name: "cpe:/a:not_ovirt-host"
+      title: "oVirt is not installed"
+      check_id: installed_env_has_no_ovirt-host_package
+
+  - ovirt-host:
+      name: "cpe:/a:ovirt-host"
+      title: "oVirt is installed"
+      check_id: installed_env_has_ovirt-host_package

--- a/shared/applicability/virtualization.yml
+++ b/shared/applicability/virtualization.yml
@@ -10,12 +10,12 @@ cpes:
       title: "Bare-metal or Virtual Machine"
       check_id: installed_env_is_a_machine
 
-  - not_ovirt-host:
-      name: "cpe:/a:not_ovirt-host"
-      title: "oVirt is not installed"
-      check_id: installed_env_has_no_ovirt-host_package
+  - no_ovirt:
+      name: "cpe:/a:no_ovirt"
+      title: "oVirt is not installed (no Host nor Manager)"
+      check_id: installed_env_has_no_ovirt
 
-  - ovirt-host:
-      name: "cpe:/a:ovirt-host"
-      title: "oVirt is installed"
-      check_id: installed_env_has_ovirt-host_package
+  - ovirt:
+      name: "cpe:/a:ovirt"
+      title: "oVirt is installed (Host or Manager)"
+      check_id: installed_env_has_ovirt

--- a/shared/checks/oval/installed_env_has_no_ovirt-host_package.xml
+++ b/shared/checks/oval/installed_env_has_no_ovirt-host_package.xml
@@ -1,0 +1,16 @@
+<def-group>
+  <definition class="inventory" id="installed_env_has_no_ovirt-host_package"
+  version="1">
+    <metadata>
+      <title>Package ovirt-host is not installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check if package ovirt-host is not installed.</description>
+    </metadata>
+    <criteria>
+      <extend_definition comment="Package ovirt-host is not installed"
+      definition_ref="installed_env_has_ovirt-host_package" negate="true"/>
+    </criteria>
+  </definition>
+</def-group>

--- a/shared/checks/oval/installed_env_has_no_ovirt-host_package.xml
+++ b/shared/checks/oval/installed_env_has_no_ovirt-host_package.xml
@@ -1,16 +1,16 @@
 <def-group>
-  <definition class="inventory" id="installed_env_has_no_ovirt-host_package"
+  <definition class="inventory" id="installed_env_has_no_ovirt"
   version="1">
     <metadata>
-      <title>Package ovirt-host is not installed</title>
+      <title>Check if the system doesn't act as an oVirt host or manager</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>Check if package ovirt-host is not installed.</description>
+      <description>Check if the system has neither ovirt-host nor ovirt-engine installed.</description>
     </metadata>
     <criteria>
       <extend_definition comment="Package ovirt-host is not installed"
-      definition_ref="installed_env_has_ovirt-host_package" negate="true"/>
+      definition_ref="installed_env_has_ovirt" negate="true"/>
     </criteria>
   </definition>
 </def-group>

--- a/shared/checks/oval/installed_env_has_ovirt-host_package.xml
+++ b/shared/checks/oval/installed_env_has_ovirt-host_package.xml
@@ -1,21 +1,21 @@
 <def-group>
 
   <definition class="inventory"
-  id="installed_env_has_ovirt-host_package" version="1">
+  id="installed_env_has_ovirt" version="1">
     <metadata>
-      <title>Package ovirt-host is installed</title>
+      <title>Check if the system acts as an oVirt host or manager</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <description>Checks if package ovirt-host is installed.</description>
+      <description>Check if the system has ovirt-host or ovirt-engine installed</description>
       <reference ref_id="cpe:/a:ovirt-host" source="CPE" />
     </metadata>
-    <criteria>
+    <criteria operator="OR">
       <criterion comment="Package ovirt-host is installed" test_ref="test_env_has_ovirt-host_installed" />
+      <criterion comment="Package ovirt-engine is installed" test_ref="test_env_has_ovirt-engine_installed" />
     </criteria>
   </definition>
 
-{{% if pkg_system == "rpm" %}}
   <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
   id="test_env_has_ovirt-host_installed" version="1"
   comment="system has package ovirt-host installed">
@@ -24,15 +24,14 @@
   <linux:rpminfo_object id="obj_env_has_ovirt-host_installed" version="1">
     <linux:name>ovirt-host</linux:name>
   </linux:rpminfo_object>
-{{% elif pkg_system == "dpkg" %}}
-  <linux:dpkginfo_test check="all" check_existence="all_exist"
-  id="test_env_has_ovirt-host_installed" version="1"
-  comment="system has package ovirt-host installed">
-    <linux:object object_ref="obj_env_has_ovirt-host_installed" />
-  </linux:dpkginfo_test>
-  <linux:dpkginfo_object id="obj_env_has_ovirt-host_installed" version="1">
-    <linux:name>ovirt-host</linux:name>
-  </linux:dpkginfo_object>
-{{% endif %}}
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_ovirt-engine_installed" version="1"
+  comment="system has package ovirt-engine installed">
+    <linux:object object_ref="obj_env_has_ovirt-engine_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_ovirt-engine_installed" version="1">
+    <linux:name>ovirt-engine</linux:name>
+  </linux:rpminfo_object>
 
 </def-group>

--- a/shared/checks/oval/installed_env_has_ovirt-host_package.xml
+++ b/shared/checks/oval/installed_env_has_ovirt-host_package.xml
@@ -1,0 +1,38 @@
+<def-group>
+
+  <definition class="inventory"
+  id="installed_env_has_ovirt-host_package" version="1">
+    <metadata>
+      <title>Package ovirt-host is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package ovirt-host is installed.</description>
+      <reference ref_id="cpe:/a:ovirt-host" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package ovirt-host is installed" test_ref="test_env_has_ovirt-host_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_ovirt-host_installed" version="1"
+  comment="system has package ovirt-host installed">
+    <linux:object object_ref="obj_env_has_ovirt-host_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_ovirt-host_installed" version="1">
+    <linux:name>ovirt-host</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_ovirt-host_installed" version="1"
+  comment="system has package ovirt-host installed">
+    <linux:object object_ref="obj_env_has_ovirt-host_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_ovirt-host_installed" version="1">
+    <linux:name>ovirt-host</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1594,3 +1594,17 @@ Add or update the following file system rule to <tt>{{{ rule_path }}}</tt>:
 
 The audit daemon must be restarted for the changes to take effect.
 {{% endmacro %}}
+
+{{#
+    Adds a boiler plate warning with a justification why a rule is disabled on RHV.
+    Note: This is only applied on RHEL8 content.
+
+    :param rationale: Explanation why RHV needs the rule disabled.
+#}}
+{{% macro ovirt_rule_notapplicable_warning(rationale) %}}
+{{%- if product == "rhel8" %}}
+- general: |-
+    This rule is disabled on Red Hat Virtualization Hosts and Managers, it will report not applicable.
+    {{{ rationale }}}.
+{{%- endif %}}
+{{% endmacro %}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1608,3 +1608,15 @@ The audit daemon must be restarted for the changes to take effect.
     {{{ rationale }}}.
 {{%- endif %}}
 {{% endmacro %}}
+
+{{#
+
+    Makes a rule not applicable on systems where oVirt is installed.
+    Note: This is only applied on RHEL8 content.
+
+#}}
+{{% macro rule_notapplicable_when_ovirt_installed() %}}
+{{%- if product == "rhel8" %}}
+- no_ovirt
+{{%- endif %}}
+{{% endmacro %}}

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -306,7 +306,8 @@ class XCCDFEntity(object):
 
         for key, default in cls.KEYS.items():
             if key in input_contents:
-                data[key] = input_contents[key]
+                if input_contents[key] is not None:
+                    data[key] = input_contents[key]
                 del input_contents[key]
                 continue
 


### PR DESCRIPTION
#### Description:

- Add CPE platform for `ovirt-host`, which is the base package for RHV virtualization hosts.
- Add the platform on RHEL8 STIG rules that should not be evaluated on RHV hosts.

#### Rationale:

- This enables specific rules from a profile to behave differently when the machine acts as a virtualization host.
