### PR TITLE
Remediation improvements for file_permissions_home_directories rule

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -2207,7 +2207,7 @@ controls:
       - l1_workstation
     automated: no  # The rule below exists, but does not have any OVAL checks or remediations.
     related_rules:
-      - file_permissions_home_dirs
+      - file_permissions_home_directories
 
   # NEEDS RULE (for user ownership)
   # https://github.com/ComplianceAsCode/content/issues/5507

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/ansible/shared.yml
@@ -25,7 +25,7 @@
 - name: Ensure interactive local users are the group-owners of their respective home directories
   ansible.builtin.file:
     path: '{{ item.0.value[4] }}'
-    mode: '0700'
+    mode: 'u-s,g-w-s,o=-'
   loop: '{{ local_users|zip(path_exists.results)|list }}'
   when:
     - item.1.stat is defined and item.1.stat.exists

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/bash/shared.sh
@@ -4,4 +4,9 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($4 >= {{{ uid_min }}} && $4 != 65534) system("chmod -f 700 "$6) }' /etc/passwd
+for home_dir in $(awk -F':' '{ if ($4 >= {{{ uid_min }}} && $4 != 65534) print $6 }' /etc/passwd); do
+    # Only update the permissions when necessary. This will avoid changing the inode timestamp when
+    # the permission is already defined as expected, therefore not impacting in possible integrity
+    # check systems that also check inodes timestamps.
+    find $home_dir -perm /7027 -exec chmod u-s,g-w-s,o=- {} \;
+done

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
@@ -24,6 +24,8 @@ identifiers:
     cce@sle15: CCE-85629-4
 
 references:
+    cis@rhel7: 6.2.13
+    cis@rhel8: 6.2.7
     cis@sle12: 6.2.6
     cis@sle15: 6.2.6
     cis@ubuntu2004: 6.2.5

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/special_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/special_permissions.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+chmod -f g-w+s,o=t /home/$USER


### PR DESCRIPTION
Adjusted the remediation to be more conservative, removing unexpected permissions
only when necessary.

It was also updated the references of this rule and adjusted the cis_rhel8 control file to use
it instead of file_permissions_home_dirs, since the second is no longer found in current
benchmarks.