### PR TITLE
Remove duplicated STIG rule. RHEL-08-010560 is now removed from V1R5.

### DIFF
--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -584,11 +584,6 @@ controls:
         rules:
             - sshd_disable_root_login
         status: automated
-    -   id: RHEL-08-010560
-        levels:
-            - medium
-        title: The auditd service must be running in RHEL 8.
-        status: pending
     -   id: RHEL-08-010561
         levels:
             - medium

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -368,9 +368,6 @@ selections:
     # RHEL-08-010550
     - sshd_disable_root_login
 
-    # RHEL-08-010560
-    - service_auditd_enabled
-
     # RHEL-08-010561
     - service_rsyslog_enabled
 

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -369,9 +369,6 @@ selections:
     # RHEL-08-010550
     - sshd_disable_root_login
 
-    # RHEL-08-010560
-    - service_auditd_enabled
-
     # RHEL-08-010561
     - service_rsyslog_enabled
 


### PR DESCRIPTION
#### Description:

- Remove duplicated STIG rule. RHEL-08-010560 is now removed from V1R5. The RHEL-08-030181 was kept to cover this requirement.
