### PR TITLE
Update references of RHEL8 STIG audit rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
@@ -58,7 +58,7 @@ references:
     stigid@ol7: OL07-00-030410
     stigid@ol8: OL08-00-030540
     stigid@rhel7: RHEL-07-030420
-    stigid@rhel8: RHEL-08-030540
+    stigid@rhel8: RHEL-08-030490
     stigid@sle12: SLES-12-020470
     stigid@sle15: SLES-15-030300
     stigid@ubuntu2004: UBTU-20-010153

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -58,7 +58,7 @@ references:
     stigid@ol7: OL07-00-030410
     stigid@ol8: OL08-00-030530
     stigid@rhel7: RHEL-07-030430
-    stigid@rhel8: RHEL-08-030530
+    stigid@rhel8: RHEL-08-030490
     stigid@sle12: SLES-12-020480
     stigid@sle15: SLES-15-030310
     stigid@ubuntu2004: UBTU-20-010154

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
@@ -61,7 +61,7 @@ references:
     stigid@ol7: OL07-00-030370
     stigid@ol8: OL08-00-030520
     stigid@rhel7: RHEL-07-030380
-    stigid@rhel8: RHEL-08-030520
+    stigid@rhel8: RHEL-08-030480
     stigid@sle12: SLES-12-020430
     stigid@sle15: SLES-15-030260
     stigid@ubuntu2004: UBTU-20-010149

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
@@ -58,7 +58,7 @@ references:
     stigid@ol7: OL07-00-030370
     stigid@ol8: OL08-00-030510
     stigid@rhel7: RHEL-07-030400
-    stigid@rhel8: RHEL-08-030510
+    stigid@rhel8: RHEL-08-030480
     stigid@sle12: SLES-12-020450
     stigid@sle15: SLES-15-030280
     stigid@ubuntu2004: UBTU-20-010150

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -75,7 +75,7 @@ references:
     stigid@ol7: OL07-00-030440
     stigid@ol8: OL08-00-030240
     stigid@rhel7: RHEL-07-030480
-    stigid@rhel8: RHEL-08-030240
+    stigid@rhel8: RHEL-08-030200
     stigid@sle12: SLES-12-020410
     stigid@sle15: SLES-15-030210
     stigid@ubuntu2004: UBTU-20-010147

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -70,7 +70,7 @@ references:
     stigid@ol7: OL07-00-030440
     stigid@ol8: OL08-00-030230
     stigid@rhel7: RHEL-07-030450
-    stigid@rhel8: RHEL-08-030230
+    stigid@rhel8: RHEL-08-030200
     stigid@sle12: SLES-12-020380
     stigid@sle15: SLES-15-030230
     stigid@ubuntu2004: UBTU-20-010144

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -58,7 +58,7 @@ references:
     stigid@ol7: OL07-00-030370
     stigid@ol8: OL08-00-030500
     stigid@rhel7: RHEL-07-030390
-    stigid@rhel8: RHEL-08-030500
+    stigid@rhel8: RHEL-08-030480
     stigid@sle12: SLES-12-020440
     stigid@sle15: SLES-15-030270
     stigid@ubuntu2004: UBTU-20-010151

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -69,7 +69,7 @@ references:
     stigid@ol7: OL07-00-030440
     stigid@ol8: OL08-00-030220
     stigid@rhel7: RHEL-07-030460
-    stigid@rhel8: RHEL-08-030220
+    stigid@rhel8: RHEL-08-030200
     stigid@sle15: SLES-15-030240
     stigid@ubuntu2004: UBTU-20-010143
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -74,7 +74,7 @@ references:
     stigid@ol7: OL07-00-030440
     stigid@ol8: OL08-00-030210
     stigid@rhel7: RHEL-07-030470
-    stigid@rhel8: RHEL-08-030210
+    stigid@rhel8: RHEL-08-030200
     stigid@sle12: SLES-12-020390
     stigid@sle15: SLES-15-030190
     stigid@ubuntu2004: UBTU-20-010145

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -70,7 +70,7 @@ references:
     stigid@ol7: OL07-00-030440
     stigid@ol8: OL08-00-030270
     stigid@rhel7: RHEL-07-030440
