### PR TITLE
Introduce nonzero_check var to accounts_password template

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -12,7 +12,11 @@
 
     -   **operation** - OVAL operation, eg. `less than or equal`
 
--   Languages: OVAL
+    -   **non_zerocheck** - effective only in OVAL checks, if
+        set to `"true"` it will test if the value is different
+        than zero. (default value: `"false"`).
+
+-   Languages: Ansible, Bash, OVAL
 
 #### auditd_lineinfile
 -   Checks configuration options of the Audit Daemon in

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -2,19 +2,22 @@
 
 #### accounts_password
 -   Checks if PAM enforces password quality requirements. Checks the
-    configuration in `/etc/pam.d/system-auth` (for RHEL 6 systems) or
-    `/etc/security/pwquality.conf` (on other systems).
+    configuration in `/etc/security/pwquality.conf`.
 
 -   Parameters:
 
-    -   **variable** - PAM `pam_cracklib` (on RHEL 6) or `pam_pwquality`
-        (on other systems) module name, eg. `ucredit`, `ocredit`
+    -   **variable** - PAM `pam_pwquality` password quality
+        requirement, eg. `ucredit`, `ocredit`
 
     -   **operation** - OVAL operation, eg. `less than or equal`
 
-    -   **non_zerocheck** - effective only in OVAL checks, if
-        set to `"true"` it will test if the value is different
-        than zero. (default value: `"false"`).
+    -   **check_zero_boundary** - effective only in OVAL checks, if
+        set to `"true"` it will test if the value respects the a zero
+        boundary operation. The operation is defined by the
+        **zero_boundary_operation** parameter (default value: `"false"`)
+
+    -   **zero_boundary_operation** - OVAL operation, eg. `greater than`
+        (default value: `"greater than"`)
 
 -   Languages: Ansible, Bash, OVAL
 

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -11,13 +11,9 @@
 
     -   **operation** - OVAL operation, eg. `less than or equal`
 
-    -   **check_zero_boundary** - effective only in OVAL checks, if
-        set to `"true"` it will test if the value respects the a zero
-        boundary operation. The operation is defined by the
-        **zero_boundary_operation** parameter (default value: `"false"`)
-
-    -   **zero_boundary_operation** - OVAL operation, eg. `greater than`
-        (default value: `"greater than"`)
+    -   **zero_comparison_operation** - (optional) OVAL operation, eg. `greater than`.
+        When set, it will test if the **variable** value matches the OVAL operation
+        when compared to zero.
 
 -   Languages: Ansible, Bash, OVAL
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -56,5 +56,4 @@ template:
     vars:
         variable: maxclassrepeat
         operation: less than or equal
-        nonzero_check: "false"
-        nonzero_check@ol7: "true"
+        nonzero_check: "true"

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -56,4 +56,5 @@ template:
     vars:
         variable: maxclassrepeat
         operation: less than or equal
-        nonzero_check: "true"
+        check_zero_boundary: "true"
+        zero_boundary_operation: greater than

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -47,7 +47,7 @@ ocil_clause: 'that is not the case'
 ocil: |-
     To check the value for maximum consecutive repeating characters, run the following command:
     <pre>$ grep maxclassrepeat /etc/security/pwquality.conf</pre>
-    For DoD systems, the output should show <tt>maxclassrepeat</tt>=4.
+    For DoD systems, the output should show <tt>maxclassrepeat</tt>=4 or less but greater than zero.
 
 platform: pam
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -56,5 +56,4 @@ template:
     vars:
         variable: maxclassrepeat
         operation: less than or equal
-        check_zero_boundary: "true"
-        zero_boundary_operation: greater than
+        zero_comparison_operation: greater than

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/rule.yml
@@ -56,3 +56,5 @@ template:
     vars:
         variable: maxclassrepeat
         operation: less than or equal
