### PR TITLE
Fix ansible remediation for configure_gnutls_tls_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
@@ -15,7 +15,7 @@
     follow: yes
   register: gnutls_file
 
-- name: "{{{ rule_title }}}: Add"
+- name: "{{{ rule_title }}}: Create file and add line"
   lineinfile:
     path: "{{ path }}"
     regexp: "{{ lineinfile_reg }}"

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/ansible/shared.yml
@@ -21,25 +21,25 @@
     regexp: "{{ lineinfile_reg }}"
     line: "{{ correct_value }}"
     create: yes
-  when: not gnutls_file.stat.exists or gnutls_file.stat.size <= correct_value|length
+  when: not gnutls_file.stat.exists
 
 - name: "{{{ rule_title }}}"
   block:
-    - name: "{{{ rule_title }}}: Existing value check"
-      lineinfile:
-        path: "{{ path }}"
-        create: false
-        regexp: "{{ lineinfile_reg }}"
-        state: absent
-      check_mode: true
-      changed_when: false
-      register: gnutls
-
     - name: "{{{ rule_title }}}: Update"
       replace:
         path: "{{ path }}"
         regexp: (\+VERS-ALL(?::-VERS-[A-Z]+\d\.\d)+)
         replace: "{{ correct_value }}"
-      when: gnutls.found is defined and gnutls.found != 1
+      register: gnutls_crypto_replaced
 
-  when: gnutls_file.stat.exists and gnutls_file.stat.size > correct_value|length
+    - name: "{{{ rule_title }}}: Existing value check"
+      lineinfile:
+        path: "{{ path }}"
+        line: "{{ correct_value }}"
+        create: false
+        regexp: "{{ lineinfile_reg }}"
+        state: present
+      when: gnutls_crypto_replaced is not changed
+
+  when: gnutls_file.stat.exists
+

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 


### PR DESCRIPTION
#### Description:

- make tests applicable for rhel9 as well
- rewrite the remediation

#### Rationale:

The remediation did not apply changes if there was no line which would match regexp.