### PR TITLE
Add note about expected crypto-policies in RHEL8 CIS profiles

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -551,6 +551,7 @@ controls:
       - l1_server
       - l1_workstation
     status: automated
+    notes: The selected crypto-policy cannot be legacy
     rules:
       - configure_crypto_policy
       - var_system_crypto_policy=default_policy
@@ -567,6 +568,7 @@ controls:
       - l2_server
       - l2_workstation
     status: automated
+    notes: The selected crypto-policy must be fips or future
     rules:
       - var_system_crypto_policy=future
 


### PR DESCRIPTION
#### Description:

- Added notes in RHEL8 CIS control files making explicit what are the expected crypto-policies in each level.

#### Rationale:

- Creating specific rules for items 1.10 and 1.11 will add complexity that we don't need (in my opinion).

Closes #5228
Closes #5229