### PR TITLE
Fix the PR URL in the Gitpod workflow that adds the comment to a PR

### DIFF
--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -62,7 +62,7 @@ jobs:
           body: |
             Start a new ephemeral environment with changes proposed in this pull request:
 
-            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#PRODUCT=${{steps.product.outputs.prop}}/${{ github.server_url }}/${{ github.repository }}/pulls/${{ github.event.pull_request.number }})
+            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#PRODUCT=${{steps.product.outputs.prop}}/${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
 
           edit-mode: replace
       - name: Create or update a trimmed comment
@@ -74,6 +74,6 @@ jobs:
           body: |
             Start a new ephemeral environment with changes proposed in this pull request:
 
-            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#${{ github.server_url }}/${{ github.repository }}/pulls/${{ github.event.pull_request.number }})
+            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
 
           edit-mode: replace


### PR DESCRIPTION


#### Description:
- Fix the PR URL in the Gitpod workflow that adds the comment to a PR.
  - The correct page URL has a "pull/" path in the singular instead of
plural.
