### PR TITLE
Determine the platform name for CIS profile descriptions and rationale

### DIFF
--- a/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
+++ b/applications/openshift/kubelet/kubelet_anonymous_auth/rule.yml
@@ -6,8 +6,10 @@ platform: {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- set platform_noun = "EKS" %}}
 {{%- else %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- set platform_noun = "OpenShift" %}}
 {{%- endif %}}
 
 title: 'Disable Anonymous Authentication to the Kubelet'
@@ -29,9 +31,9 @@ description: |-
 rationale: |-
     When enabled, requests that are not rejected by other configured
     authentication methods are treated as anonymous requests. These
-    requests are then served by the Kubelet server. OpenShift Operators should
-    rely on authentication to authorize access and disallow anonymous
-    requests.
+    requests are then served by the Kubelet server. {{{ platform_noun }}}
+    Operators should rely on authentication to authorize access and disallow
+    anonymous requests.
 
 severity: medium
 

--- a/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
+++ b/applications/openshift/kubelet/kubelet_authorization_mode/rule.yml
@@ -6,14 +6,16 @@ platform: {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- set platform_noun = "EKS" %}}
 {{%- else %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- set platform_noun = "OpenShift" %}}
 {{%- endif %}}
 
 title: 'Ensure authorization is set to Webhook'
 
 description: |-
-    Unauthenticated/unauthorized users should have no access to OpenShift nodes.
+    Unauthenticated/unauthorized users should have no access to {{{ platform_noun }}} nodes.
     The Kubelet should be set to only allow Webhook authorization.
     To ensure that the Kubelet requires authorization,
     validate that <tt>authorization</tt> is configured to <tt>Webhook</tt>
@@ -26,7 +28,7 @@ description: |-
 
 rationale: |-
     Ensuring that the authorization is configured correctly helps enforce that
-    unauthenticated/unauthorized users have no access to OpenShift nodes.
+    unauthenticated/unauthorized users have no access to {{{ platform_noun }}} nodes.
 
 identifiers:
   cce@ocp4: CCE-83593-4

--- a/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_hostname_override/rule.yml
@@ -6,14 +6,16 @@ platform: {{{ product }}}-node
 
 {{%- if product == "eks"  %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- set platform_noun = "EKS" %}}
 {{%- else %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- set platform_noun = "OpenShift" %}}
 {{%- endif %}}
 
 title: 'kubelet - Hostname Override handling'
 
 description: |-
-    Normally, OpenShift lets the kubelet get the hostname from either the
+    Normally, {{{ platform_noun }}} lets the kubelet get the hostname from either the
     cloud provider itself, or from the node's hostname. This ensures that
     the PKI allocated by the deployment uses the appropriate values, is valid
     and keeps working throughout the lifecycle of the cluster. IP addresses

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -6,17 +6,19 @@ platform: {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- set platform_noun = "EKS" %}}
 {{%- else %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- set platform_noun = "OpenShift" %}}
 {{%- endif %}}
 
 title: 'Verify Group Who Owns The Kubelet Configuration File'
 
 description: '{{{ describe_file_group_owner(file=kubeletconf_path, group="root") }}}'
 rationale: |-
-    The kubelet configuration file contains information about the configuration of the
-    OpenShift node that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    The kubelet configuration file contains information about the configuration
+    of the {{{ platform_noun }}} node that is configured on the system.
+    Protection of this file is critical for {{{ platform_noun }}} security.
 
 severity: medium
 

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -3,6 +3,12 @@ documentation_complete: true
 prodtype: eks,ocp4
 
 platform: {{{ product }}}-node
+{{%- if product == "eks" %}}
+{{%- set platform_noun = "EKS" }}}
+{{%- else %}}
+{{%- set platform_noun = "OpenShift" }}}
+{{%- endif %}}
+
 
 title: 'Verify Group Who Owns The Worker Kubeconfig File'
 
@@ -10,8 +16,8 @@ description: '{{{ describe_file_group_owner(file="/var/lib/kubelet/kubeconfig", 
 
 rationale: |-
     The worker kubeconfig file contains information about the administrative configuration of the
-    OpenShift cluster that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    {{{ platform_noun }}} cluster that is configured on the system. Protection of this file is
+    critical for {{{ platform_noun}}} security.
 
 severity: medium
 

--- a/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_owner_kubelet_conf/rule.yml
@@ -6,8 +6,10 @@ platform: {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- platform_noun = "EKS" }}
 {{%- else %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- platform_noun = "OpenShift" }}
 {{%- endif %}}
 
 title: 'Verify User Who Owns The Kubelet Configuration File'
@@ -16,8 +18,8 @@ description: '{{{ describe_file_owner(file=kubeletconf_path, owner="root") }}}'
 
 rationale: |-
     The kubelet configuration file contains information about the configuration of the
-    OpenShift node that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    {{{ platform_noun }}} node that is configured on the system. Protection of this file is
+    critical for {{{ platform_noun }}} security.
 
 severity: medium
 

--- a/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_permissions_kubelet_conf/rule.yml
@@ -6,8 +6,10 @@ platform: {{{ product }}}-node
 
 {{%- if product == "eks" %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet/kubelet-config.json" %}}
+{{%- set platform_noun = "EKS" %}}
 {{%- else %}}
 {{%- set kubeletconf_path = "/etc/kubernetes/kubelet.conf" %}}
+{{%- set platform_noun = "OpenShift" %}}
 {{%- endif %}}
 
 title: 'Verify Permissions on The Kubelet Configuration File'
@@ -18,8 +20,8 @@ description: |-
 rationale: |-
     If the kubelet configuration file is writable by a group-owner or the
     world the risk of its compromise is increased. The file contains the configuration of
-    an OpenShift node that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    an {{{ platform_noun }}} node that is configured on the system. Protection of this file is
+    critical for {{{ platform_noun }}} security.
 
 severity: medium
 

--- a/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_permissions_worker_kubeconfig/rule.yml
@@ -8,9 +8,11 @@ platforms:
 {{%- if product == "eks" %}}
 {{%- set octal_perms = "0644" %}}
 {{%- set text_perms = "-rw-r--r--" %}}
+{{%- set platform_noun = "EKS" %}}
 {{%- else %}}
 {{%- set octal_perms = "0600" %}}
 {{%- set text_perms = "-rw-------" %}}
+{{%- set platform_noun = "OpenShift" %}}
 {{%- endif %}}
 
 title: 'Verify Permissions on the Worker Kubeconfig File'
@@ -21,8 +23,8 @@ description: |-
 rationale: |-
     If the worker kubeconfig file is writable by a group-owner or the
     world the risk of its compromise is increased. The file contains the administration configuration of the
-    OpenShift cluster that is configured on the system. Protection of this file is
-    critical for OpenShift security.
+    {{{ platform_noun }}} cluster that is configured on the system. Protection of this file is
+    critical for {{{ platform_noun }}} security.
 
 severity: medium
 


### PR DESCRIPTION
We recently added a profile for the EKS CIS benchmark. Luckily, we were
able to re-use many existing rules from the OCP CIS benchmark, but when
you render the rules in an EKS deployment, they reference "OpenShift" in
various descriptions or rationale. This can be confusing to end users
who might not understand the linkage between rules and profiles in this
repository.

This commit defines a variable for rules that are shared between the EKS
and OCP CIS benchmark and displays it appropriately depending on the
product type.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
