### PR TITLE
Make rule network_nmcli_permissions applicable only when polkit is installed

### DIFF
--- a/linux_os/guide/system/network/network_nmcli_permissions/rule.yml
+++ b/linux_os/guide/system/network/network_nmcli_permissions/rule.yml
@@ -25,6 +25,9 @@ rationale: |-
     untrusted access, prevent system availability, and/or can lead to a compromise or
     attack.
 
+platforms:
+    - polkit
+
 severity: medium
 
 identifiers:

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -49,6 +49,11 @@ cpes:
       title: "Package pam is installed"
       check_id: installed_env_has_pam_package
 
+  - polkit:
+      name: "cpe:/a:polkit"
+      title: "Package pollkit is installed"
+      check_id: installed_env_has_polkit_package
+
   - postfix:
       name: "cpe:/a:postfix"
       title: "Package postfix is installed"

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -51,7 +51,7 @@ cpes:
 
   - polkit:
       name: "cpe:/a:polkit"
-      title: "Package pollkit is installed"
+      title: "Package polkit is installed"
       check_id: installed_env_has_polkit_package
 
   - postfix:

--- a/shared/checks/oval/installed_env_has_polkit_package.xml
+++ b/shared/checks/oval/installed_env_has_polkit_package.xml
@@ -1,0 +1,20 @@
+<def-group>
+
+  <definition class="inventory"
+  id="installed_env_has_polkit_package" version="1">
+    <metadata>
+      <title>Package chrony is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package polkit is installed.</description>
+      <reference ref_id="cpe:/a:polkit" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package polkit is installed" test_ref="test_env_has_polkit_installed" />
+    </criteria>
+  </definition>
+
+  {{{ oval_test_package_installed(package='polkit', evr='', test_id='test_env_has_polkit_installed') }}}
+
+</def-group>

--- a/shared/checks/oval/installed_env_has_polkit_package.xml
+++ b/shared/checks/oval/installed_env_has_polkit_package.xml
@@ -3,7 +3,7 @@
   <definition class="inventory"
   id="installed_env_has_polkit_package" version="1">
     <metadata>
-      <title>Package chrony is installed</title>
+      <title>Package polkit is installed</title>
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>


### PR DESCRIPTION
#### Description:

- add new platform polkit which checks for polkit package
- add this platform to rule network_nmcli_permissions

#### Rationale:

The rule needs polkit to be effective. If no polkit is installed, non-privileged users do not have permissions to modify network connections.