### PR TITLE
Select rules for users' min/max password age in RHEL8 CIS

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1896,20 +1896,22 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: partial  # The rule below does not validate whether all current users' PASS_MAX_DAYS setting conforms to the control.
+    status: automated
     rules:
       - accounts_maximum_age_login_defs
       - var_accounts_maximum_age_login_defs=365
+      - accounts_password_set_max_life_existing
 
   - id: 5.5.1.2
     title: Ensure minimum days between password changes is 7 or more (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: partial  # The rule below does not validate whether all current users' PASS_MIN_DAYS setting conforms to the control.
+    status: automated
     rules:
       - accounts_minimum_age_login_defs
       - var_accounts_minimum_age_login_defs=7
+      - accounts_password_set_min_life_existing
 
   - id: 5.5.1.3
     title: Ensure password expiration warning days is 7 or more (Automated)

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -26,6 +26,7 @@ identifiers:
     cce@sle15: CCE-85571-8
 
 references:
+    cis@rhel8: 5.5.1.1
     cis@ubuntu2004: 5.4.1.1
     disa: CCI-000199
     nist: IA-5(f),IA-5(1)(d),CM-6(a)

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -26,6 +26,7 @@ identifiers:
     cce@sle15: CCE-85710-2
 
 references:
+    cis@rhel8: 5.5.1.2
     cis@ubuntu2004: 5.4.1.2
     disa: CCI-000198
     nist: IA-5(f),IA-5(1)(d),CM-6(a)


### PR DESCRIPTION



#### Description:
- Select rules for RHEL8 CIS min/max password age recommendation
- Update CIS reference in the rules

#### Rationale:

- These rules check interactive user's min/max password age.
