### PR TITLE
Generate release artifacts' checksums

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,7 +60,10 @@ jobs:
           body: ${{ steps.build_changelog.outputs.changelog }}
           files: |
             build/scap-security-guide-*.tar.bz2
+            build/scap-security-guide-*.tar.bz2.sha512
             build/zipfile/scap-security-guide-*.zip
+            build/zipfile/scap-security-guide-*.zip.sha512
             build-oval510/zipfile/scap-security-guide-*.zip
+            build-oval510/zipfile/scap-security-guide-*.zip.sha512
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,7 @@ hardening guidances that have been generated from XCCDF benchmarks.
 set(CPACK_RPM_FILE_NAME "%{name}-%{version}-%{release}.rpm")
 # For older versions of cmake (e.g. v2.8) file name is defined like below
 set(CPACK_PACKAGE_FILE_NAME "scap-security-guide-${SSG_VERSION}")
+set(CPACK_PACKAGE_CHECKSUM SHA512)
 
 set(CPACK_GENERATOR "RPM;DEB")
 include(CPack)

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1464,6 +1464,7 @@ macro(ssg_build_zipfile ZIPNAME)
         COMMAND ${CMAKE_COMMAND} -E make_directory "zipfile/${ZIPNAME}/tables"
         COMMAND ${CMAKE_COMMAND} -DSOURCE="${CMAKE_BINARY_DIR}/tables/*" -DDEST="zipfile/${ZIPNAME}/tables" -P "${CMAKE_SOURCE_DIR}/cmake/CopyFiles.cmake"
         COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E tar "cvf" "${ZIPNAME}.zip" --format=zip "${ZIPNAME}"
+        COMMAND ${CMAKE_COMMAND} -E chdir "zipfile" ${CMAKE_COMMAND} -E sha512sum "${ZIPNAME}.zip" > "zipfile/${ZIPNAME}.zip.sha512"
         COMMENT "Building zipfile at ${CMAKE_BINARY_DIR}/zipfile/${ZIPNAME}.zip"
         )
 endmacro()


### PR DESCRIPTION
#### Description:

- Generate and publish checksums of the source tarball and the pre-build content zipfiles.
  - Note: CMake checksums with `sha512` algorithm were only added in CMake 3.10 and `CPACK_PACKAGE_CHECKSUM` was only added in CPack 3.7.
  - As these commands are not part of the normal content build process, I'm not bumping `cmake_minimum_required`. It should be enough to ensure that the systems doing the release have CMake > 3.10.
  - The image used for the releases is a Fedora 34 and it has CMake 3.20.

#### Rationale:

- Partially addresses #8017 
