### PR TITLE
Add ocp4 test YAML manifests for two sshd rules

### DIFF
--- a/controls/srg_gpos/SRG-OS-000024-GPOS-00007.yml
+++ b/controls/srg_gpos/SRG-OS-000024-GPOS-00007.yml
@@ -6,7 +6,7 @@ controls:
             Banner until users acknowledge the usage conditions and take explicit actions
             to log on for further access via CLI and Graphical access.
         status: does not meet
-        rationle: |-
+        rationale: |-
             The banner must be acknowledged by the user prior to allowing the user access to the operating system.
             This provides assurance that the user has seen the message and accepted the conditions for access.
             If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.

--- a/controls/srg_gpos/SRG-OS-000281-GPOS-00111.yml
+++ b/controls/srg_gpos/SRG-OS-000281-GPOS-00111.yml
@@ -5,7 +5,7 @@ controls:
         title: {{{ full_name }}} must display an explicit logoff message to users indicating
             the reliable termination of authenticated communications sessions.
         status: inherently met
-        rationle: |-
+        rationale: |-
             If a user cannot explicitly end an operating system session, the session may remain open and be exploited by an attacker; this is referred to as a zombie session.
             Users need to be aware of whether or not the session has been terminated.
 


### PR DESCRIPTION
#### Description:

- just adds tests

#### Rationale:

We had a bug in the compliance operator where several SSHD related
remediations were not rendered and we didn't notice. Having e2e test
blurbs for the rules would have helped us to catch the issues earlier.
