### PR TITLE
EKS: Provide assessments and rules for CIS section 3

### DIFF
--- a/applications/openshift/kubelet/group.yml
+++ b/applications/openshift/kubelet/group.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
 title: 'Kubernetes Kubelet Settings'
 

--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -1,8 +1,14 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'Disable Anonymous Authentication to the Kubelet'
 
@@ -10,7 +16,7 @@ description: |-
     By default, anonymous access to the Kubelet server is enabled. This
     configuration check ensures that anonymous requests to the Kubelet
     server are disabled. Edit the Kubelet server configuration file
-    <tt>/etc/kubernetes/kubelet.conf</tt> on the kubelet node(s)
+    <tt>{{{ kubeletconf_path }}}</tt> on the kubelet node(s)
     and set the below parameter:
     <pre>
     authentication:
@@ -30,6 +36,7 @@ rationale: |-
 severity: medium
 
 references:
+    cis@eks: 3.2.1
     cis@ocp4: 4.2.1
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -41,13 +48,13 @@ ocil_clause: '<tt>anonymous</tt> authentication is not set to <tt>false</tt>'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep -A1 anonymous /etc/kubernetes/kubelet.conf</pre>
+    <pre>$ sudo grep -A1 anonymous {{{ kubeletconf_path }}}</pre>
     The output should return <pre>enabled: false</pre>.
 
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".authentication.anonymous.enabled"
         values:
          - value: "false"

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -1,8 +1,14 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'Ensure authorization is set to Webhook'
 
@@ -11,7 +17,7 @@ description: |-
     The Kubelet should be set to only allow Webhook authorization.
     To ensure that the Kubelet requires authorization,
     validate that <tt>authorization</tt> is configured to <tt>Webhook</tt>
-    in <tt>/etc/kubernetes/kubelet.conf</tt>:
+    in <tt>{{{ kubeletconf_path }}}</tt>:
     <pre>
     authorization:
       mode: Webhook
@@ -29,6 +35,7 @@ identifiers:
 severity: medium
 
 references:
+    cis@eks: 3.2.2
     cis@ocp4: 4.2.2
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -37,14 +44,14 @@ ocil_clause: '<tt>authorization-mode</tt> is not configured to <tt>Webhook</tt>'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep -A1 authorization /etc/kubernetes/kubelet.conf</pre>
+    <pre>$ sudo grep -A1 authorization {{{ kubeletconf_path }}}</pre>
     Verify that the output is not set to <tt>mode: AlwaysAllow</tt>, or missing
     (defaults to <tt>mode: Webhook</tt>).
 
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".authorization.mode"
         check_existence: "any_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_client_ca/rule.yml
@@ -1,8 +1,16 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- set ca_path = "/etc/kubernetes/pki/ca.crt" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- set ca_path = "/etc/kubernetes/kubelet-ca.crt" %}}
+{{%- endif %}}
 
 title: 'kubelet - Configure the Client CA Certificate'
 
@@ -11,13 +19,13 @@ description: |-
     can subject the kubelet to man-in-the-middle attacks.
 
     To configure a client CA certificate, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubelet.conf</tt>
+    file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
     authentication:
     ...
       x509:
-        clientCAFile: /etc/kubernetes/kubelet-ca.crt
+        clientCAFile: {{{ ca_path}}}
     ...
     </pre>
 
@@ -33,13 +41,14 @@ ocil_clause: 'no client CA certificate has been configured'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep -A1 x509 /etc/kubernetes/kubelet.conf</pre>
-    The output should contain a configured certificate like <tt>/etc/kubernetes/kubelet-ca.crt</tt>.
+    <pre>$ sudo grep -A1 x509 {{{ kubeletconf_path }}}</pre>
+    The output should contain a configured certificate like <tt>{{{ ca_path}}}</tt>.
 
 identifiers:
     cce@ocp4: CCE-83724-5
 
 references:
