### PR TITLE
Update denylisted folders in choosing_policy_page.py script

### DIFF
--- a/utils/choosing_policy_page.py
+++ b/utils/choosing_policy_page.py
@@ -17,7 +17,9 @@ def get_data(ssg_root):
     for product_file in p.glob("**/product.yml"):
         product_dir = product_file.parent
         product_id = product_dir.name
-        if product_id in ["example", "test_playbook_builder_data"]:
+        # disregard folders that contain samples of product.yml files
+        # they are not a real product folder
+        if product_id in ["data", "example", "test_playbook_builder_data"]:
             continue
         with open(product_file, "r") as f:
             product_yaml = yaml.full_load(f)


### PR DESCRIPTION
#### Description:
- Update denylisted folders in choosing_policy_page.py script
  - There was another folder that contained a sample product.yml used by
tests that it's not a real product directory. This lead to an empty
section of the guide's page.

The bogus section (https://complianceascode.github.io/content/guides/index.html):
![Screenshot from 2022-02-04 19-49-59](https://user-images.githubusercontent.com/18730394/152586065-8582fc02-fee6-42a7-8aa9-f620d79c93eb.png)

@evgenyz I believe this is the last PR related to this topic :face_exhaling: 

