### PR TITLE
OCP fix rules resource_requests_quota and configure_network_policies

### DIFF
--- a/applications/openshift/general/resource_requests_quota/rule.yml
+++ b/applications/openshift/general/resource_requests_quota/rule.yml
@@ -47,9 +47,9 @@ references:
   nist: SC-5,SC-5(1),SC-5(2)
   srg: SRG-APP-000246-CTR-000605,SRG-APP-000435-CTR-001070
 
-{{% set resourcequotas_api_path = '/api/v1/resourcequotas?limit=500' %}}
-{{% set namespaces_api_path = '/api/v1/namespaces?limit=499' %}}
-{{% set clusterquotas_api_path = '/apis/quota.openshift.io/v1/clusterresourcequotas?limit=500' %}}
+{{% set resourcequotas_api_path = '/api/v1/resourcequotas' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces' %}}
+{{% set clusterquotas_api_path = '/apis/quota.openshift.io/v1/clusterresourcequotas' %}}
 {{% set clusterquotas_filter = '[.items[] | .metadata.name]' %}}
 {{% set resourcequotas_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
 {{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}

--- a/applications/openshift/general/resource_requests_quota/tests/no_quota.fail.sh
+++ b/applications/openshift/general/resource_requests_quota/tests/no_quota.fail.sh
@@ -8,7 +8,7 @@ kube_apipath="/kubernetes-api-resources"
 
 mkdir -p "$kube_apipath/apis/quota.openshift.io/v1"
 
-quota_apipath="/apis/quota.openshift.io/v1/clusterresourcequotas?limit=500"
+quota_apipath="/apis/quota.openshift.io/v1/clusterresourcequotas"
 
 # This file assumes there is no cluster qouta object
 cat <<EOF > "$kube_apipath$quota_apipath"

--- a/applications/openshift/general/resource_requests_quota/tests/only_have_cluster_quotas.pass.sh
+++ b/applications/openshift/general/resource_requests_quota/tests/only_have_cluster_quotas.pass.sh
@@ -8,7 +8,7 @@ kube_apipath="/kubernetes-api-resources"
 
 mkdir -p "$kube_apipath/apis/quota.openshift.io/v1"
 
-quota_apipath="/apis/quota.openshift.io/v1/clusterresourcequotas?limit=500"
+quota_apipath="/apis/quota.openshift.io/v1/clusterresourcequotas"
 
 # This file assumes there is a cluster qouta object
 cat <<EOF > "$kube_apipath$quota_apipath"

--- a/applications/openshift/general/resource_requests_quota/tests/only_have_quotas_per_project.fail.sh
+++ b/applications/openshift/general/resource_requests_quota/tests/only_have_quotas_per_project.fail.sh
@@ -8,7 +8,7 @@ kube_apipath="/kubernetes-api-resources"
 
 mkdir -p "$kube_apipath/api/v1"
 
-quota_apipath="/api/v1/resourcequotas?limit=500"
+quota_apipath="/api/v1/resourcequotas"
 
 # This file assumes three namespaces ns-one,ns-two,ns-three, only two have resource quota set
 
@@ -151,7 +151,7 @@ quota_filteredpath="$kube_apipath$quota_apipath#$(echo -n "$quota_apipath$quota_
 # populate filtered path with jq-filtered result
 jq "$quota_jq_filter" "$kube_apipath$quota_apipath" > "$quota_filteredpath"
 
-ns_apipath="/api/v1/namespaces?limit=499"
+ns_apipath="/api/v1/namespaces"
 
 cat <<EOF > "$kube_apipath$ns_apipath"
 {

--- a/applications/openshift/general/resource_requests_quota/tests/only_have_quotas_per_project.pass.sh
+++ b/applications/openshift/general/resource_requests_quota/tests/only_have_quotas_per_project.pass.sh
@@ -8,7 +8,7 @@ kube_apipath="/kubernetes-api-resources"
 
 mkdir -p "$kube_apipath/api/v1"
 
-quota_apipath="/api/v1/resourcequotas?limit=500"
+quota_apipath="/api/v1/resourcequotas"
 
 # This file assumes three namespaces ns-one,ns-two,ns-three, all three have resource quota set
 
@@ -187,7 +187,7 @@ quota_filteredpath="$kube_apipath$quota_apipath#$(echo -n "$quota_apipath$quota_
 # populate filtered path with jq-filtered result
 jq "$quota_jq_filter" "$kube_apipath$quota_apipath" > "$quota_filteredpath"
 
-ns_apipath="/api/v1/namespaces?limit=499"
+ns_apipath="/api/v1/namespaces"
 
 cat <<EOF > "$kube_apipath$ns_apipath"
 {

--- a/applications/openshift/general/resource_requests_quota_cluster/rule.yml
+++ b/applications/openshift/general/resource_requests_quota_cluster/rule.yml
@@ -60,14 +60,14 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/apis/quota.openshift.io/v1/clusterresourcequotas?limit=500': jqfilter}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/apis/quota.openshift.io/v1/clusterresourcequotas': jqfilter}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path('/apis/quota.openshift.io/v1/clusterresourcequotas?limit=500', jqfilter) }}}
+      {{{ openshift_filtered_path('/apis/quota.openshift.io/v1/clusterresourcequotas', jqfilter) }}}
     yamlpath: "[:]"
     entity_check: "at least one"
     values:

--- a/applications/openshift/general/resource_requests_quota_per_project/oval/shared.xml
+++ b/applications/openshift/general/resource_requests_quota_per_project/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
-{{% set resourcequota_api_path = '/api/v1/resourcequotas?limit=500' %}}
-{{% set namespaces_api_path = '/api/v1/namespaces?limit=499' %}}
+{{% set resourcequota_api_path = '/api/v1/resourcequotas' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces' %}}
 {{% set resourcequota_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
 {{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
   <definition class="compliance" id="resource_requests_quota_per_project" version="1">

--- a/applications/openshift/general/resource_requests_quota_per_project/rule.yml
+++ b/applications/openshift/general/resource_requests_quota_per_project/rule.yml
@@ -47,8 +47,8 @@ references:
   nist: SC-5,SC-5(1),SC-5(2)
   srg: SRG-APP-000246-CTR-000605,SRG-APP-000435-CTR-001070
 
-{{% set resourcequotas_api_path = '/api/v1/resourcequotas?limit=500' %}}
-{{% set namespaces_api_path = '/api/v1/namespaces?limit=499' %}}
+{{% set resourcequotas_api_path = '/api/v1/resourcequotas' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces' %}}
 {{% set resourcequotas_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
 {{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
 

--- a/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
-{{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies?limit=500' %}}
-{{% set namespaces_api_path = '/api/v1/namespaces?limit=500' %}}
+{{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces' %}}
 {{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
 {{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
   <definition class="compliance" id="configure_network_policies_namespaces" version="1">

--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -25,8 +25,8 @@ references:
     pcidss: Req-1.1.4,Req-1.2,Req-1.2.1,Req-1.3.1,Req-1.3.2,Req-2.2
     srg: SRG-APP-000038-CTR-000105,SRG-APP-000039-CTR-000110,SRG-APP-000141-CTR-000315,SRG-APP-000141-CTR-000320,SRG-APP-000142-CTR-000325,SRG-APP-000142-CTR-000330,SRG-APP-000516-CTR-001325,SRG-APP-000516-CTR-001330,SRG-APP-000516-CTR-001335,SRG-APP-000645-CTR-001410
 
-{{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies?limit=500' %}}
-{{% set namespaces_api_path = '/api/v1/namespaces?limit=500' %}}
+{{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
+{{% set namespaces_api_path = '/api/v1/namespaces' %}}
 {{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
 {{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
 


### PR DESCRIPTION
These two rules: resource_requests_quota and configure_network_policies will not work properly for clusters with more than 500 namespaces, because we had 500 item counts limits when getting api-resources, this PR will remove such limit, so that these rules will be evaluated properly.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2038909
