### PR TITLE
Add trivial bash fixes

### DIFF
--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/bash/shared.sh
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = Red Hat Enterprise Linux 7,multi_platform_fedora
 
 {{{ set_config_file(path='/etc/ntp.conf', parameter='restrict -4', value='default kod nomodify notrap nopeer noquery', create='yes', insert_after='EOF', insert_before='', insensitive=true, separator=" ", separator_regex="\s\+", prefix_regex="^\s*") }}}

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,WRLinux 1019
 
 {{{ bash_instantiate_variables ("var_tftpd_secure_directory") }}}

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/bash/shared.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = debian 11,debian 10,debian 9,multi_platform_fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,WRLinux 1019
 
 {{{ bash_instantiate_variables("var_snmpd_ro_string", "var_snmpd_rw_string") }}}

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_csh/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_csh/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = Red Hat Enterprise Linux 8,Oracle Linux 8
 
 # put line into the file

--- a/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_sh/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_client/ssh_client_use_strong_rng_sh/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = Red Hat Enterprise Linux 8,Oracle Linux 8
 
 # put line into the file

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
@@ -11,7 +11,7 @@ for f in /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf; do
 	if [ ! -e "$f" ]; then
 		continue
 	fi
-	cert=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1} f{nu=gensub("^\\s*certificate_verification\\s*=\\s*ocsp_dgst\\s*=\\s*(\\w+).*","\\1",1); if($0!=nu){cert=nu}} END{print cert}' "$f" )
+	cert=$(awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1} f{nu=gensub("^\\s*certificate_verification\\s*=\\s*ocsp_dgst\\s*=\\s*(\\w+).*","\\1",1); if($0!=nu){cert=nu}} END{print cert}' "$f")
 	if [ -n "$cert" ] ; then
 		if [ "$cert" != $var_sssd_certificate_verification_digest_function ] ; then
 			sed -i "s/^certificate_verification\s*=.*/certificate_verification = ocsp_dgst = $var_sssd_certificate_verification_digest_function/" "$f"
@@ -22,9 +22,9 @@ done
 
 if ! $found ; then
 	SSSD_CONF="/etc/sssd/conf.d/certificate_verification.conf"
-	mkdir -p $( dirname $SSSD_CONF )
-	touch $SSSD_CONF
-	chown root:root $SSSD_CONF
-	chmod 600 $SSSD_CONF
-	echo -e "[sssd]\ncertificate_verification = ocsp_dgst = $var_sssd_certificate_verification_digest_function" >> $SSSD_CONF
+	mkdir -p "$(dirname "$SSSD_CONF")"
+	touch "$SSSD_CONF"
+	chown root:root "$SSSD_CONF"
+	chmod 600 "$SSSD_CONF"
+	echo -e "[sssd]\ncertificate_verification = ocsp_dgst = $var_sssd_certificate_verification_digest_function" >> "$SSSD_CONF"
 fi

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
@@ -5,10 +5,10 @@ for f in /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf; do
 	if [ ! -e "$f" ]; then
 		continue
 	fi
-	user=$( awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1} f{nu=gensub("^\\s*user\\s*=\\s*(\\S+).*","\\1",1); if($0!=nu){user=nu}} END{print user}' $f )
+	user=$(awk '/^\s*\[/{f=0} /^\s*\[sssd\]/{f=1} f{nu=gensub("^\\s*user\\s*=\\s*(\\S+).*","\\1",1); if($0!=nu){user=nu}} END{print user}' "$f")
 	if [ -n "$user" ] ; then
 		if [ "$user" != sssd ] ; then
-			sed -i 's/^\s*user\s*=.*/user = sssd/' $f
+			sed -i 's/^\s*user\s*=.*/user = sssd/' "$f"
 		fi
 		found=true
 	fi
@@ -16,9 +16,9 @@ done
 
 if ! $found ; then
 	SSSD_CONF="/etc/sssd/conf.d/ospp.conf"
