### PR TITLE
Fix typo in test scenario for sshd_set_keepalive

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/correct_value_dot_dir.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/correct_value_dot_dir.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # variables = var_sshd_set_keepalive=0
-# plaftorm = Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 9
 
 SSHD_CONFIG="/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf"
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/wrong_value_dot_dir.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/wrong_value_dot_dir.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # variables = var_sshd_set_keepalive=0
-# plaftorm = Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 9
 
 SSHD_CONFIG="/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf"
 


### PR DESCRIPTION


#### Description:

- The typo was allowing the test scenario to be evaluated on a rhel8 platform and leading to false positives.
