### PR TITLE
OCP4: default_ingress_ca_replaced remove manual remediation

### DIFF
--- a/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e-remediation.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# You can safely patch this to a non-existent secret name, it's a no-op, but OK for testing.
-oc patch proxies.config cluster --type merge -p '{"spec":{"trustedCA":{"name":"testing"}}}'

--- a/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e.yml
+++ b/applications/openshift/networking/default_ingress_ca_replaced/tests/ocp4/e2e.yml
@@ -1,3 +1,2 @@
 ---
 default_result: FAIL
-result_after_remediation: PASS


### PR DESCRIPTION
We should remove manual remediation, as it will stop the IdP test routes from working.
