### PR TITLE
fix_rules.py: Set subcommand required

### DIFF
--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -786,6 +786,7 @@ def parse_args():
         help="Path to root of the project directory")
     parser.add_argument("--product", "-p", help="Path to the main product.yml")
     subparsers = parser.add_subparsers(title="command", help="What to perform.")
+    subparsers.required = True
     create_parser_from_functions(subparsers)
     create_other_parsers(subparsers)
     return parser.parse_args()


### PR DESCRIPTION
#### Description:

- fix_rules.py: Set subcommand required so it prints a nice message when there is no subcommand present in the command line.

#### Rationale:

- Do not traceback when there is no subcommand, for example:
```
python3 utils/fix_rules.py
usage: fix_rules.py [-h] [-y] [-d] [-j JSON] [-r ROOT] [--product PRODUCT]
                    {empty_identifiers,empty_references,prefixed_identifiers,invalid_identifiers,int_identifiers,int_references,duplicate_subkeys,sort_subkeys,sort_prodtypes,add-cce} ...
fix_rules.py: error: the following arguments are required: {empty_identifiers,empty_references,prefixed_identifiers,invalid_identifiers,int_identifiers,int_references,duplicate_subkeys,sort_subkeys,sort_prodtypes,add-cce}
```

Before:
```
python3 utils/fix_rules.py
Traceback (most recent call last):
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 808, in <module>
    __main__()
  File "/home/ggasparb/workspace/github/content/utils/fix_rules.py", line 804, in __main__
    args.func(args, subst_dict)
AttributeError: 'Namespace' object has no attribute 'func'
```