### PR TITLE
OCP4: api_server_no_adm_ctrl_plugins_disabled ignore PodSecurity

### DIFF
--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -4,9 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure all admission control plugins are enabled'
 
+
+{{% set jqfilter = '[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]' %}}
+
 description: |-
-    To make sure none of them is explicitly disabled, run the following command:
-    <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data."config.yaml"' | jq '.apiServerArguments."disable-admission-plugins"'</pre>
+    To make sure none of them is explicitly disabled except PodSecurity, run the following command:
+    <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '{{{ jqfilter }}}'</pre>
     and make sure the output is empty.
 
 rationale: |-
@@ -32,21 +35,23 @@ ocil_clause: 'No admission plugins are disabled'
 
 ocil: |-
     To verify that the list of disabled admission plugins is empty, run the following command:
-    <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '.data."config.yaml"' | jq '.apiServerArguments."disable-admission-plugins"'</pre>
+    <pre>$oc -n openshift-kube-apiserver get configmap config -o json | jq -r '{{{ jqfilter }}}'</pre>
     There should be no output.
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/api/v1/namespaces/openshift-kube-apiserver/configmaps/config': jqfilter}) | indent(4) }}}
+
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "none exist"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    filepath: |-
+      {{{ openshift_filtered_path('/api/v1/namespaces/openshift-kube-apiserver/configmaps/config', jqfilter) }}}
+    yamlpath: "[:]"
+    check_existence: "none_exist"
+    entity_check: "all"
     values:
-    - value: '"disable-admission-plugins"'
-      operation: "pattern match"
-      type: "string"
+      - value: "(.*?)"
+        operation: "pattern match"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/no_disabled.pass.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/no_disabled.pass.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# remediation = none
+
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-apiserver/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-apiserver/configmaps/config"
+
+cat <<EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiServerArguments\":{\"allow-privileged\":[\"true\"],\"disable-admission-plugins\":[]}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-05T16:43:59Z",
+        "name": "config",
+        "namespace": "openshift-kube-apiserver",
+        "resourceVersion": "18738",
+        "uid": "47d65a11-41f3-47d7-ab9a-fb57119e9d81"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/not_podsecurity.fail.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/not_podsecurity.fail.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# remediation = none
+
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-apiserver/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-apiserver/configmaps/config"
+
+cat <<EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiServerArguments\":{\"allow-privileged\":[\"true\"],\"disable-admission-plugins\":[\"notPodSecurity\"]}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-05T16:43:59Z",
+        "name": "config",
+        "namespace": "openshift-kube-apiserver",
+        "resourceVersion": "18738",
+        "uid": "47d65a11-41f3-47d7-ab9a-fb57119e9d81"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/only_podsecurity.pass.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/only_podsecurity.pass.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# remediation = none
+
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-apiserver/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-apiserver/configmaps/config"
+
+cat <<EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiServerArguments\":{\"allow-privileged\":[\"true\"],\"disable-admission-plugins\":[\"PodSecurity\"]}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-05T16:43:59Z",
+        "name": "config",
+        "namespace": "openshift-kube-apiserver",
+        "resourceVersion": "18738",
+        "uid": "47d65a11-41f3-47d7-ab9a-fb57119e9d81"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/other_than_podsecurity.fail.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/other_than_podsecurity.fail.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# remediation = none
+
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-apiserver/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-apiserver/configmaps/config"
+
+cat <<EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiServerArguments\":{\"allow-privileged\":[\"true\"],\"disable-admission-plugins\":[\"PodSecurity\",\"notPodSecurity\"]}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-05T16:43:59Z",
+        "name": "config",
+        "namespace": "openshift-kube-apiserver",
+        "resourceVersion": "18738",
+        "uid": "47d65a11-41f3-47d7-ab9a-fb57119e9d81"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath"

--- a/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e-remediation.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-# You can safely patch this to a non-existent secret name, it's a no-op, but OK for testing.
-oc patch proxies.config cluster --type merge -p '{"spec":{"trustedCA":{"name":"testing"}}}'
+# we are using an existing default secret name for testing, so it won't cause any subsequent failures on testing routes. 
+oc patch proxies.config cluster --type merge -p '{"spec":{"trustedCA":{"name":"trusted-ca-bundle"}}}'


### PR DESCRIPTION
We are going to ignore PodSecurity from the disabled admission control plugins list because it is validating only and it is disabled by default on 4.10 due to the transition from SCCs to PSs

Related Link: https://github.com/openshift/enhancements/pull/899/files
