### PR TITLE
Use authselect to edit pam files if it is present

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -41,9 +41,9 @@
       - result_authselect_check_cmd is success
     fail_msg:
     - authselect integrity check failed. Remediation aborted!
-    - This remediation could not be applied because the authselect profile is not integer, probably due to manual edition.
+    - This remediation could not be applied because the authselect profile is not intact.
+    - It is not recommended to manually edit the PAM files when authselect is available
     - In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
-    - Where authselect is in place, it is not recommended to manually edit pam files.
     success_msg:
     - authselect integrity check passed
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -35,14 +35,17 @@
     - result_authselect_check_cmd is success
     - result_authselect_features.stdout is not search("without-nullok")
 
-- name: Informative message if the authselect integrity check fails
-  debug:
-    msg:
-    - This remediation could not be applied because the authselect profile was manually modified.
+- name: Informative message based on the authselect integrity check result
+  ansible.builtin.assert:
+    that:
+      - result_authselect_check_cmd is success
+    fail_msg:
+    - authselect integrity check failed. Remediation aborted!
+    - This remediation could not be applied because the authselect profile is not integer, probably due to manual edition.
     - In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
     - Where authselect is in place, it is not recommended to manually edit pam files.
-  when:
-    - result_authselect_check_cmd is failed
+    success_msg:
+    - authselect integrity check passed
 
 - name: Ensure nullok property is absent by directly editing pam files
   replace:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -17,14 +17,6 @@
   when:
     - result_authselect_present.stat.exists
 
-- name: Get authselect current profile
-  ansible.builtin.shell:
-    cmd: authselect current -r | awk '{ print $1 }'
-  register: result_authselect_profile
-  changed_when: false
-  when:
-    - result_authselect_check_cmd is failed
-
 - name: Get authselect current features
   ansible.builtin.shell:
     cmd: authselect current | tail -n+3 | awk '{ print $2 }'
@@ -32,40 +24,27 @@
   changed_when: false
   when:
     - result_authselect_present.stat.exists
+    - result_authselect_check_cmd is success
 
-- name: Define the current authselect profile as a local fact
-  ansible.builtin.set_fact:
-    authselect_profile: "{{ result_authselect_profile.stdout }}"
-  when:
-    - result_authselect_check_cmd is failed
-    - result_authselect_profile is not skipped
-
-- name: Restore the authselect profile if manually modified
-  ansible.builtin.command:
-    cmd: authselect select {{ authselect_profile }} --force
-  register: result_pam_authselect_restore_profile
-  when:
-    - result_authselect_check_cmd is failed
-    - result_authselect_profile is not skipped
-
-- name: Restore the authselect features if manually modified
-  ansible.builtin.command:
-    cmd: authselect enable-feature {{ item }}
-  register: result_pam_authselect_restore_features
-  loop: "{{ result_authselect_features.stdout_lines }}"
-  when:
-    - result_authselect_check_cmd is failed
-    - result_authselect_features is not skipped
-
-- name: "Ensure nullok property is absent via authselect tool"
+- name: Ensure nullok property is absent via authselect tool
   ansible.builtin.command:
     cmd: authselect enable-feature without-nullok
   register: result_authselect_cmd
   when:
     - result_authselect_present.stat.exists
+    - result_authselect_check_cmd is success
     - result_authselect_features.stdout is not search("without-nullok")
 
-- name: "Ensure nullok property is absent by directly editing pam files"
+- name: Informative message if the authselect integrity check fails
+  debug:
+    msg:
+    - This remediation could not be applied because the authselect profile was manually modified.
+    - In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
+    - Where authselect is in place, it is not recommended to manually edit pam files.
+  when:
+    - result_authselect_check_cmd is failed
+
+- name: Ensure nullok property is absent by directly editing pam files
   replace:
     dest: "{{ item }}"
     regexp: 'nullok'

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/ansible/shared.yml
@@ -1,14 +1,76 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 # reboot = false
 # strategy = configure
 # complexity = low
 # disruption = medium
-- name: "Prevent Log In to Accounts With Empty Password - system-auth"
-  replace:
-    dest: /etc/pam.d/system-auth
-    regexp: 'nullok'
+- name: Check if system relies on authselect
+  ansible.builtin.stat:
+    path: /usr/bin/authselect
+  register: result_authselect_present
 
