### PR TITLE
Amend OSPP references for rsyslog omfwd/gtls configuration.

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/rule.yml
@@ -29,7 +29,7 @@ references:
     anssi: BP28(R43)
     ism: 0988,1405
     nist: AU-9(3),CM-6(a)
-    ospp: FCS_TLSC_EXT.1,FTP_ITC_EXT.1.1
+    ospp: FCS_TLSC_EXT.1,FTP_ITC_EXT.1.1,FIA_X509_EXT.1.1,FMT_SMF_EXT.1.1
     srg: SRG-OS-000480-GPOS-00227,SRG-OS-000120-GPOS-00061
 
 ocil_clause: 'omfwd is not configured with gtls and AuthMode'


### PR DESCRIPTION

#### Description:

- Amend OSPP references for rsyslog omfwd/gtls configuration.

#### Rationale:

- Using `streamdriver.CheckExtendedKeyPurpose="on"` comes from FIA_X509_EXT.1 as it calls for "validate the extendedKeyUsage field according to the following rules ...".
- The `Target="<remote system>"` comes from FMT_SMF_EXT.1 and its "Configure name/address of audit/logging server to which to send audit/logging records".
