### PR TITLE
Fix OL7 CIS URI

### DIFF
--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -24,4 +24,4 @@ platform_package_overrides:
   login_defs: "shadow-utils"
 
 reference_uris:
-  cis: 'https://benchmarks.cisecurity.org/tools2/linux/CIS_Oracle_Linux_7_Benchmark_v2.1.0.pdf'
+  cis: 'https://www.cisecurity.org/benchmark/oracle_linux/'


### PR DESCRIPTION
#### Description:

- The previous URI was resulting in 'Error 1016: Origin DNS error'.

#### Rationale:

- The new URI follows the same pattern RHEL8 and SLE15 have.