-- name: "Prevent Log In to Accounts With Empty Password - password-auth"
+- name: Check integrity of authselect current profile
+  ansible.builtin.command:
+    cmd: authselect check
+  register: result_authselect_check_cmd
+  changed_when: false
+  ignore_errors: yes
+  when:
+    - result_authselect_present.stat.exists
+
+- name: Get authselect current profile
+  ansible.builtin.shell:
+    cmd: authselect current -r | awk '{ print $1 }'
+  register: result_authselect_profile
+  changed_when: false
+  when:
+    - result_authselect_check_cmd is failed
+
+- name: Get authselect current features
+  ansible.builtin.shell:
+    cmd: authselect current | tail -n+3 | awk '{ print $2 }'
+  register: result_authselect_features
+  changed_when: false
+  when:
+    - result_authselect_present.stat.exists
+
+- name: Define the current authselect profile as a local fact
+  ansible.builtin.set_fact:
+    authselect_profile: "{{ result_authselect_profile.stdout }}"
+  when:
+    - result_authselect_check_cmd is failed
+    - result_authselect_profile is not skipped
+
+- name: Restore the authselect profile if manually modified
+  ansible.builtin.command:
+    cmd: authselect select {{ authselect_profile }} --force
+  register: result_pam_authselect_restore_profile
+  when:
+    - result_authselect_check_cmd is failed
+    - result_authselect_profile is not skipped
+
+- name: Restore the authselect features if manually modified
+  ansible.builtin.command:
+    cmd: authselect enable-feature {{ item }}
+  register: result_pam_authselect_restore_features
+  loop: "{{ result_authselect_features.stdout_lines }}"
+  when:
+    - result_authselect_check_cmd is failed
+    - result_authselect_features is not skipped
+
+- name: "Ensure nullok property is absent via authselect tool"
+  ansible.builtin.command:
+    cmd: authselect enable-feature without-nullok
+  register: result_authselect_cmd
+  when:
+    - result_authselect_present.stat.exists
+    - result_authselect_features.stdout is not search("without-nullok")
+
+- name: "Ensure nullok property is absent by directly editing pam files"
   replace:
-    dest: /etc/pam.d/password-auth
+    dest: "{{ item }}"
     regexp: 'nullok'
+  loop:
+    - /etc/pam.d/system-auth
+    - /etc/pam.d/password-auth
+  when:
+    - not result_authselect_present.stat.exists

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -1,3 +1,20 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
-sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/system-auth
-sed --follow-symlinks -i 's/\<nullok\>//g' /etc/pam.d/password-auth
+SYSTEM_AUTH="/etc/pam.d/system-auth"
+PASSWORD_AUTH="/etc/pam.d/password-auth"
+
+if [ -f /usr/bin/authselect ]; then
+    if [ $(authselect enable-feature without-nullok) ]; then
+        authselect apply-changes
+    else
+        ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
+        CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
+        authselect select $CURRENT_PROFILE --force
+        for feature in $ENABLED_FEATURES without-nullok; do
+            authselect enable-feature $feature;
+        done
+        authselect apply-changes
+    fi
+else
+    sed --follow-symlinks -i 's/\<nullok\>//g' $SYSTEM_AUTH
+    sed --follow-symlinks -i 's/\<nullok\>//g' $PASSWORD_AUTH
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -12,10 +12,11 @@ if [ -f /usr/bin/authselect ]; then
         authselect apply-changes
     else
         echo "
-This remediation could not be applied because the authselect profile was manually modified.
+authselect integrity check failed. Remediation aborted!
+This remediation could not be applied because the authselect profile is not integer, probably due to manual edition.
 In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
 Where authselect is in place, it is not recommended to manually edit pam files."
-    false
+        false
     fi
 else
     sed --follow-symlinks -i 's/\<nullok\>//g' $SYSTEM_AUTH

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -13,9 +13,9 @@ if [ -f /usr/bin/authselect ]; then
     else
         echo "
 authselect integrity check failed. Remediation aborted!
-This remediation could not be applied because the authselect profile is not integer, probably due to manual edition.
-In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
-Where authselect is in place, it is not recommended to manually edit pam files."
+This remediation could not be applied because the authselect profile is not intact.
+It is not recommended to manually edit the PAM files when authselect is available
+In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended."
         false
     fi
 else

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -1,18 +1,21 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = medium
 SYSTEM_AUTH="/etc/pam.d/system-auth"
 PASSWORD_AUTH="/etc/pam.d/password-auth"
 
 if [ -f /usr/bin/authselect ]; then
-    if [ $(authselect enable-feature without-nullok) ]; then
+    if authselect check; then
+        authselect enable-feature without-nullok
         authselect apply-changes
     else
-        ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
-        CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
-        authselect select $CURRENT_PROFILE --force
-        for feature in $ENABLED_FEATURES without-nullok; do
-            authselect enable-feature $feature;
-        done
-        authselect apply-changes
+        echo "
+This remediation could not be applied because the authselect profile was manually modified.
+In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
+Where authselect is in place, it is not recommended to manually edit pam files."
+    false
     fi
 else
     sed --follow-symlinks -i 's/\<nullok\>//g' $SYSTEM_AUTH

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -1,11 +1,14 @@
 <def-group>
