### PR TITLE
Suggest running command for setting grub2 password as root

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/rule.yml
@@ -11,9 +11,9 @@ description: |-
     Since plaintext passwords are a security risk, generate a hash for the password
     by running the following command:
     {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
-    <pre>$ grub2-mkpasswd-pbkdf2</pre>
+    <pre># grub2-mkpasswd-pbkdf2</pre>
     {{% else %}}
-    <pre>$ grub2-setpassword</pre>
+    <pre># grub2-setpassword</pre>
     {{% endif %}}
     When prompted, enter the password that was selected.
     <br /><br />

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/rule.yml
@@ -11,9 +11,9 @@ description: |-
     Since plaintext passwords are a security risk, generate a hash for the password
     by running the following command:
     {{% if product in ["sle12", "sle15", "ubuntu2004"] %}}
-    <pre>$ grub2-mkpasswd-pbkdf2</pre>
+    <pre># grub2-mkpasswd-pbkdf2</pre>
     {{% else %}}
-    <pre>$ grub2-setpassword</pre>
+    <pre># grub2-setpassword</pre>
     {{% endif %}}
     When prompted, enter the password that was selected.
     <br /><br />


### PR DESCRIPTION
#### Description:
The grub bootloader password may only be set by root.


#### Rationale:
See `Additional info:` in https://bugzilla.redhat.com/show_bug.cgi?id=2021093
