### PR TITLE
OCP4:fix controller_insecure_port_disabled rule

### DIFF
--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -16,6 +16,12 @@ description: |-
       "port": ["0"],
     ...
     </pre>
+    It is also acceptable for a system to deprecate the insecure port:
+    <pre>
+    "extendedArguments": {
+    ...
+    ...
+    </pre>
 
 rationale: |-
     The Controller Manager API service is used for health and metrics
@@ -24,6 +30,8 @@ rationale: |-
     attack surface.
 
 severity: low
+
+{{% set jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]' %}}
 
 identifiers:
     cce@ocp4: CCE-83578-5
@@ -34,8 +42,8 @@ ocil_clause: |-
 ocil: |-
     To verify that <tt>port</tt> is configured correctly,
     run the following command:
-    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson |   jq -r '.data["config.yaml"]' | jq '.extendedArguments["port"][]'</pre>
-    Verify that it's disabled (the value is <pre>0</pre>).
+    <pre>$ oc get configmaps config -n openshift-kube-controller-manager -ojson | jq '{{{ jqfilter }}}'</pre>
+    Verify that it's true in the console output (the value will be true if the insecure port is bind to loopback address or disabled) .
 
 references:
     cis@ocp4: 1.3.7
@@ -44,17 +52,18 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325,SRG-APP-000516-CTR-001330,SRG-APP-000516-CTR-001335
 
+
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config': jqfilter}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    filepath: |-
+      {{{ openshift_filtered_path('/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config', jqfilter) }}}
+    yamlpath: "[:]"
     values:
-    - value: '(\"port\":\[\"0\"\])'
-      operation: "pattern match"
-      type: "string"
+      - value: "true"
+        operation: "equals"

--- a/applications/openshift/controller/controller_insecure_port_disabled/tests/insecure_binding_disabled.pass.sh
+++ b/applications/openshift/controller/controller_insecure_port_disabled/tests/insecure_binding_disabled.pass.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-controller-manager/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config"
+
+
+cat << EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiVersion\":\"kubecontrolplane.config.openshift.io/v1\",\"extendedArguments\":{\"allocate-node-cidrs\":[\"false\"],\"cert-dir\":[\"/var/run/kubernetes\"],\"cloud-provider\":[\"aws\"],\"cluster-cidr\":[\"10.128.0.0/14\"],\"cluster-name\":[\"wenshen-51-f2xqb\"],\"cluster-signing-cert-file\":[\"/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.crt\"],\"cluster-signing-key-file\":[\"/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.key\"],\"configure-cloud-routes\":[\"false\"],\"controllers\":[\"*\",\"-ttl\",\"-bootstrapsigner\",\"-tokencleaner\"],\"enable-dynamic-provisioning\":[\"true\"],\"experimental-cluster-signing-duration\":[\"720h\"],\"feature-gates\":[\"APIPriorityAndFairness=true\",\"RotateKubeletServerCertificate=true\",\"SupportPodPidsLimit=true\",\"NodeDisruptionExclusion=true\",\"ServiceNodeExclusion=true\",\"DownwardAPIHugePages=true\",\"LegacyNodeRoleBehavior=false\"],\"flex-volume-plugin-dir\":[\"/etc/kubernetes/kubelet-plugins/volume/exec\"],\"kube-api-burst\":[\"300\"],\"kube-api-qps\":[\"150\"],\"leader-elect\":[\"true\"],\"leader-elect-resource-lock\":[\"configmaps\"],\"leader-elect-retry-period\":[\"3s\"],\"port\":[\"0\"],\"pv-recycler-pod-template-filepath-hostpath\":[\"/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml\"],\"pv-recycler-pod-template-filepath-nfs\":[\"/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml\"],\"root-ca-file\":[\"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"],\"secure-port\":[\"10257\"],\"service-account-private-key-file\":[\"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key\"],\"service-cluster-ip-range\":[\"172.30.0.0/16\"],\"use-service-account-credentials\":[\"true\"]},\"kind\":\"KubeControllerManagerConfig\",\"serviceServingCert\":{\"certFile\":\"/etc/kubernetes/static-pod-resources/configmaps/service-ca/ca-bundle.crt\"}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-24T15:53:46Z",
+        "name": "config",
+        "namespace": "openshift-kube-controller-manager",
+        "resourceVersion": "6094",
+        "uid": "cbaf5bbe-1847-433e-812d-e9c12c254547"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath" 

--- a/applications/openshift/controller/controller_insecure_port_disabled/tests/insecure_binding_other.fail.sh
+++ b/applications/openshift/controller/controller_insecure_port_disabled/tests/insecure_binding_other.fail.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-controller-manager/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config"
+
+cat << EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiVersion\":\"kubecontrolplane.config.openshift.io/v1\",\"extendedArguments\":{\"allocate-node-cidrs\":[\"false\"],\"cert-dir\":[\"/var/run/kubernetes\"],\"cloud-provider\":[\"aws\"],\"cluster-cidr\":[\"10.128.0.0/14\"],\"cluster-name\":[\"wenshen-51-f2xqb\"],\"cluster-signing-cert-file\":[\"/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.crt\"],\"cluster-signing-key-file\":[\"/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.key\"],\"configure-cloud-routes\":[\"false\"],\"controllers\":[\"*\",\"-ttl\",\"-bootstrapsigner\",\"-tokencleaner\"],\"enable-dynamic-provisioning\":[\"true\"],\"experimental-cluster-signing-duration\":[\"720h\"],\"feature-gates\":[\"APIPriorityAndFairness=true\",\"RotateKubeletServerCertificate=true\",\"SupportPodPidsLimit=true\",\"NodeDisruptionExclusion=true\",\"ServiceNodeExclusion=true\",\"DownwardAPIHugePages=true\",\"LegacyNodeRoleBehavior=false\"],\"flex-volume-plugin-dir\":[\"/etc/kubernetes/kubelet-plugins/volume/exec\"],\"kube-api-burst\":[\"300\"],\"kube-api-qps\":[\"150\"],\"leader-elect\":[\"true\"],\"leader-elect-resource-lock\":[\"configmaps\"],\"leader-elect-retry-period\":[\"3s\"],\"port\":[\"8080\"],\"pv-recycler-pod-template-filepath-hostpath\":[\"/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml\"],\"pv-recycler-pod-template-filepath-nfs\":[\"/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml\"],\"root-ca-file\":[\"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"],\"secure-port\":[\"10257\"],\"service-account-private-key-file\":[\"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key\"],\"service-cluster-ip-range\":[\"172.30.0.0/16\"],\"use-service-account-credentials\":[\"true\"]},\"kind\":\"KubeControllerManagerConfig\",\"serviceServingCert\":{\"certFile\":\"/etc/kubernetes/static-pod-resources/configmaps/service-ca/ca-bundle.crt\"}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-24T15:53:46Z",
+        "name": "config",
+        "namespace": "openshift-kube-controller-manager",
+        "resourceVersion": "6094",
+        "uid": "cbaf5bbe-1847-433e-812d-e9c12c254547"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath" 
+
+

