### PR TITLE
Set default product name when loading product yaml

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -460,3 +460,5 @@ DEFAULT_DCONF_GDM_DIR = 'gdm.d'
 DEFAULT_AIDE_CONF_PATH = '/etc/aide.conf'
 DEFAULT_AIDE_BIN_PATH = '/usr/sbin/aide'
 DEFAULT_SSH_DISTRIBUTED_CONFIG = 'false'
+DEFAULT_PRODUCT = 'example'
+

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 from glob import glob
 
 from .build_cpe import ProductCPEs
-from .constants import (product_directories,
+from .constants import (DEFAULT_PRODUCT, product_directories,
                         DEFAULT_GID_MIN,
                         DEFAULT_UID_MIN,
                         DEFAULT_GRUB2_BOOT_PATH,
@@ -71,6 +71,9 @@ def _get_implied_properties(existing_properties):
 
     if "sshd_distributed_config" not in existing_properties:
         result["sshd_distributed_config"] = DEFAULT_SSH_DISTRIBUTED_CONFIG
+
+    if "product" not in existing_properties:
+        result["product"] = DEFAULT_PRODUCT
 
     return result
 


### PR DESCRIPTION
If no product name is given, this uses the `example` product and adds it
to the implied properties.

Signed-off-by: Juan Antonio Osorio Robles <jaosorior@redhat.com>