-    stigid@rhel8: RHEL-08-030270
+    stigid@rhel8: RHEL-08-030200
     stigid@sle12: SLES-12-020370
     stigid@sle15: SLES-15-030220
     stigid@ubuntu2004: UBTU-20-010142

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -52,7 +52,7 @@ references:
     stigid@ol7: OL07-00-030910
     stigid@ol8: OL08-00-030362
     stigid@rhel7: RHEL-07-030890
-    stigid@rhel8: RHEL-08-030362
+    stigid@rhel8: RHEL-08-030361
     stigid@ubuntu2004: UBTU-20-010270
     vmmsrg: SRG-OS-000466-VMM-001870,SRG-OS-000468-VMM-001890
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/rule.yml
@@ -49,7 +49,7 @@ references:
     stigid@ol7: OL07-00-030910
     stigid@ol8: OL08-00-030363
     stigid@rhel7: RHEL-07-030900
-    stigid@rhel8: RHEL-08-030363
+    stigid@rhel8: RHEL-08-030361
     vmmsrg: SRG-OS-000466-VMM-001870,SRG-OS-000468-VMM-001890
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rmdir") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -52,7 +52,7 @@ references:
     stigid@ol7: OL07-00-030910
     stigid@ol8: OL08-00-030364
     stigid@rhel7: RHEL-07-030910
-    stigid@rhel8: RHEL-08-030364
+    stigid@rhel8: RHEL-08-030361
     stigid@ubuntu2004: UBTU-20-010267
     vmmsrg: SRG-OS-000466-VMM-001870,SRG-OS-000468-VMM-001890
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -52,7 +52,7 @@ references:
     stigid@ol7: OL07-00-030910
     stigid@ol8: OL08-00-030365
     stigid@rhel7: RHEL-07-030920
-    stigid@rhel8: RHEL-08-030365
+    stigid@rhel8: RHEL-08-030361
     stigid@ubuntu2004: UBTU-20-010268
     vmmsrg: SRG-OS-000466-VMM-001870,SRG-OS-000468-VMM-001890
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -63,7 +63,7 @@ references:
     stigid@ol7: OL07-00-030510
     stigid@ol8: OL08-00-030470
     stigid@rhel7: RHEL-07-030500
-    stigid@rhel8: RHEL-08-030470
+    stigid@rhel8: RHEL-08-030420
     stigid@sle12: SLES-12-020520
     stigid@sle15: SLES-15-030160
     stigid@ubuntu2004: UBTU-20-010158

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -66,7 +66,7 @@ references:
     stigid@ol7: OL07-00-030510
     stigid@ol8: OL08-00-030460
     stigid@rhel7: RHEL-07-030550
-    stigid@rhel8: RHEL-08-030460
+    stigid@rhel8: RHEL-08-030420
     stigid@sle12: SLES-12-020510
     stigid@sle15: SLES-15-030320
     stigid@ubuntu2004: UBTU-20-010157

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -66,7 +66,7 @@ references:
     stigid@ol7: OL07-00-030510
     stigid@ol8: OL08-00-030440
     stigid@rhel7: RHEL-07-030510
-    stigid@rhel8: RHEL-08-030440
+    stigid@rhel8: RHEL-08-030420
     stigid@sle12: SLES-12-020490
     stigid@sle15: SLES-15-030150
     stigid@ubuntu2004: UBTU-20-010155

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -60,7 +60,7 @@ references:
     stigid@ol7: OL07-00-030510
     stigid@ol8: OL08-00-030450
     stigid@rhel7: RHEL-07-030530
-    stigid@rhel8: RHEL-08-030450
+    stigid@rhel8: RHEL-08-030420
     stigid@sle12: SLES-12-020540
     stigid@sle15: SLES-15-030180
     stigid@ubuntu2004: UBTU-20-010160

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -66,7 +66,7 @@ references:
     stigid@ol7: OL07-00-030510
     stigid@ol8: OL08-00-030430
     stigid@rhel7: RHEL-07-030520