+    cis@eks: 3.2.3
     cis@ocp4: 4.2.3
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -47,8 +56,8 @@ references:
 template:
   name: yamlfile_value
   vars:
-    filepath: /etc/kubernetes/kubelet.conf
+    filepath: {{{ kubeletconf_path }}}
     yamlpath: ".authentication.x509.clientCAFile"
     values:
-      - value: "/etc/kubernetes/kubelet-ca.crt"
+      - value: "{{{ ca_path}}}"
         operation: "equals"

--- a/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
@@ -1,0 +1,51 @@
+documentation_complete: true
+
+prodtype: eks,ocp4
+
+platform: {{{ product }}}-node
+
+{{%- if product == "eks"  %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
+
+title: 'kubelet - Hostname Override handling'
+
+description: |-
+    Normally, OpenShift lets the kubelet get the hostname from either the
+    cloud provider itself, or from the node's hostname. This ensures that
+    the PKI allocated by the deployment uses the appropriate values, is valid
+    and keeps working throughout the lifecycle of the cluster. IP addresses
+    are not used, and hence this makes it easier for security analysts to
+    associate kubelet logs with the appropriate node.
+rationale: |-
+    Allowing hostnames to be overridden creates issues around resolving nodes
+    in addition to TLS configuration, certificate validation, and log correlation
+    and validation.
+{{%- if product == "ocp4"  %}}
+    However, in some cases explicit overriding this parameter is
+    necessary to ensure that the appropriate node name stays as it is in case of
+    certain upgrade conditions. e.g. as is the case in AWS and OpenStack when migrating
+    to external cloud providers.
+{{%- endif %}}
+
+severity: low
+
+references:
+    cis@eks: 3.2.8
+    cis@ocp4: 4.2.8
+    nerc-cip: CIP-003-3 R6,CIP-004-3 R3,CIP-007-3 R6.1
+    nist: CM-6,CM-6(1)
+
+{{%- if product == "eks"  %}}
+template:
+  name: yamlfile_value
+  vars:
+    filepath: {{{ kubeletconf_path }}}
+    yamlpath: ".hostname-override"
+    check_existence: "none_exist"
+    values:
+      - value: ".*"
+        operation: "pattern match"
+{{%- endif %}}

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/rule.yml
@@ -1,14 +1,20 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'kubelet - Enable Certificate Rotation'
 
 description: |-
     To enable the kubelet to rotate client certificates, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubelet.conf</tt>
+    file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
     ...
@@ -26,13 +32,14 @@ ocil_clause: 'the kubelet cannot rotate client certificate'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep rotateCertificates /etc/kubernetes/kubelet.conf</pre>
-    The output should return <tt>true</tt>.
+    <pre>$ sudo grep rotateCertificates {{{ kubeletconf_path }}}</pre>
+    The output should return nothing or <tt>true</tt>.
 
 identifiers:
     cce@ocp4: CCE-83838-3
 
 references:
+    cis@eks: 3.2.10
     cis@ocp4: 4.2.11
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -40,7 +47,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".rotateCertificates"
         values:
          - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/tests/cert_rotation_disabled.fail.sh
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/tests/cert_rotation_disabled.fail.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# remediation = none
+
+set -x
+
+kubeconfig=$(cat << EOF
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "address": "0.0.0.0",
+  "authentication": {
+    "anonymous": {
+      "enabled": false
+    },
+    "webhook": {
+      "cacheTTL": "2m0s",
+      "enabled": true
+    },
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "hairpinMode": "hairpin-veth",
+  "readOnlyPort": 0,
+  "cgroupDriver": "cgroupfs",
+  "cgroupRoot": "/",
+  "featureGates": {
+    "RotateKubeletServerCertificate": true
+  },
+  "rotateCertificates": false,
+  "protectKernelDefaults": true,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "kubeReserved": {
+    "cpu": "70m",
+    "ephemeral-storage": "1Gi",
+    "memory": "574Mi"
+  },
+  "maxPods": 29
+}
+EOF
+)
+
+# This is applicable to both OpenShift and EKS
+for path in "/etc/kubernetes/kubelet/kubelet-config.json" "/etc/kubernetes/kubelet.conf"
+do
+	mkdir -p $(dirname $path)
+	echo $kubeconfig > $path
+done

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/tests/cert_rotation_enabled.pass.sh
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/tests/cert_rotation_enabled.pass.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# remediation = none
+
+set -x
+
+kubeconfig=$(cat << EOF
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "address": "0.0.0.0",
+  "authentication": {
+    "anonymous": {
+      "enabled": false
+    },
+    "webhook": {
+      "cacheTTL": "2m0s",
+      "enabled": true
+    },
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "hairpinMode": "hairpin-veth",
+  "readOnlyPort": 0,
+  "cgroupDriver": "cgroupfs",
+  "cgroupRoot": "/",
+  "featureGates": {
+    "RotateKubeletServerCertificate": true
+  },
+  "protectKernelDefaults": true,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "rotateCertificates": true,
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "kubeReserved": {
+    "cpu": "70m",
+    "ephemeral-storage": "1Gi",
+    "memory": "574Mi"
+  },
+  "maxPods": 29
+}
+EOF
+)
+
+# This is applicable to both OpenShift and EKS
+for path in "/etc/kubernetes/kubelet/kubelet-config.json" "/etc/kubernetes/kubelet.conf"
+do
+	mkdir -p $(dirname $path)
+	echo $kubeconfig > $path
+done

--- a/applications/openshift/kubelet/kubelet_enable_cert_rotation/tests/cert_rotation_missing.fail.sh
+++ b/applications/openshift/kubelet/kubelet_enable_cert_rotation/tests/cert_rotation_missing.fail.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# remediation = none
+
+set -x
+
+kubeconfig=$(cat << EOF
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "address": "0.0.0.0",
+  "authentication": {
+    "anonymous": {
+      "enabled": false
+    },
+    "webhook": {
+      "cacheTTL": "2m0s",
+      "enabled": true
+    },
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/pki/ca.crt"
+    }
+  },
+  "authorization": {
+    "mode": "Webhook",
+    "webhook": {
+      "cacheAuthorizedTTL": "5m0s",
+      "cacheUnauthorizedTTL": "30s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "hairpinMode": "hairpin-veth",
+  "readOnlyPort": 0,
+  "cgroupDriver": "cgroupfs",
+  "cgroupRoot": "/",
+  "featureGates": {
+    "RotateKubeletServerCertificate": true
+  },
+  "protectKernelDefaults": true,
+  "serializeImagePulls": false,
+  "serverTLSBootstrap": true,
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_RSA_WITH_AES_128_GCM_SHA256"
+  ],
+  "clusterDNS": [
+    "10.100.0.10"
+  ],
+  "evictionHard": {
+    "memory.available": "100Mi",
+    "nodefs.available": "10%",
+    "nodefs.inodesFree": "5%"
+  },
+  "kubeReserved": {
+    "cpu": "70m",
+    "ephemeral-storage": "1Gi",
+    "memory": "574Mi"
+  },
+  "maxPods": 29
+}
+EOF
+)
+
+# This is applicable to both OpenShift and EKS
+for path in "/etc/kubernetes/kubelet/kubelet-config.json" "/etc/kubernetes/kubelet.conf"
+do
+	mkdir -p $(dirname $path)
+	echo $kubeconfig > $path
+done

--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -1,14 +1,20 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'kubelet - Enable Client Certificate Rotation'
 
 description: |-
     To enable the kubelet to rotate client certificates, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubelet.conf</tt>
+    file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
     featureGates:
@@ -27,13 +33,14 @@ ocil_clause: 'the kubelet cannot rotate client certificate'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep RotateKubeletClientCertificate /etc/kubernetes/kubelet.conf</pre>
+    <pre>$ sudo grep RotateKubeletClientCertificate {{{ kubeletconf_path }}}</pre>
     The output should return <tt>true</tt>.
 
 identifiers:
     cce@ocp4: CCE-83352-5
 
 references:
+    cis@eks: 3.2.10
     cis@ocp4: 4.2.11
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -41,7 +48,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".featureGates.RotateKubeletClientCertificate"
         check_existence: "any_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_iptables_util_chains/rule.yml
@@ -1,8 +1,14 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks"  %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'kubelet - Allow Automatic Firewall Configuration'
 
@@ -11,7 +17,7 @@ description: |-
     the containers required ports and connections to networking resources and destinations
     parameters potentially creating a security incident.
     To allow the kubelet to modify the firewall, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubelet.conf</tt>
+    file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>makeIPTablesUtilChains: true</pre>
 
@@ -27,13 +33,14 @@ ocil_clause: 'the kubelet cannot modify the firewall settings'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep makeIPTablesUtilChains /etc/kubernetes/kubelet.conf</pre>
+    <pre>$ sudo grep makeIPTablesUtilChains {{{ kubeletconf_path }}}</pre>
     The output should return <tt>true</tt>.
 
 identifiers:
     cce@ocp4: CCE-83775-7
 
 references:
+    cis@eks: 3.2.7
     cis@ocp4: 4.2.7
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -41,7 +48,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".makeIPTablesUtilChains"
         values:
          - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_protect_kernel_defaults/rule.yml
@@ -1,8 +1,14 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks"  %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'kubelet - Enable Protect Kernel Defaults'
 
@@ -11,6 +17,7 @@ description: |-
   Protect tuned kernel parameters from being overwritten by the kubelet.
   </p>
 
+{{%- if product == "ocp4"  %}}
   <p>
   Before enabling this kernel parameter, it's important and
   necessary to first create a <tt>MachineConfig</tt> object that persist
@@ -69,6 +76,7 @@ description: |-
   {{{ weblink(link="https://docs.openshift.com/container-platform/4.6/nodes/nodes/nodes-nodes-managing.html",
               text="the documentation") }}}
   </p>
+{{%- endif %}}
 
 rationale: |-
   Kernel parameters are usually tuned and hardened by the system administrators
@@ -85,13 +93,14 @@ ocil_clause: 'the kubelet can modify kernel parameters'
 
 ocil: |-
   Run the following command on the kubelet node(s):
-  <pre>$ sudo grep protectKernelDefaults /etc/kubernetes/kubelet.conf</pre>
+  <pre>$ sudo grep protectKernelDefaults {{{ kubeletconf_path }}}</pre>
   The output should return <tt>true</tt>.
 
 #identifiers:
 #   cce@ocp4: 
 
 references:
+  cis@eks: 3.2.6
   cis@ocp4: 4.2.6
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
@@ -99,7 +108,7 @@ references:
 template:
   name: yamlfile_value
   vars:
-    filepath: /etc/kubernetes/kubelet.conf
+    filepath: {{{ kubeletconf_path }}}
     yamlpath: ".protectKernelDefaults"
     values:
      - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_server_cert_rotation/rule.yml
@@ -1,14 +1,20 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'kubelet - Enable Server Certificate Rotation'
 
 description: |-
     To enable the kubelet to rotate server certificates, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubelet.conf</tt>
+    file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>
     featureGates:
@@ -27,13 +33,14 @@ ocil_clause: 'the kubelet cannot rotate server certificate'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep RotateKubeletServerCertificate /etc/kubernetes/kubelet.conf</pre>
+    <pre>$ sudo grep RotateKubeletServerCertificate {{{ kubeletconf_path }}}</pre>
     The output should return <tt>true</tt>.
 
 identifiers:
     cce@ocp4: CCE-83356-6
 
 references:
+    cis@eks: 3.2.11
     cis@ocp4: 4.2.12
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -41,7 +48,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".featureGates.RotateKubeletServerCertificate"
         values:
          - value: "true"

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -1,8 +1,14 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks"  %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'kubelet - Do Not Disable Streaming Timeouts'
 
@@ -10,7 +16,7 @@ description: |-
     Timouts for streaming connections should not be disabled as they help to prevent
     denial-of-service attacks.
     To configure streaming connection timeouts, edit the kubelet configuration
-    file <tt>/etc/kubernetes/kubelet.conf</tt>
+    file <tt>{{{ kubeletconf_path }}}</tt>
     on the kubelet node(s) and set the below parameter:
     <pre>streamingConnectionIdleTimeout: {{{ xccdf_value("var_streaming_connection_timeouts") }}}</pre>
 
@@ -25,13 +31,14 @@ ocil_clause: 'the streaming connection timeouts are not disabled'
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ sudo grep streamingConnectionIdleTimeout /etc/kubernetes/kubelet.conf</pre>
+    <pre>$ sudo grep streamingConnectionIdleTimeout {{{ kubeletconf_path }}}</pre>
     The output should return <tt>{{{ xccdf_value("var_streaming_connection_timeouts") }}}</tt>.
 
 identifiers:
     cce@ocp4: CCE-84097-5
 
 references:
+    cis@eks: 3.2.5
     cis@ocp4: 4.2.5
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
@@ -39,7 +46,7 @@ references:
 template:
     name: yamlfile_value
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         yamlpath: ".streamingConnectionIdleTimeout"
         check_existence: "any_exist"
         values:

--- a/applications/openshift/kubelet/kubelet_read_only_port_secured/rule.yml
+++ b/applications/openshift/kubelet/kubelet_read_only_port_secured/rule.yml
@@ -1,0 +1,48 @@
+documentation_complete: true
+
+prodtype: eks,ocp4
+
+platform: {{{ product }}}-node
+
+{{%- if product == "eks"  %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
+
+title: 'kubelet - Ensure that the --read-only-port is secured'
+
+description: |-
+  Disable the read-only port.
+
+rationale: |-
+  The Kubelet process provides a read-only API in addition to the main Kubelet API.
+  Unauthenticated access is provided to this read-only API which could possibly retrieve
+  potentially sensitive information about the cluster.
+
+severity: medium
+
+ocil_clause: 'readOnlyPort is not secured'
+
+ocil: |-
+  First, SSH to the relevant node.
+
+  Open the Kubelet config file:
+
+    cat {{{ kubeletconf_path }}}
+
+  Verify that the "readOnlyPort" argument exists and is set to 0
+
+references:
+    cis@eks: 3.2.4
+    nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
+    nist: CM-6,CM-6(1)
+
+template:
+  name: yamlfile_value
+  vars:
+    filepath: {{{ kubeletconf_path }}}
+    yamlpath: ".readOnlyPort"
+    values:
+      - value: "0"
+        operation: "equals"

--- a/applications/openshift/kubelet/kubelet_read_only_port_secured/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_read_only_port_secured/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -1,12 +1,18 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'Verify Group Who Owns The Kubelet Configuration File'
 
-description: '{{{ describe_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'
+description: '{{{ describe_file_group_owner(file=kubeletconf_path, group="root") }}}'
 rationale: |-
     The kubelet configuration file contains information about the configuration of the
     OpenShift node that is configured on the system. Protection of this file is
@@ -18,17 +24,18 @@ identifiers:
     cce@ocp4: CCE-84233-6
 
 references:
+    cis@eks: 3.1.4
     cis@ocp4: 4.1.6
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file=kubeletconf_path, group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/etc/kubernetes/kubelet.conf", group="root") }}}
+    {{{ ocil_file_group_owner(file=kubeletconf_path, group="root") }}}
 
 template:
     name: file_groupowner
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         filegid: '0'

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -1,8 +1,8 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
 
 title: 'Verify Group Who Owns The Worker Kubeconfig File'
 

--- a/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
@@ -1,12 +1,18 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'Verify User Who Owns The Kubelet Configuration File'
 
-description: '{{{ describe_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'
+description: '{{{ describe_file_owner(file=kubeletconf_path, owner="root") }}}'
 
 rationale: |-
     The kubelet configuration file contains information about the configuration of the
@@ -19,17 +25,18 @@ identifiers:
     cce@ocp4: CCE-83976-1
 
 references:
+    cis@eks: 3.1.4
     cis@ocp4: 4.1.6
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file=kubeletconf_path, owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="/etc/kubernetes/kubelet.conf", owner="root") }}}
+    {{{ ocil_file_owner(file=kubeletconf_path, owner="root") }}}
 
 template:
     name: file_owner
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         fileuid: '0'

