### PR TITLE
Assign RHEL-08-020221 to accounts_password_pam_pwhistory_remember_password_auth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -43,7 +43,7 @@ references:
     stigid@ol7: OL07-00-010270
     stigid@ol8: OL08-00-020220
     stigid@rhel7: RHEL-07-010270
-    stigid@rhel8: RHEL-08-020220
+    stigid@rhel8: RHEL-08-020221
     vmmsrg: SRG-OS-000077-VMM-000440
 
 ocil_clause: |-


### PR DESCRIPTION

#### Description:

- Assign RHEL-08-020221 to accounts_password_pam_pwhistory_remember_password_auth
  - Latest version of RHEL8 describes one item per configuration and per
file, in this case the /etc/password-auth.
