### PR TITLE
Fix `utils/rule_dir_json.py` when no product is detected when rendering OVAL

### DIFF
--- a/ssg/oval.py
+++ b/ssg/oval.py
@@ -24,7 +24,7 @@ except AttributeError:
     ET._namespace_map[ovalns] = "oval"
 
 
-def applicable_platforms(oval_file, oval_version_string=None):
+def applicable_platforms(oval_file, oval_version_string=None, product=None):
     """
     Returns the applicable platforms for a given oval file
     """
@@ -37,6 +37,9 @@ def applicable_platforms(oval_file, oval_version_string=None):
 
     oval_version_list = [int(num) for num in oval_version_string.split(".")]
     subst_dict = dict(target_oval_version=oval_version_list)
+
+    if product is not None:
+        subst_dict["product"] = product
 
     oval_filename_components = oval_file.split(os.path.sep)
     if len(oval_filename_components) > 3:

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -117,7 +117,7 @@ def handle_ovals(product_list, product_yamls, rule_obj):
         oval_product, _ = os.path.splitext(oval_name)
         oval_obj = {'name': oval_name, 'product': oval_product}
 
-        platforms = ssg.oval.applicable_platforms(oval_path)
+        platforms = ssg.oval.applicable_platforms(oval_path, product=oval_product)
         cs_platforms = ','.join(platforms)
 
         oval_obj['platforms'] = platforms


### PR DESCRIPTION
`ssh/oval.py`'s `applicable_platform` fails in some cases where a
product is not detected since it needs to be rendered in jinja.

This adds a parameter that passes the product name and takes it into use
in `utils/rule_dir_json.py`.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>