### PR TITLE
Improve error handling in the test suite

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -234,9 +234,7 @@ def run_with_stdout_logging(command, args, log_file):
     if result.stderr:
         log_file.write("STDERR: ")
         log_file.write(result.stderr)
-    if result.returncode:
-        raise RuntimeError("'%s' command returned non-zero." % command)
-    return result.stdout
+    return result
 
 
 def _exclude_garbage(tarinfo):

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -192,13 +192,15 @@ def run_stage_remediation_bash(run_type, test_env, formatting, verbose_path):
     command_string = '/bin/bash -x /{output_file}'.format(** formatting)
 
     with open(verbose_path, "a") as log_file:
+        error_msg_template = (
+            'Bash remediation for {rule_id} '.format(** formatting) +
+            'has exited with these errors: {stderr}'
+        )
         try:
-            test_env.execute_ssh_command(command_string, log_file)
+            test_env.execute_ssh_command(
+                command_string, log_file, error_msg_template=error_msg_template)
         except Exception as exc:
-            msg = (
-                'Bash script remediation run has exited with return code {} '
-                'instead of expected 0'.format(exc.returncode))
-            LogHelper.preload_log(logging.ERROR, msg, 'fail')
+            LogHelper.preload_log(logging.ERROR, str(exc), 'fail')
             return False
     return True
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -318,7 +318,6 @@ class RuleChecker(oscap.Checker):
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
                                                       self.slice_current,
                                                       self.slice_total)
-
         self._prepare_environment(sliced_scenarios_by_rule_id)
 
         with test_env.SavedState.create_from_environment(self.test_env, "tests_uploaded") as state:
@@ -432,9 +431,15 @@ class RuleChecker(oscap.Checker):
         os.close(descriptor)
         log_file_name = os.path.join(LogHelper.LOG_DIR, "env-preparation.log")
         with open(log_file_name, "a") as log_file:
-            common.run_with_stdout_logging(
+            result = common.run_with_stdout_logging(
                     "xsltproc", ("--output", temp_datastream, xslt_filename, self.datastream),
                     log_file)
+            if result.returncode:
+                msg = (
+                    "Error changing value of '{varname}': {stdout}"
+                    .format(varname=varname, stderr=result.stderr)
+                )
+                raise RuntimeError(msg)
         os.rename(temp_datastream, self.datastream)
         os.unlink(xslt_filename)
 


### PR DESCRIPTION
- `run_with_stdout_logging` returns a CompleteProcess instance instead of just stdout
- `run_with_stdout_logging` doesn't raise an exception if return code is non-zero
- `execute_ssh_command` accepts an error template that allows better user feedback

As a result, remediation errors are made visible for ssgts tests from the terminal output.