-	mkdir -p $( dirname $SSSD_CONF )
-	touch $SSSD_CONF
-	chown root:root $SSSD_CONF
-	chmod 600 $SSSD_CONF
-	echo -e "[sssd]\nuser = sssd" >> $SSSD_CONF
+	mkdir -p "$(dirname "$SSSD_CONF")"
+	touch "$SSSD_CONF"
+	chown root:root "$SSSD_CONF"
+	chmod 600 "$SSSD_CONF"
+	echo -e "[sssd]\nuser = sssd" >> "$SSSD_CONF"
 fi

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/bash/shared.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_all
 
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = restrict

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 # uncomment the option if commented

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_all
 
 {{{ set_config_file(path="/etc/rsyslog.d/encrypt.conf",

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_all
 {{{ set_config_file(path="/etc/rsyslog.d/encrypt.conf",
                     parameter="\$DefaultNetstreamDriver", value="gtls", create=true, separator=" ", separator_regex=" ")

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -12,9 +12,7 @@ readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(i
 declare -a LOG_FILE_PATHS
 
 declare -a RSYSLOG_CONFIGS
-RSYSLOG_CONFIGS=(${RSYSLOG_CONFIGS[@]} ${RSYSLOG_ETC_CONFIG})
-RSYSLOG_CONFIGS=(${RSYSLOG_CONFIGS[@]} ${RSYSLOG_INCLUDE_CONFIG[@]})
-RSYSLOG_CONFIGS=(${RSYSLOG_CONFIGS[@]} ${RSYSLOG_INCLUDE[@]})
+RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
 
 # Browse each file selected above as containing paths of log files
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
@@ -10,7 +10,7 @@ fi
 APPEND_LINE=$(sed -rn '/^\S+\s+\/var\/log\/secure$/p' /etc/rsyslog.conf)
 
 # Loop through the remote methods associative array
-for K in ${!REMOTE_METHODS[@]}
+for K in "${!REMOTE_METHODS[@]}"
 do
 	# Check to see if selector/value exists
 	if ! grep -rq "${REMOTE_METHODS[$K]}" /etc/rsyslog.*; then

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
 # platform = multi_platform_all
 
 find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type d -perm -0002 -uid +0 -exec chown root {} \;

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/bash/shared.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # platform = multi_platform_sle
 
 for SYSCMDDIRS in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin

--- a/linux_os/guide/system/permissions/permissions_local/file_permissions_local_var_log_messages/bash/shared.sh
+++ b/linux_os/guide/system/permissions/permissions_local/file_permissions_local_var_log_messages/bash/shared.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # platform = multi_platform_sle
 
 CORRECT_PERMISSIONS="/var/log/messages root:root 640"

--- a/linux_os/guide/system/permissions/permissions_local/permissions_local_audit_binaries/bash/shared.sh
+++ b/linux_os/guide/system/permissions/permissions_local/permissions_local_audit_binaries/bash/shared.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # platform = multi_platform_sle
 
 current_permissions_rules=$(grep "^/usr/sbin/au" /etc/permissions.local)

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -34,7 +34,7 @@ function remediate_gpgkey_installed {
         GPG_RESULT=$?
         # No CRC error, safe to proceed
         if [ "${GPG_RESULT}" -eq "0" ]; then
-            echo "${GPG_OUT}" | grep -vE "${FEDORA_RELEASE_FINGERPRINT}" || {
+            echo "${GPG_OUT[*]}" | grep -vE "${FEDORA_RELEASE_FINGERPRINT}" || {
             # If file doesn't contain any keys with unknown fingerprint, import it
             rpm --import "${REDHAT_RELEASE_KEY}"
             }

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -258,9 +258,9 @@ do
                 # two consecutive spaces after joining remaining parts of the rule together
                 concrete_rule="$(echo "$concrete_rule" | sed -n "s/\(.*\)\+\(-F perm=[rwax]\+\ \?\)\+/\1#\2#/p")"
 
-                # Split concrete_rule into head, perm, and tail sections using hash '#' delimiter
+                # Split concrete_rule into head and tail sections using hash '#' delimiter
+                # The second column contains the permission section, which we don't need to extract
                 rule_head=$(cut -d '#' -f 1 <<< "$concrete_rule")
-                rule_perm=$(cut -d '#' -f 2 <<< "$concrete_rule")
                 rule_tail=$(cut -d '#' -f 3 <<< "$concrete_rule")
 
                 # Remove permissions section from existing rule in the file
@@ -1514,9 +1514,6 @@ then
 fi
 {{%- endif %}}
 
-# Indicator that we want to append $full_rule into $audit_file or edit a rule in it
-append_expected_rule=0
-
 # After converting to jinja, we cannot return; therefore we skip the rest of the macro if needed instead
 skip=1
 
@@ -1579,7 +1576,7 @@ do
         done
     else
         # If there is any candidate rule, it is compliant; skip rest of macro
-        if [[ $candidate_rules ]]
+        if [ "${#candidate_rules[@]}" -gt 0 ]
         then
             skip=0
         fi
@@ -1599,7 +1596,7 @@ if [ "$skip" -ne 0 ]; then
     if [ -z ${rule_to_edit+x} ]
     then
         # Build full_rule while avoid adding double spaces when other_filters is empty
-        if [[ ${syscall_a} ]]
+        if [ "${#syscall_a[@]}" -gt 0 ]
         then
             syscall_string=""
             for syscall in "${syscall_a[@]}"


### PR DESCRIPTION
Implement trivial fixes mainly related to
- quoting
- unused variables
- bash shebangs that cause problems if they are present in our source snippets - the build system may not preserve them on the first line of the bash remediation content.