### PR TITLE
Add workaround to gitpod so the container image can be built.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -15,5 +15,6 @@ tasks:
       mkdir -p .vscode && cp .gitpod.launch.json .vscode/launch.json
       sed -i "s/&&DEFAULT_PRODUCT&&/$PRODUCT/g" .vscode/launch.json
       ssh-keygen -N '' -f ~/.ssh/id_rsa
+      sed -i 's/^ARG ADDITIONAL_PACKAGES/ARG ADDITIONAL_PACKAGES\nADD https:\/\/github.com\/AkihiroSuda\/clone3-workaround\/releases\/download\/v1.0.0\/clone3-workaround.x86_64 \/clone3-workaround\nRUN chmod 755 \/clone3-workaround\nSHELL ["\/clone3-workaround","\/bin\/sh", "-c"]\n/g' Dockerfiles/test_suite-fedora
       docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f Dockerfiles/test_suite-fedora .
       ./build_product $PRODUCT --datastream-only

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -435,7 +435,7 @@ class DockerTestEnv(ContainerTestEnv):
             img, "/usr/sbin/sshd -p {} -D".format(self.internal_ssh_port),
             name="{0}_{1}".format(self._name_stem, container_name),
             ports={"{}".format(self.internal_ssh_port): None},
-            detach=True)
+            detach=True, security_opt=["seccomp=unconfined"])
         return result
 
     def get_ip_address(self):


### PR DESCRIPTION
#### Description:

- Add workaround to gitpod so the container image can be built.

#### Rationale:

- This hackish workaround was the only way I found to get the docker build working. I expected that it would work with latest versions of docker as described in the articles/issues below but I didn't have success. I'm not sure if it was because of gitpod builds something was not being updated, but it didn't seem to be the case, I even tried updating packages manually.
- (solution comes from here) https://medium.com/nttlabs/ubuntu-21-10-and-fedora-35-do-not-work-on-docker-20-10-9-1cd439d9921
- https://github.com/containerd/containerd/issues/6203
- https://github.com/moby/moby/issues/42680

There is still something wrong when it tries to run oscap on Fedora which also seems related to the links above. Needs more investigation. On my fork it used to work because it had very different versions of packages and I believe at that point the build was done and was kept to be used in future environments.
```
E: oscap: Cannot create probe thread [oscap(96):oscap(7f96eec82900):sch_queue.c:63:sch_queue_connect]
D: oscap: FAIL: errno=1, Operation not permitted. [oscap(96):oscap(7f96eec82900):seap.c:117:SEAP_connect]
W: oscap: Can't connect: 1, Operation not permitted. [oscap(96):oscap(7f96eec82900):oval_probe_ext.c:447:oval_probe_comm]
E: oscap: Connect: retry limit (0) reached. [oscap(96):oscap(7f96eec82900):oval_probe_ext.c:457:oval_probe_comm]
OpenSCAP Error: Can't connect to the probe [/builddir/build/BUILD/openscap-1.3.5/src/OVAL/oval_probe_ext.c:461]
```
