### PR TITLE
RHEL9 OSPP: drop some rules disabling kernel module loading

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -161,11 +161,8 @@ selections:
     - auditd_name_format
 
     ### Module Blacklist
-    - kernel_module_cramfs_disabled
     - kernel_module_bluetooth_disabled
     - kernel_module_sctp_disabled
-    - kernel_module_firewire-core_disabled
-    - kernel_module_atm_disabled
     - kernel_module_can_disabled
     - kernel_module_tipc_disabled
 


### PR DESCRIPTION
#### Description:

- drop three rules which disable loading of certain kernel modules from rhel9 ospp

#### Rationale:

- rules no longer relevant