### PR TITLE
Clarify that log_format and name_format affects specifically information included in the audit records, not events for which audit records get generated.

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_log_format/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 references:
     disa: CCI-000366
     nist: CM-6,AU-3
-    ospp: FAU_GEN.1
+    ospp: FAU_GEN.1.2
     srg: SRG-OS-000255-GPOS-00096,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-030063
     stigid@rhel8: RHEL-08-030063

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
@@ -24,7 +24,7 @@ identifiers:
 references:
     disa: CCI-001851
     nist: CM-6,AU-3
-    ospp: FAU_GEN.1
+    ospp: FAU_GEN.1.2
     srg: SRG-OS-000039-GPOS-00017,SRG-OS-000342-GPOS-00133,SRG-OS-000479-GPOS-00224
     stigid@ol7: OL07-00-030211
     stigid@ol8: OL08-00-030062


### PR DESCRIPTION

#### Description:

- Clarify that log_format and name_format affects specifically information included in the audit records, not events for which audit records get generated.

#### Rationale:

- Where it is clear which part of SFR is related to the configuration checked and set by the rule, it makes sense to be more specific.
