### PR TITLE
Fix typo in OCIL of coreos_slub_debug_kernel_argument

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/poisoning/coreos_slub_debug_kernel_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/coreos_slub_debug_kernel_argument/rule.yml
@@ -32,7 +32,7 @@ ocil: |-
     ('options' line) in <tt>/boot/loader/entries/*.conf</tt>. If they include
     <tt>slub_debug=P</tt>, then SLUB/SLAB poisoning is enabled at boot time.
     <br /><br />
-    To ensure <tt>vsyscall=none</tt> is configured on the installed kernel, add
+    To ensure <tt>slub_debug=P</tt> is configured on the installed kernel, add
     the kernel argument via a <pre>MachineConfig</pre> object to the appropriate
     pools.
 


### PR DESCRIPTION
#### Description:

- The OCIL described something else than the rule was about

#### Rationale:

- Just a small typo found during RHCOS STIG work
