### PR TITLE
Update grub2_kernel_trust_cpu_rng tests to work on RHEL8 and RHEL9

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/boot_parameter.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/boot_parameter.pass.sh
@@ -5,4 +5,8 @@ if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
     sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=N\2/' /boot/config-`uname -r`
 fi
 
+{{% if product == "rhel8" %}}
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) random.trust_cpu=on"
+{{% else %}}
+grubby --update-kernel=ALL --args="random.trust_cpu=on"
+{{% endif %}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_but_overridden.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_but_overridden.fail.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 # make sure that the option is overridden through boot parameter
+{{% if product == "rhel8" %}}
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) random.trust_cpu=off"
+{{% else %}}
+grubby --update-kernel=ALL --args="random.trust_cpu=off"
+{{% endif %}}
 
 if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
     sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=y\2/' /boot/config-`uname -r`

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
@@ -1,10 +1,14 @@
 #!/bin/bash
 
 # make sure that the option is not configured through boot parameter
+{{% if product == "rhel8" %}}
 file="/boot/grub2/grubenv"
 if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
+{{% else %}}
+grubby --update-kernel=ALL --remove-args="random.trust_cpu"
+{{% endif %}}
 
 if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
     sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=Y\2/' /boot/config-`uname -r`

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/missing.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/missing.fail.sh
@@ -4,7 +4,11 @@ if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
     sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=N\2/' /boot/config-`uname -r`
 fi
 
+{{% if product == "rhel8" %}}
 file="/boot/grub2/grubenv"
 if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
+{{% else %}}
+grubby --update-kernel=ALL --remove-args="random.trust_cpu"
+{{% endif %}}


### PR DESCRIPTION

#### Description:
- Make the test scenarios for `grub2_kernel_trust_cpu_rng` compatible with RHEL8 and RHEL9.
  The RHEL9 checks for the `/boot/loader/entries/*.conf` whereas RHEL8 checks for `/boot/grub/grubenv`

#### Rationale:

- Follow up from https://github.com/ComplianceAsCode/content/pull/8057
