### PR TITLE
Fix compare-ds GH Action

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -84,7 +84,6 @@ jobs:
           body="${body//$'\r'/'%0D'}"
           echo ::set-output name=log::$body
       - name: Find Comment
-        if: ${{ steps.compare_ds.outputs.COMPARE_DS_OUTPUT_SIZE != '0'}}
         uses: peter-evans/find-comment@v1
         id: fc
         with:
@@ -108,3 +107,10 @@ jobs:
 
             </details>
           edit-mode: replace
+      - name: Delete existing comment in case new commits trigger no changes in Compare DS tool
+        if: ${{ (steps.compare_ds.outputs.COMPARE_DS_OUTPUT_SIZE == '0' || steps.ctf.outputs.CTF_OUTPUT_SIZE == '0') && steps.fc.outputs.comment-id != 0 }}
+        uses: jungwinter/comment@v1
+        with:
+          type: delete
+          comment_id: ${{ steps.fc.outputs.comment-id }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -16,11 +16,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - name: Find forking point
         env:
           BASE_BRANCH: ${{ github.base_ref }}
-        run: echo "::set-output name=FORK_POINT::$(git merge-base --fork-point origin/$BASE_BRANCH)"
+        run: echo "::set-output name=FORK_POINT::$(git merge-base origin/$BASE_BRANCH ${{ github.event.pull_request.head.sha }})"
         id: fork_point
       - name: Checkout fork point
         uses: actions/checkout@v2


### PR DESCRIPTION
#### Description:

- The previous solution to find the forking point was not actually working and now it checks out specifically the commit from the Pull Request to compare. It was always comparing with latest master, and sometimes the PR has an outdated branch so we have to take this into consideration.
- It also adds logic to delete a previously put comment by `compare-ds` when a new update makes the pull request to have no changes regarding previous state.

I've tested the changes in my private fork as the changes are only reflected when they are merged because they use the special event trigger `pull_request_target`.