### PR TITLE
Clarify controleval.py help text

### DIFF
--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -99,13 +99,17 @@ def create_parser():
     subparsers = parser.add_subparsers(dest="subcmd", required=True)
     statsparser = subparsers.add_parser(
         'stats',
-        help="outputs statistics for the given benchmark and level.")
-    statsparser.add_argument("-i", "--id", dest="id", help="id of the controls file.",
-                             required=True)
-    statsparser.add_argument("-l", "--level", dest="level", help="level to display statistics of.",
-                             required=True)
-    statsparser.add_argument("-p", "--product", type=str,
-                             help="Product to check has required references")
+        help="calculate and return the statistics for the given benchmark")
+    statsparser.add_argument(
+        "-i", "--id",
+        help="the ID or name of the controls file in the controls/ directory",
+        required=True)
+    statsparser.add_argument(
+        "-l", "--level",
+        help="the compliance target level to analyze",
+        required=True)
+    statsparser.add_argument(
+        "-p", "--product", help="product to check has required references")
     return parser
 
 


### PR DESCRIPTION
The controleval.py script has some required arguments that you need to
supply for it to work. This commit updates the help text for users so
that it's easier to understand what arguments to provide. The following
was done in this commit:

  - Remove redundant dest argument parameters (defaults to the flag)
  - Remove redundant type definition for the --product argument (str is
    the default)
  - Apply a consistent format to the help textS
  - Provide a list of choices for the --level argument
  - The the user where to find the ID for a controls file
