### PR TITLE
Add missing rsync dependency to gh-pages workflow

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -12,7 +12,7 @@ jobs:
       PAGES_DIR: __pages
     steps:
       - name: Install Deps
-        run: dnf install -y cmake git ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible-lint expat libxslt python3-pip
+        run: dnf install -y cmake git ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible-lint expat libxslt python3-pip rsync
       - name: Install deps python
         run: pip3 install json2html
       - name: Checkout


### PR DESCRIPTION
#### Description:

- Add missing rsync dependency to gh-pages workflow.

#### Rationale:

- Without this package the github action is not able to publish the
generated artifacts.

The page preview led to a confusion because what was being presented there was something previously built.
