### PR TITLE
Create OVAL check for selinux_context_elevation_for_sudo [OL7]

### DIFF
--- a/linux_os/guide/system/selinux/selinux_context_elevation_for_sudo/oval/shared.xml
+++ b/linux_os/guide/system/selinux/selinux_context_elevation_for_sudo/oval/shared.xml
@@ -1,0 +1,78 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Elevate The SELinux Context When An Administrator Calls The Sudo Command") }}}
+    <criteria comment="Sudo elevate the SELinux type and role to sysadm_t and sysadm_r"
+    operator="AND" >
+      <criterion comment="check configuration in /etc/sudoers and /etc/sudoers.d/*" 
+      test_ref="test_sudo_selinux_elevation_type" />
+      <criterion comment="check configuration in /etc/sudoers and /etc/sudoers.d/*" 
+      test_ref="test_sudo_selinux_elevation_role" />
+      <criterion comment="Verify that results come from only one file" 
+      test_ref="test_sudo_selinux_context_elevation_for_sudo_n_files" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist"
+  comment="check correct configuration in /etc/sudoers and /etc/sudoers.d/*"
+  id="test_sudo_selinux_elevation_type" version="1">
+    <ind:object object_ref="obj_sudo_selinux_elevation_type"/>
+    <ind:state state_ref="state_sudo_selinux_elevation_type" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist"
+  comment="check correct configuration in /etc/sudoers and /etc/sudoers.d/*"
+  id="test_sudo_selinux_elevation_role" version="1">
+    <ind:object object_ref="obj_sudo_selinux_elevation_role"/>
+    <ind:state state_ref="state_sudo_selinux_elevation_role" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_sudo_selinux_elevation_type" version="1">
+    <ind:filepath operation="pattern match">^/etc/sudoers(\.d/.*)?$</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*%wheel.*TYPE=(\w+).*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="obj_sudo_selinux_elevation_role" version="1">
+    <ind:filepath operation="pattern match">^/etc/sudoers(\.d/.*)?$</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*%wheel.*ROLE=(\w+).*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_sudo_selinux_elevation_type"
+  version="1">
+    <ind:subexpression operation="equals">sysadm_t</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_sudo_selinux_elevation_role"
+  version="1">
+    <ind:subexpression operation="equals">sysadm_r</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:variable_test check="all" check_existence="all_exist"
+  comment="Verify that results come from only one file"
+  id="test_sudo_selinux_context_elevation_for_sudo_n_files" version="1">
+    <ind:object object_ref="obj_sudo_selinux_context_elevation_for_sudo_n_files" />
+    <ind:state state_ref="state_sudo_selinux_context_elevation_for_sudo_n_files" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sudo_selinux_context_elevation_for_sudo_n_files" version="1">
+    <ind:var_ref>local_variable_counter_sudo_selinux_context_elevation_for_sudo_n_files</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_sudo_selinux_context_elevation_for_sudo_n_files" version="1">
+    <ind:value operation="equals" datatype="int">1</ind:value>
+  </ind:variable_state>
+
+  <local_variable comment="Items counter" datatype="int" 
+  id="local_variable_counter_sudo_selinux_context_elevation_for_sudo_n_files" version="1">
+    <count>
+        <unique>
+            <object_component object_ref="obj_sudo_selinux_elevation_role"
+            item_field="filepath" />
+            <object_component object_ref="obj_sudo_selinux_elevation_type"
+            item_field="filepath" />
+        </unique>
+    </count>
+  </local_variable>
+
+</def-group>


### PR DESCRIPTION
#### Description:

- Implement first version of OVAL check for the rule selinux_context_elevation_for_sudo. 

#### Rationale:

- This rule didn't have automated content, Done to meet DISA STIG OL07-00-020023  requirement
