### PR TITLE
Increase audit_ospp_general and audit_immutable_login_uids test coverage

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/file_missing.fail.sh
@@ -1,0 +1,3 @@
+# packages = audit
+
+rm -f /etc/audit/rules.d/11-loginuid.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/file_not_identical.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/file_not_identical.fail.sh
@@ -1,0 +1,4 @@
+# packages = audit
+
+cp $SHARED/audit/11-loginuid.rules /etc/audit/rules.d/
+echo "some additional text" >> /etc/audit/rules.d/11-loginuid.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/file_missing.fail.sh
@@ -1,0 +1,3 @@
+# packages = audit
+
+rm -f /etc/audit/rules.d/30-ospp-v42.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/file_not_identical.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/file_not_identical.fail.sh
@@ -1,0 +1,4 @@
+# packages = audit
+
+cp $SHARED/audit/30-ospp-v42.rules /etc/audit/rules.d/
+echo "some additional text" >> /etc/audit/rules.d/30-ospp-v42.rules


### PR DESCRIPTION
#### Description:
These audit rules have only pass test scenarios. We need to have also fail tests to check that they fail when it's expected

#### Rationale:
Increase test coverage for audit rules from https://bugzilla.redhat.com/show_bug.cgi?id=2000264 
