### PR TITLE
honor CPE logical expressions when generating Bash and Ansible remediations

### DIFF
--- a/build-scripts/collect_remediations.py
+++ b/build-scripts/collect_remediations.py
@@ -45,6 +45,9 @@ def parse_args():
         "--fixes-from-templates-dir", required=True,
         help="directory from which we will collect fixes generated from "
         "templates")
+    p.add_argument(
+        "--platforms-dir", required=True,
+        help="directory from which we collect compiled platforms")
 
     return p.parse_args()
 
@@ -116,6 +119,16 @@ def main():
 
     product = ssg.utils.required_key(env_yaml, "product")
     output_dirs = prepare_output_dirs(args.output_dir, args.remediation_type)
+
+    for platform_file in os.listdir(args.platforms_dir):
+        platform_path = os.path.join(args.platforms_dir, platform_file)
+        try:
+            platform = ssg.build_yaml.Platform.from_yaml(platform_path, env_yaml)
+        except ssg.build_yaml.DocumentationNotComplete:
+            # Happens on non-debug build when a platform is
+            # "documentation-incomplete"
+            continue
+        env_yaml["product_cpes"].platforms[platform.name] = platform
 
     for rule_file in os.listdir(args.resolved_rules_dir):
         rule_path = os.path.join(args.resolved_rules_dir, rule_file)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -199,7 +199,7 @@ macro(ssg_collect_remediations PRODUCT LANGUAGES)
     endforeach(LANGUAGE ${LANGUAGES})
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/collect-remediations-${PRODUCT}"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/collect_remediations.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${REMEDIATION_TYPE_OPTIONS} --output-dir "${CMAKE_CURRENT_BINARY_DIR}/fixes" --fixes-from-templates-dir "${BUILD_REMEDIATIONS_DIR}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/collect_remediations.py" --resolved-rules-dir "${CMAKE_CURRENT_BINARY_DIR}/rules" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" ${REMEDIATION_TYPE_OPTIONS} --output-dir "${CMAKE_CURRENT_BINARY_DIR}/fixes" --fixes-from-templates-dir "${BUILD_REMEDIATIONS_DIR}" --platforms-dir "${CMAKE_CURRENT_BINARY_DIR}/platforms"
         COMMAND ${CMAKE_COMMAND} -E touch "${CMAKE_CURRENT_BINARY_DIR}/collect-remediations-${PRODUCT}"
         # Acutally we mean that it depends on resolved rules.
         DEPENDS ${PRODUCT}-compile-all

--- a/shared/applicability/arch.yml
+++ b/shared/applicability/arch.yml
@@ -4,9 +4,11 @@ cpes:
       name: "cpe:/a:not_s390x_arch"
       title: "System architecture is not S390X"
       check_id: proc_sys_kernel_osrelease_arch_not_s390x
+      bash_conditional: "! grep -q s390x /proc/sys/kernel/osrelease"
 
   - s390x_arch:
       name: "cpe:/a:s390x_arch"
       title: "System architecture is S390X"
       check_id: proc_sys_kernel_osrelease_arch_s390x
+      bash_conditional: 'grep -q s390x /proc/sys/kernel/osrelease'
 

--- a/shared/applicability/bootloaders.yml
+++ b/shared/applicability/bootloaders.yml
@@ -5,3 +5,4 @@ cpes:
       title: "Package grub2 is installed"
       check_id: installed_env_has_grub2_package
       bash_conditional: {{{ bash_pkg_conditional("grub2") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("grub2") }}}

--- a/shared/applicability/bootloaders.yml
+++ b/shared/applicability/bootloaders.yml
@@ -4,3 +4,4 @@ cpes:
       name: "cpe:/a:grub2"
       title: "Package grub2 is installed"
       check_id: installed_env_has_grub2_package
+      bash_conditional: {{{ bash_pkg_conditional("grub2") }}}

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -3,12 +3,13 @@ cpes:
       name: "cpe:/a:audit"
       title: "Package audit is installed"
       check_id: installed_env_has_audit_package
-#      bash_conditional: {{ pkg_bash_conditional(audit) }}
+      bash_conditional: {{{ pkg_bash_conditional("audit") }}}
 
   - chrony:
       name: "cpe:/a:chrony"
       title: "Package chrony is installed"
       check_id: installed_env_has_chrony_package
