### PR TITLE
Introduce a shellcheck test

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -38,7 +38,7 @@ jobs:
       image: opensuse/leap:15
     steps:
       - name: Install Deps
-        run: zypper install -y git cmake make openscap-utils python3-PyYAML bats python3-pytest python3-pytest-cov python3-Jinja2 python3-setuptools libxslt-tools libxml2-tools libexpat1 libexpat-devel libexpat1 expat
+        run: zypper install -y git cmake make openscap-utils python3-PyYAML bats python3-pytest python3-pytest-cov python3-Jinja2 python3-setuptools libxslt-tools libxml2-tools libexpat1 libexpat-devel libexpat1 expat ShellCheck
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
@@ -77,7 +77,7 @@ jobs:
       - name: Install Deps
         uses: mstksg/get-package@master
         with:
-          apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml python3-setuptools ansible-lint python3-github bats python3-pytest python3-pytest-cov
+          apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml python3-setuptools ansible-lint python3-github bats python3-pytest python3-pytest-cov shellcheck
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
@@ -105,7 +105,7 @@ jobs:
       image: fedora:34
     steps:
       - name: Install Deps
-        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip
+        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck
       - name: Install deps python
         run: pip install ruamel.yaml yamlpath
       - name: Checkout
@@ -139,7 +139,7 @@ jobs:
       image: fedora:rawhide
     steps:
       -   name: Install Deps
-          run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip
+          run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck
       -   name: Install deps python
           run: pip install ruamel.yaml yamlpath
       -   name: Checkout

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ set(SSG_TARGET_OVAL_VERSION "${SSG_TARGET_OVAL_MAJOR_VERSION}.${SSG_TARGET_OVAL_
 
 option(SSG_BUILD_SCAP_12_DS "If enabled, ssg-*-ds-1.2.xml will be built along with ssg-*-ds.xml" TRUE)
 option(SSG_OVAL_SCHEMATRON_VALIDATION_ENABLED "If enabled, schematron validation will be performed as part of the ctest tests. Schematron takes a lot of time to complete but can find more issues than just plain XSD validation." TRUE)
-option(SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED "If enabled, shellcheck validation of bash fixes will be performed as part of the ctest tests. Shellcheck tests don't pass right now, this option is discouraged until that's fixed." FALSE)
+option(SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED "If enabled, shellcheck validation of bash fixes will be performed as part of the ctest tests. Shellcheck tests don't pass right now, this option is discouraged until that's fixed." TRUE)
 option(SSG_LINKCHECKER_VALIDATION_ENABLED "If enabled, linkchecker will be used to validate URLs in all the HTML guides and tables." TRUE)
 option(SSG_SVG_IN_XCCDF_ENABLED "If enabled, the built XCCDFs will include the SVG SCAP Security Guide logo." TRUE)
 option(SSG_SEPARATE_SCAP_FILES_ENABLED "If enabled, separate SCAP files (OVAL, XCCDF, CPE dict, ...) will be installed alongside the source data-streams" TRUE)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -211,14 +211,6 @@ macro(ssg_collect_remediations PRODUCT LANGUAGES)
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/collect-remediations-${PRODUCT}"
     )
     if (SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED AND SHELLCHECK_EXECUTABLE)
-        # Doesn't work, as the glob is evaluated at cmake-time instead of test exec time
-        file(GLOB BASH_SNIPPETS "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash/*.sh")
-        add_test(
-            NAME "${PRODUCT}-bash-shellcheck2"
-	    COMMAND "${SHELLCHECK_EXECUTABLE}" -s bash -S warning ${BASH_SNIPPETS}
-        )
-        set_tests_properties("${PRODUCT}-bash-shellcheck2" PROPERTIES LABELS quick)
-
         add_test(
             NAME "${PRODUCT}-bash-shellcheck"
 	    COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -210,6 +210,21 @@ macro(ssg_collect_remediations PRODUCT LANGUAGES)
         generate-internal-${PRODUCT}-all-fixes
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/collect-remediations-${PRODUCT}"
     )