-    stigid@rhel8: RHEL-08-030430
+    stigid@rhel8: RHEL-08-030420
     stigid@sle12: SLES-12-020530
     stigid@sle15: SLES-15-030170
     stigid@ubuntu2004: UBTU-20-010159

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -51,7 +51,7 @@ references:
     stigid@ol7: OL07-00-030820
     stigid@ol8: OL08-00-030380
     stigid@rhel7: RHEL-07-030821
-    stigid@rhel8: RHEL-08-030380
+    stigid@rhel8: RHEL-08-030360
     stigid@sle12: SLES-12-020740
     stigid@sle15: SLES-15-030530
     stigid@ubuntu2004: UBTU-20-010180

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -560,6 +560,8 @@ selections:
 
     # RHEL-08-020220
     - accounts_password_pam_pwhistory_remember_system_auth
+
+    # RHEL-08-020221
     - accounts_password_pam_pwhistory_remember_password_auth
 
     # RHEL-08-020230

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -714,18 +714,11 @@ selections:
 
     # RHEL-08-030200
     - audit_rules_dac_modification_lremovexattr
-
-    # RHEL-08-030210
     - audit_rules_dac_modification_removexattr
-
-    # RHEL-08-030220
     - audit_rules_dac_modification_lsetxattr
-
-    # RHEL-08-030230
     - audit_rules_dac_modification_fsetxattr
-
-    # RHEL-08-030240
     - audit_rules_dac_modification_fremovexattr
+    - audit_rules_dac_modification_setxattr
 
     # RHEL-08-030250
     - audit_rules_privileged_commands_chage
@@ -733,8 +726,6 @@ selections:
     # RHEL-08-030260
     - audit_rules_execution_chcon
 
-    # RHEL-08-030270
-    - audit_rules_dac_modification_setxattr
 
     # RHEL-08-030280
     - audit_rules_privileged_commands_ssh_agent
@@ -789,27 +780,17 @@ selections:
 
     # RHEL-08-030360
     - audit_rules_kernel_module_loading_init
+    - audit_rules_kernel_module_loading_finit
 
     # RHEL-08-030361
     - audit_rules_file_deletion_events_rename
-
-    # RHEL-08-030362
     - audit_rules_file_deletion_events_renameat
-
-    # RHEL-08-030363
     - audit_rules_file_deletion_events_rmdir
-
-    # RHEL-08-030364
     - audit_rules_file_deletion_events_unlink
-
-    # RHEL-08-030365
     - audit_rules_file_deletion_events_unlinkat
 
     # RHEL-08-030370
     - audit_rules_privileged_commands_gpasswd
-
-    # RHEL-08-030380
-    - audit_rules_kernel_module_loading_finit
 
     # RHEL-08-030390
     - audit_rules_kernel_module_loading_delete
@@ -822,41 +803,21 @@ selections:
 
     # RHEL-08-030420
     - audit_rules_unsuccessful_file_modification_truncate
-
-    # RHEL-08-030430
     - audit_rules_unsuccessful_file_modification_openat
-
-    # RHEL-08-030440
     - audit_rules_unsuccessful_file_modification_open
-
-    # RHEL-08-030450
     - audit_rules_unsuccessful_file_modification_open_by_handle_at
-
-    # RHEL-08-030460
     - audit_rules_unsuccessful_file_modification_ftruncate
-
-    # RHEL-08-030470
     - audit_rules_unsuccessful_file_modification_creat
 
     # RHEL-08-030480
     - audit_rules_dac_modification_chown
+    - audit_rules_dac_modification_lchown
+    - audit_rules_dac_modification_fchownat
+    - audit_rules_dac_modification_fchown
 
     # RHEL-08-030490
     - audit_rules_dac_modification_chmod
-
-    # RHEL-08-030500
-    - audit_rules_dac_modification_lchown
-
-    # RHEL-08-030510
-    - audit_rules_dac_modification_fchownat
-
-    # RHEL-08-030520
-    - audit_rules_dac_modification_fchown
-
-    # RHEL-08-030530
     - audit_rules_dac_modification_fchmodat