+      bash_conditional: {{{ pkg_bash_conditional("chrony") }}}
 
   - gdm:
       name: "cpe:/a:gdm"

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -4,6 +4,7 @@ cpes:
       title: "Package audit is installed"
       check_id: installed_env_has_audit_package
       bash_conditional: {{{ bash_pkg_conditional("audit") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("audit") }}}
 
   - chrony:
       name: "cpe:/a:chrony"
@@ -17,30 +18,35 @@ cpes:
       title: "Package gdm is installed"
       check_id: installed_env_has_gdm_package
       bash_conditional: {{{ bash_pkg_conditional("gdm") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("gdm") }}}
 
   - libuser:
       name: "cpe:/a:libuser"
       title: "Package libuser is installed"
       check_id: installed_env_has_libuser_package
       bash_conditional: {{{ bash_pkg_conditional("libuser") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("libuser") }}}
 
   - login_defs:
       name: "cpe:/a:login_defs"
       title: "Package providing /etc/login.defs is installed"
       check_id: installed_env_has_login_defs
       bash_conditional: {{{ bash_pkg_conditional("login_defs") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("login-defs") }}}
 
   - net-snmp:
       name: "cpe:/a:net-snmp"
       title: "Package net-snmp is installed"
       check_id: installed_env_has_net-snmp_package
       bash_conditional: {{{ bash_pkg_conditional("net-snmp") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("net-snmp") }}}
 
   - nss-pam-ldapd:
       name: "cpe:/a:nss-pam-ldapd"
       title: "Package nss-pam-ldapd is installed"
       check_id: installed_env_has_nss-pam-ldapd_package
       bash_conditional: {{{ bash_pkg_conditional("nss-pam-ldapd") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("nss-pam-ldapd") }}}
 
   - ntp:
       name: "cpe:/a:ntp"
@@ -59,18 +65,21 @@ cpes:
       title: "Package pam is installed"
       check_id: installed_env_has_pam_package
       bash_conditional: {{{ bash_pkg_conditional("pam") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("pam") }}}
 
   - postfix:
       name: "cpe:/a:postfix"
       title: "Package postfix is installed"
       check_id: installed_env_has_postfix_package
       bash_conditional: {{{ bash_pkg_conditional("postfix") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("postfix") }}}
 
   - sssd:
       name: "cpe:/a:sssd"
       title: "Package sssd-common is installed"
       check_id: installed_env_has_sssd-common_package
       bash_conditional: {{{ bash_pkg_conditional("sssd") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("sssd") }}}
 
   - sssd-ldap:
       name: "cpe:/a:sssd-ldap"
@@ -82,21 +91,25 @@ cpes:
       title: "Package sudo is installed"
       check_id: installed_env_has_sudo_package
       bash_conditional: {{{ bash_pkg_conditional("sudo") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("sudo") }}}
 
   - systemd:
       name: "cpe:/a:systemd"
       title: "Package systemd is installed"
       check_id: installed_env_has_systemd_package
       bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}
 
   - yum:
       name: "cpe:/a:yum"
       title: "Package yum is installed"
       check_id: installed_env_has_yum_package
       bash_conditional: {{{ bash_pkg_conditional("yum") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}
 
   - zypper:
       name: "cpe:/a:zypper"
       title: "Package zypper is installed"
       check_id: installed_env_has_zypper_package
       bash_conditional: {{{ bash_pkg_conditional("zypper") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("zypper") }}}

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -32,7 +32,7 @@ cpes:
       title: "Package providing /etc/login.defs is installed"
       check_id: installed_env_has_login_defs
       bash_conditional: {{{ bash_pkg_conditional("login_defs") }}}
-      ansible_conditional: {{{ ansible_pkg_conditional("login-defs") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("login_defs") }}}
 
   - net-snmp:
       name: "cpe:/a:net-snmp"

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -10,6 +10,7 @@ cpes:
       title: "Package chrony is installed"
       check_id: installed_env_has_chrony_package
       bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}
 
   - gdm:
       name: "cpe:/a:gdm"
@@ -46,6 +47,7 @@ cpes:
       title: "Package ntp is installed"
       check_id: installed_env_has_ntp_package
       bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("ntp") }}}
 
   - ocp4-master-node:
       name: "cpe:/a:ocp4-master-node"

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -3,13 +3,13 @@ cpes:
       name: "cpe:/a:audit"
       title: "Package audit is installed"
       check_id: installed_env_has_audit_package
-      bash_conditional: {{{ pkg_bash_conditional("audit") }}}
+      bash_conditional: {{{ bash_pkg_conditional("audit") }}}
 
   - chrony:
       name: "cpe:/a:chrony"
       title: "Package chrony is installed"
       check_id: installed_env_has_chrony_package
