### PR TITLE
Fix typo in configure_usbguard_auditbackend rule

### DIFF
--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
@@ -32,7 +32,7 @@ references:
 ocil_clause: 'AuditBackend is not set to LinuxAudit'
 
 ocil: |-
-    To verify that Linux Audit logging si enabled for the USBGuard daemon,
+    To verify that Linux Audit logging is enabled for the USBGuard daemon,
     run the following command:
     <pre>$ sudo grep AuditBackend /etc/usbguard/usbguard-daemon.conf</pre>
     The output should be


### PR DESCRIPTION
Replace "si" with "is" in the ``ocil`` description of the ``configure_usbguard_auditbackend`` rule.

#### Description:

Fix typo in ``configure_usbguard_auditbackend`` rule.

#### Rationale:

Fixes a typo.
