### PR TITLE
Fix require_emergency_target_auth and require_singleuser_auth in RHEL9

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -9,7 +9,7 @@
       create: yes
       dest: /usr/lib/systemd/system/emergency.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "rhel8", "ol8"] -%}}
+      {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
@@ -2,7 +2,7 @@
 
 service_file="/usr/lib/systemd/system/emergency.service"
 
-{{% if product in ["fedora", "rhel8", "ol8"] -%}}
+{{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell emergency"
 {{%- else -%}}
 sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -12,7 +12,7 @@
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "rhel8", "ol8"] -%}}
+    {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -24,7 +24,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_emergency_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/emergency.service</ind:filepath>
-    {{%- if product in ["fedora", "rhel8", "ol8"] -%}}
+    {{%- if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/usr/lib/systemd/systemd-sulogin-shell[\s]+emergency</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
     To check if authentication is required for emergency mode, run the following command:
     <pre>$ grep sulogin /usr/lib/systemd/system/emergency.service</pre>
     The output should be similar to the following, and the line must begin with
-    {{% if product in ["fedora", "rhel8", "ol8"] -%}}
+    {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
         ExecStart and /usr/lib/systemd/systemd-sulogin-shell.
         <pre>ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency</pre>
     {{%- else -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 
 service_file="/usr/lib/systemd/system/emergency.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -10,7 +10,7 @@
       create: yes
       dest: /usr/lib/systemd/system/rescue.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "rhel8", "ol8"] -%}}
+      {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue"
       {{% elif product in ["rhel7"] %}}
       line: 'ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -4,7 +4,7 @@
 
 service_file="/usr/lib/systemd/system/rescue.service"
 
-{{% if product in ["fedora", "rhel8", "ol8"] -%}}
+{{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell rescue"
 {{%- elif product in ["rhel7"] -%}}
 sulogin='/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -20,7 +20,7 @@
   {{%- if init_system == "systemd" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "rhel8", "ol8", "rhcos4"] -%}}
+    {{% if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4"] -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -32,7 +32,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
-    {{%- if product in ["fedora", "rhel8", "ol8", "rhcos4"] -%}}
+    {{%- if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4"] -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -59,7 +59,7 @@ ocil: |-
     To check if authentication is required for single-user mode, run the following command:
     <pre>$ grep sulogin /usr/lib/systemd/system/rescue.service</pre>
     The output should be similar to the following, and the line must begin with
-    {{% if product in ["fedora", "rhel8", "ol8", "rhcos4"] -%}}
+    {{% if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4"] -%}}
         ExecStart and /usr/lib/systemd/systemd-sulogin-shell.
         <pre>ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue</pre>
     {{%- elif product in ["rhel7"] -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 
 service_file="/usr/lib/systemd/system/rescue.service"
 sulogin="/usr/lib/systemd/systemd-sulogin-shell"


### PR DESCRIPTION


#### Description:
- Fix require_emergency_target_auth and require_singleuser_auth in RHEL9
  - These rules didn't take RHEL9 into Jinja if statements. Then it was
using code that is used for RHEL7 which is not compatible.

#### Rationale:

- Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1999576
