### PR TITLE
Override templated test scenario for grub2_kernel_trust_cpu_rng

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Based on shared/templates/grub2_bootloader_argument/tests/arg_not_there.fail.sh
+# platform = Red Hat Enterprise Linux 8
+
+# Removes audit argument from kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
+	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
+fi
+
+# Fake the kernel compile config, this is necessary when the distro's kernel is already compiled
+# with CONFIG_RANDOM_TRUST_CPU=y (e.g. RHEL > 8.3)
+if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
+    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=N\2/' /boot/config-`uname -r`
+fi

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/wrong_value.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Based on shared/templates/grub2_bootloader_argument/tests/wrong_value.fail.sh
+# platform = Red Hat Enterprise Linux 8
+
+# Break the argument in kernel command line in /boot/grub2/grubenv
+file="/boot/grub2/grubenv"
+if grep -q '^.*{{{ARG_NAME}}}=.*'  "$file" ; then
+	# modify the GRUB command-line if the arg already exists
+	sed -i 's/\(^.*\){{{ARG_NAME}}}=[^[:space:]]*\(.*\)/\1 {{{ARG_NAME}}}=wrong \2/'  "$file"
+else
+	# no arg is present, append it
+	sed -i 's/\(^.*\(vmlinuz\|kernelopts\).*\)/\1 {{{ARG_NAME}}}=wrong/'  "$file"
+fi
+
+# Fake the kernel compile config, this is necessary when the distro's kernel is already compiled
+# with CONFIG_RANDOM_TRUST_CPU=y (e.g. RHEL > 8.3)
+if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
+    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=N\2/' /boot/config-`uname -r`
+fi


### PR DESCRIPTION
#### Description:

- Override `grub2_bootloader_argument` templated tests (`arg_not_there.fail.sh` and `wrong_value.fail.sh`) so that the compile time kernel option is also disabled, and the initial scan fails as expected.

#### Rationale:

- The grub2 kernel parameter `random.trust_cpu_rng' can also be set in the kernel during compile time.
  Since RHEL-8.3 `CONFIG_RANDOM_TRUST_CPU_RNG` is set to Y, so some templated test needs to fake override the kernel compile config options.

#### Test scenario results

Before patch:
```
[alderaan content{master}]$ python3 tests/test_suite.py rule  --libvirt qemu:///session rhel85 --datastream build/ssg-rhel8-ds.xml grub2_kernel_trust_cpu_rng                                                                                 
Setting console output to log level INFO                                                                                                                                                                                                      
INFO - The base image option has not been specified, choosing libvirt-based test environment.                                                                                                                                                 
INFO - Logging into /home/wsato/git/content/logs/rule-custom-2022-01-13-0001/test_suite.log                                                                                                                                                   
libvirt: QEMU Driver error : Guest agent is not responding: QEMU guest agent is not connected                                                                                                                                                 
WARNING - Script arg_not_there_etcdefaultgrub.fail.sh is not applicable on given platform                                                                                                                                                     
WARNING - Script wrong_value_entries.fail.sh is not applicable on given platform                                                                                                                                                              
INFO - xccdf_org.ssgproject.content_rule_grub2_kernel_trust_cpu_rng                                                                                                                                                                           
ERROR - Script arg_not_there.fail.sh using profile (all) found issue:                                                                                                                                                                         
ERROR - Rule evaluation resulted in pass, instead of expected fail during initial stage                                                                                                                                                       
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_grub2_kernel_trust_cpu_rng'.                                                                                                                                      
INFO - Script correct_value.pass.sh using profile (all) OK                                                                                                                                                                                    
ERROR - Script wrong_value.fail.sh using profile (all) found issue:                                                                                                                                                                           
ERROR - Rule evaluation resulted in pass, instead of expected fail during initial stage                                                                                                                                                       
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_grub2_kernel_trust_cpu_rng'.                                                                                                                                      
INFO - Script boot_parameter.pass.sh using profile (all) OK                                                                                                                                                                                   
INFO - Script missing.fail.sh using profile (all) OK                                                                                                                                                                                          
INFO - Script compiled.pass.sh using profile (all) OK                                                                                                                                                                                         
INFO - Script compiled_but_overridden.fail.sh using profile (all) OK                                                   
INFO - Script compiled_uppercase.pass.sh using profile (all) OK  
```

After patch:
```
python3 tests/test_suite.py rule  --libvirt qemu:///session rhel85 --datastream build/ssg-rhel8-ds.xml grub2_kernel_trust_cpu_rng
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/wsato/git/content/logs/rule-custom-2022-01-13-0017/test_suite.log
libvirt: QEMU Driver error : Guest agent is not responding: QEMU guest agent is not connected
WARNING - Script arg_not_there_etcdefaultgrub.fail.sh is not applicable on given platform
WARNING - Script wrong_value_entries.fail.sh is not applicable on given platform
INFO - xccdf_org.ssgproject.content_rule_grub2_kernel_trust_cpu_rng
INFO - Script arg_not_there.fail.sh using profile (all) OK
INFO - Script correct_value.pass.sh using profile (all) OK
INFO - Script wrong_value.fail.sh using profile (all) OK
INFO - Script boot_parameter.pass.sh using profile (all) OK
INFO - Script missing.fail.sh using profile (all) OK
INFO - Script compiled.pass.sh using profile (all) OK
INFO - Script compiled_but_overridden.fail.sh using profile (all) OK
INFO - Script compiled_uppercase.pass.sh using profile (all) OK
```
