### PR TITLE
remove configure_gnutls_tls_crypto_policy from rhel9

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhel9
+prodtype: fedora,ol8,rhel8
 
 title: 'Configure GnuTLS library to use DoD-approved TLS Encryption'
 

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -215,7 +215,7 @@ selections:
     - configure_openssl_tls_crypto_policy
 
     # RHEL-08-010295
-    - configure_gnutls_tls_crypto_policy
+    #- configure_gnutls_tls_crypto_policy - the format changed in rhel9, needs new rule
 
     # RHEL-08-010300
     - file_permissions_binary_dirs


### PR DESCRIPTION
#### Description:

- remove rhel9 prodtype from the rule
- remove the rule from all rhel9 profiles

#### Rationale:

- the format of configuration for gnutls has changed in rhel9 and the rule can't be used in the current form.