-      bash_conditional: {{{ pkg_bash_conditional("chrony") }}}
+      bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
 
   - gdm:
       name: "cpe:/a:gdm"
@@ -25,6 +25,7 @@ cpes:
       name: "cpe:/a:login_defs"
       title: "Package providing /etc/login.defs is installed"
       check_id: installed_env_has_login_defs
+      bash_conditional: {{{ bash_pkg_conditional("login_defs") }}}
 
   - net-snmp:
       name: "cpe:/a:net-snmp"

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -3,6 +3,7 @@ cpes:
       name: "cpe:/a:audit"
       title: "Package audit is installed"
       check_id: installed_env_has_audit_package
+#      bash_conditional: {{ pkg_bash_conditional(audit) }}
 
   - chrony:
       name: "cpe:/a:chrony"

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -15,11 +15,13 @@ cpes:
       name: "cpe:/a:gdm"
       title: "Package gdm is installed"
       check_id: installed_env_has_gdm_package
+      bash_conditional: {{{ bash_pkg_conditional("gdm") }}}
 
   - libuser:
       name: "cpe:/a:libuser"
       title: "Package libuser is installed"
       check_id: installed_env_has_libuser_package
+      bash_conditional: {{{ bash_pkg_conditional("libuser") }}}
 
   - login_defs:
       name: "cpe:/a:login_defs"
@@ -31,16 +33,19 @@ cpes:
       name: "cpe:/a:net-snmp"
       title: "Package net-snmp is installed"
       check_id: installed_env_has_net-snmp_package
+      bash_conditional: {{{ bash_pkg_conditional("net-snmp") }}}
 
   - nss-pam-ldapd:
       name: "cpe:/a:nss-pam-ldapd"
       title: "Package nss-pam-ldapd is installed"
       check_id: installed_env_has_nss-pam-ldapd_package
+      bash_conditional: {{{ bash_pkg_conditional("nss-pam-ldapd") }}}
 
   - ntp:
       name: "cpe:/a:ntp"
       title: "Package ntp is installed"
       check_id: installed_env_has_ntp_package
+      bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
 
   - ocp4-master-node:
       name: "cpe:/a:ocp4-master-node"
@@ -51,16 +56,19 @@ cpes:
       name: "cpe:/a:pam"
       title: "Package pam is installed"
       check_id: installed_env_has_pam_package
+      bash_conditional: {{{ bash_pkg_conditional("pam") }}}
 
   - postfix:
       name: "cpe:/a:postfix"
       title: "Package postfix is installed"
       check_id: installed_env_has_postfix_package
+      bash_conditional: {{{ bash_pkg_conditional("postfix") }}}
 
   - sssd:
       name: "cpe:/a:sssd"
       title: "Package sssd-common is installed"
       check_id: installed_env_has_sssd-common_package
+      bash_conditional: {{{ bash_pkg_conditional("sssd") }}}
 
   - sssd-ldap:
       name: "cpe:/a:sssd-ldap"
@@ -71,18 +79,22 @@ cpes:
       name: "cpe:/a:sudo"
       title: "Package sudo is installed"
       check_id: installed_env_has_sudo_package
+      bash_conditional: {{{ bash_pkg_conditional("sudo") }}}
 
   - systemd:
       name: "cpe:/a:systemd"
       title: "Package systemd is installed"
       check_id: installed_env_has_systemd_package
+      bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
 
   - yum:
       name: "cpe:/a:yum"
       title: "Package yum is installed"
       check_id: installed_env_has_yum_package
+      bash_conditional: {{{ bash_pkg_conditional("yum") }}}
 
   - zypper:
       name: "cpe:/a:zypper"
       title: "Package zypper is installed"
       check_id: installed_env_has_zypper_package
+      bash_conditional: {{{ bash_pkg_conditional("zypper") }}}

--- a/shared/applicability/virtualization.yml
+++ b/shared/applicability/virtualization.yml
@@ -10,3 +10,4 @@ cpes:
       title: "Bare-metal or Virtual Machine"
       check_id: installed_env_is_a_machine
       bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+      ansible_conditional: 'ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]'

--- a/shared/applicability/virtualization.yml
+++ b/shared/applicability/virtualization.yml
@@ -9,3 +9,4 @@ cpes:
       name: "cpe:/a:machine"
       title: "Bare-metal or Virtual Machine"
       check_id: installed_env_is_a_machine