-
-    # RHEL-08-030540
     - audit_rules_dac_modification_fchmod
 
     # RHEL-08-030550

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -715,27 +715,17 @@ selections:
 
     # RHEL-08-030200
     - audit_rules_dac_modification_lremovexattr
-
-    # RHEL-08-030210
     - audit_rules_dac_modification_removexattr
-
-    # RHEL-08-030220
     - audit_rules_dac_modification_lsetxattr
-
-    # RHEL-08-030230
     - audit_rules_dac_modification_fsetxattr
-
-    # RHEL-08-030240
     - audit_rules_dac_modification_fremovexattr
+    - audit_rules_dac_modification_setxattr
 
     # RHEL-08-030250
     - audit_rules_privileged_commands_chage
 
     # RHEL-08-030260
     - audit_rules_execution_chcon
-
-    # RHEL-08-030270
-    - audit_rules_dac_modification_setxattr
 
     # RHEL-08-030280
     - audit_rules_privileged_commands_ssh_agent
@@ -790,27 +780,17 @@ selections:
 
     # RHEL-08-030360
     - audit_rules_kernel_module_loading_init
+    - audit_rules_kernel_module_loading_finit
 
     # RHEL-08-030361
     - audit_rules_file_deletion_events_rename
-
-    # RHEL-08-030362
     - audit_rules_file_deletion_events_renameat
-
-    # RHEL-08-030363
     - audit_rules_file_deletion_events_rmdir
-
-    # RHEL-08-030364
     - audit_rules_file_deletion_events_unlink
-
-    # RHEL-08-030365
     - audit_rules_file_deletion_events_unlinkat
 
     # RHEL-08-030370
     - audit_rules_privileged_commands_gpasswd
-
-    # RHEL-08-030380
-    - audit_rules_kernel_module_loading_finit
 
     # RHEL-08-030390
     - audit_rules_kernel_module_loading_delete
@@ -823,41 +803,21 @@ selections:
 
     # RHEL-08-030420
     - audit_rules_unsuccessful_file_modification_truncate
-
-    # RHEL-08-030430
     - audit_rules_unsuccessful_file_modification_openat
-
-    # RHEL-08-030440
     - audit_rules_unsuccessful_file_modification_open
-
-    # RHEL-08-030450
     - audit_rules_unsuccessful_file_modification_open_by_handle_at
-
-    # RHEL-08-030460
     - audit_rules_unsuccessful_file_modification_ftruncate
-
-    # RHEL-08-030470
     - audit_rules_unsuccessful_file_modification_creat
 
     # RHEL-08-030480
     - audit_rules_dac_modification_chown
+    - audit_rules_dac_modification_lchown
+    - audit_rules_dac_modification_fchownat
+    - audit_rules_dac_modification_fchown
 
     # RHEL-08-030490
     - audit_rules_dac_modification_chmod
-
-    # RHEL-08-030500
-    - audit_rules_dac_modification_lchown
-
-    # RHEL-08-030510
-    - audit_rules_dac_modification_fchownat
-
-    # RHEL-08-030520
-    - audit_rules_dac_modification_fchown
-
-    # RHEL-08-030530
     - audit_rules_dac_modification_fchmodat
-
-    # RHEL-08-030540
     - audit_rules_dac_modification_fchmod
 
     # RHEL-08-030550

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -561,6 +561,8 @@ selections:
 
     # RHEL-08-020220
     - accounts_password_pam_pwhistory_remember_system_auth
+
+    # RHEL-08-020221
     - accounts_password_pam_pwhistory_remember_password_auth
 
     # RHEL-08-020230


### PR DESCRIPTION
#### Description:

- The rules were grouped together during last release and they should have the same STIG id as other STIG ids have been deleted. We are keeping them as separate rules since we think it's still better for tailoring and our rules can remediate within the same line of audit config. The only concern is that the exact ordering might not be identical to what STIG has in its verbiage.