-  <definition class="compliance" id="no_empty_passwords" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("The file /etc/pam.d/system-auth should not contain the nullok option") }}}
     <criteria>
-      <criterion comment="make sure the nullok option is not used in /etc/pam.d/system-auth" test_ref="test_no_empty_passwords" />
+      <criterion comment="make sure the nullok option is not used in /etc/pam.d/system-auth"
+                 test_ref="test_no_empty_passwords" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="make sure nullok is not used in /etc/pam.d/system-auth" id="test_no_empty_passwords" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+                              id="test_no_empty_passwords"
+                              comment="make sure nullok is not used in /etc/pam.d/system-auth">
     <ind:object object_ref="object_no_empty_passwords" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -73,8 +73,8 @@ ocil: |-
 
 warnings:
     - general: |-
-       If the system relies on <tt>authselect</tt> tool to manage pam settings, the remediation
+       If the system relies on <tt>authselect</tt> tool to manage PAM settings, the remediation
        will also use <tt>authselect</tt> tool. However, if any manual modification was made in
-       pam files, the <tt>authselect</tt> integrity check will fail and the remediation will be
+       PAM files, the <tt>authselect</tt> integrity check will fail and the remediation will be
        aborted in order to preserve intentional changes. In this case, an informative message will
        be shown in the remediation report.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -70,3 +70,11 @@ ocil: |-
     If this produces any output, it may be possible to log into accounts
     with empty passwords. Remove any instances of the <tt>nullok</tt> option to
     prevent logins with empty passwords.
+
+warnings:
+    - general: |-
+       If the system relies on <tt>authselect</tt> tool to manage pam settings, the remediation
+       will also use <tt>authselect</tt> tool. However, if any manual modification was made in
+       pam files, the <tt>authselect</tt> integrity check will fail and the remediation will be
+       aborted in order to preserve intentional changes. In this case, an informative message will
+       be shown in the remediation report.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# remediation = none
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
-# This modification will break the integrity checks done by authselect. The remediation
-# should be robust enough to deal with possible manual and unvalidated modification.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
-else
-   sed -i "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+# This modification will break the current authselect profile and will be detected by the
+# authselect integrity check, aborting the remediation and showing an informative message
+# in the remediation report.
+if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
+   sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
+# packages = authselect
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = none
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
-# This modification will break the current authselect profile and will be detected by the
-# authselect integrity check, aborting the remediation and showing an informative message
-# in the remediation report.
-if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
-   sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
+# This modification will break the integrity checks done by authselect. The remediation
+# should be robust enough to deal with possible manual and unvalidated modification.
+if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+else
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+
+# This modification will break the integrity checks done by authselect. The remediation
+# should be robust enough to deal with possible manual and unvalidated modification.
+if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+else
+   sed -i "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
@@ -5,8 +5,7 @@
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
-# This modification will break the integrity checks done by authselect. The remediation
-# should be robust enough to deal with possible manual and unvalidated modification.
+# This modification will break the integrity checks done by authselect.
 if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
 	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_present.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = authselect
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+
+authselect select sssd --force
+if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
+    authselect disable-feature without-nullok
+    authselect apply-changes
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-sed -i '/nullok/d' /etc/pam.d/system-auth
+sed -i --follow-symlinks '/nullok/d' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-
 sed -i '/nullok/d' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+
 sed -i '/nullok/d' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 sed -i '/nullok/d' $SYSTEM_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_multiple_times.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_multiple_times.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
-
-echo "auth  sufficient  pam_unix.so try_first_pass nullok" >> $SYSTEM_AUTH_FILE
-echo "auth  required    pam_unix.so nullok" >> $SYSTEM_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
-    sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
+    if [ -f /usr/bin/authselect ]; then
+        authselect disable-feature without-nullok
+        authselect apply-changes
+    else
+        sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
+    fi
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
+# packages = authselect
+# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
-    if [ -f /usr/bin/authselect ]; then
-        authselect disable-feature without-nullok
-        authselect apply-changes
-    else
-        sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
-    fi
+    sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
-echo "auth  sufficient  pam_unix.so try_first_pass nullok" >> /etc/pam.d/system-auth
+if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
+    sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_secure.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_secure.pass.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
-
-sed -i '/nullok/d' $SYSTEM_AUTH_FILE
-echo "auth  sufficient  pam_unix.so nullok_secure" >> $SYSTEM_AUTH_FILE


### PR DESCRIPTION
#### Description:

The remediation included in no_empty_passwords rule was editing pam
files directly, making them inconsistent for the `authselect` tool.

#### Rationale:

It is not recommended to edit pam files directly when a proper tool exists.

- Partially Fixes #8022
