### PR TITLE
Add rationale to controls

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -1118,6 +1118,7 @@ The `status` key may hold the following values:
 
 * `automated`: The control is addressed by the product and can be automatically
                checked for.
+* `does not meet`: The control is not met by the product
 
 Note that if the `status` key is missing from a control definition, the default
 status will be `pending`.
@@ -1213,6 +1214,8 @@ controls:
     description: >-
       The features configured at the level of launched services
       should be limited to the strict minimum.
+    rationale: >- 
+        Minimization of configuration helps to reduce attack surface.
     status: supported
     note: >-
       This is individual depending on the system workload

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -72,6 +72,7 @@ class Control(ssg.build_yaml.SelectionHandler):
         self.notes = ""
         self.title = ""
         self.description = ""
+        self.rationale = ""
         self.automated = ""
         self.status = None
         self.mitigation = ""
@@ -89,6 +90,7 @@ class Control(ssg.build_yaml.SelectionHandler):
         control.id = ssg.utils.required_key(control_dict, "id")
         control.title = control_dict.get("title")
         control.description = control_dict.get("description")
+        control.rationale = control_dict.get("rationale")
         control.status = Status.from_control_info(control.id, control_dict.get("status", None))
         control.automated = control_dict.get("automated", "no")
         control.status_justification = control_dict.get('status_justification')

--- a/tests/unit/ssg-module/data/controls_dir/abcd.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd.yml
@@ -22,6 +22,8 @@ controls:
     description: >-
       The features configured at the level of launched services
       should be limited to the strict minimum.
+    rationale: >-
+      Minimization of configuration helps to reduce attack surface.
     automated: no
     note: >-
       This is individual depending on the system workload

--- a/tests/unit/ssg-module/data/controls_dir/jklm.yml
+++ b/tests/unit/ssg-module/data/controls_dir/jklm.yml
@@ -9,6 +9,8 @@ controls:
     description: >-
       The features configured at the level of launched services
       should be limited to the strict minimum.
+    rationale: >-
+        Minimization of configuration helps to reduce attack surface.
     automated: no
     note: >-
       This is individual depending on the system workload

--- a/tests/unit/ssg-module/data/controls_dir/qrst/r2_r3.yml
+++ b/tests/unit/ssg-module/data/controls_dir/qrst/r2_r3.yml
@@ -4,6 +4,8 @@ controls:
         description: >-
             The features configured at the level of launched services
             should be limited to the strict minimum.
+        rationale: >-
+            Minimization of configuration helps to reduce attack surface.
         automated: no
         note: >-
             This is individual depending on the system workload

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -37,6 +37,7 @@ def _load_test(profile):
     assert c_r2.automated == "no"
     assert c_r2.note == "This is individual depending on the system " \
                         "workload therefore needs to be audited manually."
+    assert c_r2.rationale == "Minimization of configuration helps to reduce attack surface."
     assert len(c_r2.selected) == 0
     assert not c_r2.notes
     c_r4 = controls_manager.get_control(profile, "R4")
@@ -284,5 +285,5 @@ def test_load_control_from_folder():
     _load_test("jklm")
 
 
-def test_load_control_from_folder():
+def test_load_control_from_folder_and_file():
     _load_test("qrst")

--- a/utils/create_srg_export.py
+++ b/utils/create_srg_export.py
@@ -154,10 +154,12 @@ def handle_control(product: str, control: ssg.controls.Control, csv_writer: csv.
             csv_writer.writerow(row)
     else:
         row = create_base_row(control, srgs)
+        row['Requirement'] = control.description
         row['Mitigation'] = control.mitigation
         row['Artifact Description'] = control.artifact_description
         row['Status Justification'] = control.status_justification
         row['Status'] = DisaStatus.from_string(control.status)
+        row['Vul Discussion'] = control.rationale
         csv_writer.writerow(row)
 
 


### PR DESCRIPTION
#### Description:

Added a rationale key to controls.

#### Rationale:

 This is for rules in controls like STIG that do not have rules but need line in an export with a rationale.
