### PR TITLE
Fix ansible lint issues and SLE variable selector using explicit forbidden `default` value

### DIFF
--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -501,7 +501,6 @@ controls:
     automated: yes
     rules:
     - chronyd_specify_remote_server
-    - var_multiple_time_servers=default
     - chronyd_run_as_chrony_user
 
   - id: 2.2.1.4

--- a/controls/cis_sle_15.yml
+++ b/controls/cis_sle_15.yml
@@ -541,7 +541,6 @@ controls:
     automated: yes
     rules:
       - chronyd_specify_remote_server
-      - var_multiple_time_servers=default
       - chronyd_run_as_chrony_user
 
   - id: 2.2.2

--- a/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/ansible/shared.yml
@@ -16,7 +16,9 @@
 
 
 - name: Read signatures in GPG key
-  shell: gpg --with-fingerprint --with-colons "{{ item }}" | grep -A1 "^pub" | grep "^fpr" | cut -d ":" -f 10
+  shell: |-
+    set -o pipefail
+    gpg --with-fingerprint --with-colons "{{ item }}" | grep -A1 "^pub" | grep "^fpr" | cut -d ":" -f 10
   changed_when: False
   register: suse_gpg_fingerprints
   check_mode: no

--- a/tests/ansible-lint_config.yml
+++ b/tests/ansible-lint_config.yml
@@ -4,3 +4,4 @@ skip_list:
   - '303' # Using command rather than module
   - '403' # Package installs should not use latest
   - '503' # Tasks that run when changed should likely be handlers
+  - no-tabs # Rule permissions_local_var_log uses explicit \t character


### PR DESCRIPTION
#### Description:

- Minor fixes to content so they pass tests and build properly.


@truzzon this [commit](https://github.com/ComplianceAsCode/content/commit/bc9a779ad85951c2d4eb5bc2ab08f1adeee44669) fixes an issue with the variable selector and doesn't change the end result. I am just considering if the intention is actually to use the `suse` selector for this [variable](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/services/ntp/var_multiple_time_servers.var#L16).