### PR TITLE
Fix wrongly used filepath value instead of directory in sshd macro

### DIFF
--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -896,8 +896,8 @@
   {{{ oval_line_in_directory_state(value) | indent (2) }}}
 
   {{%- if missing_parameter_pass %}}
-  {{{ oval_line_in_directory_test(sshd_config_path, parameter, missing_parameter_pass) | indent(2) }}}
-  {{{ oval_line_in_directory_object(sshd_config_path, parameter=parameter, missing_parameter_pass=missing_parameter_pass, ** case_insensitivity_kwargs) | indent(2) }}}
+  {{{ oval_line_in_directory_test(sshd_config_dir, parameter, missing_parameter_pass) | indent(2) }}}
+  {{{ oval_line_in_directory_object(sshd_config_dir, parameter=parameter, missing_parameter_pass=missing_parameter_pass, ** case_insensitivity_kwargs) | indent(2) }}}
   {{%- endif %}}
   {{%- endif %}}
 </def-group>


### PR DESCRIPTION
#### Description:
In RHEL9, sshd configurations can be placed in config directory. If default value (missing configuration) is correct, we need to test absence of the configuration in both - `sshd_config` and `sshd_config.d` directory.

Found via (`param_conflict.fail.sh` puts wrong value in sshd config file, `param_conflict_directory.fail.sh` puts wrong value in sshd config directory):
```
$ python3 tests/test_suite.py rule --libvirt qemu:///session test-suite-rhel9 --datastream build/ssg-rhel9-ds.xml --scenarios param_conflict disable_host_auth                                                       

Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/mlysonek/SCAP/content/logs/rule-custom-2022-01-05-1100/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_disable_host_auth
INFO - Script param_conflict.fail.sh using profile (all) OK
ERROR - Script param_conflict_directory.fail.sh using profile (all) found issue:
ERROR - Rule evaluation resulted in pass, instead of expected fail during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_disable_host_auth'.
```

#### Rationale:
Directory check needs to search sshd config directory, not config file - wrong value has been used in sshd macro.