--- a/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_worker_kubeconfig/rule.yml
@@ -1,8 +1,8 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
 
 title: 'Verify User Who Owns The Worker Kubeconfig File'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@ocp4: CCE-83408-5
 
 references:
+    cis@eks: 3.1.2
     cis@ocp4: 4.1.10
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)

--- a/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
@@ -1,13 +1,19 @@
 documentation_complete: true
 
-prodtype: ocp4
+prodtype: eks,ocp4
 
-platform: ocp4-node
+platform: {{{ product }}}-node
+
+{{%- if product == "eks" %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- else %}}
+{{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- endif %}}
 
 title: 'Verify Permissions on The Kubelet Configuration File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/kubelet.conf", perms="0644") }}}
+    {{{ describe_file_permissions(file=kubeletconf_path, perms="0644") }}}
 
 rationale: |-
     If the kubelet configuration file is writable by a group-owner or the
@@ -21,17 +27,18 @@ identifiers:
     cce@ocp4: CCE-83470-5
 
 references:
+    cis@eks: 3.1.3
     cis@ocp4: 4.1.5
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/kubelet.conf", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file=kubeletconf_path, perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/kubelet.conf", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file=kubeletconf_path, perms="-rw-r--r--") }}}
 
 template:
     name: file_permissions
     vars:
