### PR TITLE
These auditd configurations affect the whole SFR, not just its specific parts.

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 references:
     disa: CCI-000366
     nist: CM-6
-    ospp: FAU_GEN.1.1.c
+    ospp: FAU_GEN.1
     srg: SRG-OS-000062-GPOS-00031,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-030061
     stigid@rhel8: RHEL-08-030061

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -47,7 +47,7 @@ identifiers:
 
 references:
     nist: AU-2(a)
-    ospp: FAU_GEN.1.1.c
+    ospp: FAU_GEN.1
     srg: SRG-OS-000365-GPOS-00152,SRG-OS-000475-GPOS-00220
 
 ocil_clause: 'the file does not exist or the content differs'


### PR DESCRIPTION
#### Description:

- These auditd configurations affect the whole SFR, not just its specific parts.

#### Rationale:

- The FAU_GEN.1.1.c lists selections but other part of the SFR are also related to these configurations.