### PR TITLE
Fix gh-pages build.

### DIFF
--- a/utils/generate_html_pages.sh
+++ b/utils/generate_html_pages.sh
@@ -31,7 +31,7 @@ products=$(echo -e "import ssg.constants\nprint(ssg.constants.product_directorie
 for product in $products
 do
     if [ -d build/$product ]; then
-    mkdir -p $STATS_DIR/$product/product-statistics
+    mkdir -p $STATS_DIR/$product
     if [ -f build/$product/product-statistics/statistics.html ]; then
         cp -rf build/$product/product-statistics $STATS_DIR/$product/product-statistics
         echo "<li><a href=\"$product/product-statistics/statistics.html\">Statistics for product: ${product}</a></li>" >> $STATS_DIR/index.html


### PR DESCRIPTION

#### Description:
- Fix gh-pages build.
  - It's creating a double product-statistics page generating broken links.

@Mab879 It turned out that it didn't require that directory. It started creating a duplicated `product-statistics` folder.