--- a/applications/openshift/controller/controller_insecure_port_disabled/tests/no_insecure_port.pass.sh
+++ b/applications/openshift/controller/controller_insecure_port_disabled/tests/no_insecure_port.pass.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# remediation = none
+yum install -y jq
+
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/api/v1/namespaces/openshift-kube-controller-manager/configmaps"
+
+config_apipath="/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config"
+
+cat << EOF > "$kube_apipath$config_apipath"
+{
+    "apiVersion": "v1",
+    "data": {
+        "config.yaml": "{\"apiVersion\":\"kubecontrolplane.config.openshift.io/v1\",\"extendedArguments\":{\"allocate-node-cidrs\":[\"false\"],\"cert-dir\":[\"/var/run/kubernetes\"],\"cloud-provider\":[\"aws\"],\"cluster-cidr\":[\"10.128.0.0/14\"],\"cluster-name\":[\"wenshen-51-f2xqb\"],\"cluster-signing-cert-file\":[\"/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.crt\"],\"cluster-signing-key-file\":[\"/etc/kubernetes/static-pod-certs/secrets/csr-signer/tls.key\"],\"configure-cloud-routes\":[\"false\"],\"controllers\":[\"*\",\"-ttl\",\"-bootstrapsigner\",\"-tokencleaner\"],\"enable-dynamic-provisioning\":[\"true\"],\"experimental-cluster-signing-duration\":[\"720h\"],\"feature-gates\":[\"APIPriorityAndFairness=true\",\"RotateKubeletServerCertificate=true\",\"SupportPodPidsLimit=true\",\"NodeDisruptionExclusion=true\",\"ServiceNodeExclusion=true\",\"DownwardAPIHugePages=true\",\"LegacyNodeRoleBehavior=false\"],\"flex-volume-plugin-dir\":[\"/etc/kubernetes/kubelet-plugins/volume/exec\"],\"kube-api-burst\":[\"300\"],\"kube-api-qps\":[\"150\"],\"leader-elect\":[\"true\"],\"leader-elect-resource-lock\":[\"configmaps\"],\"leader-elect-retry-period\":[\"3s\"],\"pv-recycler-pod-template-filepath-hostpath\":[\"/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml\"],\"pv-recycler-pod-template-filepath-nfs\":[\"/etc/kubernetes/static-pod-resources/configmaps/recycler-config/recycler-pod.yaml\"],\"root-ca-file\":[\"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"],\"secure-port\":[\"10257\"],\"service-account-private-key-file\":[\"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account.key\"],\"service-cluster-ip-range\":[\"172.30.0.0/16\"],\"use-service-account-credentials\":[\"true\"]},\"kind\":\"KubeControllerManagerConfig\",\"serviceServingCert\":{\"certFile\":\"/etc/kubernetes/static-pod-resources/configmaps/service-ca/ca-bundle.crt\"}}"
+    },
+    "kind": "ConfigMap",
+    "metadata": {
+        "creationTimestamp": "2022-01-24T15:53:46Z",
+        "name": "config",
+        "namespace": "openshift-kube-controller-manager",
+        "resourceVersion": "6094",
+        "uid": "cbaf5bbe-1847-433e-812d-e9c12c254547"
+    }
+}
+EOF
+
+jq_filter='[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$config_apipath" > "$filteredpath" 
+
+


### PR DESCRIPTION
This rule was checking if insecure port only binds to the loopback address, since the --port flag is deprecated from kube controller manager, the insecure port is disabled, therefore we updated this rule to check if the insecure port is present, or does it bind to a loopback address

Related Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=2040132, 

Github commit:https://github.com/openshift/cluster-kube-controller-manager-operator/commit/fc8d3bb3b90a22854e9d678351512823da725673#diff-eb046ac1c42be018b202cbf3b94b1f08716c318b257aa4931784c48fe0174372
