### PR TITLE
sshd_lineinfile ansible macro dir support and directory check fix

### DIFF
--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -174,8 +174,12 @@ value: :code:`Setting={{ varname1 }}`
   We also specify the validation program here; -t specifies test and -f allows
   Ansible to pass a file at a different path.
 #}}
-{{%- macro ansible_sshd_set(msg='', parameter='', value='') %}}
+{{%- macro ansible_sshd_set(msg='', parameter='', value='', config_is_distributed="false") %}}
+{{%- if config_is_distributed == "true" %}}
+{{{ ansible_set_config_file_dir(msg, config_file="/etc/ssh/sshd_config", config_dir="/etc/ssh/sshd_config.d", set_file="/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf", parameter=parameter, separator_regex="\s+", value=value, prefix_regex="^\s*", create='yes', validate='/usr/sbin/sshd -t -f %s', insert_after='', insert_before="^[#\s]*Match") }}}
+{{%- else %}}
 {{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^[#\s]*Match") }}}
+{{%- endif %}}
 {{%- endmacro %}}
 
 

--- a/shared/macros-ansible.jinja
+++ b/shared/macros-ansible.jinja
@@ -157,8 +157,7 @@ value: :code:`Setting={{ varname1 }}`
 {{%- set new_line = parameter + separator + value -%}}
 - name: '{{{ msg or rule_title }}}'
   block:
-    {{{ ansible_lineinfile("Check for duplicate values", config_file, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True)|indent }}}
-    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
+    {{{ ansible_lineinfile("Deduplicate values from " + config_file, config_file, regex=line_regex, create='no', state='absent')|indent }}}
     {{{ ansible_stat("Check if " + config_dir + " exists", path=config_dir, register=dir_exists)|indent }}}
     {{{ ansible_find("Check if the parameter " + parameter + " is present in " + config_dir, paths=config_dir, contains=line_regex, register=dir_parameter, when=find_when)|indent }}}
     {{{ ansible_lineinfile("Remove parameter from files in " + config_dir, path="{{ item.path }}", regex=line_regex, state="absent", with_items=lineinfile_items, when=lineinfile_when)|indent }}}

--- a/shared/templates/sshd_lineinfile/ansible.template
+++ b/shared/templates/sshd_lineinfile/ansible.template
@@ -6,6 +6,7 @@
 {{{
     ansible_sshd_set(
         parameter=PARAMETER,
-        value=VALUE
+        value=VALUE,
+        config_is_distributed=sshd_distributed_config
     )
 }}}


### PR DESCRIPTION
#### Description:
Add support for directory check in sshd macro:

- `config_file="/etc/ssh/sshd_config"` - remove configuration from this file
- `config_dir="/etc/ssh/sshd_config.d"` - remove configuration from this directory
- `set_file="/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf"` - configure in this file - we use the same file in Bash remediation

Fix for `ansible_set_config_file_dir`:

- it did not remove configuration line from `config_file` because of `dupes.found is defined and dupes.found > 1` condition was resulting in false

