### PR TITLE
Item 5.7 from RHEL8 CIS is not fully automatable

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1993,14 +1993,16 @@ controls:
       - no_direct_root_logins
       - securetty_root_login_console_only
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5541
   - id: 5.7
     title: Ensure access to the su command is restricted (Automated)
     levels:
       - l1_server
       - l1_workstation
     status: partial
+    notes: |-
+      The recommendation states the the members of the "wheel" group should be checked and match the
+      site policy. But the site policy may allow or require different users for the group, so the
+      members of the "wheel" group need to be checked manually.
     rules:
       - use_pam_wheel_for_su
 


### PR DESCRIPTION

#### Description:

- Add note clarifying why status of item `5.7` is `partial`

#### Rationale:

- RHEL8 CIS 5.7 recommends that the members of the 'wheel' group be checked against the site policy. But the site policy may allow or require the group to have different users.

- Closes #5541