+        nonzero_check: "false"
+        nonzero_check@ol7: "true"

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
+	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 4/' /etc/security/pwquality.conf
+else
+	echo "maxclassrepeat = 4" >> /etc/security/pwquality.conf
+fi
+

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value_less_than_variable.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value_less_than_variable.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
+	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 2/' /etc/security/pwquality.conf
+else
+	echo "maxclassrepeat = 2" >> /etc/security/pwquality.conf
+fi
+

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/negative_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/negative_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
+	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = -1/' /etc/security/pwquality.conf
+else
+	echo "maxclassrepeat = -1" >> /etc/security/pwquality.conf
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
+	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 5/' /etc/security/pwquality.conf
+else
+	echo "maxclassrepeat = 5" >> /etc/security/pwquality.conf
+fi
+

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value_0.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value_0.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
+	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 0/' /etc/security/pwquality.conf
+else
+	echo "maxclassrepeat = 0" >> /etc/security/pwquality.conf
+fi
+

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -4,6 +4,10 @@
     <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
       <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
       <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
+      {{% if NONZERO_CHECK %}}
+      <criterion comment="{{{ VARIABLE }}} not set to zero"
+      test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_nonzero" />
+      {{% endif %}}
     </criteria>
   </definition>
 
@@ -23,6 +27,19 @@
   <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}" version="3">
     <ind:subexpression datatype="int" operation="{{{ OPERATION }}}" var_ref="var_password_pam_{{{ VARIABLE }}}" />
   </ind:textfilecontent54_state>
+
+  {{% if NONZERO_CHECK %}}
+  <ind:textfilecontent54_test check="all"
+  comment="check the configuration of /etc/security/pwquality.conf"
+  id="test_password_pam_pwquality_{{{ VARIABLE }}}_nonzero" version="1">
+    <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}" />
+    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}_nonzero" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}_nonzero" version="1">
+    <ind:subexpression datatype="int" operation="not equal" >0</ind:subexpression>
+  </ind:textfilecontent54_state>
+  {{% endif %}}
 
   <external_variable comment="External variable for pam_{{{ VARIABLE }}}" datatype="int" id="var_password_pam_{{{ VARIABLE }}}" version="3" />
 </def-group>

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -4,9 +4,9 @@
     <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
       <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
       <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
-      {{% if NONZERO_CHECK %}}
-      <criterion comment="{{{ VARIABLE }}} not set to zero"
-      test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_nonzero" />
+      {{% if CHECK_ZERO_BOUNDARY %}}
+      <criterion comment="{{{ VARIABLE }}} zero boundary check with operation {{{ ZERO_BOUNDARY_OPERATION }}}"
+      test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_zero_boundary" />
       {{% endif %}}
     </criteria>
   </definition>
@@ -28,16 +28,16 @@
     <ind:subexpression datatype="int" operation="{{{ OPERATION }}}" var_ref="var_password_pam_{{{ VARIABLE }}}" />
   </ind:textfilecontent54_state>
 
-  {{% if NONZERO_CHECK %}}
+  {{% if CHECK_ZERO_BOUNDARY %}}
   <ind:textfilecontent54_test check="all"
   comment="check the configuration of /etc/security/pwquality.conf"
-  id="test_password_pam_pwquality_{{{ VARIABLE }}}_nonzero" version="1">
+  id="test_password_pam_pwquality_{{{ VARIABLE }}}_zero_boundary" version="1">
     <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}" />
-    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}_nonzero" />
+    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}_zero_boundary" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}_nonzero" version="1">
-    <ind:subexpression datatype="int" operation="not equal" >0</ind:subexpression>
+  <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}_zero_boundary" version="1">
+    <ind:subexpression datatype="int" operation="{{{ ZERO_BOUNDARY_OPERATION }}}" >0</ind:subexpression>
   </ind:textfilecontent54_state>
   {{% endif %}}
 

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -4,18 +4,17 @@
     <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
       <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
       <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
-      {{% if CHECK_ZERO_BOUNDARY %}}
-      <criterion comment="{{{ VARIABLE }}} zero boundary check with operation {{{ ZERO_BOUNDARY_OPERATION }}}"
-      test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_zero_boundary" />
-      {{% endif %}}
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all"
+  <ind:textfilecontent54_test check="all" state_operator="AND"
   comment="check the configuration of /etc/security/pwquality.conf"
   id="test_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
     <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}" />
     <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}" />
