### PR TITLE
Fix remediation of display_login_attempts rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
@@ -1,54 +1,171 @@
-{{% if product in ["sle12", "sle15"] %}}
-{{% set pam_lastlog_filename = "login" %}}
-{{% else %}}
-{{% set pam_lastlog_filename = "postlogin" %}}
-{{% endif %}}
-
-# platform = multi_platform_sle,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+# platform = multi_platform_rhel,multi_platform_sle,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_wrlinux
 # reboot = false
 # strategy = configure
 # complexity = low
 # disruption = low
 
-- name: Check if pam_lastlog.so is set
-  lineinfile:
-    path: /etc/pam.d/{{{ pam_lastlog_filename }}}
-    regexp: '^\s*(session)(\s+)[^\s]+(\s+)(pam_lastlog\.so)(\s+)(.*)'
+- name: Check for expected pam_lastlog.so entry
+  ansible.builtin.lineinfile:
+    path: "/etc/pam.d/postlogin"
+    create: no
+    regexp: '^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$'
     state: absent
-  check_mode: yes
+  check_mode: true
   changed_when: false
-  register: pam_lastlog_exists
+  register: result_pam_lastlog_present
 
-- name: Make sure pam_lastlog.so control is required
-  replace:
-    path: /etc/pam.d/{{{ pam_lastlog_filename }}}
-    regexp: ^\s*(session)(\s+)[^\s]+(\s+)(pam_lastlog\.so)(\s+)(.*)
-    replace: '\1\2required\3\4\5\6'
-  register: control_update_result
+- name: Check if system relies on authselect
+  ansible.builtin.stat:
+    path: /usr/bin/authselect
+  register: result_authselect_present
 
-- name: Add control for pam_lastlog.so module
-  lineinfile:
-    path: /etc/pam.d/{{{ pam_lastlog_filename }}}
-    line: 'session required pam_lastlog.so showfailed'
-  when: not pam_lastlog_exists.found
-  register: add_new_pam_lastlog_control_result
+- name: "Remediation where authselect tool is present"
+  block:
+    - name: Check the integrity of the current authselect profile
+      ansible.builtin.command:
+        cmd: authselect check
+      register: result_authselect_check_cmd
+      changed_when: false
+      ignore_errors: true
 
-- name: Add 'showfailed' arg to pam_lastlog.so module
-  pamd:
-    name: {{{ pam_lastlog_filename }}}
-    type: session
-    control: required
-    module_path: pam_lastlog.so
-    module_arguments: showfailed
-    state: args_present
-  when: not add_new_pam_lastlog_control_result.changed
+    - name: Informative message based on the authselect integrity check result
+      ansible.builtin.assert:
+        that:
+          - result_authselect_check_cmd is success
+        fail_msg:
+        - authselect integrity check failed. Remediation aborted!
+        - This remediation could not be applied because the authselect profile is not intact.
+        - It is not recommended to manually edit the PAM files when authselect is available.
+        - In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
+        success_msg:
+        - authselect integrity check passed
 
