### PR TITLE
Fix confusing wording in var_accounts_tmout

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
+++ b/linux_os/guide/system/accounts/accounts-session/var_accounts_tmout.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Account Inactivity Timeout (minutes)'
+title: 'Account Inactivity Timeout (seconds)'
 
 description: |-
     In an interactive shell, the value is interpreted as the


### PR DESCRIPTION
#### Description:

This PR fixes the confusing wording in `var_accounts_tmout`, swapping "(minutes)" for the more accurate "(seconds)".

#### Rationale:

This makes the timeout variable value more clear, especially within SCAP Workbench where the "(minutes)" wording is misleading.

A user looking at this could conclude (wrongly) based on the current wording that the default value for this timeout is 600 minutes rather than 600 seconds:
![image](https://user-images.githubusercontent.com/13152214/146642336-144e6dce-f675-45fd-812f-64aa24e3612c.png)

I appreciate that within the policy files, the selector names used are actually in minutes rather than seconds (e.g. `30_min`, `10_min`), but since those values also include the units I don't think there's much room for ambiguity there even if we switch the title of this var to read "(seconds)".