### PR TITLE
Remove more deprecated RHEL6 references from the project.

### DIFF
--- a/build_product
+++ b/build_product
@@ -266,7 +266,7 @@ set_no_derivatives_options() {
 	if grep -q 'rhel' <<< "${_arg_product[*]}"; then
 		CMAKE_OPTIONS+=("-DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=OFF")
 	fi
-	if grep -q 'rhel\(6\|7\)' <<< "${_arg_product[*]}"; then
+	if grep -q 'rhel7' <<< "${_arg_product[*]}"; then
 		CMAKE_OPTIONS+=("-DSSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED:BOOL=OFF")
 	fi
 }

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -629,7 +629,7 @@ macro(ssg_build_sds PRODUCT)
         )
     endif()
 
-    if("${PRODUCT}" MATCHES "rhel(6|7|8|9)")
+    if("${PRODUCT}" MATCHES "rhel(7|8|9)")
         add_test(
             NAME "missing-cces-${PRODUCT}"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"

--- a/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_enhanced-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_enhanced-ks.cfg
@@ -49,11 +49,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_high-ks.cfg
@@ -49,11 +49,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_intermediary-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_intermediary-ks.cfg
@@ -49,11 +49,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_minimal-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-anssi_nt28_minimal-ks.cfg
@@ -49,11 +49,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-cis-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis-ks.cfg
@@ -48,11 +48,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-cis_server_l1-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis_server_l1-ks.cfg
@@ -48,11 +48,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l1-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l1-ks.cfg
@@ -48,11 +48,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l2-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-cis_workstation_l2-ks.cfg
@@ -48,11 +48,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-e8-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-e8-ks.cfg
@@ -48,11 +48,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-hipaa-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-hipaa-ks.cfg
@@ -48,11 +48,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-ospp-ks.cfg
@@ -49,11 +49,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-stig-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-stig-ks.cfg
@@ -40,11 +40,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel7/kickstart/ssg-rhel7-stig_gui-ks.cfg
+++ b/products/rhel7/kickstart/ssg-rhel7-stig_gui-ks.cfg
@@ -40,11 +40,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_minimal-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-cis_server_l1-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis_server_l1-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l1-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l1-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l2-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis_workstation_l2-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cui-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-e8-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-hipaa-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-ospp-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_enhanced-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_high-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_intermediary-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-anssi_bp28_minimal-ks.cfg
@@ -44,11 +44,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-cis_server_l1-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_server_l1-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l1-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l1-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l2-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cis_workstation_l2-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-cui-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-e8-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-e8-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-hipaa-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-hipaa-ks.cfg
@@ -45,11 +45,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --device eth0 --bootproto dhcp --noipv6
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-ospp-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)

--- a/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
@@ -42,11 +42,6 @@ keyboard us
 # --device	device to be activated and / or configured with the network command
 # --bootproto	method to obtain networking configuration for device (default dhcp)
 # --noipv6	disable IPv6 on this device
-#
-# NOTE: Usage of DHCP will fail CCE-27021-5 (DISA FSO RHEL-06-000292). To use static IP configuration,
-#       "--bootproto=static" must be used. For example:
-# network --bootproto=static --ip=10.0.2.15 --netmask=255.255.255.0 --gateway=10.0.2.254 --nameserver 192.168.2.1,192.168.3.1
-#
 network --onboot yes --bootproto dhcp
 
 # Set the system's root password (required)


### PR DESCRIPTION
#### Description:

- Remove more deprecated RHEL6 references from the project.

#### Rationale:

- RHEL6 content is not part of the project anymore for a long time now.
