### PR TITLE
Oval update for two rules to only allow results from only one file [ol7]

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
@@ -3,6 +3,10 @@
     {{{ oval_metadata("'Ensure sudo timestamp_timeout is appropriate - sudo timestamp_timeout") }}}
     <criteria comment="The timestamp_timeout should be configured" >
       <criterion comment="check configuration in /etc/sudoers" test_ref="test_sudo_timestamp_timeout" />
+      {{% if product == "ol7" %}}
+      <criterion comment="Verify that results come from only one file" 
+      test_ref="test_sudo_require_reauthentication_n_files" />
+      {{% endif %}}
     </criteria>
   </definition>
 
@@ -21,5 +25,32 @@
   version="1">
     <ind:subexpression datatype="int" operation="greater than or equal">0</ind:subexpression>
   </ind:textfilecontent54_state>
+
+  {{% if product == "ol7" %}}
+  <ind:variable_test check="all" check_existence="all_exist"
+  comment="Verify that results come from only one file"
+  id="test_sudo_require_reauthentication_n_files" version="1">
+    <ind:object object_ref="obj_sudo_require_reauthentication_n_files" />
+    <ind:state state_ref="state_sudo_require_reauthentication_n_files" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sudo_require_reauthentication_n_files" version="1">
+    <ind:var_ref>local_variable_counter_sudo_require_reauthentication_n_files</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_sudo_require_reauthentication_n_files" version="1">
+    <ind:value operation="equals" datatype="int">1</ind:value>
+  </ind:variable_state>
+
+  <local_variable comment="Items counter" datatype="int" 
+  id="local_variable_counter_sudo_require_reauthentication_n_files" version="1">
+    <count>
+        <unique>
+          <object_component object_ref="obj_sudo_timestamp_timeout"
+          item_field="filepath" />
+        </unique>
+    </count>
+  </local_variable>
+  {{% endif %}}
 
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
@@ -3,10 +3,6 @@
     {{{ oval_metadata("'Ensure sudo timestamp_timeout is appropriate - sudo timestamp_timeout") }}}
     <criteria comment="The timestamp_timeout should be configured" >
       <criterion comment="check configuration in /etc/sudoers" test_ref="test_sudo_timestamp_timeout" />
-      {{% if product == "ol7" %}}
-      <criterion comment="Verify that results come from only one file" 
-      test_ref="test_sudo_require_reauthentication_n_files" />
-      {{% endif %}}
     </criteria>
   </definition>
 
@@ -25,32 +21,5 @@
   version="1">
     <ind:subexpression datatype="int" operation="greater than or equal">0</ind:subexpression>
   </ind:textfilecontent54_state>
-
-  {{% if product == "ol7" %}}
-  <ind:variable_test check="all" check_existence="all_exist"
-  comment="Verify that results come from only one file"
-  id="test_sudo_require_reauthentication_n_files" version="1">
-    <ind:object object_ref="obj_sudo_require_reauthentication_n_files" />
-    <ind:state state_ref="state_sudo_require_reauthentication_n_files" />
-  </ind:variable_test>
-
-  <ind:variable_object id="obj_sudo_require_reauthentication_n_files" version="1">
-    <ind:var_ref>local_variable_counter_sudo_require_reauthentication_n_files</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_state id="state_sudo_require_reauthentication_n_files" version="1">
-    <ind:value operation="equals" datatype="int">1</ind:value>
-  </ind:variable_state>
-
-  <local_variable comment="Items counter" datatype="int" 
-  id="local_variable_counter_sudo_require_reauthentication_n_files" version="1">
-    <count>
-        <unique>
-          <object_component object_ref="obj_sudo_timestamp_timeout"
-          item_field="filepath" />
-        </unique>
-    </count>
-  </local_variable>
-  {{% endif %}}
 
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/oval/shared.xml
@@ -5,9 +5,7 @@
       <criterion comment="Check Defaults !targetpw exists in /etc/sudoers file" test_ref="test_sudoers_targetpw_config" />
       <criterion comment="Check Defaults !rootpw exists in /etc/sudoers file" test_ref="test_sudoers_rootpw_config" />
       <criterion comment="Check Defaults !runaspw exists in /etc/sudoers file" test_ref="test_sudoers_runaspw_config" />
-      {{% if product == "ol7" %}}
       <criterion comment="Verify that results come from only one file" test_ref="test_sudoers_passwd_n_files" />
-      {{% endif %}}
       </criteria>
   </definition>
 
@@ -44,7 +42,6 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product == "ol7" %}}
   <ind:variable_test check="all" check_existence="all_exist"
   comment="Verify that results come from only one file"
   id="test_sudoers_passwd_n_files" version="1">
@@ -73,6 +70,5 @@
       </unique>
     </count>
   </local_variable>
-  {{% endif %}}
 
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/oval/shared.xml
@@ -5,6 +5,9 @@
       <criterion comment="Check Defaults !targetpw exists in /etc/sudoers file" test_ref="test_sudoers_targetpw_config" />
       <criterion comment="Check Defaults !rootpw exists in /etc/sudoers file" test_ref="test_sudoers_rootpw_config" />
       <criterion comment="Check Defaults !runaspw exists in /etc/sudoers file" test_ref="test_sudoers_runaspw_config" />
+      {{% if product == "ol7" %}}
+      <criterion comment="Verify that results come from only one file" test_ref="test_sudoers_passwd_n_files" />
+      {{% endif %}}
       </criteria>
   </definition>
 
@@ -40,5 +43,36 @@
     <ind:pattern operation="pattern match">^Defaults !runaspw$\r?\n</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{% if product == "ol7" %}}
+  <ind:variable_test check="all" check_existence="all_exist"
+  comment="Verify that results come from only one file"
+  id="test_sudoers_passwd_n_files" version="1">
+    <ind:object object_ref="obj_sudoers_passwd_n_files" />
+    <ind:state state_ref="state_sudoers_passwd_n_files" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_sudoers_passwd_n_files" version="1">
+    <ind:var_ref>local_variable_counter_sudoers_passwd_n_files</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_sudoers_passwd_n_files" version="1">
+    <ind:value operation="equals" datatype="int">1</ind:value>
+  </ind:variable_state>
+
+  <local_variable comment="Items counter" datatype="int" 
+  id="local_variable_counter_sudoers_passwd_n_files" version="1">
+    <count>
+      <unique> 
+        <object_component object_ref="object_test_sudoers_targetpw_config"
+        item_field="filepath" />
+        <object_component object_ref="object_test_sudoers_rootpw_config"
+        item_field="filepath" />
+        <object_component object_ref="object_test_sudoers_runaspw_config"
+        item_field="filepath" />
+      </unique>
+    </count>
+  </local_variable>
+  {{% endif %}}
 
 </def-group>

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_passwd_multiple_files.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_passwd_multiple_files.fail.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,SUSE Linux Enterprise 15
+# packages = sudo
+
+echo 'Defaults !targetpw' >> /etc/sudoers
+echo 'Defaults !rootpw' >> /etc/sudoers.d/00-file1
+echo 'Defaults !runaspw' >> /etc/sudoers


### PR DESCRIPTION
#### Description:

- Update OVAL of sudoers_validate_passwd & sudo_require_reauthentication to only allow that the required configuration is located only in one file

#### Rationale:

- This is introduced in latest DISA STIG profile v2r6. Both OL07-00-010342 & OL07-00-010343 implemented in SSG in sudoers_validate_passwd & sudo_require_reauthentication respectevely added the statement "If results are returned from more than one file location, this is a finding"
