### PR TITLE
Removed criteria in OVAL check of require_singleuser_auth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -6,9 +6,11 @@
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_rescue_service" />
+      {{%- if product != "ol8" -%}}
       <criterion test_ref="test_require_rescue_service_runlevel1" />
       <criterion test_ref="test_no_custom_runlevel1_target" negate="true"/>
       <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
+      {{%- endif -%}}
     </criteria>
     {{%- else -%}}
     <criteria>
@@ -40,6 +42,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  {{%- if product != "ol8" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that the systemd rescue.service is in the runlevel1.target"
     id="test_require_rescue_service_runlevel1" version="1">
@@ -74,6 +77,7 @@
     <unix:path operation="equals">/etc/systemd/system</unix:path>
     <unix:filename operation="pattern match">^runlevel1.target$</unix:filename>
   </unix:file_object>
+  {{%- endif -%}}
   {{%- else -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="Tests that the SINGLE variable in the /etc/sysconfig/init file is set to /sbin/sulogin, to ensure that a password must be entered to access single user mode"

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -6,7 +6,7 @@
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_rescue_service" />
-      {{%- if product != "ol8" -%}}
+      {{%- if product not in ["ol8", "rhel8"] -%}}
       <criterion test_ref="test_require_rescue_service_runlevel1" />
       <criterion test_ref="test_no_custom_runlevel1_target" negate="true"/>
       <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
@@ -42,7 +42,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{%- if product != "ol8" -%}}
+  {{%- if product not in ["ol8", "rhel8"] -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that the systemd rescue.service is in the runlevel1.target"
     id="test_require_rescue_service_runlevel1" version="1">


### PR DESCRIPTION
#### Description:

- Removed unnecessary criteria in OVAL check of **require_singleuser_auth** rule

#### Rationale:

- DISA, in its stig profile for OL08-00-010151 and RHEL-08-010151, only requires the presence of:
`ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue `
in the `/usr/lib/systemd/system/rescue.service` file. The other criteria are not mentioned.