+      bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -676,3 +676,10 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     - { path: /etc/sudoers }
     - "{{ sudoers.files }}"
 {{%- endmacro -%}}
+
+{{%- macro ansible_pkg_conditional(package) -%}}
+{{%- if package in platform_package_overrides -%}}
+  {{%- set package = platform_package_overrides[package] -%}}
+{{%- endif -%}}
+'"{{{ package }}}" in ansible_facts.packages'
+{{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1638,6 +1638,25 @@ if [ "$skip" -ne 0 ]; then
 fi
 {{%- endmacro %}}
 
-{{%- macro pkg_bash_conditional(pkg_name) -%}}
-rpm -qa {{{ pkg_name }}}
+{{%- macro bash_pkg_conditional(package) -%}}
+{{%- if package in platform_package_overrides -%}}
+  {{%- set package = platform_package_overrides[package] -%}}
+{{%- endif -%}}
+  {{% if pkg_system is defined %}}
+    {{%- if pkg_system == "rpm" -%}}
+        {{{ bash_pkg_conditional_rpm(package) }}}
+    {{%- elif pkg_system == "dpkg" -%}}
+        {{{ bash_pkg_conditional_dpkg(package) }}}
+    {{%- else -%}}
+JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
+    {{%- endif -%}}
+{{% endif %}}
+{{%- endmacro -%}}
+
+{{%- macro bash_pkg_conditional_rpm(package) -%}}
+rpm -q {{{ package }}}
 {{%- endmacro %}}
+
+{{%- macro bash_pkg_conditional_dpkg (package) -%}}
+dpkg -l {{{ package }}}
+{{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1639,5 +1639,5 @@ fi
 {{%- endmacro %}}
 
 {{%- macro pkg_bash_conditional(pkg_name) -%}}
-rpm -qa {pkg_name}
+rpm -qa {{{ pkg_name }}}
 {{%- endmacro %}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1654,9 +1654,9 @@ JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
 {{%- endmacro -%}}
 
 {{%- macro bash_pkg_conditional_rpm(package) -%}}
-rpm -q {{{ package }}}
+rpm --quiet -q {{{ package }}}
 {{%- endmacro %}}
 
 {{%- macro bash_pkg_conditional_dpkg (package) -%}}
-dpkg -l {{{ package }}}
+dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q installed
 {{%- endmacro -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1637,3 +1637,7 @@ if [ "$skip" -ne 0 ]; then
     fi
 fi
 {{%- endmacro %}}
+
+{{%- macro pkg_bash_conditional(pkg_name) -%}}
+rpm -qa {pkg_name}
+{{%- endmacro %}}

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -203,7 +203,9 @@ class CPEALLogicalTest(Function):
             cond += "! "
             op = " "
         cond += "( "
-        child_bash_conds = [a.to_bash_conditional() for a in self.args if a.to_bash_conditional() != '']
+        child_bash_conds = [
+            a.to_bash_conditional() for a in self.args
+            if a.to_bash_conditional() != '']
         if self.is_or():
             op = "||"
         elif self.is_and():
@@ -218,7 +220,9 @@ class CPEALLogicalTest(Function):
             cond += "not "
             op = " "
         cond += "( "
-        child_ansible_conds = [a.to_ansible_conditional() for a in self.args if a.to_ansible_conditional() != '']
+        child_ansible_conds = [
+            a.to_ansible_conditional() for a in self.args
+            if a.to_ansible_conditional() != '']
         if self.is_or():
             op = " or "
         elif self.is_and():

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -203,7 +203,7 @@ class CPEALLogicalTest(Function):
             cond += "! "
             op = " "
         cond += "( "
-        child_bash_conds = [a.to_bash_conditional() for a in self.args]
+        child_bash_conds = [a.to_bash_conditional() for a in self.args if a.to_bash_conditional() != '']
         if self.is_or():
             op = "||"
         elif self.is_and():
@@ -218,7 +218,7 @@ class CPEALLogicalTest(Function):
             cond += "not "
             op = " "
         cond += "( "
-        child_ansible_conds = [a.to_ansible_conditional() for a in self.args]
+        child_ansible_conds = [a.to_ansible_conditional() for a in self.args if a.to_ansible_conditional() != '']
         if self.is_or():
             op = " or "
         elif self.is_and():

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -220,9 +220,9 @@ class CPEALLogicalTest(Function):
         cond += "( "
         child_ansible_conds = [a.to_ansible_conditional() for a in self.args]
         if self.is_or():
-            op = "or"
+            op = " or "
         elif self.is_and():
-            op = "and"
+            op = " and "
         cond += op.join(child_ansible_conds)
         cond += " )"
         return cond

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -156,6 +156,9 @@ class CPEItem(object):
         self.bash_conditional = ""
         if "bash_conditional" in cpeitem_data.keys():
             self.bash_conditional = cpeitem_data["bash_conditional"]
+        self.ansible_conditional = ""
+        if "ansible_conditional" in cpeitem_data.keys():
+            self.ansible_conditional = cpeitem_data["ansible_conditional"]
 
     def to_xml_element(self, cpe_oval_filename):
         cpe_item = ET.Element("{%s}cpe-item" % CPEItem.ns)
@@ -209,6 +212,20 @@ class CPEALLogicalTest(Function):
         cond += " )"
         return cond
 
+    def to_ansible_conditional(self):
+        cond = ""
+        if self.is_not():
+            cond += "not "
+            op = " "
+        cond += "( "
+        child_ansible_conds = [a.to_ansible_conditional() for a in self.args]
+        if self.is_or():
+            op = "or"
+        elif self.is_and():
+            op = "and"
+        cond += op.join(child_ansible_conds)
+        cond += " )"
+        return cond
 
 
 class CPEALFactRef (Symbol):
@@ -220,9 +237,11 @@ class CPEALFactRef (Symbol):
         super(CPEALFactRef, self).__init__(obj)
         self.cpe_name = obj  # we do not want to modify original name used for platforms
         self.bash_conditional = ""
+        self.ansible_conditional = ""
 
     def enrich_with_cpe_info(self, cpe_products):
         self.bash_conditional = cpe_products.get_cpe(self.cpe_name).bash_conditional
+        self.ansible_conditional = cpe_products.get_cpe(self.cpe_name).ansible_conditional
         self.cpe_name = cpe_products.get_cpe_name(self.cpe_name)
 
     def to_xml_element(self):
@@ -234,6 +253,8 @@ class CPEALFactRef (Symbol):
     def to_bash_conditional(self):
         return self.bash_conditional
 
+    def to_ansible_conditional(self):
+        return self.ansible_conditional
 
 def extract_subelement(objects, sub_elem_type):
     """

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -209,8 +209,6 @@ class CPEALLogicalTest(Function):
         cond += " )"
         return cond
 
-    def get_objects(self):
-        return self.objects
 
 
 class CPEALFactRef (Symbol):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -153,12 +153,8 @@ class CPEItem(object):
         self.name = cpeitem_data["name"]
         self.title = cpeitem_data["title"]
         self.check_id = cpeitem_data["check_id"]
-        self.bash_conditional = ""
-        if "bash_conditional" in cpeitem_data.keys():
-            self.bash_conditional = cpeitem_data["bash_conditional"]
-        self.ansible_conditional = ""
-        if "ansible_conditional" in cpeitem_data.keys():
-            self.ansible_conditional = cpeitem_data["ansible_conditional"]
+        self.bash_conditional = cpeitem_data.get("bash_conditional", "")
+        self.ansible_conditional = cpeitem_data.get("ansible_conditional", "")
 
     def to_xml_element(self, cpe_oval_filename):
         cpe_item = ET.Element("{%s}cpe-item" % CPEItem.ns)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -190,9 +190,9 @@ class CPEALLogicalTest(Function):
 
         return cpe_test
 
-    def replace_cpe_names(self, cpe_products):
+    def enrich_with_cpe_info(self, cpe_products):
         for arg in self.args:
-            arg.replace_cpe_names(cpe_products)
+            arg.enrich_with_cpe_info(cpe_products)
 
     def to_bash_conditional(self):
         cond = ""
@@ -223,7 +223,8 @@ class CPEALFactRef (Symbol):
         self.cpe_name = obj  # we do not want to modify original name used for platforms
         self.bash_conditional = ""
 
-    def replace_cpe_names(self, cpe_products):
+    def enrich_with_cpe_info(self, cpe_products):
+        self.bash_conditional = cpe_products.get_cpe(self.cpe_name).bash_conditional
         self.cpe_name = cpe_products.get_cpe_name(self.cpe_name)
 
     def to_xml_element(self):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -466,24 +466,6 @@ class AnsibleRemediation(Remediation):
                 return None
             return result
 
-    def generate_platform_conditional(self, platform):
-        if platform == "machine":
-            return 'ansible_virtualization_type not in '\
-                '["docker", "lxc", "openvz", "podman", "container"]'
-        elif platform is not None:
-            # Assume any other platform is a Package CPE
-
-            if platform in self.local_env_yaml["platform_package_overrides"]:
-                platform = self.local_env_yaml["platform_package_overrides"].get(platform)
-
-                # Workaround for platforms that are not Package CPEs
-                # Skip platforms that are not about packages installed
-                # These should be handled in the remediation itself
-                if not platform:
-                    return
-
-            return '"' + platform + '" in ansible_facts.packages'
-
 
 class AnacondaRemediation(Remediation):
     def __init__(self, file_path):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -228,6 +228,8 @@ class BashRemediation(Remediation):
 
     def parse_from_file_with_jinja(self, env_yaml):
         self.local_env_yaml.update(env_yaml)
+        print (env_yaml["product_cpes"].platforms.keys())
+        print (self.local_env_yaml["product_cpes"].platforms.keys())
         result = super(BashRemediation, self).parse_from_file_with_jinja(self.local_env_yaml)
 
         # Avoid platform wrapping empty fix text
@@ -237,19 +239,19 @@ class BashRemediation(Remediation):
         if stripped_fix_text == "":
             return result
 
-        rule_specific_platforms = set()
-        inherited_platforms = set()
+        rule_specific_cpe_platform_names = set()
+        inherited_cpe_platform_names = set()
         if self.associated_rule:
             # There can be repeated inherited platforms and rule platforms
-            inherited_platforms.update(self.associated_rule.inherited_platforms)
-            if self.associated_rule.platforms is not None:
-                rule_specific_platforms = {
-                    p for p in self.associated_rule.platforms if p not in inherited_platforms}
+            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
+            if self.associated_rule.cpe_platform_names is not None:
+                rule_specific_cpe_platform_names = {
+                    p for p in self.associated_rule.cpe_platform_names if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            self.generate_platform_conditional(p) for p in inherited_platforms]
+            env_yaml["product_cpes"].platforms[p].to_bash_conditional() for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            self.generate_platform_conditional(p) for p in rule_specific_platforms]
+            env_yaml["product_cpes"].platforms[p].to_bash_conditional() for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
             p for p in inherited_conditionals if p is not None])

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -245,7 +245,7 @@ class BashRemediation(Remediation):
             env_yaml["product_cpes"].platforms[p].to_bash_conditional() for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
-            p for p in inherited_conditionals if p is not None])
+            p for p in inherited_conditionals if p != ''])
         rule_specific_conditionals = sorted([
             p for p in rule_specific_conditionals if p != ''])
 
@@ -403,7 +403,7 @@ class AnsibleRemediation(Remediation):
             self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional() for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
-            p for p in inherited_conditionals if p is not None])
+            p for p in inherited_conditionals if p != ''])
         rule_specific_conditionals = sorted([
             p for p in rule_specific_conditionals if p != ''])
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -237,12 +237,15 @@ class BashRemediation(Remediation):
             inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
             if self.associated_rule.cpe_platform_names is not None:
                 rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names if p not in inherited_cpe_platform_names}
+                    p for p in self.associated_rule.cpe_platform_names
+                    if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            env_yaml["product_cpes"].platforms[p].to_bash_conditional() for p in inherited_cpe_platform_names]
+            env_yaml["product_cpes"].platforms[p].to_bash_conditional()
+            for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            env_yaml["product_cpes"].platforms[p].to_bash_conditional() for p in rule_specific_cpe_platform_names]
+            env_yaml["product_cpes"].platforms[p].to_bash_conditional()
+            for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
             p for p in inherited_conditionals if p != ''])
@@ -395,12 +398,15 @@ class AnsibleRemediation(Remediation):
             inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
             if self.associated_rule.cpe_platform_names is not None:
                 rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names if p not in inherited_cpe_platform_names}
+                    p for p in self.associated_rule.cpe_platform_names
+                    if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional() for p in inherited_cpe_platform_names]
+            self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional()
+            for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional() for p in rule_specific_cpe_platform_names]
+            self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional()
+            for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
             p for p in inherited_conditionals if p != ''])

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -247,7 +247,7 @@ class BashRemediation(Remediation):
         inherited_conditionals = sorted([
             p for p in inherited_conditionals if p is not None])
         rule_specific_conditionals = sorted([
-            p for p in rule_specific_conditionals if p is not None])
+            p for p in rule_specific_conditionals if p != ''])
 
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -388,24 +388,24 @@ class AnsibleRemediation(Remediation):
 
     def update_when_from_rule(self, to_update):
         additional_when = []
-
-        # There can be repeated inherited platforms and rule platforms
-        inherited_platforms = set()
-        rule_specific_platforms = set()
-        inherited_platforms.update(self.associated_rule.inherited_platforms)
-        if self.associated_rule.platforms is not None:
-            rule_specific_platforms = {
-                p for p in self.associated_rule.platforms if p not in inherited_platforms}
+        rule_specific_cpe_platform_names = set()
+        inherited_cpe_platform_names = set()
+        if self.associated_rule:
+            # There can be repeated inherited platforms and rule platforms
+            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
+            if self.associated_rule.cpe_platform_names is not None:
+                rule_specific_cpe_platform_names = {
+                    p for p in self.associated_rule.cpe_platform_names if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            self.generate_platform_conditional(p) for p in inherited_platforms]
+            self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional() for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            self.generate_platform_conditional(p) for p in rule_specific_platforms]
+            self.local_env_yaml["product_cpes"].platforms[p].to_ansible_conditional() for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
             p for p in inherited_conditionals if p is not None])
         rule_specific_conditionals = sorted([
-            p for p in rule_specific_conditionals if p is not None])
+            p for p in rule_specific_conditionals if p != ''])
 
         # remove conditionals related to package CPEs if the updated task
         # collects package facts

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1258,6 +1258,7 @@ class Rule(XCCDFEntity):
         inherited_platforms=lambda: list(),
         template=lambda: None,
         cpe_platform_names=lambda: set(),
+        bash_conditional = lambda: None,
         ** XCCDFEntity.KEYS
     )
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1262,7 +1262,7 @@ class Rule(XCCDFEntity):
         template=lambda: None,
         cpe_platform_names=lambda: set(),
         inherited_cpe_platform_names=lambda: list(),
-        bash_conditional = lambda: None,
+        bash_conditional=lambda: None,
         ** XCCDFEntity.KEYS
     )
 
@@ -2076,7 +2076,7 @@ class Platform(XCCDFEntity):
 
 def add_platform_if_not_defined(platform, env_yaml):
     # check if the platform is already in the dictionary. If yes, return the existing one
-    for p  in env_yaml["product_cpes"].platforms.values():
+    for p in env_yaml["product_cpes"].platforms.values():
         if platform == p:
             return p
     env_yaml["product_cpes"].platforms[platform.id_] = platform

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -2050,10 +2050,15 @@ class Platform(XCCDFEntity):
     def to_xml_element(self):
         return self.xml_content
 
+    def to_bash_conditional(self):
+        return self.bash_conditional
+
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):
         platform = super(Platform, cls).from_yaml(yaml_file, env_yaml)
         platform.xml_content = ET.fromstring(platform.xml_content)
+        platform.test = env_yaml["product_cpes"].algebra.parse(
+            platform.original_expression, simplify=True)
         return platform
 
     def __eq__(self, other):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -2011,7 +2011,9 @@ class Platform(XCCDFEntity):
     MANDATORY_KEYS = [
         "name",
         "xml_content",
-        "original_expression"
+        "original_expression",
+        "bash_conditional",
+        "ansible_conditional"
     ]
 
     prefix = "cpe-lang"
@@ -2029,6 +2031,7 @@ class Platform(XCCDFEntity):
         platform.original_expression = expression
         platform.xml_content = platform.get_xml()
         platform.bash_conditional = platform.test.to_bash_conditional()
+        platform.ansible_conditional = platform.test.to_ansible_conditional()
         return platform
 
     def get_xml(self):
@@ -2052,6 +2055,9 @@ class Platform(XCCDFEntity):
 
     def to_bash_conditional(self):
         return self.bash_conditional
+
+    def to_ansible_conditional(self):
+        return self.ansible_conditional
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -2022,6 +2022,7 @@ class Platform(XCCDFEntity):
         platform.name = id
         platform.original_expression = expression
         platform.xml_content = platform.get_xml()
+        platform.bash_conditional = platform.test.to_bash_conditional()
         return platform
 
     def get_xml(self):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1258,6 +1258,7 @@ class Rule(XCCDFEntity):
         inherited_platforms=lambda: list(),
         template=lambda: None,
         cpe_platform_names=lambda: set(),
+        inherited_cpe_platform_names=lambda: list(),
         bash_conditional = lambda: None,
         ** XCCDFEntity.KEYS
     )
@@ -1880,8 +1881,8 @@ class BuildLoader(DirectoryLoader):
             self.all_rules[rule.id_] = rule
             self.loaded_group.add_rule(rule, env_yaml=self.env_yaml)
 
-            if self.loaded_group.platforms:
-                rule.inherited_platforms += self.loaded_group.platforms
+            if self.loaded_group.cpe_platform_names:
+                rule.inherited_cpe_platform_names += self.loaded_group.cpe_platform_names
 
             rule.normalize(self.env_yaml["product"])
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -2024,7 +2024,7 @@ class Platform(XCCDFEntity):
         id = test.as_id()
         platform = cls(id)
         platform.test = test
-        platform.test.replace_cpe_names(env_yaml["product_cpes"])
+        platform.test.enrich_with_cpe_info(env_yaml["product_cpes"])
         platform.name = id
         platform.original_expression = expression
         platform.xml_content = platform.get_xml()

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1051,7 +1051,8 @@ class Group(XCCDFEntity):
         # parse platform definition and get CPEAL platform
         if data["platforms"]:
             for platform in data["platforms"]:
-                cpe_platform = parse_platform(platform, env_yaml)
+                cpe_platform = Platform.from_text(platform, env_yaml)
+                cpe_platform = add_platform_if_not_defined(cpe_platform, env_yaml)
                 data["cpe_platform_names"].add(cpe_platform.id_)
         return data
 
@@ -1196,7 +1197,8 @@ class Group(XCCDFEntity):
         # Once the group has inherited properties, update cpe_names
         if env_yaml:
             for platform in group.platforms:
-                cpe_platform = parse_platform(platform, env_yaml)
+                cpe_platform = Platform.from_text(platform, env_yaml)
+                cpe_platform = add_platform_if_not_defined(cpe_platform, env_yaml)
                 group.cpe_platform_names.add(cpe_platform.id_)
 
     def _pass_our_properties_on_to(self, obj):
@@ -1215,7 +1217,8 @@ class Group(XCCDFEntity):
         # Once the rule has inherited properties, update cpe_platform_names
         if env_yaml:
             for platform in rule.platforms:
-                cpe_platform = parse_platform(platform, env_yaml)
+                cpe_platform = Platform.from_text(platform, env_yaml)
+                cpe_platform = add_platform_if_not_defined(cpe_platform, env_yaml)
                 rule.cpe_platform_names.add(cpe_platform.id_)
 
     def __str__(self):
@@ -1317,7 +1320,8 @@ class Rule(XCCDFEntity):
                 or env_yaml and rule.prodtype == "all"):
             # parse platform definition and get CPEAL platform
             for platform in rule.platforms:
-                cpe_platform = parse_platform(platform, env_yaml)
+                cpe_platform = Platform.from_text(platform, env_yaml)
+                cpe_platform = add_platform_if_not_defined(cpe_platform, env_yaml)
                 rule.cpe_platform_names.add(cpe_platform.id_)
 
 
@@ -2059,15 +2063,10 @@ class Platform(XCCDFEntity):
             return self.test == other.test
 
 
-def parse_platform(expression, env_yaml):
-    """
-    parses the expression and returns a CPEALPlatform instance It either creates a
-    new one or if equal instance already exists, it returns the existing one.
-    """
-    platform = Platform.from_text(expression, env_yaml)
+def add_platform_if_not_defined(platform, env_yaml):
     # check if the platform is already in the dictionary. If yes, return the existing one
-    for k,v  in env_yaml["product_cpes"].platforms.items():
-        if platform == v:
-            return v
+    for p  in env_yaml["product_cpes"].platforms.values():
+        if platform == p:
+            return p
     env_yaml["product_cpes"].platforms[platform.id_] = platform
     return platform


### PR DESCRIPTION
What currently does not work is:
- when generating Ansible conditionals, platform_package_overrides is not honored. No idea why, I need help.
- one unit SSG test needs to be modified.
Other things should work very nicely, I did comparisons of datastreams generated from this branch and from master and we should not break anything.

#### Description:

- create new Jinja macros for creating of conditionals for installed packages
- put correct conditionals to definitions of CPE items (shared/applicability/...)
- get ridf of some magic functions in build_remediations.py (platform package overrides, selection of packaging system) this is now handled by JInja
- some tweaks to parsing of conditionals, especially ignore them if they are empty

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