+    if (SSG_SHELLCHECK_BASH_FIXES_VALIDATION_ENABLED AND SHELLCHECK_EXECUTABLE)
+        # Doesn't work, as the glob is evaluated at cmake-time instead of test exec time
+        file(GLOB BASH_SNIPPETS "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash/*.sh")
+        add_test(
+            NAME "${PRODUCT}-bash-shellcheck2"
+	    COMMAND "${SHELLCHECK_EXECUTABLE}" -s bash -S warning ${BASH_SNIPPETS}
+        )
+        set_tests_properties("${PRODUCT}-bash-shellcheck2" PROPERTIES LABELS quick)
+
+        add_test(
+            NAME "${PRODUCT}-bash-shellcheck"
+	    COMMAND "${CMAKE_SOURCE_DIR}/utils/shellcheck_wrapper.sh" "${SHELLCHECK_EXECUTABLE}" "${CMAKE_BINARY_DIR}/${PRODUCT}/fixes/bash" -s bash -S warning
+        )
+        set_tests_properties("${PRODUCT}-bash-shellcheck" PROPERTIES LABELS quick)
+    endif()
 endmacro()
 
 # Builds the XML document containing all remediations of the given language.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/bash/shared.sh
@@ -7,9 +7,9 @@ if [ -f /usr/bin/authselect ]; then
         CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
         # Standard profiles delivered with authselect should not be modified.
         # If not already in use, a custom profile is created preserving the enabled features.
-        if [[ ! $CURRENT_PROFILE == custom/* ]]; then
+        if [[ ! "$CURRENT_PROFILE" == custom/* ]]; then
             ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
-            authselect create-profile hardening -b $CURRENT_PROFILE
+            authselect create-profile hardening -b "$CURRENT_PROFILE"
             CURRENT_PROFILE="custom/hardening"
             # Ensure a backup before changing the profile
             authselect apply-changes -b --backup=before-pwquality-hardening.backup
@@ -21,8 +21,8 @@ if [ -f /usr/bin/authselect ]; then
         # Include the desired configuration in the custom profile
         CUSTOM_FILE="/etc/authselect/$CURRENT_PROFILE/$PAM_FILE"
         # The line should be included on the top password section
-		if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_FILE) -eq 0 ]; then
-  		  sed -i --follow-symlinks '0,/^password.*/s/^password.*/password    requisite                                    pam_pwquality.so\n&/' $CUSTOM_FILE
+		if [ "$(grep -c "^\s*password.*requisite.*pam_pwquality.so" "$CUSTOM_FILE")" -eq 0 ]; then
+		    sed -i --follow-symlinks '0,/^password.*/s/^password.*/password    requisite                                    pam_pwquality.so\n&/' "$CUSTOM_FILE"
 		fi
         authselect apply-changes -b --backup=after-pwquality-hardening.backup
     else
@@ -35,7 +35,7 @@ In cases where the default authselect profile does not cover a specific demand, 
     fi
 else
     FILE_PATH="/etc/pam.d/$PAM_FILE"
-    if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $FILE_PATH) -eq 0 ]; then
-        sed -i --follow-symlinks '0,/^password.*/s/^password.*/password    requisite                                    pam_pwquality.so\n&/' $FILE_PATH
+    if [ "$(grep -c "^\s*password.*requisite.*pam_pwquality.so" "$FILE_PATH")" -eq 0 ]; then
+        sed -i --follow-symlinks '0,/^password.*/s/^password.*/password    requisite                                    pam_pwquality.so\n&/' "$FILE_PATH"
     fi
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/bash/shared.sh
@@ -21,7 +21,7 @@ if [ -f /usr/bin/authselect ]; then
         # Include the desired configuration in the custom profile
         CUSTOM_FILE="/etc/authselect/$CURRENT_PROFILE/$PAM_FILE"
         # The line should be included on the top password section
