### PR TITLE
CFE-214 : SC-6 : CaC rule that checks workloads for resource requests/limits

### DIFF
--- a/applications/openshift/general/resource_requests_limits_in_daemonset/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/rule.yml
@@ -1,0 +1,58 @@
+prodtype: ocp4
+
+title: Ensure that all daemonsets has resource limits
+
+description: |-
+  When deploying an application, it is important to tune based on memory and CPU consumption,
+  allocating enough resources for the application to function properly. Images provided by
+  OpenShift Dedicated behave properly within the confines of the memory they are allocated.
+  However, any applicaiton images must pay attention to the specific resources required to
+  ensure they are available.
+
+  If the node where a Pod is running has enough of a resource available, it's possible (and allowed)
+  for a container to use more resource than its request for that resource specifies.
+  However, a container is not allowed to use more than its resource limit.
+
+# todo : better if we can keep openshift document link for this reference,
+
+rationale: |-
+  Resource requests/limits provide constraints that limit aggregate resource consumption
+  per container. This helps prevent resource starvation. When deploying your
+  application, it is important to tune based on memory and CPU consumption,
+  allocating enough resources for the application to function properly.
+
+
+identifiers: {}
+
+references:
+  nist: SC-6
+
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+
+ocil_clause: 'Resource requests and limits is not set'
+
+ocil: |-
+    Run the following command to retrieve a list of daemonsets that does not have resource requests and limits:
+    <pre>$  oc get daemonset.apps  --all-namespaces -o json  | jq '{{{ jqfilter }}}'</pre>
+    Make sure that there is output nothing in the result.
+
+severity: medium
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_cluster_setting({'/apis/apps/v1/daemonsets?limit=500': jqfilter}) | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: |-
+      {{{ openshift_filtered_path('/apis/apps/v1/daemonsets?limit=500', jqfilter) }}}
+    yamlpath: "[:]"
+    check_existence: "none_exist"
+    entity_check: "all"
+    values:
+      - value: "(.*?)"
+        operation: "pattern match"
+
+

