### PR TITLE
Fix configure firewalld ports

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
@@ -82,13 +82,23 @@
             <literal_component>.xml</literal_component>
         </concat>
   </local_variable>
+{{% if product in ["fedora", "rhel9"] %}}
+  <ind:textfilecontent54_object comment="Check config of all NIC"
+  id="object_nic_assigned_to_firewalld_zone" version="2">
+    <ind:path>/etc/NetworkManager/system-connections</ind:path>
+    <ind:filename operation="pattern match">.*\.nmconnection</ind:filename>
+    <ind:pattern operation="pattern match">^zone=(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% else %}}
   <ind:textfilecontent54_object comment="Check config of all NIC"
   id="object_nic_assigned_to_firewalld_zone" version="1">
     <ind:path>/etc/sysconfig/network-scripts</ind:path>
     <ind:filename operation="pattern match">ifcfg-.*</ind:filename>
     <ind:pattern operation="pattern match">^ZONE=(.*)$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
+{{% endif %}}
 
   <ind:textfilecontent54_state comment="port ssh is listening" id="state_sshd_listening_port" version="1">
     <ind:subexpression datatype="int" operation="equals" var_ref="sshd_listening_port" />

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/oval/shared.xml
@@ -88,7 +88,7 @@
     <ind:path>/etc/NetworkManager/system-connections</ind:path>
     <ind:filename operation="pattern match">.*\.nmconnection</ind:filename>
     <ind:pattern operation="pattern match">^zone=(.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% else %}}
   <ind:textfilecontent54_object comment="Check config of all NIC"
@@ -96,7 +96,7 @@
     <ind:path>/etc/sysconfig/network-scripts</ind:path>
     <ind:filename operation="pattern match">ifcfg-.*</ind:filename>
     <ind:pattern operation="pattern match">^ZONE=(.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="equals">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}
 


### PR DESCRIPTION
#### Description:

- Update the path where the check `firewalld_sshd_port_enabled` checks for NIC configuration.
- Fixes failures on rule `configure_firewalld_ports`. (The rule check is the same as `firewalld_sshd_port_enabled`'s check.

#### Rationale:

- The path changed in recent Fedoras and RHEL9:
  - https://fedoramagazine.org/nmstate-a-declarative-networking-config-tool/
  - https://access.redhat.com/solutions/5313011

- Related to https://github.com/ComplianceAsCode/content/issues/7752. Addresses fails on rule `configure_firewalld_ports`. 
