### PR TITLE
Update ensure_oracle_gpgkey_installed

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
@@ -1,8 +1,14 @@
 # platform = multi_platform_ol
 # OL fingerprints below retrieved from Oracle Linux Yum Server "Frequently Asked Questions"
 # https://yum.oracle.com/faq.html#a10
-readonly OL_FINGERPRINT="42144123FECFC55B9086313D72F97B74EC551F03"
-readonly OL8_FINGERPRINT="76FD3DB13AB67410B89DB10E82562EA9AD986DA3"
+readonly OL_RELEASE_FINGERPRINT="{{{ release_key_fingerprint }}}"
+readonly OL_AUXILIARY_FINGERPRINT="{{{ auxiliary_key_fingerprint }}}"
+
+FINGERPRINTS_REGEX="${OL_RELEASE_FINGERPRINT}"
+
+if [[ -n "$OL_AUXILIARY_FINGERPRINT" ]]; then
+    FINGERPRINTS_REGEX+="|${OL_AUXILIARY_FINGERPRINT}"
+fi
 
 # Location of the key we would like to import (once it's integrity verified)
 readonly OL_RELEASE_KEY="/etc/pki/rpm-gpg/RPM-GPG-KEY-oracle"
@@ -21,7 +27,7 @@ then
   then
     # Filter just hexadecimal fingerprints from gpg's output from
     # processing of a key file
