### PR TITLE
Fix Profile title to Node instead of Platform

### DIFF
--- a/products/ocp4/profiles/nerc-cip-node.profile
+++ b/products/ocp4/profiles/nerc-cip-node.profile
@@ -13,7 +13,7 @@ reference: https://www.nerc.com/pa/Stand/AlignRep/One%20Stop%20Shop.xlsx
 title: >-
   North American Electric Reliability Corporation (NERC) Critical Infrastructure
   Protection (CIP) cybersecurity standards profile for the 
-  Red Hat OpenShift Container Platform - Platform level
+  Red Hat OpenShift Container Platform - Node level
 
 description: |-
     This compliance profile reflects a set of security recommendations for


### PR DESCRIPTION
#### Description:

- It appears that the title of this profile should refer to Node level instead of Platform level.

#### Rationale:

The ocp4-nerc-cip-node profile is a node-level profile.  The format of the ocp4-moderate-node title  is similar and this change would be consistent with the format of that title.

