### PR TITLE
Mark as Manual RHEL7 CIS items that are manual

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -264,14 +264,14 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 1.2.2
     title: Ensure package manager repositories are configured (Manual)
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 1.2.3
     title: Ensure gpgcheck is globally activated (Automated)
@@ -288,21 +288,21 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 1.2.4
     title: Ensure Red Hat Subscription Manager connection is configured (Manual)
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 1.2.5
     title: Disable the rhnsd Daemon (Manual)
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 1.3.1
     title: Ensure AIDE is installed (Automated)
@@ -527,7 +527,7 @@ controls:
     title: Ensure GNOME Display Manager is removed (Manual)
     levels:
     - l2_server
-    automated: no
+    status: manual
 
   - id: 1.8.2
     title: Ensure GDM login banner is configured (Automated)
@@ -563,7 +563,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 2.1.1
     title: Ensure xinetd is not installed (Automated)
@@ -579,7 +579,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 2.2.1.2
     title: Ensure chrony is configured (Automated)
@@ -815,14 +815,14 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.1.1
     title: Disable IPv6 (Manual)
     levels:
     - l2_server
     - l2_workstation
-    automated: no
+    status: manual
 
   - id: 3.1.2
     title: Ensure wireless interfaces are disabled (Automated)
@@ -1029,14 +1029,14 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.5.1.7
     title: Ensure firewalld drops unnecessary services and ports (Manual)
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.5.2.1
     title: Ensure nftables is installed (Automated)
@@ -1066,7 +1066,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.5.2.5
     title: Ensure an nftables table exists (Automated)
@@ -1094,7 +1094,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.5.2.9
     title: Ensure nftables default deny firewall policy (Automated)
@@ -1154,7 +1154,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.5.3.2.3
     title: Ensure iptables rules exist for all open ports (Automated)
@@ -1198,7 +1198,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 3.5.3.3.3
     title: Ensure ip6tables firewall rules exist for all open ports (Automated)
@@ -1494,7 +1494,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 4.2.1.5
     title: Ensure rsyslog is configured to send logs to a remote log host (Automated)
@@ -1510,7 +1510,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 4.2.2.1
     title: Ensure journald is configured to send logs to rsyslog (Automated)
@@ -1544,14 +1544,14 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 4.2.4
     title: Ensure logrotate is configured (Manual)
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 5.1.1
     title: Ensure cron daemon is enabled and running (Automated)
@@ -2039,7 +2039,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 5.7
     title: Ensure access to the su command is restricted (Automated)
@@ -2055,7 +2055,7 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: no
+    status: manual
 
   - id: 6.1.2
     title: Ensure permissions on /etc/passwd are configured (Automated)
@@ -2177,14 +2177,14 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 6.1.14
     title: Audit SGID executables (Manual)
     levels:
     - l1_server
     - l1_workstation
-    automated: no
+    status: manual
 
   - id: 6.2.1
     title: Ensure accounts in /etc/passwd use shadowed passwords (Automated)


### PR DESCRIPTION
#### Description:

- Put `Manual` status to manual items from RHEL7 CIS benchmark.

#### Rationale:

- This way we are more explicit about items that we don't plan to implement
- The manual controls are reported as such in `controleval.py` and facilitate assessment of the implementation level