-        filepath: /etc/kubernetes/kubelet.conf
+        filepath: {{{ kubeletconf_path }}}
         filemode: '0644'

--- a/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
@@ -3,11 +3,7 @@ documentation_complete: true
 prodtype: eks,ocp4
 
 platforms:
-{{%- if product == "eks" %}}
-- eks-node
-{{%- else %}}
-- ocp4-node
-{{%- endif %}}
+- {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set octal_perms = "0644" %}}

--- a/controls/cis_eks.yml
+++ b/controls/cis_eks.yml
@@ -141,8 +141,10 @@ controls:
         The kubeconfig file for kubelet controls various parameters for the kubelet service in the
         worker node. You should set its file ownership to maintain the integrity of the file. The file
         should be owned by root:root.
-      status: pending
-      rules: []
+      status: automated
+      rules:
+      - file_owner_worker_kubeconfig
+      - file_groupowner_worker_kubeconfig
     - id: 3.1.3
       title: >-
         3.1.3 Ensure that the kubelet configuration file has permissions set to 644 or more restrictive
@@ -158,10 +160,11 @@ controls:
         specified by the --config argument. If this file is specified you should restrict its file
         permissions to maintain the integrity of the file. The file should be writable by only the
         administrators on the system.
-      status: pending
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - file_permissions_kubelet_conf
     - id: 3.1.4
       title: >-
         3.1.4 Ensure that the kubelet configuration file ownership is set to root:root
