### PR TITLE
Add condition to SCAPVal script that will trigger when SCAP standard is updated

### DIFF
--- a/tests/run_scapval.py
+++ b/tests/run_scapval.py
@@ -45,6 +45,11 @@ def process_results(result_path):
             else:
                 print("    %s: %s" % (id_, status))
                 ret_val = False
+        if status == "PASS":
+            if ('ssg-ocp4-ds' in result_path or 'ssg-eks-ds' in result_path) and id_ == "SRC-329":
+                print("    %s: %s" % (
+                    id_, "FAIL (yamlfilecontent_test is probably standardized by now."
+                    "You should update the waiver.)"))
     return ret_val
 
 


### PR DESCRIPTION
#### Description:

- Add condition that will trigger when SCAP standard is updated.

#### Rationale:

- This will trigger when the SCAP is updated to include `yamlfilecontent_test` and SCAPVal starts to accept this new test as part of the standard. Then we need to remove the waiver in order to not shadow further SRC-329 failures. This is applicable only to OCP4 and EKS content so far.
