### PR TITLE
fix wrong Jinja macro for audit_rules_execution_restorecon

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_restorecon/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["rhel8", "rhel9" "sle15"] %}}
+{{%- if product in ["rhel8", "rhel9", "sle15"] %}}
   {{%- set perm_x="-F perm=x " %}}
 {{%- endif %}}
 


### PR DESCRIPTION
#### Description:

add missing comma in if statement

#### Rationale:

the perm=x was not put in place