### PR TITLE
Update rule to only remove the graphical interface

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/ansible/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/ansible/shared.yml
@@ -14,12 +14,3 @@
       - xorg-x11-server-Xwayland
 {{% endif %}}
     state: absent
-
-
-- name: Switch to multi-user runlevel
-  file:
-    src: /usr/lib/systemd/system/multi-user.target
-    dest: /etc/systemd/system/default.target
-    state: link
-    force: yes
-

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/bash/shared.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/bash/shared.sh
@@ -12,6 +12,3 @@
 {{% if product not in ["rhel7", "ol7"] %}}
 {{{ bash_package_remove("xorg-x11-server-Xwayland") }}}
 {{% endif %}}
-
-# configure run level
-systemctl set-default multi-user.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/oval/shared.xml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/oval/shared.xml
@@ -2,10 +2,6 @@
   <definition class="compliance" id="xwindows_remove_packages" version="1">
     {{{ oval_metadata("Ensure that the default runlevel target is set to multi-user.target.") }}}
     <criteria>
-      {{%- if init_system == "systemd" and target_oval_version != [5, 10] %}}
-      <extend_definition comment="system is configured to boot into multi-user.target"
-        definition_ref="xwindows_runlevel_target" />
-      {{%- endif %}}
       <criterion comment="package xorg-x11-server-Xorg is not installed"
         test_ref="package_xorg-x11-server-Xorg_removed" />
       <extend_definition comment="package xorg-x11-server-common is removed"

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -19,14 +19,6 @@ description: |-
     {{% else %}}
     <pre>sudo {{{ pkg_manager }}} remove xorg-x11-server-Xorg xorg-x11-server-common xorg-x11-server-utils xorg-x11-server-Xwayland</pre>
     {{% endif %}}
-    Additionally, setting the system's default target to
-    <tt>multi-user.target</tt> will prevent automatic startup of the X server.
-    To do so, run:
-    <pre>$ systemctl set-default multi-user.target</pre>
-    You should see the following output:
-    <pre>Removed symlink /etc/systemd/system/default.target.
-    Created symlink from /etc/systemd/system/default.target to /usr/lib/systemd/system/multi-user.target.</pre>
-
 
 rationale: |-
     Unnecessary service packages must not be installed to decrease the attack surface of the system. X windows has a long history of security
@@ -72,6 +64,8 @@ warnings:
         The installation and use of a Graphical User Interface (GUI) increases your attack vector and decreases your
         overall security posture. Removing the package xorg-x11-server-common package will remove the graphical target
         which might bring your system to an inconsistent state requiring additional configuration to access the system
