### PR TITLE
SC-12: Add ingress_controller_certificate rule

### DIFF
--- a/applications/openshift/networking/ingress_controller_certificate/rule.yml
+++ b/applications/openshift/networking/ingress_controller_certificate/rule.yml
@@ -1,0 +1,48 @@
+prodtype: ocp4
+
+title: 'Ensure that the default Ingress certificate has been replaced'
+
+description: |-
+  Check that the default Ingress certificate has been replaced.
+
+rationale: |-
+  OpenShift auto-generates several PKIs to serve TLS on different
+  endpoints of the system. It is possible and necessary to configure a
+  custom PKI which allows external clients to trust the endpoints.
+
+  The Ingress Operator is the component responsible for enabling external
+  access to OpenShift Container Platform cluster services. The aforementioned
+  operator creates an internal CA and issues a wildcard certificate that is
+  valid for applications under the .apps sub-domain. Both the web console
+  and CLI use this certificate as well. The certificate and key would need
+  to be replaced since a certificate coming from a trusted provider is
+  needed.
+
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/security/certificates/replacing-default-ingress-certificate.html") }}}
+
+severity: medium
+
+references:
+  nist: SC-12
+
+ocil_clause: 'Ingress Operator default certificate needs to be replaced'
+
+ocil: |-
+  Verify that the ingresscontroller.operator/default resource contains the name of a certificate secret:
+    <tt>oc get ingresscontroller.operator/default -n openshift-ingress-operator -ojsonpath='{ .spec."defaultCertificate"."name" }'</tt>
+  The result should be the name of a valid secret. If none, the default Ingress certificate is in use.
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/operator.openshift.io/v1/namespaces/openshift-ingress-operator/ingresscontrollers/default") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: /apis/operator.openshift.io/v1/namespaces/openshift-ingress-operator/ingresscontrollers/default
+    yamlpath: ".spec.defaultCertificate.name"
+    check_existence_yamlpath: ".metadata.name"
+    values:
+    - value: ".+"
+      operation: "pattern match"

--- a/applications/openshift/networking/ingress_controller_certificate/tests/ocp4/e2e-remediation.sh
+++ b/applications/openshift/networking/ingress_controller_certificate/tests/ocp4/e2e-remediation.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# we are using an existing default secret name for testing, so it won't cause any subsequent failures on testing routes.
+oc patch ingresscontroller.operator default --type merge -p '{"spec":{"defaultCertificate":{"name":"router-certs-default"}}}' -n openshift-ingress-operator

--- a/applications/openshift/networking/ingress_controller_certificate/tests/ocp4/e2e.yml
+++ b/applications/openshift/networking/ingress_controller_certificate/tests/ocp4/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS

--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -13866,7 +13866,7 @@ controls:
     https://issues.redhat.com/browse/CMP-496
   rules: []
 - id: SC-12
-  status: pending
+  status: automated
   notes: |-
     While OpenShift allows to provide a custom PKI for external-facing TLS
     endpoints such as routes, there are far more internal-only trust stores
@@ -13897,7 +13897,8 @@ controls:
     Note that a full respose to externally-facing certificates will be provided
     separately and is being tracked with:
     https://issues.redhat.com/browse/CMP-1042
-  rules: []
+  rules:
+    - ingress_controller_certificate
   description: |-
     The organization establishes and manages cryptographic keys for required cryptography employed within the information system in accordance with [Assignment: organization-defined requirements for key generation, distribution, storage, access, and destruction].
 


### PR DESCRIPTION
Add a rule that checks for the use of a defaultCertificate for ingress.

https://issues.redhat.com/browse/CMP-1042