### PR TITLE
Set automated controls in RHEL7 to automated

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1501,7 +1501,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
     - rsyslog_remote_loghost
 
@@ -2232,7 +2232,7 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    automated: yes
+    status: automated
     rules:
       - group_unique_name
 


### PR DESCRIPTION

#### Description:

- Move `automated:yes` to `status:automated` in RHEL7 CIS

#### Rationale:

- The key 'status' works better when tracking the implementation state of the control items.
