### PR TITLE
Use correct config file in ensure_gpgcheck_local_packages

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -3,29 +3,11 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: Check existence of yum on Fedora
-  stat:
-    path: /etc/yum.conf
-  register: yum_config_file
-  check_mode: no
-  when: ansible_distribution == "Fedora"
-
-# Old versions of Fedora use yum
 
 - name: Ensure GPG check Enabled for Local Packages (Yum)
   ini_file:
-    dest: /etc/yum.conf
+    dest: {{{ pkg_manager_config_file }}}
     section: main
     option: localpkg_gpgcheck
     value: 1
     create: True
-  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or yum_config_file.stat.exists)
-
-- name: Ensure GPG check Enabled for Local Packages (DNF)
-  ini_file:
-    dest: /etc/dnf/dnf.conf
-    section: main
-    option: localpkg_gpgcheck
-    value: 1
-    create: True
-  when: ansible_distribution == "Fedora"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -10,4 +10,5 @@
     section: main
     option: localpkg_gpgcheck
     value: 1
+    no_extra_spaces: yes
     create: True

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/comment.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# packages = python3-libselinux
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# packages = python3-libselinux
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/line_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# packages = python3-libselinux
 
 . $SHARED/group_updating_utils.sh
 

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+# packages = python3-libselinux
 
 . $SHARED/group_updating_utils.sh
 


### PR DESCRIPTION
#### Description:

- Apply the remediation to the package managers' config file defined by `product.yml`
- Add the package python3-libselinux to tests for `ensure_gpgcheck_local_packages`

#### Rationale:

- The RHEL remediation was hardcoded to use YUM, but depending on the major version, DNF could be used too.
