### PR TITLE
Align RHEL7 and 8 CIS requirement for .rhosts file

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -2330,6 +2330,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: no # we have a rule but it removes additionally /etc/hosts.equiv
-    related_rules:
+    status: automated
+    notes: The rule also removes /etc/hosts.equiv
+    rules:
     - no_rsh_trust_files

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -2270,6 +2270,7 @@ controls:
       - l1_server
       - l1_workstation
     status: automated
+    notes: The rule also removes /etc/hosts.equiv
     rules:
       - no_rsh_trust_files
 


### PR DESCRIPTION

#### Description:

- Select `no_rsh_trust_files` for RHEL7 CIS 6.2.17 and consider it automated.

#### Rationale:

- The rule selected for "Ensure no users have .rhosts files" removes .rhosts and /etc/hosts.equiv.
 These files configure different PoVs of the same feature (trusting remote hosts and host-user pairs).
- I believe it should be safe to remove both files in the scope of CIS profiles.

