### PR TITLE
Adapt to a shift to a simpler datatype

### DIFF
--- a/utils/render-rules.py
+++ b/utils/render-rules.py
@@ -21,7 +21,7 @@ class HtmlOutput(template_renderer.Renderer):
     TEMPLATE_NAME = "rules-template.html"
 
     def _get_all_compiled_profiles(self):
-        compiled_profiles = glob(str(self.built_content_path / "profiles" / "*.profile"))
+        compiled_profiles = glob(os.path.join(self.built_content_path, "profiles", "*.profile"))
         profiles = []
         for p in compiled_profiles:
             profiles.append(ssg.build_yaml.Profile.from_yaml(p, self.env_yaml))


### PR DESCRIPTION
Rendering became part of the build process due to its role in generating tables, so it had to be Python2-compatible.
As a result, some utilities were still assuming usage of pathlib, while there are only strings now.