### PR TITLE
On OSPP installation, the primary reason for having rsyslog installed…

### DIFF
--- a/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
@@ -31,6 +31,7 @@ references:
     iso27001-2013: A.12.4.1,A.12.4.2,A.12.4.3,A.12.4.4,A.12.7.1
     nist: CM-6(a)
     nist-csf: PR.PT-1
+    ospp: FTP_ITC_EXT.1.1
     srg: SRG-OS-000479-GPOS-00224,SRG-OS-000051-GPOS-00024,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-030670
     stigid@rhel8: RHEL-08-030670


### PR DESCRIPTION

#### Description:

- Add SFR reference.

#### Rationale:

- On OSPP installation, the primary reason for having rsyslog installed  is to enable the trusted channel for auditing.
