### PR TITLE
Add .d directory in OVAL check of `sshd_set_keepalive`

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
@@ -25,8 +25,14 @@
         <extend_definition comment="rpm package openssh-server installed"
         definition_ref="package_openssh-server_installed" />
         {{% endif %}}
-        <criterion comment="Check ClientAliveCountMax in /etc/ssh/sshd_config"
-        test_ref="test_sshd_clientalivecountmax" />
+        <criteria comment="sshd is configured" operator="OR">
+          <criterion comment="Check ClientAliveCountMax in /etc/ssh/sshd_config"
+          test_ref="test_sshd_clientalivecountmax" />
+          {{%- if sshd_distributed_config == "true" %}}
+          <criterion comment="Check ClientAliveCountMax in /etc/ssh/sshd_config.d/ files"
+          test_ref="test_sshd_clientalivecountmax_dir" />
+          {{%- endif %}}
+        </criteria>
       </criteria>
     </criteria>
   </definition>
@@ -45,6 +51,21 @@
     <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveCountMax[\s]+([\d]+)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{%- if sshd_distributed_config == "true" %}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="Tests the value of the ClientAliveCountMax setting in the /etc/ssh/sshd_config.d/ files"
+  id="test_sshd_clientalivecountmax_dir" version="1">
+    <ind:object object_ref="obj_sshd_clientalivecountmax_dir" />
+    <ind:state state_ref="state_sshd_clientalivecountmax" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_sshd_clientalivecountmax_dir" version="1">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveCountMax[\s]+([\d]+)[\s]*(?:#.*)?$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{%- endif %}}
 
   <external_variable comment="ClientAliveCountMax value" datatype="int"
   id="var_sshd_set_keepalive" version="1" />

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/correct_value_dot_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/correct_value_dot_dir.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# variables = var_sshd_set_keepalive=0
+# plaftorm = Red Hat Enterprise Linux 9
+
+SSHD_CONFIG="/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf"
+
+. "$SHARED/utilities.sh"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+	sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "ClientAliveCountMax 0"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/wrong_value_dot_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/wrong_value_dot_dir.fail.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# variables = var_sshd_set_keepalive=0
+# plaftorm = Red Hat Enterprise Linux 9
+
+SSHD_CONFIG="/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf"
+
+. "$SHARED/utilities.sh"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+	sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "ClientAliveCountMax 3"


### PR DESCRIPTION
#### Description:

- Add .d directory in OVAL check of sshd_set_keepalive.
  - This should fix problems in RHEL9 where the rule sshd_set_idle_timeout
uses this OVAL check as extend definition and RHEL9 only remediates
under the .d directories.

#### Rationale:

- Related to https://github.com/ComplianceAsCode/content/issues/7752#issuecomment-1004975221

