### PR TITLE
fix problems with trailing blank lines in audit rules

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
@@ -9,8 +9,7 @@ title: 'Configure auditing of unsuccessful file accesses'
 -a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-access
 -a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-access
 -a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-access
-" %}}
+-a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-access" %}}
 
 description: |-
     Ensure that unsuccessful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-3-access-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
@@ -8,8 +8,7 @@ title: 'Configure auditing of successful file accesses'
 "## Successful file access (any other opens) This has to go last.
 ## These next two are likely to result in a whole lot of events
 -a always,exit -F arch=b32 -S open,openat,open_by_handle_at -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-access
--a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-access
-" %}}
+-a always,exit -F arch=b64 -S open,openat,open_by_handle_at -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-access" %}}
 
 description: |-
     Ensure that successful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-3-access-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -17,7 +17,6 @@ title: 'Configure basic parameters of Audit system'
 
 ## Set failure mode to syslog
 -f 1
-
 " %}}
 
 description: |-

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/10-base-config.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
@@ -17,8 +17,7 @@ title: 'Configure auditing of unsuccessful file creations'
 -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
 -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
 -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
-" %}}
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create" %}}
 
 description: |-
     Ensure that unsuccessful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-1-create-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
@@ -11,8 +11,7 @@ title: 'Configure auditing of successful file creations'
 -a always,exit -F arch=b32 -S open -F a1&amp;0100 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
 -a always,exit -F arch=b64 -S open -F a1&amp;0100 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
 -a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
-" %}}
+-a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create" %}}
 
 description: |-
     Ensure that successful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-1-create-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -9,8 +9,7 @@ title: 'Configure auditing of unsuccessful file deletions'
 -a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
 -a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
 -a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
-" %}}
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete" %}}
 
 description: |-
     Ensure that unsuccessful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-4-delete-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
@@ -7,8 +7,7 @@ title: 'Configure auditing of successful file deletions'
 {{% set file_contents_audit_delete_success =
 "## Successful file delete
 -a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete
-" %}}
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete" %}}
 
 description: |-
     Ensure that successful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-4-delete-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -7,7 +7,6 @@ title: 'Configure immutable Audit login UIDs'
 {{% set file_contents_audit_immutable_login =
 "## Make the loginuid immutable. This prevents tampering with the auid.
 --loginuid-immutable
-
 " %}}
 
 description: |-

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/11-loginuid.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -17,8 +17,7 @@ title: 'Configure auditing of unsuccessful file modifications'
 -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
 -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
 -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
-" %}}
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification" %}}
 
 description: |-
     Ensure that unsuccessful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-2-modify-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
@@ -11,8 +11,7 @@ title: 'Configure auditing of successful file modifications'
 -a always,exit -F arch=b32 -S open -F a1&amp;01003 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
 -a always,exit -F arch=b64 -S open -F a1&amp;01003 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
 -a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
-" %}}
+-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification" %}}
 
 description: |-
     Ensure that successful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-2-modify-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
@@ -10,8 +10,7 @@ title: 'Configure auditing of loading and unloading of kernel modules'
 -a always,exit -F arch=b32 -S init_module,finit_module -F key=module-load
 -a always,exit -F arch=b64 -S init_module,finit_module -F key=module-load
 -a always,exit -F arch=b32 -S delete_module -F key=module-unload
--a always,exit -F arch=b64 -S delete_module -F key=module-unload
-" %}}
+-a always,exit -F arch=b64 -S delete_module -F key=module-unload" %}}
 
 description: |-
     Ensure that loading and unloading of kernel modules is audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/43-module-load.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -84,7 +84,6 @@ title: 'Perform general configuration of Audit for OSPP'
 ## FPT_SRP_EXT.1 Software Restriction Policies. This event is intended to
 ## state results from that policy. This would be handled entirely by
 ## that daemon.
-
 " %}}
 
 description: |-

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -9,8 +9,7 @@ title: 'Configure auditing of unsuccessful ownership changes'
 -a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
 -a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
 -a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
-" %}}
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-6-owner-change-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -7,8 +7,7 @@ title: 'Configure auditing of successful ownership changes'
 {{% set file_contents_audit_owner_change_success =
 "## Successful ownership change
 -a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-owner-change
-" %}}
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-owner-change" %}}
 
 description: |-
     Ensure that successful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-6-owner-change-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -9,8 +9,7 @@ title: 'Configure auditing of unsuccessful permission changes'
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
 -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
-" %}}
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change file or directory permissions are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-5-perm-change-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -7,8 +7,7 @@ title: 'Configure auditing of successful permission changes'
 {{% set file_contents_audit_perm_change_success =
 "## Successful permission change
 -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-perm-change
-" %}}
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-perm-change" %}}
 
 description: |-
     Ensure that successful attempts to modify permissions of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/tests/rules_from_audit_package.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+cp /usr/share/audit/sample-rules/30-ospp-v42-5-perm-change-success.rules /etc/audit/rules.d/

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -295,7 +295,7 @@ value: :code:`Setting={{ varname1 }}`
   copy:
     dest: "{{{ filepath }}}"
     content: |+
-        {{{ contents|trim()|indent(8) }}}
+        {{{ contents|indent(8) }}}
     force: yes
 {{%- endmacro %}}
 

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1160,7 +1160,7 @@ fi
 #}}
 {{%- macro bash_file_contents(filepath='', contents='') %}}
 cat << 'EOF' > {{{ filepath }}}
-{{{ contents|trim() }}}
+{{{ contents }}}
 EOF
 {{%- endmacro %}}
 

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -734,7 +734,7 @@
     </ind:textfilecontent54_object>
 
     <ind:textfilecontent54_state id="state_whole_file_contents_{{{ filepath_id }}}" version="1">
-      <ind:text operation="equals">{{{ contents|trim() }}}
+      <ind:text operation="equals">{{{ contents }}}
 </ind:text>
     </ind:textfilecontent54_state>
 

--- a/tests/shared/audit/10-base-config.rules
+++ b/tests/shared/audit/10-base-config.rules
@@ -10,3 +10,4 @@
 
 ## Set failure mode to syslog
 -f 1
+

--- a/tests/shared/audit/11-loginuid.rules
+++ b/tests/shared/audit/11-loginuid.rules
@@ -1,2 +1,3 @@
 ## Make the loginuid immutable. This prevents tampering with the auid.
 --loginuid-immutable
+

--- a/tests/shared/audit/30-ospp-v42.rules
+++ b/tests/shared/audit/30-ospp-v42.rules
@@ -77,3 +77,4 @@
 ## FPT_SRP_EXT.1 Software Restriction Policies. This event is intended to
 ## state results from that policy. This would be handled entirely by
 ## that daemon.
+


### PR DESCRIPTION
#### Description:

- add tests which put content from /usr/share/audit/sample-rules into /etc/audit/rules.d to test if our content is OK with shipped rules
- modify the file_contents macros for OVAL, Bash and Ansible so that they do not strip trailing blank lines
- correct test data in tests/shared/audit
- correct hardcoded content of policy files within actual rules

#### Rationale:

In the content, we suggest that it is possible to use files from the /usr/share/audit/sample-rules/ directory to configure Audit. This is relevant mainly for OSPP profiles. However, our checks marked the rule as failed when those files shipped by audit package were used. It was because of trailing blank lines.