### PR TITLE
Update OL8 stig profile rule selection

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/rule.yml
@@ -33,6 +33,7 @@ references:
     nist: AC-6(1),CM-6(a)
     nist-csf: PR.IP-2
     srg: SRG-OS-000480-GPOS-00228,SRG-OS-000480-GPOS-00227
+    stigid@ol8: OL08-00-020353
     stigid@rhel8: RHEL-08-020353
 
 ocil_clause: 'the above command returns no output, or if the umask is configured incorrectly'

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -35,6 +35,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),CM-6(b),CM-6.1(iv)
     nist-csf: DE.CM-1,PR.DS-4,PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol8: OL08-00-040260
     stigid@sle12: SLES-12-030364
     stigid@sle15: SLES-15-040381
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/rule.yml
@@ -27,7 +27,6 @@ references:
     anssi: BP28(R40)
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
-    stigid@ol8: OL08-00-010700
     stigid@rhel8: RHEL-08-010700
 
 ocil_clause: 'there is output'

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/rule.yml
@@ -34,6 +34,7 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021031
+    stigid@ol8: OL08-00-010700
     stigid@rhel7: RHEL-07-021031
 
 ocil_clause: 'there is output'

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -1101,6 +1101,7 @@ selections:
 
     # OL08-00-040260
     - sysctl_net_ipv4_ip_forward
+    - sysctl_net_ipv6_conf_all_forwarding
 
     # OL08-00-040261
     - sysctl_net_ipv6_conf_all_accept_ra

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -411,7 +411,7 @@ selections:
     - accounts_user_home_paths_only
 
     # OL08-00-010700
-    - dir_perms_world_writable_root_owned
+    - dir_perms_world_writable_system_owned
 
     # OL08-00-010710
 

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -610,6 +610,7 @@ selections:
 
     # OL08-00-020353
     - accounts_umask_etc_bashrc
+    - accounts_umask_etc_csh_cshrc
 
     # OL08-00-030000
     - audit_rules_suid_privilege_function


### PR DESCRIPTION
#### Description:

- Add `accounts_umask_etc_csh_cshrc` and `sysctl_net_ipv6_conf_all_forwarding` rules to OL8 stig profile
- Also replace `dir_perms_world_writable_root_owned` with `dir_perms_world_writable_system_owned`
- Update the `stigid@ol8` entries on the corresponding rules

#### Rationale:

- Oracle Linux STIG efforts