@@ -176,10 +179,12 @@ controls:
         specified by the --config argument. If this file is specified you should restrict its file
         permissions to maintain the integrity of the file. The file should be writable by only the
         administrators on the system.
-      status: pending
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - file_groupowner_kubelet_conf
+      - file_owner_kubelet_conf
   - id: '3.2'
     title: >-
       3.2 Kubelet
@@ -196,69 +201,186 @@ controls:
 
       If the --config argument is present, this gives the location of the Kubelet config file. This
       config file could be in JSON or YAML format depending on your distribution.
-    status: pending
+    status: automated
     levels:
     - level_2
     controls:
     - id: 3.2.1
       title: >-
         3.2.1 Ensure that the --anonymous-auth argument is set to false
-      status: pending
+      description: |-
+        Description:
+
+        Disable anonymous requests to the Kubelet server.
+
+        Rationale:
+
+        When enabled, requests that are not rejected by other configured authentication methods
+        are treated as anonymous requests. These requests are then served by the Kubelet server.
+        You should rely on authentication to authorize access and disallow anonymous requests.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_anonymous_auth
     - id: 3.2.2
       title: >-
         3.2.2 Ensure that the --authorization-mode argument is not set to AlwaysAllow
-      status: pending
+      description: |-
+        Description:
+
+        Do not allow all requests. Enable explicit authorization.
+
+        Rationale:
+
+        Kubelets, by default, allow all authenticated requests (even anonymous ones) without
+        needing explicit authorization checks from the apiserver. You should restrict this behavior
+        and only allow explicitly authorized requests.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_authorization_mode
     - id: 3.2.3
       title: >-
         3.2.3 Ensure that the --client-ca-file argument is set as appropriate
