### PR TITLE
Fix the metadata propagation of SCE checks

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1259,6 +1259,7 @@ class Rule(XCCDFEntity):
         requires=lambda: list(),
         platform=lambda: None,
         platforms=lambda: set(),
+        sce_metadata=lambda: dict(),
         inherited_platforms=lambda: list(),
         template=lambda: None,
         cpe_platform_names=lambda: set(),


### PR DESCRIPTION
#### Description:

Add the SCE metadata to the list of Rule attributes that must be generated in
the intermediate yaml files.

#### Rationale:

SCE metadata was not forwarded to the intermediate build
representation (build/<product>/rules/<rule_name>.yml, the expanded version of
the product.yml for check `rule_name`).
As a consequence, the condition at line 1262 of
ssg/build_yaml.py@f8c2cd395f2638a7426b7853d1eaf77a0f246506 was never true,
hence the build system wasn't generating the
<xccdf-1.2:check system="http://open-scap.org/page/SCE">...</xccdf-1.2:check>
section at line 1586 of ssg/build_yaml.py@f8c2cd395f2638a7426b7853d1eaf77a0f246506,
and finally the content of the SCE file itself ended up being
"garbage-collected" because no check referenced it, and was thus
discarded from the DataStream.


Fixes #7946.