-        again. If a GUI is an operational requirement, a tailored profile that removes this rule should used before
+        again. </br>
+        The rule 'xwindows_runlevel_target' can be used to configure the system to boot into the multi-user.target.</br>
+        If a GUI is an operational requirement, a tailored profile that removes this rule should be used before
         continuing installation.
 {{{ ovirt_rule_notapplicable_warning("X11 graphic libraries are dependency of OpenStack Cinderlib storage provider") | indent(4) }}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -64,8 +64,8 @@ warnings:
         The installation and use of a Graphical User Interface (GUI) increases your attack vector and decreases your
         overall security posture. Removing the package xorg-x11-server-common package will remove the graphical target
         which might bring your system to an inconsistent state requiring additional configuration to access the system
-        again. </br>
-        The rule 'xwindows_runlevel_target' can be used to configure the system to boot into the multi-user.target.</br>
+        again.
+        The rule <tt>xwindows_runlevel_target</tt> can be used to configure the system to boot into the multi-user.target.
         If a GUI is an operational requirement, a tailored profile that removes this rule should be used before
         continuing installation.
 {{{ ovirt_rule_notapplicable_warning("X11 graphic libraries are dependency of OpenStack Cinderlib storage provider") | indent(4) }}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/correct_target.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/correct_target.pass.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-yum -y remove xorg-x11-server-Xorg xorg-x11-server-common xorg-x11-server-utils xorg-x11-server-Xwayland
-
-systemctl set-default multi-user.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/correct_target_under_lib.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/correct_target_under_lib.pass.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-yum -y remove xorg-x11-server-Xorg xorg-x11-server-common xorg-x11-server-utils xorg-x11-server-Xwayland
-
-ln -sf /lib/systemd/system/multi-user.target /etc/systemd/system/default.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/packages_installed.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/packages_installed.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+{{{ bash_package_install("xorg-x11-server-Xorg") }}}
+{{{ bash_package_install("xorg-x11-server-utils") }}}
+{{{ bash_package_install("xorg-x11-server-common") }}}
+{{% if product not in ["rhel7", "ol7"] %}}
+{{{ bash_package_install("xorg-x11-server-Xwayland") }}}
+{{% endif %}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/packages_installed_removed.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/packages_installed_removed.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# based on shared/templates/package_removed/tests/package-installed-removed.pass.sh
+
+{{{ bash_package_install("xorg-x11-server-Xorg") }}}
+{{{ bash_package_install("xorg-x11-server-utils") }}}
+{{{ bash_package_install("xorg-x11-server-common") }}}
+{{% if product not in ["rhel7", "ol7"] %}}
+{{{ bash_package_install("xorg-x11-server-Xwayland") }}}
+{{% endif %}}
+
+{{{ bash_package_remove("xorg-x11-server-Xorg") }}}
+{{{ bash_package_remove("xorg-x11-server-utils") }}}
+{{{ bash_package_remove("xorg-x11-server-common") }}}
+{{% if product not in ["rhel7", "ol7"] %}}
+{{{ bash_package_remove("xorg-x11-server-Xwayland") }}}
+{{% endif %}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/packages_removed.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/packages_removed.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+{{{ bash_package_remove("xorg-x11-server-Xorg") }}}
+{{{ bash_package_remove("xorg-x11-server-utils") }}}
+{{{ bash_package_remove("xorg-x11-server-common") }}}
+{{% if product not in ["rhel7", "ol7"] %}}
+{{{ bash_package_remove("xorg-x11-server-Xwayland") }}}
+{{% endif %}}

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel7_packages_installed_correct_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel7_packages_installed_correct_target.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 7
-# packages = xorg-x11-server-Xorg,xorg-x11-server-common,xorg-x11-server-utils
-

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel7_packages_installed_wrong_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel7_packages_installed_wrong_target.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 7
-# packages = xorg-x11-server-Xorg,xorg-x11-server-common,xorg-x11-server-utils
-
-systemctl set-default graphical.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel8_packages_installed_correct_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel8_packages_installed_correct_target.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 8
-# packages = xorg-x11-server-Xorg,xorg-x11-server-common,xorg-x11-server-utils,xorg-x11-server-Xwayland
-

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel8_packages_installed_wrong_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/rhel8_packages_installed_wrong_target.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# platform = Red Hat Enterprise Linux 8
-# packages = xorg-x11-server-Xorg,xorg-x11-server-common,xorg-x11-server-utils,xorg-x11-server-Xwayland
-
-systemctl set-default graphical.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/wrong_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/wrong_target.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-yum -y remove xorg-x11-server-Xorg xorg-x11-server-common xorg-x11-server-utils xorg-x11-server-Xwayland
-
-systemctl set-default graphical.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/wrong_target_under_lib.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/tests/wrong_target_under_lib.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-yum -y remove xorg-x11-server-Xorg xorg-x11-server-common xorg-x11-server-utils xorg-x11-server-Xwayland
-
-ln -sf /lib/systemd/system/graphical.target /etc/systemd/system/default.target


### PR DESCRIPTION

#### Description:

- Removed configuration of runlevel target from rule `xwindows_remove_packages`.
- Remediations now only remove the graphical interface packages.
- The warning now mentions the rule that can be used to set the runlevel target.

#### Rationale:

- The rule was doing two configurations at once, removing graphical environment and setting the target runlevel.
  Now it only removes packages related to the graphical interface, the target runlevel is set by `xwindows_runlevel_target`.

