### PR TITLE
Update sysctl template remediation to comment parameters from /etc/sysctl.d/*.conf

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/tests/wrong_value_d_directory.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/tests/wrong_value_d_directory.fail.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+. $SHARED/sysctl.sh
+
+setting_name="kernel.randomize_va_space"
+setting_value="2"
+# sysctl -w "$setting_name=$setting_value"
+if grep -q "^$setting_name" /usr/lib/sysctl.d/50-sysctl.conf; then
+    sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /usr/lib/sysctl.d/50-sysctl.conf
+else
+    echo "$setting_name = $setting_value" >> /usr/lib/sysctl.d/50-sysctl.conf
+fi
+
+setting_name="kernel.randomize_va_space"
+setting_value="0"
+# sysctl -w "$setting_name=$setting_value"
+if grep -q "^$setting_name" /etc/sysctl.d/99-sysctl.conf; then
+    sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /etc/sysctl.d/99-sysctl.conf
+else
+    echo "$setting_name = $setting_value" >> /etc/sysctl.d/99-sysctl.conf
+fi
+
+sysctl --system

--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -3,6 +3,21 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
+
+- name: List /etc/sysctl.d/*.conf files
+  find:
+    paths: "/etc/sysctl.d/"
+    contains: '^[\s]*{{{ SYSCTLVAR }}}.*$'
+    patterns: "*.conf"
+  register: find_sysctl_d
+
+- name: Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
+  replace:
+    path: "{{ item }}"
+    regexp: '^[\s]*{{{ SYSCTLVAR }}}'
+    replace: '#{{{ SYSCTLVAR }}}'
+  loop: "{{ find_sysctl_d.files }}"
+
 {{%- if SYSCTLVAL == "" %}}
 - (xccdf-var sysctl_{{{ SYSCTLID }}}_value)
 

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -4,6 +4,17 @@
 # complexity = low
 # disruption = medium
 
+# Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
+for f in /etc/sysctl.d/*.conf ; do
+  matching_list=$(grep -P '^(?!#).*[\s]+{{{ SYSCTLVAR }}}.*$' $f | uniq )
+  if ! test -z "$matching_list"; then
+    while IFS= read -r entry; do
+      # comment out "{{{ SYSCTLVAR }}}" matches to preserve user data
+      sed -i "s/^${entry}$/# &/g" $f
+    done <<< "$matching_list"
+  fi
+done
+
 {{%- if SYSCTLVAL == "" %}}
 {{{ bash_instantiate_variables("sysctl_" + SYSCTLID + "_value") }}}
 


### PR DESCRIPTION
#### Description:

- Update sysctl template remediation to comment parameters from /etc/sysctl.d/*.conf
  - Comment out any parameters found in /etc/sysctl.d/*.conf files before
remediating to /etc/sysctl.conf.
