### PR TITLE
Update dconf_db_up_to_date description to include dconf specific dirs

### DIFF
--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/rule.yml
@@ -6,7 +6,11 @@ title: 'Make sure that the dconf databases are up-to-date with regards to respec
 
 description: |-
     By default, DConf uses a binary database as a data backend.
-    The system-level database is compiled from keyfiles in the /etc/dconf/db/ directory by the <pre>dconf update</pre> command.
+    The system-level database is compiled from keyfiles in the /etc/dconf/db/
+    directory by the <pre>dconf update</pre> command. More specifically, content present
+    in the following directories:
+    <pre>/etc/dconf/db/{{{dconf_gdm_dir}}}</pre>
+    <pre>/etc/dconf/db/local.d</pre>
 
 rationale: |-
     Unlike text-based keyfiles, the binary database is impossible to check by OVAL.


### PR DESCRIPTION
#### Description:

- Update dconf_db_up_to_date description to include dconf specific dirs.

#### Rationale:

- The OVAL check looks exactly for those directories so there are no misalignment.

#### Rendered HTML:

![Screenshot from 2022-01-03 14-39-21](https://user-images.githubusercontent.com/18730394/147937401-fa36b8e0-5cab-4457-9c2d-0b42a0da7a21.png)

