### PR TITLE
Use var ansible_pkg_mgr to determine GPG checking

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/ansible/shared.yml
@@ -3,15 +3,6 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: Check existence of yum on Fedora
-  stat:
-    path: /etc/yum.conf
-  register: yum_config_file
-  check_mode: no
-  when: ansible_distribution == "Fedora"
-
-# Old versions of Fedora use yum
-
 - name: Ensure GPG check is globally activated (yum)
   ini_file:
     dest: /etc/yum.conf
@@ -20,7 +11,7 @@
     value: 1
     no_extra_spaces: yes
     create: False
-  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or yum_config_file.stat.exists)
+  when: ansible_pkg_mgr == "yum"
 
 - name: Ensure GPG check is globally activated (dnf)
   ini_file:
@@ -30,4 +21,4 @@
     value: 1
     no_extra_spaces: yes
     create: False
-  when: ansible_distribution == "Fedora"
+  when: ansible_pkg_mgr == "dnf"

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -3,15 +3,6 @@
 # strategy = unknown
 # complexity = low
 # disruption = medium
-- name: Check existence of yum on Fedora
-  stat:
-    path: /etc/yum.conf
-  register: yum_config_file
-  check_mode: no
-  when: ansible_distribution == "Fedora"
-
-# Old versions of Fedora use yum
-
 - name: Ensure GPG check Enabled for Local Packages (Yum)
   ini_file:
     dest: /etc/yum.conf
@@ -19,7 +10,7 @@
     option: localpkg_gpgcheck
     value: 1
     create: True
-  when: (ansible_distribution == "RedHat" or ansible_distribution == "CentOS" or ansible_distribution == "Scientific" or yum_config_file.stat.exists)
+  when: ansible_pkg_mgr == "yum"
 
 - name: Ensure GPG check Enabled for Local Packages (DNF)
   ini_file:
@@ -28,4 +19,4 @@
     option: localpkg_gpgcheck
     value: 1
     create: True
-  when: ansible_distribution == "Fedora"
+  when: ansible_pkg_mgr == "dnf"


### PR DESCRIPTION
#### Description:

Use package manager from Ansible facts to determine which task should be run for GPG checking

#### Rationale:

* GPG check will work on all EL distribution using yum or dnf, including RockyOS