### PR TITLE
Revert temporary removal of rule

### DIFF
--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -163,6 +163,7 @@ selections:
     - auditd_log_format
     - auditd_freq
     - auditd_name_format
+    - auditd_audispd_syslog_plugin_activated
 
     ### Module Blacklist
     - kernel_module_cramfs_disabled

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -55,6 +55,7 @@ selections:
 - audit_owner_change_success
 - audit_perm_change_failed
 - audit_perm_change_success
+- auditd_audispd_syslog_plugin_activated
 - auditd_data_retention_flush
 - auditd_freq
 - auditd_local_events


### PR DESCRIPTION
The rule got removed in https://github.com/ComplianceAsCode/content/pull/5181 but it was not re-introduced later.

Fixes: #8074 