### PR TITLE
Add backends attribute to template in rules schema

### DIFF
--- a/shared/schemas/rule.json
+++ b/shared/schemas/rule.json
@@ -64,6 +64,10 @@
         "vars": {
           "type": "object",
           "uniqueItems": true
+        },
+        "backends": {
+          "type": "object",
+          "uniqueItems": true
         }
       }
     }


### PR DESCRIPTION
#### Description:

Adds `backends`  to  `template` properties in rule schema.

#### Rationale:

For rules like `mount_option_dev_shm_noexec`