-		if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_FILE) -eq 0 ]; then
+		if [ "$(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_FILE)" -eq 0 ]; then
   		  sed -i --follow-symlinks '0,/^password.*/s/^password.*/password    requisite                                    pam_pwquality.so\n&/' $CUSTOM_FILE
 		fi
         authselect apply-changes -b --backup=after-pwquality-hardening.backup
@@ -35,7 +35,7 @@ In cases where the default authselect profile does not cover a specific demand, 
     fi
 else
     FILE_PATH="/etc/pam.d/$PAM_FILE"
-    if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $FILE_PATH) -eq 0 ]; then
+    if [ "$(grep -c "^\s*password.*requisite.*pam_pwquality.so" $FILE_PATH)" -eq 0 ]; then
         sed -i --follow-symlinks '0,/^password.*/s/^password.*/password    requisite                                    pam_pwquality.so\n&/' $FILE_PATH
     fi
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_min_pass_age.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_min_pass_age.fail.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# packages = passwd
+
 BAD_PAS_AGE=-1
 
 # Configure the OS to enforce a password age < 1 of each accout  

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_stig.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # variables = var_accounts_minimum_age_login_defs=1
+# packages = passwd
 
 # make existing entries pass
 for acct in $(awk -F: '{print $1}' /etc/shadow ); do

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_stig_blank.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_stig_blank.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # variables = var_accounts_minimum_age_login_defs=1
+# packages = passwd
 
 # make existing entities pass
 for acct in $(awk -F: '{print $1}' /etc/shadow ); do

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/bash/shared.sh
@@ -20,7 +20,7 @@ if [ -f /usr/bin/authselect ]; then
         fi
         # Include the desired configuration in the custom profile
         CUSTOM_PASSWORD_AUTH="/etc/authselect/$CURRENT_PROFILE/password-auth"
-		if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
+		if ! grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_PASSWORD_AUTH; then
 			sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$var_password_pam_unix_rounds/" $CUSTOM_PASSWORD_AUTH
 		else
 			sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$var_password_pam_unix_rounds \3/g" $CUSTOM_PASSWORD_AUTH

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/bash/shared.sh
@@ -20,7 +20,7 @@ if [ -f /usr/bin/authselect ]; then
         fi
         # Include the desired configuration in the custom profile
         CUSTOM_SYSTEM_AUTH="/etc/authselect/$CURRENT_PROFILE/system-auth"
-		if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
+		if ! grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_SYSTEM_AUTH; then
 			sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$var_password_pam_unix_rounds/" $CUSTOM_SYSTEM_AUTH
 		else
 			sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$var_password_pam_unix_rounds \3/g" $CUSTOM_SYSTEM_AUTH

--- a/utils/shellcheck_wrapper.sh
+++ b/utils/shellcheck_wrapper.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+shellcheck_executable="$1"
+shift
+scripts_directory="$1"
+shift
+shellcheck_options=("$@")
+
+scripts_count=$(ls "$scripts_directory" | wc -l)
+if [ "$scripts_count" -eq 0 ]; then
+    exit 0
+else
+    "$shellcheck_executable" "${shellcheck_options[@]}" "$scripts_directory"/*
+fi


### PR DESCRIPTION
Review all generated remediations by shellcheck, and fix issues this test uncovers.

The tool actually found quite a lot of bugs - it's not just about missing quotes that are not needed anyway.

Remarks:
- I was unable to integrate the test with `cmake` so it would run shellcheck with a shell-expandable wildcard argument, so I have created a wrapper script that performs the expansion. The `shellcheck2` test is an artifact of that dead-end approach, so you may have an idea how to finish it, so the wrapper script is not needed.
- I reckon that there may be future modifications of `pam` remediations incoming, so although they produce warnings, I haven't fixed them all.