--- a/applications/openshift/general/resource_requests_limits_in_daemonset/tests/has_resource_request_limits_but_not_complete_set.fail.sh
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/tests/has_resource_request_limits_but_not_complete_set.fail.sh
@@ -1,0 +1,665 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/daemonsets"
+
+daemonsets_apipath="/apis/apps/v1/daemonsets?limit=500"
+
+# This file assumes that we have 6 daemonsets, and
+# for all the Daemonset either requests or limits were not defined.
+cat <<EOF > "$kube_apipath$daemonsets_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T09:59:03Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-with-resource-limits-cpu",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "65764",
+                "uid": "6d6569bd-a0f8-49c9-9fdd-7be82edbf444"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "100m"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T09:59:03Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-with-resource-limits-memory",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "65760",
+                "uid": "3173bd96-b186-4a94-9f37-9f5942c108f9"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "limits": {
+                                        "memory": "200Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T09:59:02Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-with-resource-request-cpu",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "65768",
+                "uid": "09259b00-a98f-4964-98ab-39cb6d3dc237"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "100m"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T09:59:02Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-with-resource-request-memory",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "65770",
+                "uid": "5e341b2d-3ec7-4900-978c-fdf3156f5753"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "requests": {
+                                        "memory": "200Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T10:00:50Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-without-resource-limits",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "66626",
+                "uid": "4c68d210-fed0-4cde-a2f1-c65b72a7d378"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "200Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T10:00:50Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-without-resource-request",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "66614",
+                "uid": "d7bd5e6b-36a5-481c-bb7b-234efea1ad21"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "200Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$daemonsets_apipath#$(echo -n "$daemonsets_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$daemonsets_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_daemonset/tests/has_resource_requests_Limits.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/tests/has_resource_requests_Limits.pass.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/daemonsets"
+
+daemonsets_apipath="/apis/apps/v1/daemonsets?limit=500"
+
+# This file assumes that we have 1 daemonsets & have the resource requests and limits
+cat <<EOF > "$kube_apipath$daemonsets_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T10:03:47Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-with-resource",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "68310",
+                "uid": "cd79c924-3d9b-48cc-9c22-37d6821a8c91"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "100m",
+                                        "memory": "200Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "100m",
+                                        "memory": "200Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$daemonsets_apipath#$(echo -n "$daemonsets_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$daemonsets_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_daemonset/tests/no_daemonsets.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/tests/no_daemonsets.pass.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/daemonsets"
+
+daemonsets_apipath="/apis/apps/v1/daemonsets?limit=500"
+
+# This file assumes that we dont have any daemonsets.
+cat <<EOF > "$kube_apipath$daemonsets_apipath"
+{
+    "apiVersion": "v1",
+    "items": [],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$daemonsets_apipath#$(echo -n "$daemonsets_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$daemonsets_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_daemonset/tests/no_resource_request_limits.fail.sh
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/tests/no_resource_request_limits.fail.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/daemonsets"
+
+daemonsets_apipath="/apis/apps/v1/daemonsets?limit=500"
+
+# This file assumes that we have 1 daemonsets & dont have the resource requests and limits
+cat <<EOF > "$kube_apipath$daemonsets_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T10:05:11Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-without-resource",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "69807",
+                "uid": "18fd39c9-f493-4c02-a8fd-2f5fc9dc90f4"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$daemonsets_apipath#$(echo -n "$daemonsets_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$daemonsets_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_daemonset/tests/ocp4/e2e.yml
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/general/resource_requests_limits_in_daemonset/tests/skip_openshif_kube_ns_resource_requests_Limits.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_daemonset/tests/skip_openshif_kube_ns_resource_requests_Limits.pass.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/daemonsets"
+
+daemonsets_apipath="/apis/apps/v1/daemonsets?limit=500"
+
+# This file assumes that we have 1 daemonsets & have the resource requests and limits
+cat <<EOF > "$kube_apipath$daemonsets_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "DaemonSet",
+            "metadata": {
+                "annotations": {
+                    "deprecated.daemonset.template.generation": "1"
+                },
+                "creationTimestamp": "2021-12-30T10:03:47Z",
+                "generation": 1,
+                "labels": {
+                    "k8s-app": "fluentd-logging"
+                },
+                "name": "fluentd-with-resource",
+                "namespace": "kube-system",
+                "resourceVersion": "68310",
+                "uid": "cd79c924-3d9b-48cc-9c22-37d6821a8c91"
+            },
+            "spec": {
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "name": "fluentd-elasticsearch"
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "name": "fluentd-elasticsearch"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "quay.io/fluentd_elasticsearch/fluentd:v2.5.2",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "fluentd-elasticsearch",
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/var/log",
+                                        "name": "varlog"
+                                    },
+                                    {
+                                        "mountPath": "/var/lib/docker/containers",
+                                        "name": "varlibdockercontainers",
+                                        "readOnly": true
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30,
+                        "tolerations": [
+                            {
+                                "effect": "NoSchedule",
+                                "key": "node-role.kubernetes.io/master",
+                                "operator": "Exists"
+                            }
+                        ],
+                        "volumes": [
+                            {
+                                "hostPath": {
+                                    "path": "/var/log",
+                                    "type": ""
+                                },
+                                "name": "varlog"
+                            },
+                            {
+                                "hostPath": {
+                                    "path": "/var/lib/docker/containers",
+                                    "type": ""
+                                },
+                                "name": "varlibdockercontainers"
+                            }
+                        ]
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "maxSurge": 0,
+                        "maxUnavailable": 1
+                    },
+                    "type": "RollingUpdate"
+                }
+            },
+            "status": {
+                "currentNumberScheduled": 6,
+                "desiredNumberScheduled": 6,
+                "numberAvailable": 6,
+                "numberMisscheduled": 0,
+                "numberReady": 6,
+                "observedGeneration": 1,
+                "updatedNumberScheduled": 6
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$daemonsets_apipath#$(echo -n "$daemonsets_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$daemonsets_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_deployment/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/rule.yml
@@ -1,0 +1,56 @@
+prodtype: ocp4
+
+title: Ensure that all deployments has resource limits
+
+description: |-
+  When deploying an application, it is important to tune based on memory and CPU consumption,
+  allocating enough resources for the application to function properly. Images provided by
+  OpenShift Dedicated behave properly within the confines of the memory they are allocated.
+  However, any applicaiton images must pay attention to the specific resources required to
+  ensure they are available.
+
+  If the node where a Pod is running has enough of a resource available, it's possible (and allowed)
+  for a container to use more resource than its request for that resource specifies.
+  However, a container is not allowed to use more than its resource limit.
+
+# todo : better if we can keep openshift document link for this reference,
+
+rationale: |-
+  Resource requests/limits provide constraints that limit aggregate resource consumption
+  per container. This helps prevent resource starvation. When deploying your
+  application, it is important to tune based on memory and CPU consumption,
+  allocating enough resources for the application to function properly.
+
+
+identifiers: {}
+
+references:
+  nist: SC-6
+
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+
+ocil_clause: 'Resource requests and limits is not set'
+
+ocil: |-
+    Run the following command to retrieve a list of deployments that does not have resource requests and limits:
+    <pre>$  oc get deployment.apps  --all-namespaces -o json  | jq '{{{ jqfilter }}}'</pre>
+    Make sure that there is output nothing in the result.
+
+severity: medium
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_cluster_setting({'/apis/apps/v1/deployments?limit=500': jqfilter}) | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: |-
+      {{{ openshift_filtered_path('/apis/apps/v1/deployments?limit=500', jqfilter) }}}
+    yamlpath: "[:]"
+    check_existence: "none_exist"
+    entity_check: "all"
+    values:
+      - value: "(.*?)"
+        operation: "pattern match"

--- a/applications/openshift/general/resource_requests_limits_in_deployment/tests/has_resource_request_limits_but_not_complete_set.fail.sh
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/tests/has_resource_request_limits_but_not_complete_set.fail.sh
@@ -1,0 +1,581 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/deployments"
+
+deployment_apipath="/apis/apps/v1/deployments?limit=500"
+
+# This file assumes that we have 6 deployments, and
+# for all the deployment either requests or limits were not defined.
+cat <<EOF > "$kube_apipath$deployment_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:48:58Z",
+                "generation": 1,
+                "name": "deployment-with-resource-only-limits-cpu",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "37315",
+                "uid": "debdd0ff-889a-4771-872b-efb0ee9b65de"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "500m"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:58Z",
+                        "lastUpdateTime": "2021-12-30T08:48:58Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:58Z",
+                        "lastUpdateTime": "2021-12-30T08:48:58Z",
+                        "message": "ReplicaSet \"deployment-with-resource-only-limits-cpu-89974b47d\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:48:58Z",
+                "generation": 1,
+                "name": "deployment-with-resource-only-limits-memory",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "37300",
+                "uid": "a66ab700-10d1-46ce-89f3-9178e3cfa2f0"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "memory": "128Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:58Z",
+                        "lastUpdateTime": "2021-12-30T08:48:58Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:58Z",
+                        "lastUpdateTime": "2021-12-30T08:48:58Z",
+                        "message": "ReplicaSet \"deployment-with-resource-only-limits-memory-7df6bc97c5\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:48:57Z",
+                "generation": 1,
+                "name": "deployment-with-resource-only-requests-cpu",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "37273",
+                "uid": "f0644762-8b6c-4bbc-b324-6e8724219826"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "250m"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:57Z",
+                        "lastUpdateTime": "2021-12-30T08:48:57Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:57Z",
+                        "lastUpdateTime": "2021-12-30T08:48:57Z",
+                        "message": "ReplicaSet \"deployment-with-resource-only-requests-cpu-6d58f6464\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:48:57Z",
+                "generation": 1,
+                "name": "deployment-with-resource-only-requests-memory",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "37258",
+                "uid": "0bda87e6-f052-49ae-a3e4-61ae246c7300"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:57Z",
+                        "lastUpdateTime": "2021-12-30T08:48:57Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:57Z",
+                        "lastUpdateTime": "2021-12-30T08:48:57Z",
+                        "message": "ReplicaSet \"deployment-with-resource-only-requests-memory-9c49df96b\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:48:57Z",
+                "generation": 1,
+                "name": "deployment-without-resource-limits",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "37246",
+                "uid": "e0132dfd-d709-4e5a-9be2-43b031a34e49"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "250m",
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:57Z",
+                        "lastUpdateTime": "2021-12-30T08:48:57Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:57Z",
+                        "lastUpdateTime": "2021-12-30T08:48:57Z",
+                        "message": "ReplicaSet \"deployment-without-resource-limits-f9b649dcb\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:48:58Z",
+                "generation": 1,
+                "name": "deployment-without-resource-requests",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "37288",
+                "uid": "8bd83687-8246-4ace-a76a-b61874b2395c"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "128Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:58Z",
+                        "lastUpdateTime": "2021-12-30T08:48:58Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:48:58Z",
+                        "lastUpdateTime": "2021-12-30T08:48:58Z",
+                        "message": "ReplicaSet \"deployment-without-resource-requests-5cfbc579c\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$deployment_apipath#$(echo -n "$deployment_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$deployment_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_deployment/tests/has_resource_requests_Limits.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/tests/has_resource_requests_Limits.pass.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/deployments"
+
+deployment_apipath="/apis/apps/v1/deployments?limit=500"
+
+# This file assumes that we have 1 deployments & have the resource requests and limits
+cat <<EOF > "$kube_apipath$deployment_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:30:52Z",
+                "generation": 1,
+                "name": "deployment-with-resource",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "34637",
+                "uid": "55e83898-3925-475e-ad96-b1fb098f6dfd"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "250m",
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:30:52Z",
+                        "lastUpdateTime": "2021-12-30T08:30:52Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:40:53Z",
+                        "lastUpdateTime": "2021-12-30T08:40:53Z",
+                        "message": "ReplicaSet \"deployment-with-resource-7b5977cd56\" has timed out progressing.",
+                        "reason": "ProgressDeadlineExceeded",
+                        "status": "False",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$deployment_apipath#$(echo -n "$deployment_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$deployment_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_deployment/tests/no_deployments.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/tests/no_deployments.pass.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/deployments"
+
+deployment_apipath="/apis/apps/v1/deployments?limit=500"
+
+# This file assumes that we dont have any deployments.
+cat <<EOF > "$kube_apipath$deployment_apipath"
+{
+    "apiVersion": "v1",
+    "items": [],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$deployment_apipath#$(echo -n "$deployment_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$deployment_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_deployment/tests/no_resource_request_limits.fail.sh
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/tests/no_resource_request_limits.fail.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/deployments"
+
+deployment_apipath="/apis/apps/v1/deployments?limit=500"
+
+# This file assumes that we have 1 deployments & dont have the resource requests and limits
+cat <<EOF > "$kube_apipath$deployment_apipath"{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:46:56Z",
+                "generation": 1,
+                "name": "deployment-without-any-resource",
+                "namespace": "cmp-resource-test",
+                "resourceVersion": "36650",
+                "uid": "a5be26ae-edc4-4f39-850d-b63dea9be926"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:46:56Z",
+                        "lastUpdateTime": "2021-12-30T08:46:56Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:46:56Z",
+                        "lastUpdateTime": "2021-12-30T08:46:56Z",
+                        "message": "ReplicaSet \"deployment-without-any-resource-7848d4b86f\" is progressing.",
+                        "reason": "ReplicaSetUpdated",
+                        "status": "True",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+
+EOF
+
+
+jq_filter='[ .items[] |select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$deployment_apipath#$(echo -n "$deployment_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$deployment_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_deployment/tests/ocp4/e2e.yml
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/general/resource_requests_limits_in_deployment/tests/skip_openshift_kube_ns_resource_requests_Limits.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_deployment/tests/skip_openshift_kube_ns_resource_requests_Limits.pass.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/deployments"
+
+deployment_apipath="/apis/apps/v1/deployments?limit=500"
+
+# This file assumes that we have 1 deployments & have the resource requests and limits
+cat <<EOF > "$kube_apipath$deployment_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "Deployment",
+            "metadata": {
+                "annotations": {
+                    "deployment.kubernetes.io/revision": "1"
+                },
+                "creationTimestamp": "2021-12-30T08:30:52Z",
+                "generation": 1,
+                "name": "deployment-without-resource",
+                "namespace": "kube-system",
+                "resourceVersion": "34637",
+                "uid": "55e83898-3925-475e-ad96-b1fb098f6dfd"
+            },
+            "spec": {
+                "progressDeadlineSeconds": 600,
+                "replicas": 1,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "strategy": {
+                    "rollingUpdate": {
+                        "maxSurge": "25%",
+                        "maxUnavailable": "25%"
+                    },
+                    "type": "RollingUpdate"
+                },
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "nginx",
+                                "imagePullPolicy": "Always",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File"
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                }
+            },
+            "status": {
+                "conditions": [
+                    {
+                        "lastTransitionTime": "2021-12-30T08:30:52Z",
+                        "lastUpdateTime": "2021-12-30T08:30:52Z",
+                        "message": "Deployment does not have minimum availability.",
+                        "reason": "MinimumReplicasUnavailable",
+                        "status": "False",
+                        "type": "Available"
+                    },
+                    {
+                        "lastTransitionTime": "2021-12-30T08:40:53Z",
+                        "lastUpdateTime": "2021-12-30T08:40:53Z",
+                        "message": "ReplicaSet \"deployment-without-resource-7b5977cd56\" has timed out progressing.",
+                        "reason": "ProgressDeadlineExceeded",
+                        "status": "False",
+                        "type": "Progressing"
+                    }
+                ],
+                "observedGeneration": 1,
+                "replicas": 1,
+                "unavailableReplicas": 1,
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$deployment_apipath#$(echo -n "$deployment_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$deployment_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/rule.yml
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/rule.yml
@@ -1,0 +1,58 @@
+prodtype: ocp4
+
+title: Ensure that all statefulsets has resource limits
+
+description: |-
+  When deploying an application, it is important to tune based on memory and CPU consumption,
+  allocating enough resources for the application to function properly. Images provided by
+  OpenShift Dedicated behave properly within the confines of the memory they are allocated.
+  However, any applicaiton images must pay attention to the specific resources required to
+  ensure they are available.
+
+  If the node where a Pod is running has enough of a resource available, it's possible (and allowed)
+  for a container to use more resource than its request for that resource specifies.
+  However, a container is not allowed to use more than its resource limit.
+
+# todo : better if we can keep openshift document link for this reference,
+
+rationale: |-
+  Resource requests/limits provide constraints that limit aggregate resource consumption
+  per container. This helps prevent resource starvation. When deploying your
+  application, it is important to tune based on memory and CPU consumption,
+  allocating enough resources for the application to function properly.
+
+
+identifiers: {}
+
+references:
+  nist: SC-6
+
+{{% set jqfilter = '[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]' %}}
+
+ocil_clause: 'Resource requests and limits is not set'
+
+ocil: |-
+    Run the following command to retrieve a list of statefulsets that does not have resource requests and limits:
+    <pre>$  oc get statefulset.apps --all-namespaces -o json  | jq '{{{ jqfilter }}}'</pre>
+    Make sure that there is output nothing in the result.
+
+severity: medium
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_cluster_setting({'/apis/apps/v1/statefulsets?limit=500': jqfilter}) | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: |-
+      {{{ openshift_filtered_path('/apis/apps/v1/statefulsets?limit=500', jqfilter) }}}
+    yamlpath: "[:]"
+    check_existence: "none_exist"
+    entity_check: "all"
+    values:
+      - value: "(.*?)"
+        operation: "pattern match"
+
+

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/tests/has_resource_request_limits_but_not_complete_set.fail.sh
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/tests/has_resource_request_limits_but_not_complete_set.fail.sh
@@ -1,0 +1,683 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/statefulsets"
+
+statefulset_apipath="/apis/apps/v1/statefulsets?limit=500"
+
+# This file assumes that we have 6 statefulsets, and
+# for all the statefulsets either requests or limits were not defined.
+cat <<EOF > "$kube_apipath$statefulset_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:20:31Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-with-resource-limits-cpu",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "47739",
+                "uid": "0eadfce8-1e47-4bd8-9509-549e0305cf63"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "500m"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-with-resource-limits-cpu-7f9d7b6b54",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-with-resource-limits-cpu-7f9d7b6b54",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:20:31Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-with-resource-limits-memory",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "47724",
+                "uid": "01855501-31b8-4780-9974-2c6d007cc875"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "memory": "128Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-with-resource-limits-memory-77cb666474",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-with-resource-limits-memory-77cb666474",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:20:30Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-with-resource-request-memory",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "47703",
+                "uid": "4f51487e-57ef-427c-b329-df2e1f119fe7"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-with-resource-request-memory-5b7f4469d5",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-with-resource-request-memory-5b7f4469d5",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:20:31Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-with-resource-requests-cpu",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "47715",
+                "uid": "33cdfcea-163d-4406-bbab-545e0eac0656"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "250m"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-with-resource-requests-cpu-7dc58fddd4",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-with-resource-requests-cpu-7dc58fddd4",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:20:32Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-without-resource-limits",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "47760",
+                "uid": "b80561dc-1458-4793-871c-98554b50c3a3"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "250m",
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-without-resource-limits-d5c8547df",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-without-resource-limits-d5c8547df",
+                "updatedReplicas": 1
+            }
+        },
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:20:31Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-without-resource-request",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "47748",
+                "uid": "4edd04fc-ea5d-4c81-830e-9090d4573a54"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "128Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-without-resource-request-687c59b58",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-without-resource-request-687c59b58",
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$statefulset_apipath#$(echo -n "$statefulset_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$statefulset_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/tests/has_resource_requests_Limits.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/tests/has_resource_requests_Limits.pass.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/statefulsets"
+
+statefulset_apipath="/apis/apps/v1/statefulsets?limit=500"
+
+# This file assumes that we have 1 Statefulsets & have the resource requests and limits
+cat <<EOF > "$kube_apipath$statefulset_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:24:51Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-with-resource",
+                "namespace": "cmp-resource-limit-test",
+                "resourceVersion": "49281",
+                "uid": "0daf3608-56f9-4d95-8aac-db9ed249b7f8"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {
+                                    "limits": {
+                                        "cpu": "500m",
+                                        "memory": "128Mi"
+                                    },
+                                    "requests": {
+                                        "cpu": "250m",
+                                        "memory": "64Mi"
+                                    }
+                                },
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-with-resource-5f8c9544c7",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-with-resource-5f8c9544c7",
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] |select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$statefulset_apipath#$(echo -n "$statefulset_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$statefulset_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/tests/no_resource_request_limits.fail.sh
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/tests/no_resource_request_limits.fail.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/statefulsets"
+
+statefulset_apipath="/apis/apps/v1/statefulsets?limit=500"
+
+# This file assumes that we have 1 statefulsets & dont have the resource requests and limits
+cat <<EOF > "$kube_apipath$statefulset_apipath"
+{
+    "apiVersion": "apps/v1",
+    "kind": "StatefulSet",
+    "metadata": {
+        "creationTimestamp": "2021-12-30T09:26:47Z",
+        "generation": 1,
+        "labels": {
+            "app": "nginx"
+        },
+        "name": "statefulset-without-resource",
+        "namespace": "cmp-resource-limit-test",
+        "resourceVersion": "50061",
+        "uid": "db840d4a-776b-421a-8fdd-572da583beac"
+    },
+    "spec": {
+        "podManagementPolicy": "OrderedReady",
+        "replicas": 14,
+        "revisionHistoryLimit": 10,
+        "selector": {
+            "matchLabels": {
+                "app": "nginx"
+            }
+        },
+        "serviceName": "nginx",
+        "template": {
+            "metadata": {
+                "creationTimestamp": null,
+                "labels": {
+                    "app": "nginx"
+                }
+            },
+            "spec": {
+                "containers": [
+                    {
+                        "image": "k8s.gcr.io/nginx-slim:0.8",
+                        "imagePullPolicy": "IfNotPresent",
+                        "name": "nginx",
+                        "ports": [
+                            {
+                                "containerPort": 80,
+                                "name": "web",
+                                "protocol": "TCP"
+                            }
+                        ],
+                        "resources": {},
+                        "terminationMessagePath": "/dev/termination-log",
+                        "terminationMessagePolicy": "File",
+                        "volumeMounts": [
+                            {
+                                "mountPath": "/usr/share/nginx/html",
+                                "name": "www"
+                            }
+                        ]
+                    }
+                ],
+                "dnsPolicy": "ClusterFirst",
+                "restartPolicy": "Always",
+                "schedulerName": "default-scheduler",
+                "securityContext": {},
+                "terminationGracePeriodSeconds": 30
+            }
+        },
+        "updateStrategy": {
+            "rollingUpdate": {
+                "partition": 0
+            },
+            "type": "RollingUpdate"
+        },
+        "volumeClaimTemplates": [
+            {
+                "apiVersion": "v1",
+                "kind": "PersistentVolumeClaim",
+                "metadata": {
+                    "creationTimestamp": null,
+                    "name": "www"
+                },
+                "spec": {
+                    "accessModes": [
+                        "ReadWriteOnce"
+                    ],
+                    "resources": {
+                        "requests": {
+                            "storage": "1Gi"
+                        }
+                    },
+                    "storageClassName": "thin-disk",
+                    "volumeMode": "Filesystem"
+                },
+                "status": {
+                    "phase": "Pending"
+                }
+            }
+        ]
+    },
+    "status": {
+        "collisionCount": 0,
+        "currentReplicas": 1,
+        "currentRevision": "statefulset-without-resource-b46f789c4",
+        "observedGeneration": 1,
+        "replicas": 1,
+        "updateRevision": "statefulset-without-resource-b46f789c4",
+        "updatedReplicas": 1
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$statefulset_apipath#$(echo -n "$statefulset_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$statefulset_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/tests/no_statfulsets.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/tests/no_statfulsets.pass.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/statefulsets"
+
+statefulset_apipath="/apis/apps/v1/statefulsets?limit=500"
+
+# This file assumes that we dont have any statefulsets.
+cat <<EOF > "$kube_apipath$statefulset_apipath"
+{
+    "apiVersion": "v1",
+    "items": [],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] | select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$statefulset_apipath#$(echo -n "$statefulset_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$statefulset_apipath" > "$filteredpath"

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/tests/ocp4/e2e.yml
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/general/resource_requests_limits_in_statefulset/tests/skip_openshift_kubesystem_ns_resource_requests_Limits.pass.sh
+++ b/applications/openshift/general/resource_requests_limits_in_statefulset/tests/skip_openshift_kubesystem_ns_resource_requests_Limits.pass.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/apps/v1/statefulsets"
+
+statefulset_apipath="/apis/apps/v1/statefulsets?limit=500"
+
+# This file assumes that we have 1 Statefulsets & have the resource requests and limits
+cat <<EOF > "$kube_apipath$statefulset_apipath"
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "apps/v1",
+            "kind": "StatefulSet",
+            "metadata": {
+                "creationTimestamp": "2021-12-30T09:24:51Z",
+                "generation": 1,
+                "labels": {
+                    "app": "nginx"
+                },
+                "name": "statefulset-with-resource",
+                "namespace": "kube-system",
+                "resourceVersion": "49281",
+                "uid": "0daf3608-56f9-4d95-8aac-db9ed249b7f8"
+            },
+            "spec": {
+                "podManagementPolicy": "OrderedReady",
+                "replicas": 14,
+                "revisionHistoryLimit": 10,
+                "selector": {
+                    "matchLabels": {
+                        "app": "nginx"
+                    }
+                },
+                "serviceName": "nginx",
+                "template": {
+                    "metadata": {
+                        "creationTimestamp": null,
+                        "labels": {
+                            "app": "nginx"
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "image": "k8s.gcr.io/nginx-slim:0.8",
+                                "imagePullPolicy": "IfNotPresent",
+                                "name": "nginx",
+                                "ports": [
+                                    {
+                                        "containerPort": 80,
+                                        "name": "web",
+                                        "protocol": "TCP"
+                                    }
+                                ],
+                                "resources": {},
+                                "terminationMessagePath": "/dev/termination-log",
+                                "terminationMessagePolicy": "File",
+                                "volumeMounts": [
+                                    {
+                                        "mountPath": "/usr/share/nginx/html",
+                                        "name": "www"
+                                    }
+                                ]
+                            }
+                        ],
+                        "dnsPolicy": "ClusterFirst",
+                        "restartPolicy": "Always",
+                        "schedulerName": "default-scheduler",
+                        "securityContext": {},
+                        "terminationGracePeriodSeconds": 30
+                    }
+                },
+                "updateStrategy": {
+                    "rollingUpdate": {
+                        "partition": 0
+                    },
+                    "type": "RollingUpdate"
+                },
+                "volumeClaimTemplates": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "PersistentVolumeClaim",
+                        "metadata": {
+                            "creationTimestamp": null,
+                            "name": "www"
+                        },
+                        "spec": {
+                            "accessModes": [
+                                "ReadWriteOnce"
+                            ],
+                            "resources": {
+                                "requests": {
+                                    "storage": "1Gi"
+                                }
+                            },
+                            "storageClassName": "thin-disk",
+                            "volumeMode": "Filesystem"
+                        },
+                        "status": {
+                            "phase": "Pending"
+                        }
+                    }
+                ]
+            },
+            "status": {
+                "collisionCount": 0,
+                "currentReplicas": 1,
+                "currentRevision": "statefulset-with-resource-5f8c9544c7",
+                "observedGeneration": 1,
+                "replicas": 1,
+                "updateRevision": "statefulset-with-resource-5f8c9544c7",
+                "updatedReplicas": 1
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}
+EOF
+
+
+jq_filter='[ .items[] |select(.metadata.namespace | startswith("kube-") or startswith("openshift-") | not) | select( .spec.template.spec.containers[].resources.requests.cpu == null  or  .spec.template.spec.containers[].resources.requests.memory == null or .spec.template.spec.containers[].resources.limits.cpu == null  or  .spec.template.spec.containers[].resources.limits.memory == null )  | .metadata.name ]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$statefulset_apipath#$(echo -n "$statefulset_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$statefulset_apipath" > "$filteredpath"

