### PR TITLE
Fix ansible accounts umask ansible remediations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -5,8 +5,16 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
-- name: Set user umask in /etc/bashrc
+- name: Replace user umask in /etc/bashrc
   replace:
-      path: /etc/bashrc
-      regexp: "umask.*"
-      replace: "umask {{ var_accounts_user_umask }}"
+    path: /etc/bashrc
+    regexp: "umask.*"
+    replace: "umask {{ var_accounts_user_umask }}"
+  register: umask_replace
+
+- name: Append user umask in /etc/bashrc
+  lineinfile:
+    create: yes
+    path: /etc/bashrc
+    line: "umask {{ var_accounts_user_umask }}"
+  when: umask_replace is not changed

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/missing.fail.sh
@@ -1,0 +1,3 @@
+
+#!/bin/bash
+sed -i '/umask/d' /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/wrong_multiple.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/bashrc
+echo "umask 000" >> /etc/bashrc
+echo "umask 000" >> /etc/bashrc
+echo "umask 000" >> /etc/bashrc
+umask 000

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
@@ -5,8 +5,16 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
-- name: Set user umask in /etc/csh.cshrc
+- name: Replace user umask in /etc/csh.cshrc
   replace:
-      path: /etc/csh.cshrc
-      regexp: "umask.*"
-      replace: "umask {{ var_accounts_user_umask }}"
+    path: /etc/csh.cshrc
+    regexp: "umask.*"
+    replace: "umask {{ var_accounts_user_umask }}"
+  register: umask_replace
+
+- name: Append user umask in /etc/csh.cshrc
+  lineinfile:
+    create: yes
+    path: /etc/csh.cshrc
+    line: "umask {{ var_accounts_user_umask }}"
+  when: umask_replace is not changed

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/missing.fail.sh
@@ -1,0 +1,3 @@
+
+#!/bin/bash
+sed -i '/umask/d' /etc/csh.cshrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/stig_correct.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+# platform = Red Hat Enterprise Linux 8
+
+sed -i '/umask/d' /etc/csh.cshrc
+echo "umask 077" >> /etc/csh.cshrc
+umask 077

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/super_compliant.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/super_compliant.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/csh.cshrc
+echo "umask 777" >> /etc/csh.cshrc
+umask 777

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/wrong.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/csh.cshrc
+echo "umask 000" >> /etc/csh.cshrc
+umask 000

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/wrong_multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/wrong_multiple.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+sed -i '/umask/d' /etc/csh.cshrc
+echo "umask 000" >> /etc/csh.cshrc
+echo "umask 000" >> /etc/csh.cshrc
+echo "umask 000" >> /etc/csh.cshrc
+umask 000

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -6,8 +6,15 @@
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
 - name: Ensure the Default UMASK is Set Correctly
+  replace:
+    path: /etc/login.defs
+    regexp: "^UMASK"
+    replace: "UMASK {{ var_accounts_user_umask }}"
+  register: umask_replace
+
+- name: Ensure the Default UMASK is Appended Correctly
   lineinfile:
     create: yes
-    dest: /etc/login.defs
-    regexp: ^UMASK
+    path: /etc/login.defs
     line: "UMASK {{ var_accounts_user_umask }}"
+  when: umask_replace is not changed

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/correct_value.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
-
 if grep -q "^UMASK" /etc/login.defs; then
 
 	sed -i "s/^UMASK.*/UMASK 077/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/missing.fail.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i '/^UMASK.*/d' /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/super_compliance.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/super_compliance.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
-
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/UMASK 177/" /etc/login.defs
 else

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_configuration.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_configuration.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
-
 if grep -q "^UMASK" /etc/login.defs; then
 	sed -i "s/^UMASK.*/umask 077/" /etc/login.defs
 else

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_multiple.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+sed -i '/UMASK/d' /etc/bashrc
+echo "UMASK 077" >> /etc/bashrc
+echo "UMASK 077" >> /etc/bashrc
+echo "UMASK 077" >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_value.fail.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-#
-# profiles = xccdf_org.ssgproject.content_profile_ospp
-
-if grep -q "^UMASK" /etc/login.defs; then
-	sed -i "s/^UMASK.*/UMASK 027/" /etc/login.defs
-else
-	echo "UMASK 027" >> /etc/login.defs
-fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
@@ -5,8 +5,16 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
-- name: Set user umask in /etc/profile
+- name: Replace user umask in /etc/profile
   replace:
-      path: /etc/profile
-      regexp: "umask.*"
-      replace: "umask {{ var_accounts_user_umask }}"
+    path: /etc/profile
+    regexp: "umask.*"
+    replace: "umask {{ var_accounts_user_umask }}"
+  register: umask_replace
+
+- name: Append user umask in /etc/profile
+  lineinfile:
+    create: yes
+    path: /etc/profile
+    line: "umask {{ var_accounts_user_umask }}"
+  when: umask_replace is not changed

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/missing.fail.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -i '/umask/d' /etc/profile


### PR DESCRIPTION


#### Description:

- Fix ansible accounts umask ansible remediations
  - It now correctly handles the case when there is no line present in the
file by using the lineinfile ansible module.