-      status: pending
+      description: |-
+        Description:
+
+        Enable Kubelet authentication using certificates.
+
+        Rationale:
+
+        The connections from the apiserver to the kubelet are used for fetching logs for pods,
+        attaching (through kubectl) to running pods, and using the kubelet’s port-forwarding
+        functionality. These connections terminate at the kubelet’s HTTPS endpoint. By default, the
+        apiserver does not verify the kubelet’s serving certificate, which makes the connection
+        subject to man-in-the-middle attacks, and unsafe to run over untrusted and/or public
+        networks. Enabling Kubelet certificate authentication ensu
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_configure_client_ca
     - id: 3.2.4
       title: >-
         3.2.4 Ensure that the --read-only-port is secured
-      status: pending
+      description: |-
+        Description:
+
+        Disable the read-only port.
+
+        Rationale:
+
+        The Kubelet process provides a read-only API in addition to the main Kubelet API.
+        Unauthenticated access is provided to this read-only API which could possibly retrieve
+        potentially sensitive information about the cluster.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_read_only_port_secured
     - id: 3.2.5
       title: >-
         3.2.5 Ensure that the --streaming-connection-idle-timeout argument is not set to 0
-      status: pending
+      description: |-
+        Description:
+
+        Do not disable timeouts on streaming connections.
+
+        Rationale:
+
+        Setting idle timeouts ensures that you are protected against Denial-of-Service attacks,
+        inactive connections and running out of ephemeral ports.
+        Note: By default, --streaming-connection-idle-timeout is set to 4 hours which might be
+        too high for your environment. Setting this as appropriate would additionally ensure that
+        such streaming connections are timed out after serving legitimate use cases.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_enable_streaming_connections
     - id: 3.2.6
       title: >-
         3.2.6 Ensure that the --protect-kernel-defaults argument is set to true
