### PR TITLE
sshd_set_idle_timeout .d directory check support

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -25,8 +25,14 @@
         <extend_definition comment="rpm package openssh-server installed"
         definition_ref="package_openssh-server_installed" />
         {{% endif %}}
-        <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
-        test_ref="test_sshd_idle_timeout" />
+        <criteria comment="ClientAliveInterval is configured correctly" operator="OR">
+          <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config"
+          test_ref="test_sshd_idle_timeout" />
+          {{%- if sshd_distributed_config == "true" %}}
+          <criterion comment="Check ClientAliveInterval in /etc/ssh/sshd_config.d/"
+          test_ref="test_sshd_idle_timeout_config_dir" />
+          {{%- endif %}}
+        </criteria>
         <extend_definition comment="The SSH ClientAliveCountMax is set to zero" definition_ref="sshd_set_keepalive" />
       </criteria>
     </criteria>
@@ -44,6 +50,22 @@
     <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveInterval[\s]+(\d+)[\s]*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{%- if sshd_distributed_config == "true" %}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="timeout is configured in config directory" id="test_sshd_idle_timeout_config_dir" version="1">
+    <ind:object object_ref="object_sshd_idle_timeout_config_dir" />
+    <ind:state state_ref="state_timeout_value_upper_bound" />
+    <ind:state state_ref="state_timeout_value_lower_bound" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_sshd_idle_timeout_config_dir" version="2">
+    <ind:path>/etc/ssh/sshd_config.d</ind:path>
+    <ind:filename operation="pattern match">.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveInterval[\s]+(\d+)[\s]*(?:#.*)?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{%- endif %}}
 
   <ind:textfilecontent54_state comment="upper bound of ClientAliveInterval in seconds"
   id="state_timeout_value_upper_bound" version="1">

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value_directory.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/correct_value_directory.pass.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+SSHD_CONFIG_DIR="/etc/ssh/sshd_config.d"
+SSHD_CONFIG="${SSHD_CONFIG_DIR}/good_config.conf"
+
+mkdir -p $SSHD_CONFIG_DIR
+touch $SSHD_CONFIG
+
+if grep -q "^\s*ClientAliveInterval" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*ClientAliveInterval.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "ClientAliveInterval 200" >> $SSHD_CONFIG
+echo "ClientAliveCountMax 0" >> $SSHD_CONFIG

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/param_conflict_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/param_conflict_directory.fail.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+SSHD_CONFIG_DIR="/etc/ssh/sshd_config.d"
+SSHD_CONFIG_BAD="${SSHD_CONFIG_DIR}/bad_config.conf"
+SSHD_CONFIG_GOOD="${SSHD_CONFIG_DIR}/good_config.conf"
+
+mkdir -p $SSHD_CONFIG_DIR
+touch $SSHD_CONFIG
+
+. "$SHARED/utilities.sh"
+
+if grep -q "^\s*ClientAliveInterval" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*ClientAliveInterval.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "ClientAliveInterval 6000" > $SSHD_CONFIG_BAD
+echo "ClientAliveInterval 200" > $SSHD_CONFIG_GOOD
+echo "ClientAliveCountMax 0" > $SSHD_CONFIG_GOOD

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/wrong_value_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/wrong_value_directory.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+SSHD_CONFIG_DIR="/etc/ssh/sshd_config.d"
+SSHD_CONFIG="${SSHD_CONFIG_DIR}/bad_config.conf"
+
+mkdir -p $SSHD_CONFIG_DIR
+touch $SSHD_CONFIG
+
+if grep -q "^\s*ClientAliveInterval" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*ClientAliveInterval.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "ClientAliveInterval 6000" > $SSHD_CONFIG
+echo "ClientAliveCountMax 0" > $SSHD_CONFIG


### PR DESCRIPTION
#### Description:
Add .d directory OVAL check for sshd_set_idle_timeout. SSH configuration in directory support is added in RHEL9

#### Rationale:

Follow-up of #8028
Related to #7752 
