### PR TITLE
RHEL7 CIS: Select rules for home dirpermission and owners

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -2273,8 +2273,8 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no # we have rule, but no check or remediations
-    related_rules:
+    status: automated
+    rules:
     - accounts_user_interactive_home_directory_exists
 
   - id: 6.2.12
@@ -2282,8 +2282,8 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no # rule missing checks and remediations
-    related_rules:
+    status: automated
+    rules:
     - file_ownership_home_directories
 
   - id: 6.2.13
@@ -2291,8 +2291,8 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no # rule missing checks and remediations
-    related_rules:
+    status: automated
+    rules:
     - file_permissions_home_directories
 
   - id: 6.2.14

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
@@ -27,6 +27,7 @@ identifiers:
     cce@sle15: CCE-85628-6
 
 references:
+    cis@rhel7: 6.2.11
     cis@rhel8: 6.2.20
     cis@sle12: 6.2.5
     cis@sle15: 6.2.5

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel7: CCE-80531-7
 
 references:
+    cis@rhel7: 6.2.12
     cis@sle12: 6.2.7
     cis@sle15: 6.2.7
     disa: CCI-000366


### PR DESCRIPTION
#### Description:

- Select rules for RHEL7 CIS `6.2.11`, `6.2.12` and `6.2.13`

#### Rationale:

- The rules were implemented in 
- Similar to https://github.com/ComplianceAsCode/content/pull/8004/commits/7fc6326bb65ed831c393004b581424362c341087