-      status: pending
+      description: |-
+        Description:
+
+        Protect tuned kernel parameters from overriding kubelet default kernel parameter values.
+
+        Rationale:
+
+        Kernel parameters are usually tuned and hardened by the system administrators before
+        putting the systems into production. These parameters protect the kernel and the system.
+        Your kubelet kernel defaults that rely on such parameters should be appropriately set to
+        match the desired secured system state. Ignoring this could potentially lead to running
+        pods with undesired kernel behavior.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_enable_protect_kernel_defaults
     - id: 3.2.7
       title: >-
         3.2.7 Ensure that the --make-iptables-util-chains argument is set to true
-      status: pending
+      description: |-
+        Description:
+
+        Allow Kubelet to manage iptables.
+
+        Rationale:
+
+        Kubelets can automatically manage the required changes to iptables based on how you
+        choose your networking options for the pods. It is recommended to let kubelets manage
+        the changes to iptables. This ensures that the iptables configuration remains in sync with
+        pods networking configuration. Manually configuring iptables with dynamic pod network
+        configuration changes might hamper the communication between pods/containers and to
+        the outside world. You might have iptables rules too restrictive or too open.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_enable_iptables_util_chains
     - id: 3.2.8
       title: >-
         3.2.8 Ensure that the --hostname-override argument is not set