-- name: Remove 'silent' arg for pam_lastlog.so module
-  pamd:
-    name: {{{ pam_lastlog_filename }}}
-    type: session
-    control: required
-    module_path: pam_lastlog.so
-    module_arguments: silent
-    state: args_absent
-  when: not add_new_pam_lastlog_control_result.changed
+    - name: Get authselect current profile
+      ansible.builtin.shell:
+        cmd: authselect current -r | awk '{ print $1 }'
+      register: result_authselect_profile
+      changed_when: false
+      when:
+        - result_authselect_check_cmd is success
+
+    - name: Define the current authselect profile as a local fact
+      ansible.builtin.set_fact:
+        authselect_current_profile: "{{ result_authselect_profile.stdout }}"
+        authselect_custom_profile: "{{ result_authselect_profile.stdout }}"
+      when:
+        - result_authselect_profile is not skipped
+        - result_authselect_profile.stdout is match("custom/")
+
+    - name: Define the new authselect custom profile as a local fact
+      ansible.builtin.set_fact:
+        authselect_current_profile: "{{ result_authselect_profile.stdout }}"
+        authselect_custom_profile: "custom/hardening"
+      when:
+        - result_authselect_profile is not skipped
+        - result_authselect_profile.stdout is not match("custom/")
+
+    - name: Get authselect current features to also enable them in the custom profile
+      ansible.builtin.shell:
+        cmd: authselect current | tail -n+3 | awk '{ print $2 }'
+      register: result_authselect_features
+      changed_when: false
+      when:
+        - result_authselect_profile is not skipped
+        - authselect_current_profile is not match("custom/")
+
+    - name: Check if any custom profile with the same name was already created in the past
+      ansible.builtin.stat:
+        path: /etc/authselect/{{ authselect_custom_profile }}
+      register: result_authselect_custom_profile_present
+      changed_when: false
+      when:
+        - authselect_current_profile is not match("custom/")
+
+    - name: Create a custom profile based on the current profile
+      ansible.builtin.command:
+        cmd: authselect create-profile hardening -b sssd
+      when:
+        - result_authselect_check_cmd is success
+        - authselect_current_profile is not match("custom/")
+        - not result_authselect_custom_profile_present.stat.exists
+
+    - name: Ensure the silent option is not present in the custom profile
+      ansible.builtin.replace:
+        dest: "/etc/authselect/{{ authselect_custom_profile }}/postlogin"
+        regexp: '^(session.*required.*pam_lastlog.so).*$'
+        replace: '\g<1> showfailed'
+      when:
+        - result_authselect_profile is not skipped
+
+    - name: Ensure the desired configuration is present in the custom profile
+      ansible.builtin.lineinfile:
+        dest: "/etc/authselect/{{ authselect_custom_profile }}/postlogin"
+        insertbefore: ^session.*
+        firstmatch: yes
+        line: "session     required                   pam_lastlog.so showfailed"
+      when:
+        - result_authselect_profile is not skipped
+
+    - name: Ensure a backup of current authselect profile before selecting the custom profile
+      ansible.builtin.command:
+        cmd: authselect apply-changes -b --backup=before-pwhistory-hardening.backup
+      register: result_authselect_backup
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
+        - authselect_current_profile is not match("custom/")
+        - authselect_custom_profile is not match(authselect_current_profile)
+
+    - name: Ensure the custom profile is selected
+      ansible.builtin.command:
+        cmd: authselect select {{ authselect_custom_profile }} --force
+      register: result_pam_authselect_select_profile
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
+        - authselect_current_profile is not match("custom/")
+        - authselect_custom_profile is not match(authselect_current_profile)
+
+    - name: Restore the authselect features in the custom profile
+      ansible.builtin.command:
+        cmd: authselect enable-feature {{ item }}
+      loop: "{{ result_authselect_features.stdout_lines }}"
+      when:
+        - result_authselect_profile is not skipped
+        - result_authselect_features is not skipped
+        - result_pam_authselect_select_profile is not skipped
+
+    - name: Ensure the custom profile changes are applied
+      ansible.builtin.command:
+        cmd: authselect apply-changes -b --backup=after-pwhistory-hardening.backup
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
+  when:
+  - result_pam_lastlog_present.found == 0
+  - result_authselect_present.stat.exists
+
+# For systems without authselect
+- name: "Remediation where authselect tool is not present and PAM files are directly edited"
+  block:
+    {{% if product in ["sle12", "sle15"] %}}
+    {{% set pam_lastlog_filename = "login" %}}
+    {{% else %}}
+    {{% set pam_lastlog_filename = "postlogin" %}}
+    {{% endif %}}
+
+    - name: Ensure the silent option is not present in PAM files
+      ansible.builtin.replace:
+        dest: /etc/pam.d/{{{ pam_lastlog_filename }}}
+        regexp: '^(session.*required.*pam_lastlog.so).*$'
+        replace: '\g<1> showfailed'
+
+    - name: Ensure the desired configuration is present in PAM files
+      ansible.builtin.lineinfile:
+        dest: /etc/pam.d/{{{ pam_lastlog_filename }}}
+        insertbefore: ^session.*
+        firstmatch: yes
+        line: "session     required                   pam_lastlog.so showfailed"
+  when:
+    - result_pam_lastlog_present.found == 0
+    - not result_authselect_present.stat.exists

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -1,11 +1,52 @@
-{{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
-{{% set pam_lastlog_path = "/etc/pam.d/login" %}}
-{{% else %}}
-{{% set pam_lastlog_path = "/etc/pam.d/postlogin" %}}
-{{% endif %}}
 # platform = multi_platform_sle,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ubuntu
 
-{{{ bash_ensure_pam_module_options(pam_lastlog_path, 'session', 'required', 'pam_lastlog.so', 'showfailed', "", "") }}}
+if [ -f /usr/bin/authselect ]; then
+    if authselect check; then
+        CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
+        # Standard profiles delivered with authselect should not be modified.
+        # If not already in use, a custom profile is created preserving the enabled features.
+        if [[ ! $CURRENT_PROFILE == custom/* ]]; then
+            ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
+            authselect create-profile hardening -b $CURRENT_PROFILE
+            CURRENT_PROFILE="custom/hardening"
+            # Ensure a backup before changing the profile
+            authselect apply-changes -b --backup=before-pwhistory-hardening.backup
+            authselect select $CURRENT_PROFILE
+            for feature in $ENABLED_FEATURES; do
+                authselect enable-feature $feature;
+            done
+        fi
+        # Include the desired configuration in the custom profile
+        CUSTOM_POSTLOGIN="/etc/authselect/$CURRENT_PROFILE/postlogin"
+        # The line should be included on the top of postlogin file
+        if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+            sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
+        fi
+        if grep -q "^\s*session.*required.*pam_lastlog.so.*silent.*"; then
+            # remove 'silent' option
+            sed -i --follow-symlinks 's/^\(session.*required.*pam_lastlog.so\).*/\1 showfailed/g' $CUSTOM_POSTLOGIN
+        fi
+        authselect apply-changes -b --backup=after-pwhistory-hardening.backup
+    else
+        echo "
+authselect integrity check failed. Remediation aborted!
+This remediation could not be applied because the authselect profile is not intact.
+It is not recommended to manually edit the PAM files when authselect is available.
+In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended."
+        false
+    fi
+else
+    {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
+    {{% set pam_lastlog_path = "/etc/pam.d/login" %}}
+    {{% else %}}
+    {{% set pam_lastlog_path = "/etc/pam.d/postlogin" %}}
+    {{% endif %}}
 
-# remove 'silent' option
-sed -i --follow-symlinks -E -e 's/^([^#]+pam_lastlog\.so[^#]*)\ssilent/\1/' '{{{ pam_lastlog_path }}}'
+    if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" {{{ pam_lastlog_path }}}) -eq 0 ]; then
+        sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' {{{ pam_lastlog_path }}}
+    fi
+    if grep -q "^\s*session.*required.*pam_lastlog.so.*silent.*" {{{ pam_lastlog_path }}}; then
+        # remove 'silent' option
+        sed -i --follow-symlinks 's/^\(session.*required.*pam_lastlog.so\).*/\1 showfailed/g' {{{ pam_lastlog_path }}}
+    fi
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_missing.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = authselect
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+
+CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
+sed -i --follow-symlinks '/session.*required.*pam_lastlog.so.*showfailed/d' $CUSTOM_POSTLOGIN
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_present.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = authselect
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+
+CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
+if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+    sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
+fi
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_modified_pam.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = authselect
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# remediation = none
+
+SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+
+# This modification will break the integrity checks done by authselect.
+if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+else
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_silent_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_silent_present.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = authselect
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+
+CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
+if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+    sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so silent showfailed\n&/' $CUSTOM_POSTLOGIN
+fi
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_ubuntu
+# platform = Red Hat Enterprise Linux 7,multi_platform_ol,multi_platform_ubuntu
 
 {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
 rm -f /etc/pam.d/login

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/default_config.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/default_config.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_ubuntu
+# platform = Red Hat Enterprise Linux 7,multi_platform_ol,multi_platform_ubuntu
 
 {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
 {{% set pam_lastlog_path = "/etc/pam.d/login" %}}

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Enterprise Linux 7,multi_platform_ol
 
 rm -f /etc/pam.d/postlogin
 # pamd ansible module has a bug that if there is only one line in the file it raises an Out of Index exception

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value_silent.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value_silent.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_ubuntu
+# platform = Red Hat Enterprise Linux 7,multi_platform_ol,multi_platform_ubuntu
 
 {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
 {{% set pam_lastlog_path = "/etc/pam.d/login" %}}


### PR DESCRIPTION
Fix the remediation to properly configure PAM. The remediations were also updated to use `authselect` where the tool is present.
