### PR TITLE
Don't treat 'no_ovirt' and 'ovirt' as packages

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -423,6 +423,8 @@ XCCDF_PLATFORM_TO_PACKAGE = {
   "non-uefi": None,
   "not_s390x_arch": None,
   "s390x_arch": None,
+  "ovirt": None,
+  "no_ovirt": None,
 }
 
 # _version_name_map = {


### PR DESCRIPTION


#### Description:

- Exclude 'no_ovirt' and 'ovirt' during translation from platform to package. These platforms are about ovirt-engine and ovirt-host packages, and there is no support for multiple packages right now.
- This preserves the remediation functionality of the rules with `no_ovirt` platform.

#### Rationale:

- This is a workaround.
- At the moment the remediation aspect of these platforms are not well supported in the project. But with the addition of CPE Applicability Language, this will be better supported.
  See for example: https://github.com/ComplianceAsCode/content/blob/cpe_logical_expressions/shared/applicability/virtualization.yml#L13-L14