-      status: pending
+      description: |-
+        Description:
+
+        Do not override node hostnames.
+
+        Rationale:
+
+        Overriding hostnames could potentially break TLS setup between the kubelet and the
+        apiserver. Additionally, with overridden hostnames, it becomes increasingly difficult to
+        associate logs with a particular node and process them for security analytics. Hence, you
+        should setup your kubelet nodes with resolvable FQDNs and avoid overriding the
+        hostnames with IPs.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_disable_hostname_override
     - id: 3.2.9
       title: >-
         3.2.9 Ensure that the --eventRecordQPS argument is set to 0 or a level which ensures appropriate event capture
+      # TODO(jaosorior): I'm unsure how to check this as the value is not
+      # set in EKS, but the result of evaluating the dynamic config
+      # endpoint gives out a correct value... so it seems that it
+      # just passes by default.
+      description: |-
+        Description:
+
+        Security relevant information should be captured. The --eventRecordQPS flag on the
+        Kubelet can be used to limit the rate at which events are gathered. Setting this too low
+        could result in relevant events not being logged, however the unlimited setting of 0 could
+        result in a denial of service on the kubelet.
+
+        Rationale:
+
+        It is important to capture all events and not restrict event creation. Events are an important
+        source of security information and analytics that ensure that your environment is
+        consistently monitored using the event data.
       status: pending
       levels:
       - level_2
@@ -266,17 +388,46 @@ controls:
     - id: 3.2.10
       title: >-
         3.2.10 Ensure that the --rotate-certificates argument is not set to false
-      status: pending
+      description: |-
+        Description:
+
+        Enable kubelet client certificate rotation.
+
+        Rationale:
+
+        The --rotate-certificates setting causes the kubelet to rotate its client certificates by
+        creating new CSRs as its existing credentials expire. This automated periodic rotation
+        ensures that the there is no downtime due to expired certificates and thus addressing
+        availability in the CIA security triad.
+      status: automated
       levels:
       - level_2
-      rules: []
+      rules:
+      - kubelet_enable_client_cert_rotation
+      - kubelet_enable_cert_rotation
     - id: 3.2.11
       title: >-
         3.2.11 Ensure that the RotateKubeletServerCertificate argument is set to true
-      status: pending
+      description: |-
+        Description:
+
+        Enable kubelet server certificate rotation.
+
+        Rationale:
+
+        RotateKubeletServerCertificate causes the kubelet to both request a serving certificate
+        after bootstrapping its client credentials and rotate the certificate as its existing credentials
+        expire. This automated periodic rotation ensures that the there are no downtimes due to
+        expired certificates and thus addressing availability in the CIA security triad.
+
+        Note: This recommendation only applies if you let kubelets get their certificates from the
+        API server. In case your kubelet certificates come from an outside authority/tool (e.g.
+        Vault) then you need to take care of rotation yourself.
+      status: automated
       levels:
       - level_1
-      rules: []
+      rules:
+      - kubelet_enable_server_cert_rotation
 - id: '4'
   title: >-
     4 Policies


### PR DESCRIPTION
Most of these already had automation in OpenShift, so we're just
re-using it.

Some required a new rule (e.g. `kubelet_read_only_port_secured`).

While for other controls, we re-introduced a rule that had been
previously deleted (e.g. `kubelet_disable_hostname_override`).

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>