### PR TITLE
Add place for site specific information

### DIFF
--- a/applications/intro/site-local/group.yml
+++ b/applications/intro/site-local/group.yml
@@ -1,0 +1,6 @@
+documentation_complete: true
+
+title: "Site Specific Information"
+
+description: |-
+  {{{ xccdf_value("site_local_message") }}}

--- a/applications/intro/site-local/group.yml
+++ b/applications/intro/site-local/group.yml
@@ -3,4 +3,4 @@ documentation_complete: true
 title: "Site Specific Information"
 
 description: |-
-  {{{ xccdf_value("site_local_message") }}}
+  {{{ xccdf_value("var_site_local_message") }}}

--- a/applications/intro/site-local/var_site_local_message.var
+++ b/applications/intro/site-local/var_site_local_message.var
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Site Local Message'
+
+description: |-
+  Enter an specific site local message for administrators configuring system security.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: Please review the administration policy for your environment.


### PR DESCRIPTION
#### Description:

Add a location to insert site specific information in tailoring files

#### Rationale:

For my site I'd like to add a link to our site computing policy for sys admins, admin training guides for PII, and system registration process.  There isn't a great place to put that information in a tailored profile today.

In my local tests I couldn't seem to get this to work, so I fear I'm doing something wrongly....
