### PR TITLE
Update ocil_clause of encrypt_partitions to exclude boot partition

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -90,6 +90,7 @@ ocil: |-
     /dev/sda2: UUID=" bc98d7ef-6g54-321h-1d24-9870de2ge1a2
     " TYPE="crypto_LUKS"</pre>
     <br /><br />
-    Pseudo-file systems, such as /proc, /sys, and tmpfs, are not required to use disk encryption and are not a finding.
+    The boot partition and pseudo-file systems, such as /proc, /sys, and tmpfs,
+    are not required to use disk encryption and are not a finding.
 
 platform: machine


### PR DESCRIPTION
#### Description:

- Update ocil_clause of encrypt_partitions to exclude boot partition.
  - Boot partitions are not part of required partitions to be encrypted.
