### PR TITLE
Fix OCP4 and EKS SCAP validation

### DIFF
--- a/applications/openshift/general/resource_requests_quota_per_project/oval/shared.xml
+++ b/applications/openshift/general/resource_requests_quota_per_project/oval/shared.xml
@@ -86,7 +86,7 @@
   <!-- Comparison -->
   <!-- This verifies that the filtered namespaces are equal to the namespaces with resourcequota -->
   <ind:variable_state id="state_elements_count_for_resource_requests_quota_per_project" version="1">
-    <ind:value var_ref="local_variable_counter_resource_requests_quotas_filtered_namespaces"/>
+    <ind:value datatype="int" var_ref="local_variable_counter_resource_requests_quotas_filtered_namespaces"/>
   </ind:variable_state>
   
   <!-- OCP data root declaration -->

--- a/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
@@ -86,7 +86,7 @@
   <!-- Comparison -->
   <!-- This verifies that the filtered namespaces are equal to the namespaces with NetworkPolicies -->
   <ind:variable_state id="state_elements_count_for_configure_network_policies_namespaces" version="1">
-    <ind:value var_ref="local_variable_counter_configure_network_policies_filtered_namespaces"/>
+    <ind:value datatype="int" var_ref="local_variable_counter_configure_network_policies_filtered_namespaces"/>
   </ind:variable_state>
   
   <!-- OCP data root declaration -->

--- a/shared/templates/yamlfile_value/oval.template
+++ b/shared/templates/yamlfile_value/oval.template
@@ -33,7 +33,9 @@
   <ind:yamlfilecontent_test id="test_{{{ rule_id }}}" check="all" check_existence="{{{ CHECK_EXISTENCE|default("only_one_exists") }}}"
     {{{ {'comment': "In the file '" + FILEPATH + "' find only one object at path '" + YAMLPATH + "'."}|xmlattr }}} version="1">
     <ind:object object_ref="object_{{{ rule_id }}}"/>
+    {{% if CHECK_EXISTENCE != "none_exist" %}}
     <ind:state state_ref="state_{{{ rule_id }}}"/>
+    {{% endif %}}
   </ind:yamlfilecontent_test>
   {{% else %}}
   <ind:variable_test id="test_{{{ rule_id }}}" check="all" check_existence="all_exist" comment="Variable test to check XCCDF variable" version="1">
@@ -101,7 +103,7 @@
   </local_variable>
 
   <ind:variable_state id="state_elements_count_for_{{{ rule_id }}}" version="1">
-    <ind:value var_ref="local_variable_counter_control_{{{ rule_id }}}"/>
+    <ind:value datatype="int" var_ref="local_variable_counter_control_{{{ rule_id }}}"/>
   </ind:variable_state>
   {{% endif %}}
 


### PR DESCRIPTION
#### Description:

- Fix OCP4 and EKS SCAP validation
  - Requirement: SRC-330
    - No state should be referenced when check_existence has a value of 'none_exist'
    - inconsistent datatype between the variable and an associated var_ref
