### PR TITLE
Update accounts_authorized_local_users for OL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ol,multi_platform_sle
+# platform = multi_platform_sle
 
 {{{ bash_instantiate_variables("var_accounts_authorized_local_users_regex") }}}
 
@@ -13,4 +13,3 @@ for username in $( sed 's/:.*//' /etc/passwd ) ; do
 		userdel $username ;
 	fi
 done
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/rule.yml
@@ -45,7 +45,7 @@ references:
 
 ocil_clause: 'there are unauthorized local user accounts on the system'
 
-{{% if 'rhel' in product %}}
+{{% if 'rhel' in product or 'ol' in product %}}
 warnings:
     - general: |-
         Automatic remediation of this control is not available. Due the unique

--- a/linux_os/guide/system/accounts/accounts-restrictions/var_accounts_authorized_local_users_regex.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/var_accounts_authorized_local_users_regex.var
@@ -11,7 +11,7 @@ description: |-
     OVAL regular expression is used for the user list.
     The list starts with '^' and ends with '$' so that it matches exactly the
     username, not any string that includes the username. Users are separated with '|'.
-    For example, three users: bin, oracle and sapadm are allowd, then the list is
+    For example, three users: bin, oracle and sapadm are allowed, then the list is
     <tt>^(bin|oracle|sapadm)$</tt>. The user <tt>root</tt> is the only user that is hard coded
     in OVAL that is always allowed on the operating system.
 
@@ -22,7 +22,8 @@ operator: pattern match
 interactive: true
 
 options:
+    ol7: "^(abrt|adm|avahi|bin|chrony|clevis|cockpit-ws|cockpit-wsinstance|colord|daemon|dbus|dnsmasq|flatpak|ftp|games|gdm|geoclue|gluster|gnome-initial-setup|halt|libstoragemgmt|lp|mail|nfsnobody|nobody|ntp|operator|oprofile|oracle|pcp|pegasus|pipewire|polkitd|postfix|pulse|qemu|radvd|rngd|root|rpc|rpcuser|rtkit|saned|saslauth|setroubleshoot|shutdown|sshd|sssd|sync|systemd-bus-proxy|systemd-coredump|systemd-network|systemd-resolve|tcpdump|tss|unbound|usbmuxd$|uuidd)$"
+    ol8: "^(abrt|adm|avahi|bin|chrony|clevis|cockpit-ws|cockpit-wsinstance|colord|daemon|dbus|dnsmasq|flatpak|ftp|games|gdm|geoclue|gluster|gnome-initial-setup|halt|libstoragemgmt|lp|mail|nfsnobody|nobody|ntp|operator|oprofile|oracle|pcp|pegasus|pipewire|polkitd|postfix|pulse|qemu|radvd|rngd|root|rpc|rpcuser|rtkit|saned|saslauth|setroubleshoot|shutdown|sshd|sssd|sync|systemd-bus-proxy|systemd-coredump|systemd-network|systemd-resolve|tcpdump|tss|unbound|usbmuxd$|uuidd)$"
+    ol7forsap: "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd)$"
     rhel7: "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|systemd-resolve|systemd-coredump|sssd|rngd)$"
     rhel8: "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|systemd-resolve|systemd-coredump|sssd|rngd)$"
-    ol7forsap: "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd)$"
-    saponol7 : "^(root|bin|daemon|adm|lp|sync|shutdown|halt|mail|operator|games|ftp|nobody|pegasus|systemd-bus-proxy|systemd-network|dbus|polkitd|abrt|unbound|tss|libstoragemgmt|rpc|colord|usbmuxd$|pcp|saslauth|geoclue|setroubleshoot|rtkit|chrony|qemu|radvd|rpcuser|nfsnobody|pulse|gdm|gnome-initial-setup|postfix|avahi|ntp|sshd|tcpdump|oprofile|uuidd|[a-z][a-z0-9][a-z0-9]adm|ora[a-z][a-z0-9][a-z0-9]|sapadm|oracle)$"

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -18,6 +18,7 @@ selections:
     - var_password_pam_ocredit=1
     - var_password_pam_lcredit=1
     - var_password_pam_ucredit=1
+    - var_accounts_authorized_local_users_regex=ol7
     - var_accounts_passwords_pam_faillock_unlock_time=never
     - var_accounts_passwords_pam_faillock_fail_interval=900
     - var_accounts_passwords_pam_faillock_deny=3

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -42,7 +42,7 @@ selections:
     - sshd_approved_macs=stig
     - sshd_approved_ciphers=stig
     - sshd_idle_timeout_value=10_minutes
-    - var_accounts_authorized_local_users_regex=rhel8
+    - var_accounts_authorized_local_users_regex=ol8
     - var_accounts_passwords_pam_faillock_deny=3
     - var_accounts_passwords_pam_faillock_fail_interval=900
     - var_accounts_passwords_pam_faillock_unlock_time=never


### PR DESCRIPTION
#### Description:

- Add oracle options for `var_accounts_authorized_local_users_regex` and use these values on OL7 and OL8 stig profiles
- Do not generate bash content for this rule for OL
- Also build warning for missing remediation for OL

#### Rationale:

- Users tend to carelessly run remediations. The remediation for this rule might leave the users without access to the system.
