### PR TITLE
Fix missing argument for grep command in bash remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -22,7 +22,7 @@ if [ -f /usr/bin/authselect ]; then
         if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
             sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
         fi
-        if grep -q "^\s*session.*required.*pam_lastlog.so.*silent.*"; then
+        if grep -q "^\s*session.*required.*pam_lastlog.so.*silent.*" $CUSTOM_POSTLOGIN; then
             # remove 'silent' option
             sed -i --follow-symlinks 's/^\(session.*required.*pam_lastlog.so\).*/\1 showfailed/g' $CUSTOM_POSTLOGIN
         fi


### PR DESCRIPTION
Fix missing argument for grep command in bash remediation

Rule: display_login_attempts
Impact on `authselect` remediation