### PR TITLE
Configuring the CA certificate targets the TLS "internal" requirements, so FTP_ITC_EXT.1.1 is not needed.

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
@@ -27,7 +27,7 @@ identifiers:
 references:
     anssi: BP28(R43)
     ism: 0988,1405
-    ospp: FCS_TLSC_EXT.1,FTP_ITC_EXT.1.1
+    ospp: FCS_TLSC_EXT.1
     srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: 'CA certificate for rsyslog remote logging via TLS is not set'


### PR DESCRIPTION

#### Description:

- ITC_EXT.1.1 is not needed.

#### Rationale:

- Configuring the CA certificate targets the TLS "internal" requirements.
