### PR TITLE
Ensuring immutable UIDs is related to the subject identity required by FAU_GEN.1.2, it does not affect for wihch events audit records will be generated.

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -37,7 +37,7 @@ identifiers:
 references:
     disa: CCI-000162
     nist: AU-2(a)
-    ospp: FAU_GEN.1.1.c
+    ospp: FAU_GEN.1.2
     srg: SRG-OS-000462-GPOS-00206,SRG-OS-000475-GPOS-00220,SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029
     stigid@ol8: OL08-00-030122
     stigid@rhel8: RHEL-08-030122


### PR DESCRIPTION

#### Description:

- Ensuring immutable UIDs is related to the subject identity required by FAU_GEN.1.2, it does not affect for wihch events audit records will be generated.

#### Rationale:

- Avoid confusion about the purpose of the configuration.
