### PR TITLE
Add RHEL-08-040321 to RHEL8 STIG profile

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
@@ -39,6 +39,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
+    stigid@rhel8: RHEL-08-040321
 
 ocil_clause: 'the X windows display server is running and/or has not been disabled'
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -1169,6 +1169,9 @@ selections:
     # RHEL-08-040320
     - xwindows_remove_packages
 
+    # RHEL-08-040321
+    - xwindows_runlevel_target
+
     # RHEL-08-040330
     - network_sniffer_disabled
 

--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -35,3 +35,6 @@ extends: stig
 selections:
     # RHEL-08-040320
     - '!xwindows_remove_packages'
+
+    # RHEL-08-040321
+    - '!xwindows_runlevel_target'

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -398,6 +398,7 @@ selections:
 - usbguard_generate_policy
 - wireless_disable_interfaces
 - xwindows_remove_packages
+- xwindows_runlevel_target
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
 - var_accounts_user_umask=077


### PR DESCRIPTION


#### Description:

- Add RHEL-08-040321 with rule `xwindows_runlevel_target`

#### Rationale:

- The RHEL8 STIG V1R5 doesn't recommend the systems to target the graphical
environment by default.