+  {{%- if ZERO_COMPARISON_OPERATION %}}
+    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}_zero_comparison" />
+  {{%- endif %}}
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
@@ -28,18 +27,11 @@
     <ind:subexpression datatype="int" operation="{{{ OPERATION }}}" var_ref="var_password_pam_{{{ VARIABLE }}}" />
   </ind:textfilecontent54_state>
 
-  {{% if CHECK_ZERO_BOUNDARY %}}
-  <ind:textfilecontent54_test check="all"
-  comment="check the configuration of /etc/security/pwquality.conf"
-  id="test_password_pam_pwquality_{{{ VARIABLE }}}_zero_boundary" version="1">
-    <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}" />
-    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}_zero_boundary" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}_zero_boundary" version="1">
-    <ind:subexpression datatype="int" operation="{{{ ZERO_BOUNDARY_OPERATION }}}" >0</ind:subexpression>
+  {{%- if ZERO_COMPARISON_OPERATION %}}
+  <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}_zero_comparison" version="1">
+    <ind:subexpression datatype="int" operation="{{{ ZERO_COMPARISON_OPERATION }}}" >0</ind:subexpression>
   </ind:textfilecontent54_state>
-  {{% endif %}}
+  {{%- endif %}}
 
   <external_variable comment="External variable for pam_{{{ VARIABLE }}}" datatype="int" id="var_password_pam_{{{ VARIABLE }}}" version="3" />
 </def-group>

--- a/shared/templates/accounts_password/template.py
+++ b/shared/templates/accounts_password/template.py
@@ -3,6 +3,5 @@ from ssg.utils import parse_template_boolean_value
 def preprocess(data, lang):
     if lang == "oval":
         data["sign"] = "-?" if data["variable"].endswith("credit") else ""
-    data["check_zero_boundary"] = parse_template_boolean_value(data, parameter="check_zero_boundary", default_value=False)
-    data["zero_boundary_operator"] = data.get("zero_boundary_operator", "greater than")
+    data["zero_comparison_operation"] = data.get("zero_comparison_operation", None)
     return data

--- a/shared/templates/accounts_password/template.py
+++ b/shared/templates/accounts_password/template.py
@@ -1,4 +1,7 @@
+from ssg.utils import parse_template_boolean_value
+
 def preprocess(data, lang):
     if lang == "oval":
         data["sign"] = "-?" if data["variable"].endswith("credit") else ""
+    data["nonzero_check"] = parse_template_boolean_value(data, parameter="nonzero_check", default_value=False)
     return data

--- a/shared/templates/accounts_password/template.py
+++ b/shared/templates/accounts_password/template.py
@@ -3,5 +3,6 @@ from ssg.utils import parse_template_boolean_value
 def preprocess(data, lang):
     if lang == "oval":
         data["sign"] = "-?" if data["variable"].endswith("credit") else ""
-    data["nonzero_check"] = parse_template_boolean_value(data, parameter="nonzero_check", default_value=False)
+    data["check_zero_boundary"] = parse_template_boolean_value(data, parameter="check_zero_boundary", default_value=False)
+    data["zero_boundary_operator"] = data.get("zero_boundary_operator", "greater than")
     return data


### PR DESCRIPTION
#### Description:

- Added nonzero_check variable with default value set to False to the accounts_password template. And implement conditionally this behavior in which OVAL checks if the value obtained is different to 0.This could be useful to future rules since zero is a special value in a few related configurations
- This new variable has been implemented in the accounts_password_pam_maxclassrepeat rule

#### Rationale:

- For OL7 the STIG id OL07-00-010190 needs to check both if maxclassrepeat is less than 4 and different to 0. For this reason included the variable nonzero_check with default value False this way the rule keeps using the template accounts_password without modifying other rules behaviour. 
- Since DISA's requirements go in this direction(also RHEL's new profile states the same) the variable has been updated to be True as default value in accounts_password_pam_maxclassrepeat rule
