### PR TITLE
Kickstart file for ANSSI using authselect

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
@@ -68,6 +68,12 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # Set the system time zone (required)
 timezone --utc America/New_York
 

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -68,6 +68,12 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing
 selinux --enforcing

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
@@ -68,6 +68,12 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # Set the system time zone (required)
 timezone --utc America/New_York
 

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_minimal-ks.cfg
@@ -58,6 +58,12 @@ network --onboot yes --bootproto dhcp
 # to see how to create encrypted password form for different plaintext password
 rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # Set the system time zone (required)
 timezone --utc America/New_York
 

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
@@ -68,6 +68,12 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # Set the system time zone (required)
 timezone --utc America/New_York
 

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
@@ -68,6 +68,12 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing
 selinux --enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
@@ -68,6 +68,12 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # Set the system time zone (required)
 timezone --utc America/New_York
 

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
@@ -58,6 +58,12 @@ network --onboot yes --bootproto dhcp
 # to see how to create encrypted password form for different plaintext password
 rootpw --iscrypted $6$0WWGZ1e6icT$1KiHZK.Nzp3HQerfiy8Ic3pOeCWeIzA.zkQ7mkvYT3bNC5UeGK2ceE5b6TkSg4D/kiSudkT04QlSKknsrNE220
 
+# Set up the authentication options for the system (required)
+# sssd profile sets sha512 to hash passwords
+# passwords are shadowed by default
+# See the manual page for authselect-profile for a complete list of possible options.
+authselect select sssd
+
 # Set the system time zone (required)
 timezone --utc America/New_York
 


### PR DESCRIPTION
Since rhel8, it is recommended to use authselect profiles to make PAM settings more manageable and less error prone.

This makes possible to properly apply the remediations for required PAM rules.