### PR TITLE
OCP fix insecureEdgeTerminationPolicy check

### DIFF
--- a/applications/openshift/networking/routes_protected_by_tls/rule.yml
+++ b/applications/openshift/networking/routes_protected_by_tls/rule.yml
@@ -31,7 +31,7 @@ ocil_clause: 'The proper insecureEdgeTerminationPolicy is not set'
 ocil: |-
     Run the following command to retrieve the compliancesuites in the system:
     <pre>$ oc get routes --all-namespaces</pre>
-    Make sure that every route object has either <tt>Disable</tt> or <tt>Redirect</tt>
+    Make sure that every route object has either <tt>None</tt> or <tt>Redirect</tt>
     in the <tt>.spec.tls.insecureEdgeTerminationPolicy</tt> setting.
 
 severity: medium
@@ -50,5 +50,5 @@ template:
     entity_check: "all"
     check_existence: "all_exist"
     values:
-      - value: "^(Disable|Redirect)$"
+      - value: "^(None|Redirect)$"
         operation: "pattern match"

--- a/applications/openshift/networking/routes_protected_by_tls/tests/all_route.pass.sh
+++ b/applications/openshift/networking/routes_protected_by_tls/tests/all_route.pass.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# remediation = none
+
+mkdir -p /kubernetes-api-resources/apis/route.openshift.io/v1/
+
+cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=500
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "creationTimestamp": "2022-02-07T15:44:41Z",
+                "labels": {
+                    "app": "oauth-openshift"
+                },
+                "name": "oauth-openshift",
+                "namespace": "openshift-authentication",
+                "resourceVersion": "20112",
+                "uid": "f90675f0-6090-4222-8b41-bf32d522d9ac"
+            },
+            "spec": {
+                "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
+                "port": {
+                    "targetPort": 6443
+                },
+                "tls": {
+                    "insecureEdgeTerminationPolicy": "Redirect",
+                    "termination": "passthrough"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "oauth-openshift",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2022-02-07T15:47:15Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
+                        "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
+                        "routerName": "default",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2022-02-07T15:48:36Z",
+                "labels": {
+                    "app.kubernetes.io/component": "query-layer",
+                    "app.kubernetes.io/instance": "thanos-querier",
+                    "app.kubernetes.io/name": "thanos-query",
+                    "app.kubernetes.io/version": "0.22.0"
+                },
+                "name": "thanos-querier",
+                "namespace": "openshift-monitoring",
+                "resourceVersion": "22723",
+                "uid": "a9aee465-0939-466a-a187-5d1c3e97d8e9"
+            },
+            "spec": {
+                "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                "port": {
+                    "targetPort": "web"
+                },
+                "tls": {
+                    "insecureEdgeTerminationPolicy": "Redirect",
+                    "termination": "reencrypt"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "thanos-querier",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2022-02-07T15:48:36Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                        "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
+                        "routerName": "default",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}

--- a/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_allow.fail.sh
+++ b/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_allow.fail.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# remediation = none
+
+mkdir -p /kubernetes-api-resources/apis/route.openshift.io/v1/
+
+cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=500
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "creationTimestamp": "2022-02-07T15:44:41Z",
+                "labels": {
+                    "app": "oauth-openshift"
+                },
+                "name": "oauth-openshift",
+                "namespace": "openshift-authentication",
+                "resourceVersion": "20112",
+                "uid": "f90675f0-6090-4222-8b41-bf32d522d9ac"
+            },
+            "spec": {
+                "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
+                "port": {
+                    "targetPort": 6443
+                },
+                "tls": {
+                    "insecureEdgeTerminationPolicy": "Allow",
+                    "termination": "passthrough"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "oauth-openshift",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2022-02-07T15:47:15Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
+                        "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
+                        "routerName": "default",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2022-02-07T15:48:36Z",
+                "labels": {
+                    "app.kubernetes.io/component": "query-layer",
+                    "app.kubernetes.io/instance": "thanos-querier",
+                    "app.kubernetes.io/name": "thanos-query",
+                    "app.kubernetes.io/version": "0.22.0"
+                },
+                "name": "thanos-querier",
+                "namespace": "openshift-monitoring",
+                "resourceVersion": "22723",
+                "uid": "a9aee465-0939-466a-a187-5d1c3e97d8e9"
+            },
+            "spec": {
+                "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                "port": {
+                    "targetPort": "web"
+                },
+                "tls": {
+                    "insecureEdgeTerminationPolicy": "Redirect",
+                    "termination": "reencrypt"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "thanos-querier",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2022-02-07T15:48:36Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                        "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
+                        "routerName": "default",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}

--- a/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_none.pass.sh
+++ b/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_none.pass.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# remediation = none
+
+mkdir -p /kubernetes-api-resources/apis/route.openshift.io/v1/
+
+cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=500
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "creationTimestamp": "2022-02-07T15:44:41Z",
+                "labels": {
+                    "app": "oauth-openshift"
+                },
+                "name": "oauth-openshift",
+                "namespace": "openshift-authentication",
+                "resourceVersion": "20112",
+                "uid": "f90675f0-6090-4222-8b41-bf32d522d9ac"
+            },
+            "spec": {
+                "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
+                "port": {
+                    "targetPort": 6443
+                },
+                "tls": {
+                    "insecureEdgeTerminationPolicy": "None",
+                    "termination": "passthrough"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "oauth-openshift",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2022-02-07T15:47:15Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
+                        "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
+                        "routerName": "default",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        },
+        {
+            "apiVersion": "route.openshift.io/v1",
+            "kind": "Route",
+            "metadata": {
+                "annotations": {
+                    "openshift.io/host.generated": "true"
+                },
+                "creationTimestamp": "2022-02-07T15:48:36Z",
+                "labels": {
+                    "app.kubernetes.io/component": "query-layer",
+                    "app.kubernetes.io/instance": "thanos-querier",
+                    "app.kubernetes.io/name": "thanos-query",
+                    "app.kubernetes.io/version": "0.22.0"
+                },
+                "name": "thanos-querier",
+                "namespace": "openshift-monitoring",
+                "resourceVersion": "22723",
+                "uid": "a9aee465-0939-466a-a187-5d1c3e97d8e9"
+            },
+            "spec": {
+                "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                "port": {
+                    "targetPort": "web"
+                },
+                "tls": {
+                    "insecureEdgeTerminationPolicy": "Redirect",
+                    "termination": "reencrypt"
+                },
+                "to": {
+                    "kind": "Service",
+                    "name": "thanos-querier",
+                    "weight": 100
+                },
+                "wildcardPolicy": "None"
+            },
+            "status": {
+                "ingress": [
+                    {
+                        "conditions": [
+                            {
+                                "lastTransitionTime": "2022-02-07T15:48:36Z",
+                                "status": "True",
+                                "type": "Admitted"
+                            }
+                        ],
+                        "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                        "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
+                        "routerName": "default",
+                        "wildcardPolicy": "None"
+                    }
+                ]
+            }
+        }
+    ],
+    "kind": "List",
+    "metadata": {
+        "resourceVersion": "",
+        "selfLink": ""
+    }
+}


### PR DESCRIPTION
We should check route insecureEdgeTerminationPolicy is None/Redirect instead of Disabled/Redirect according to: https://github.com/openshift/api/blob/31ffd77a8f025c73b5d19b390af353f9775e7ef1/route/v1/types.go#L270

Related BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2002695