-    echo "${GPG_OUT[*]}" | grep -vE "${OL_FINGERPRINT}|${OL8_FINGERPRINT}" || {
+    echo "${GPG_OUT[*]}" | grep -vE "$FINGERPRINTS_REGEX" || {
       # If $ OL_RELEASE_KEY file doesn't contain any keys with unknown fingerprint, import it
       rpm --import "${OL_RELEASE_KEY}"
     }

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/oval/shared.xml
@@ -1,18 +1,19 @@
+{{% if pkg_version %}}
+{{# If pkg_version isn't defined, then the rule should be NOTCHECKED, because we don't have data needed for the check #}}
 <def-group>
   <definition class="compliance" id="ensure_oracle_gpgkey_installed" version="1">
     {{{ oval_metadata("The Oracle Linux key packages are required to be installed.") }}}
-    <criteria comment="Vendor GPG keys" operator="OR">
-      <criteria comment="Oracle Vendor GPG Keys" operator="AND">
-        <criteria comment="Oracle Linux Release Installed" operator="OR">
-          <extend_definition comment="Oracle Linux 7 installed" definition_ref="installed_OS_is_ol7_family" />
-          <extend_definition comment="Oracle Linux 8 installed" definition_ref="installed_OS_is_ol8_family" />
-        </criteria>
-        <criteria comment="Oracle GPG Key Installed" operator="OR">
-            <criterion comment="package gpg-pubkey-ec551f03-53619141 is installed"
-            test_ref="test_package_gpgkey-ec551f03-53619141_installed" />
-            <criterion comment="package gpg-pubkey-ad986da3-5cabf60d is installed"
-            test_ref="test_package_gpgkey-ad986da3-5cabf60d_installed" />
-        </criteria>
+    <criteria comment="Oracle Vendor Keys" operator="AND">
+      <criteria comment="Oracle Installed" operator="OR">
+        <extend_definition comment="{{{ product }}} installed" definition_ref="installed_OS_is_{{{ product }}}_family" />
+      </criteria>
+      <criteria comment="Oracle Vendor Keys Installed" operator="OR">
+        <criterion comment="package gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}} is installed"
+            test_ref="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" />
+        {{% if aux_pkg_version %}}
+        <criterion comment="package gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}} is installed"
+            test_ref="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" />
+        {{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -22,30 +23,33 @@
     <linux:name>gpg-pubkey</linux:name>
   </linux:rpminfo_object>
 
-  <!-- Test for OL6 and OL7 key -->
+  <!-- Test for Oracle release key -->
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-ec551f03-53619141_installed" version="1"
-  comment="Oracle Linux key package is installed">
+      id="test_package_gpgkey-{{{ pkg_version }}}-{{{ pkg_release }}}_installed" version="1"
+      comment="Oracle release key package is installed">
     <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-ec551f03-53619141" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-ec551f03-53619141" version="1">
-    <linux:release>53619141</linux:release>
-    <linux:version>ec551f03</linux:version>
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ pkg_version }}}-{{{ pkg_release }}}" version="1">
+    <linux:release>{{{ pkg_release }}}</linux:release>
+    <linux:version>{{{ pkg_version }}}</linux:version>
   </linux:rpminfo_state>
 
-  <!-- Test for OL8 key -->
+  <!-- Test for Oracle auxiliary key -->
+  {{% if aux_pkg_version %}}
   <linux:rpminfo_test check="only one" check_existence="at_least_one_exists"
-  id="test_package_gpgkey-ad986da3-5cabf60d_installed" version="1"
-  comment="Oracle Linux 8 key package is installed">
+  id="test_package_gpgkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}_installed" version="1"
+  comment="Oracle auxiliary key package is installed">
     <linux:object object_ref="object_package_gpg-pubkey" />
-    <linux:state state_ref="state_package_gpg-pubkey-ad986da3-5cabf60d" />
+    <linux:state state_ref="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" />
   </linux:rpminfo_test>
 
-  <linux:rpminfo_state id="state_package_gpg-pubkey-ad986da3-5cabf60d" version="1">
-    <linux:release>5cabf60d</linux:release>
-    <linux:version>ad986da3</linux:version>
+  <linux:rpminfo_state id="state_package_gpg-pubkey-{{{ aux_pkg_version }}}-{{{ aux_pkg_release }}}" version="1">
+    <linux:release>{{{ aux_pkg_release }}}</linux:release>
+    <linux:version>{{{ aux_pkg_version }}}</linux:version>
   </linux:rpminfo_state>
+  {{% endif %}}
 
 </def-group>
+{{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/rule.yml
@@ -15,7 +15,11 @@ description: |-
     the Oracle installation CD-ROM or DVD. Assuming the disc is mounted
     in <tt>/media/cdrom</tt>, use the following command as the root user to import
     it into the keyring:
-    <pre>$ sudo rpm --import /media/cdrom/RPM-GPG-KEY</pre>
+    <pre>$ sudo rpm --import /media/cdrom/RPM-GPG-KEY-oracle</pre>
+
+    Alternatively, the key may be pre-loaded during the Oracle installation. In
+    such cases, the key can be installed by running the following command:
+    <pre>sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-oracle</pre>
 
 rationale: |-
     Changes to software components can have significant effects on the

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -10,6 +10,12 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+pkg_release: "53619141"
+pkg_version: "ec551f03"
+
+release_key_fingerprint: "42144123FECFC55B9086313D72F97B74EC551F03"
+
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../../shared/applicability"

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -10,6 +10,12 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+pkg_release: "5cabf60d"
+pkg_version: "ad986da3"
+
+release_key_fingerprint: "76FD3DB13AB67410B89DB10E82562EA9AD986DA3"
+
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../../shared/applicability"
@@ -23,12 +29,5 @@ cpes:
 platform_package_overrides:
   login_defs: "shadow-utils"
 
-cpes_root: "../../shared/applicability"
-cpes:
-  - ol8:
-      name: "cpe:/o:oracle:linux:8"
-      title: "Oracle Linux 8"
-      check_id: installed_OS_is_ol8_family
-
 reference_uris:
-  cis: ''
+  cis: 'https://www.cisecurity.org/benchmark/oracle_linux/'

--- a/products/ol9/product.yml
+++ b/products/ol9/product.yml
@@ -10,6 +10,16 @@ profiles_root: "./profiles"
 pkg_manager: "yum"
 
 init_system: "systemd"
+
+pkg_release: "61e772ef"
+pkg_version: "8d8b756f"
+
+aux_pkg_release: "61e77439"
+aux_pkg_version: "8b4efbe6"
+
+release_key_fingerprint: "3E6D826D3FBAB389C2F38E34BC4D06A08D8B756F"
+auxiliary_key_fingerprint: "982231759C7467065D0CE9B2A7DD07088B4EFBE6"
+
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../../shared/applicability"


### PR DESCRIPTION
#### Description:

- Remove hardcoded fingerprints from bash remediation and add them as variables in the respective product.yml files
- Add logic to bash script to allow having a release key only, or both a release and backup keys
- Also modify the OVAL content to use the template approach to generate product-specific content
- Additionally add `pkg_release` and `pkg_version` entries to the OL product.yml files to be able to use the OVAL template approach

#### Rationale:

- Since the OL9 product was introduced, this update was needed
- Also using the template approach for the OVAL content makes it easier to maintain
