### PR TITLE
Select an older version of Fedora image (34) in gitpod.

### DIFF
--- a/.gitpod.launch.json
+++ b/.gitpod.launch.json
@@ -65,7 +65,7 @@
           "--add-product-to-fips-certified",
           "fedora",
           "--add-platform",
-          "cpe:/o:fedoraproject:fedora:35",
+          "&&CPE&&",
           "${command:content-navigator.getRuleId}"
       ]
     },

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -12,8 +12,11 @@ tasks:
   - name: Prepare Env
     init: |
       [ -z "$PRODUCT" ] && PRODUCT="fedora"
+      [ -z "$CONTAINER" ] && CONTAINER="fedora:34"
+      [ -z "$CPE" ] && CPE="cpe:/o:fedoraproject:fedora:34"
       mkdir -p .vscode && cp .gitpod.launch.json .vscode/launch.json
       sed -i "s/&&DEFAULT_PRODUCT&&/$PRODUCT/g" .vscode/launch.json
+      sed -i "s,&&CPE&&,$CPE,g" .vscode/launch.json
       ssh-keygen -N '' -f ~/.ssh/id_rsa
-      docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f Dockerfiles/test_suite-fedora .
+      docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite --build-arg IMAGE=$CONTAINER -f Dockerfiles/test_suite-fedora .
       ./build_product $PRODUCT --datastream-only

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -1,5 +1,6 @@
 # This Dockerfile is a minimal example for a RHEL-based SSG test suite target container.
-FROM fedora
+ARG IMAGE=fedora
+FROM $IMAGE
 
 ENV AUTH_KEYS=/root/.ssh/authorized_keys
 


### PR DESCRIPTION
#### Description:
- Select an older version of Fedora image (34) in gitpod.
  - The current version (35) is not working due to a problem with docker and
clone3 system call. It should be updated in the future, but for now it
should be able to build the 34 image. Adapt the script to proper fill
the context of Fedora 34 image.

#### Rationale:

- This is a mitigation for: https://github.com/ComplianceAsCode/content/pull/8157
