### PR TITLE
scap_val: Add java protocol handler for cases when using OpenJRE

### DIFF
--- a/tests/run_scapval.py
+++ b/tests/run_scapval.py
@@ -54,6 +54,7 @@ def test_datastream(datastream_path,  scapval_path, scap_version):
     scapval_command = [
             "java",
             "-Xmx1024m",
+            "-Djava.protocol.handler.pkgs=sun.net.www.protocol",
             "-jar", scapval_path,
             "-scapversion", scap_version,
             "-file", datastream_path,


### PR DESCRIPTION
#### Description:

- scap_val: Add java protocol handler for cases when using OpenJRE

#### Rationale:

- That's what you can find the in scapval.sh script NIST provides in their scap_val zip file
  - https://csrc.nist.gov/Projects/Security-Content-Automation-Protocol/SCAP-Releases/scap-1-3
