### PR TITLE
The write_logs is related to where audit records end up stored, not what records get generated.

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/rule.yml
@@ -21,7 +21,7 @@ identifiers:
 
 references:
     nist: CM-6
-    ospp: FAU_GEN.1.1.c
+    ospp: FAU_STG.1
     srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: write_logs isn't set to yes


### PR DESCRIPTION

#### Description:

- Update the OSPP SFR reference.

#### Rationale:

- The write_logs is related to where audit records end up stored, not what records get generated.