--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -13263,7 +13263,10 @@ controls:
     [2] https://docs.openshift.com/container-platform/4.7/applications/quotas/quotas-setting-per-project.html
     [3] https://docs.openshift.com/container-platform/4.7/applications/quotas/quotas-setting-across-multiple-projects.html
     [4] https://docs.openshift.com/container-platform/4.7/nodes/pods/nodes-pods-priority.html
-  rules: []
+  rules:
+  - resource_requests_limits_in_deployment
+  - resource_requests_limits_in_daemonset
+  - resource_requests_limits_in_statefulset
   description: |-
     The information system protects the availability of resources by allocating [Assignment: organization-defined resources] by [Selection (one or more); priority; quota; [Assignment: organization-defined security safeguards]].
 


### PR DESCRIPTION
CFE-214 : Inital commit with basic rule to validate resource request

#### Description:

  When deploying an application, it is important to tune based on memory and CPU consumption,
  allocating enough resources for the application to function properly. Images provided by
  OpenShift Dedicated behave properly within the confines of the memory they are allocated.
  However, any applicaiton images must pay attention to the specific resources required to
  ensure they are available.

  If the node where a Pod is running has enough of a resource available, it's possible (and allowed)
  for a container to use more resource than its request for that resource specifies.
  However, a container is not allowed to use more than its resource limit.

#### Rationale:

  Resource requests/limits provide constraints that limit aggregate resource consumption
  per container. This helps prevent resource starvation. When deploying your
  application, it is important to tune based on memory and CPU consumption,
  allocating enough resources for the application to function properly.

- Fixes # CFE-214
