### PR TITLE
Align description of grub2 rules with checks and remediations

### DIFF
--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -54,24 +54,6 @@ ocil_clause: 'auditing is not enabled at boot time'
 ocil: |-
     {{{ ocil_grub2_argument("audit=1") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product in ["rhel7", "ol7", "rhel8", "ol8"] %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: grub2
 
 template:

--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -7,15 +7,8 @@ title: 'Enable Auditing for Processes Which Start Prior to the Audit Daemon'
 description: |-
     To ensure all processes can be audited, even those which start
     prior to the audit daemon, add the argument <tt>audit=1</tt> to the default
-    GRUB 2 command line for the Linux operating system in
-{{% if product in ["rhel7", "ol7"] %}}
-    <tt>/etc/default/grub</tt>, so that the line looks similar to
-    <pre>GRUB_CMDLINE_LINUX="... audit=1 ..."</pre>
-    In case the <tt>GRUB_DISABLE_RECOVERY</tt> is set to true, then the parameter should be added to the <tt>GRUB_CMDLINE_LINUX_DEFAULT</tt> instead.
-{{% else %}}
-    <tt>{{{ grub2_boot_path }}}/grubenv</tt>, in the manner below:
-    <pre># grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit=1"</pre>
-{{% endif %}}
+    GRUB 2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("audit=1") | indent(4) }}}
 
 rationale: |-
     Each process on the system carries an "auditable" flag which indicates whether
@@ -59,39 +52,7 @@ references:
 ocil_clause: 'auditing is not enabled at boot time'
 
 ocil: |-
-{{% if product in ["rhel7", "ol7", "sle12","sle15"] %}}
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If it includes <tt>audit=1</tt>, then auditing
-    is enabled at boot time.
-    First check if the GRUB recovery is enabled:
-    <pre>$ grep 'GRUB_DISABLE_RECOVERY' /etc/default/grub</pre>
-    If this option is set to true, then check that a line is output by the following command:
-    <pre>$ grep 'GRUB_CMDLINE_LINUX_DEFAULT.*audit=1.*' /etc/default/grub</pre>
-    If the recovery is disabled, check the line with
-    <pre>$ grep 'GRUB_CMDLINE_LINUX.*audit=1.*' /etc/default/grub</pre>.
-    Moreover, current Grub2 config file in <tt>/etc/grub2/grub.cfg</tt> must be checked.
-    <pre># grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v 'audit=1'</pre>
-    This command should not return any output. If it does, update the configuration with
-    <pre># grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
-    <br /><br />
-    Alternatively, to ensure <tt>audit=1</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="audit=1"</pre>
-    <br />
-{{% else %}}
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. If they include <tt>audit=1</tt>, then auditing
-    is enabled at boot time.
-    <pre># grep 'kernelopts.*audit=1.*' {{{ grub2_boot_path }}}/grubenv</pre>
-    <br /><br />
-    To ensure <tt>audit=1</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre># grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit=1"</pre>
-    <br />
-{{% endif %}}
-
+    {{{ ocil_grub2_argument("audit=1") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -7,9 +7,8 @@ title: 'Extend Audit Backlog Limit for the Audit Daemon'
 description: |-
     To improve the kernel capacity to queue all log events, even those which occurred
     prior to the audit daemon, add the argument <tt>audit_backlog_limit=8192</tt> to the default
-    GRUB 2 command line for the Linux operating system in
-    <tt>/etc/default/grub</tt>, in the manner below:
-    <pre>GRUB_CMDLINE_LINUX="crashkernel=auto rd.lvm.lv=VolGroup/LogVol06 rd.lvm.lv=VolGroup/lv_swap rhgb quiet rd.shell=0 audit=1 audit_backlog_limit=8192"</pre>
+    GRUB 2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("audit_backlog_limit=8192") | indent(4) }}}
 
 rationale: |-
     audit_backlog_limit sets the queue length for audit events awaiting transfer
@@ -40,15 +39,7 @@ references:
 ocil_clause: 'audit backlog limit is not configured'
 
 ocil: |-
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If they include <tt>audit=1</tt>, then auditing
-    is enabled at boot time.
-    <br /><br />
-    To ensure <tt>audit_backlog_limit=8192</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="audit_backlog_limit=8192"</pre>
-    <br />
+    {{{ ocil_grub2_argument("audit_backlog_limit=8192") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -41,24 +41,6 @@ ocil_clause: 'audit backlog limit is not configured'
 ocil: |-
     {{{ ocil_grub2_argument("audit_backlog_limit=8192") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: grub2
 
 template:

--- a/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_enable_iommu_force/rule.yml
@@ -5,9 +5,10 @@ title: 'IOMMU configuration directive'
 description: |-
     On x86 architecture supporting VT-d, the IOMMU manages the access control policy between the hardware devices and some
         of the system critical units such as the memory.
+    {{{ describe_grub2_argument("iommu=force") | indent(4) }}}
 
 rationale: |-
-    On x86 architectures, activating the I/OMMU prevents the system from arbritrary accesses potentially made by
+    On x86 architectures, activating the I/OMMU prevents the system from arbitrary accesses potentially made by
         hardware devices.
 
 severity: unknown
@@ -21,6 +22,12 @@ references:
     anssi: BP28(R11)
 
 platform: machine
+
+ocil_clause: 'I/OMMU is not activated'
+
+ocil: |-
+    {{{ ocil_grub2_argument("iommu=force") | indent(4) }}}
+
 
 warnings:
   - functionality:

--- a/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_init_on_alloc_argument/rule.yml
@@ -6,12 +6,8 @@ title: 'Configure kernel to zero out memory before allocation'
 
 description: |-
     To configure the kernel to zero out memory before allocating it, add the
-    <tt>init_on_alloc=1</tt> argument to the default GRUB 2 command line for
-    the Linux operating system in <tt>/etc/default/grub</tt>, in the manner
-    below:
-    <pre>GRUB_CMDLINE_LINUX="crashkernel=auto quiet rd.shell=0 audit=1 audit_backlog_limit=8192 init_on_alloc=1"</pre>
-    Update the boot parameter for existing kernels by running the following command:
-    <pre># grubby --update-kernel=ALL --args="init_on_alloc=1"</pre>
+    <tt>init_on_alloc=1</tt> argument to the default GRUB 2 command line.
+    {{{ describe_grub2_argument("init_on_alloc=1") | indent(4) }}}
 
 rationale: |-
     When the kernel configuration option <tt>init_on_alloc</tt> is enabled,
@@ -27,15 +23,7 @@ identifiers:
 ocil_clause: 'the kernel is not configured to zero out memory before allocation'
 
 ocil: |-
-    Make sure that the kernel is configured to zero out memory before
-    allocation. Ensure that the parameter is configured in
-    <tt>/etc/default/grub</tt>:
-    <pre>grep GRUB_CMDLINE_LINUX /etc/default/grub</pre>
-    The output should contain <tt>init_on_alloc=1</tt>.
-    Run the following command to display command line parameters of all
-    installed kernels:
-    <pre># grubby --info=ALL | grep args</pre>
-    Ensure that each line contains the <tt>init_on_alloc=1</tt> parameter.
+    {{{ ocil_grub2_argument("init_on_alloc=1") | indent(4) }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/rule.yml
@@ -11,8 +11,8 @@ description: |-
     <tt>Y</tt>, make sure that it is not overridden with the boot parameter.
     There must not exist the boot parameter <tt>random.trust_cpu=off</tt>. If
     the option is not compiled in, make sure that <tt>random.trust_cpu=on</tt>
-    is configured as a boot parameter by running the following command:
-    <pre>sudo grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) random.trust_cpu=on"</pre>
+    is configured as a boot parameter.
+    {{{ describe_grub2_argument("random.trust_cpu=on") | indent(4) }}}
 
 rationale: |-
     The Linux kernel offers an option which signifies if the kernel should trust
@@ -44,11 +44,8 @@ ocil: |-
     option is not overridden through a boot parameter:
     <pre>sudo grep 'kernelopts.*random\.trust_cpu=off.*' {{{ grub2_boot_path }}}/grubenv</pre>
     The command should not return any output. If the option is not compiled into
-    the kernel, check that the option is configured through boot parameter with
-    the following command:
-    <pre>sudo grep 'kernelopts.*random\.trust_cpu=on.*' {{{ grub2_boot_path }}}/grubenv</pre>
-    If the command does not return any output, then the boot parameter is
-    missing.
+    the kernel, check that the option is configured through boot parameter.
+    {{{ ocil_grub2_argument("random.trust_cpu=on") | indent(4) }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -34,24 +34,6 @@ ocil_clause: 'Kernel page-table isolation is not enabled'
 ocil: |-
     {{{ ocil_grub2_argument("pti=on") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product in ["rhel8", "ol8"] %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: machine
 
 template:

--- a/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_pti_argument/rule.yml
@@ -7,9 +7,8 @@ title: 'Enable Kernel Page-Table Isolation (KPTI)'
 description: |-
     To enable Kernel page-table isolation,
     add the argument <tt>pti=on</tt> to the default
-    GRUB 2 command line for the Linux operating system in
-    <tt>/etc/default/grub</tt>, in the manner below:
-    <pre>GRUB_CMDLINE_LINUX="pti=on"</pre>
+    GRUB 2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("pti=on") | indent(4) }}}
 
 rationale: |-
     Kernel page-table isolation is a kernel feature that mitigates
@@ -33,15 +32,7 @@ references:
 ocil_clause: 'Kernel page-table isolation is not enabled'
 
 ocil: |-
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If they include <tt>pti=on</tt>,
-    then Kernel page-table isolation is enabled at boot time.
-    <br /><br />
-    To ensure <tt>pti=on</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="pti=on</pre>
-    <br />
+    {{{ ocil_grub2_argument("pti=on") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -34,24 +34,6 @@ ocil_clause: 'vsyscalls are enabled'
 ocil: |-
     {{{ ocil_grub2_argument("vsyscall=none") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: machine
 
 template:

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/rule.yml
@@ -7,9 +7,8 @@ title: 'Disable vsyscalls'
 description: |-
     To disable use of virtual syscalls,
     add the argument <tt>vsyscall=none</tt> to the default
-    GRUB 2 command line for the Linux operating system in
-    <tt>/etc/default/grub</tt>, in the manner below:
-    <pre>GRUB_CMDLINE_LINUX="vsyscall=none"</pre>
+    GRUB 2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("vsyscall=none") | indent(4) }}}
 
 rationale: |-
     Virtual Syscalls provide an opportunity of attack for a user who has control
@@ -33,15 +32,7 @@ references:
 ocil_clause: 'vsyscalls are enabled'
 
 ocil: |-
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If they include <tt>vsyscall=none</tt>,
-    then virtyal syscalls are not enabled at boot time.
-    <br /><br />
-    To ensure <tt>vsyscall=none</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="vsyscall=none</pre>
-    <br />
+    {{{ ocil_grub2_argument("vsyscall=none") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -7,20 +7,8 @@ title: 'Ensure IPv6 is disabled through kernel boot parameter'
 description: |-
     To disable IPv6 protocol support in the Linux kernel,
     add the argument <tt>ipv6.disable=1</tt> to the default
-    GRUB2 command line for the Linux operating system in
-{{% if product in ["rhel7", "ol7"] %}}
-    <tt>/etc/default/grub</tt>, so that the line looks similar to
-    <pre>GRUB_CMDLINE_LINUX="... ipv6.disable=1 ..."</pre>
-    In case the <tt>GRUB_DISABLE_RECOVERY</tt> is set to true, then the parameter should be added to the <tt>GRUB_CMDLINE_LINUX_DEFAULT</tt> instead.
-    Run one of following command to ensure that the configuration is applied when booting currently installed kernels:
-    <pre>sudo grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
-    or
-    <pre>sudo /sbin/grubby --update-kernel=ALL --args="ipv6.disable=1"</pre>
-{{% else %}}
-    <tt>{{{ grub2_boot_path }}}/grubenv</tt>, in the manner below:
-    <pre>sudo  grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) ipv6.disable=1"</pre>
-{{% endif %}}
-
+    GRUB2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("ipv6.disable=1") | indent(4) }}}
 
 rationale: |-
     Any unnecessary network stacks, including IPv6, should be disabled to reduce
@@ -40,34 +28,7 @@ references:
 ocil_clause: 'IPv6 is not disabled'
 
 ocil: |-
-    {{% if product in ["rhel7", "ol7"] %}}
-    Inspect the form of default GRUB2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. Check if it includes <tt>ipv6.disable=1</tt>.
-    First check if the GRUB recovery is enabled:
-    <pre>grep 'GRUB_DISABLE_RECOVERY' /etc/default/grub</pre>
-    If this option is set to true, then check that the following line is output by the following command:
-    <pre>grep 'GRUB_CMDLINE_LINUX_DEFAULT.*ipv6.disable=1.*' /etc/default/grub</pre>
-    If the recovery is disabled, check the line with
-    <pre>grep 'GRUB_CMDLINE_LINUX.*ipv6.disable=1.*' /etc/default/grub</pre>.
-    Moreover, current GRUB2 config file in <tt>/etc/grub2/grub.cfg</tt> must be checked.
-    <pre>sudo grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v 'ipv6.disable=1'</pre>
-    This command should not return any output. If it does, update the configuration with one of following commands:
-    <pre>sudo grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
-    or
-    <pre>sudo /sbin/grubby --update-kernel=ALL --args="ipv6.disable=1"</pre>
-    <br />
-{{% else %}}
-    Inspect the form of default GRUB2 command line for the Linux operating system
-    in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. Check if it includes <tt>ipv6.disable=1</tt>.
-    <pre>sudo grep 'kernelopts.*ipv6.disable=1.*' {{{ grub2_boot_path }}}/grubenv</pre>
-    <br /><br />
-    To ensure <tt>ipv6.disable=1</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>sudo grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) ipv6.disable=1"</pre>
-    <br />
-{{% endif %}}
-
+    {{{ ocil_grub2_argument("ipv6.disable=1") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/grub2_ipv6_disable_argument/rule.yml
@@ -30,24 +30,6 @@ ocil_clause: 'IPv6 is not disabled'
 ocil: |-
     {{{ ocil_grub2_argument("ipv6.disable=1") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command:
-        <pre>sudo grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command:
-{{% if product in ["rhel7", "ol7", "rhel8", "ol8"] %}}
-        <pre>sudo grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>sudo grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: grub2
 
 template:

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
@@ -7,9 +7,8 @@ title: 'Enable page allocator poisoning'
 description: |-
     To enable poisoning of free pages,
     add the argument <tt>page_poison=1</tt> to the default
-    GRUB 2 command line for the Linux operating system in
-    <tt>/etc/default/grub</tt>, in the manner below:
-    <pre>GRUB_CMDLINE_LINUX="page_poison=1"</pre>
+    GRUB 2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("page_poison=1") | indent(4) }}}
 
 rationale: |-
     Poisoning writes an arbitrary value to freed pages, so any modification or
@@ -35,15 +34,7 @@ references:
 ocil_clause: 'page allocator poisoning is not enabled'
 
 ocil: |-
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If they include <tt>page_poison=1</tt>,
-    then page poisoning is enabled at boot time.
-    <br /><br />
-    To ensure <tt>page_poison=1</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="page_poison=1</pre>
-    <br />
+    {{{ ocil_grub2_argument("page_poison=1") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_page_poison_argument/rule.yml
@@ -36,24 +36,6 @@ ocil_clause: 'page allocator poisoning is not enabled'
 ocil: |-
     {{{ ocil_grub2_argument("page_poison=1") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: grub2
 
 template:

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -36,24 +36,6 @@ ocil_clause: 'SLUB/SLAB poisoning is not enabled'
 ocil: |-
     {{{ ocil_grub2_argument("slub_debug=P") | indent(4) }}}
 
-warnings:
-    - management: |-
-        The GRUB 2 configuration file, <tt>grub.cfg</tt>,
-        is automatically updated each time a new kernel is installed. Note that any
-        changes to <tt>/etc/default/grub</tt> require rebuilding the <tt>grub.cfg</tt>
-        file. To update the GRUB 2 configuration file manually, use the
-        <pre>grub2-mkconfig -o</pre> command as follows:
-        <ul>
-        <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
-        <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
-        <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-{{% if product in ["rhel7", "rhel8", "ol7", "ol8"] %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
-{{% else %}}
-        <pre>~]# grub2-mkconfig -o /boot/efi/EFI/fedora/grub.cfg</pre></li>
-{{% endif %}}
-        </ul>
-
 platform: grub2
 
 template:

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -7,9 +7,8 @@ title: 'Enable SLUB/SLAB allocator poisoning'
 description: |-
     To enable poisoning of SLUB/SLAB objects,
     add the argument <tt>slub_debug=P</tt> to the default
-    GRUB 2 command line for the Linux operating system in
-    <tt>/etc/default/grub</tt>, in the manner below:
-    <pre>GRUB_CMDLINE_LINUX="slub_debug=P"</pre>
+    GRUB 2 command line for the Linux operating system.
+    {{{ describe_grub2_argument("slub_debug=P") | indent(4) }}}
 
 rationale: |-
     Poisoning writes an arbitrary value to freed objects, so any modification or
@@ -35,15 +34,7 @@ references:
 ocil_clause: 'SLUB/SLAB poisoning is not enabled'
 
 ocil: |-
-    Inspect the form of default GRUB 2 command line for the Linux operating system
-    in <tt>/etc/default/grub</tt>. If they include <tt>slub_debug=P</tt>,
-    then SLUB/SLAB poisoning is enabled at boot time.
-    <br /><br />
-    To ensure <tt>slub_debug=P</tt> is configured on all installed kernels, the
-    following command may be used:
-    <br />
-    <pre>$ sudo /sbin/grubby --update-kernel=ALL --args="slub_debug=P</pre>
-    <br />
+    {{{ ocil_grub2_argument("slub_debug=P") | indent(4) }}}
 
 warnings:
     - management: |-

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1626,7 +1626,7 @@ The audit daemon must be restarted for the changes to take effect.
     The parameter should be in form `parameter=value`.
 #}}
 {{%- macro describe_grub2_argument(arg_name_value) -%}}
-{{%- if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product -%}}
+{{%- if product in ["rhel7", "ol7", "rhel8", "ol8", "rhel9"] or 'ubuntu' in product -%}}
 To ensure that <tt>{{{ arg_name_value }}}</tt> is added as a kernel command line
 argument to newly installed kernels, ad <tt>{{{ arg_name_value }}}</tt> to the
 default Grub2 command line for Linux operating systems.  Modify the line within
@@ -1649,7 +1649,7 @@ Configure the default Grub2 kernel command line to contain {{{ arg_name_value }}
     The parameter should have form `parameter=value`.
 #}}
 {{%- macro ocil_grub2_argument(arg_name_value) -%}}
-{{%- if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product -%}}
+{{%- if product in ["rhel7", "ol7", "rhel8", "ol8", "rhel9"] or 'ubuntu' in product -%}}
 Inspect the form of default GRUB 2 command line for the Linux operating system
 in <tt>/etc/default/grub</tt>. If it includes <tt>{{{ arg_name_value }}}</tt>,
 then the parameter will be configured for newly installed kernels.
@@ -1660,8 +1660,12 @@ If this option is set to true, then check that a line is output by the following
 If the recovery is disabled, check the line with
 <pre>$ grep 'GRUB_CMDLINE_LINUX.*{{{ arg_name_value }}}.*' /etc/default/grub</pre>.
 {{%- if 'ubuntu' in product -%}}
-Moreover, current Grub2 config file in <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> must be checked.
-<pre># grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v '{{{ arg_name_value }}}'</pre>
+Moreover, current Grub config file <tt>grub.cfg</tt> must be checked. The file can be found
+either in <tt>{{{ grub2_boot_path }}}</tt> in case of legacy BIOS systems, or in <tt>{{{ grub2_uefi_boot_path }}}</tt> in case of UEFI systems.
+If they include <tt>{{{ arg_name_value }}}</tt>, then the parameter
+is configured at boot time.
+<pre># grep vmlinuz GRUB_CFG_FILE_PATH | grep -v '{{{ arg_name_value }}}'</pre>
+Fill in <tt>GRUB_CFG_FILE_PATH</tt> based on information above.
 This command should not return any output.
 {{%- else -%}}
 Moreover, command line parameters for currently installed kernels should be checked as well.
@@ -1678,6 +1682,7 @@ in <tt>grubenv</tt> that can be found either in <tt>{{{ grub2_boot_path }}}</tt>
 {{%- endif %}}
 If they include <tt>{{{ arg_name_value }}}</tt>, then the parameter
 is configured at boot time.
-<pre># grep 'kernelopts.*{{{ arg_name_value }}}.*' {{{ grub2_boot_path }}}/grubenv</pre>
+<pre># grep 'kernelopts.*{{{ arg_name_value }}}.*' GRUBENV_FILE_LOCATION</pre>
+Fill in <tt>GRUBENV_FILE_LOCATION</tt> based on information above.
 {{%- endif -%}}
 {{%- endmacro -%}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1652,7 +1652,7 @@ Configure the default Grub2 kernel command line to contain {{{ arg_name_value }}
 {{%- if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product -%}}
 Inspect the form of default GRUB 2 command line for the Linux operating system
 in <tt>/etc/default/grub</tt>. If it includes <tt>{{{ arg_name_value }}}</tt>,
-then auditinng will be enabled for newly installed kernels.
+then the parameter will be configured for newly installed kernels.
 First check if the GRUB recovery is enabled:
 <pre>$ grep 'GRUB_DISABLE_RECOVERY' /etc/default/grub</pre>
 If this option is set to true, then check that a line is output by the following command:
@@ -1671,8 +1671,8 @@ The command should not return any output.
 {{%- endif -%}}
 {{%- else -%}}
 Inspect the form of default GRUB 2 command line for the Linux operating system
-in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. If they include <tt>{{{ arg_name_value }}}</tt>, then auditing
-is enabled at boot time.
+in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. If they include <tt>{{{ arg_name_value }}}</tt>, then the parameter
+is configured at boot time.
 <pre># grep 'kernelopts.*{{{ arg_name_value }}}.*' {{{ grub2_boot_path }}}/grubenv</pre>
 {{%- endif -%}}
 {{%- endmacro -%}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1620,3 +1620,59 @@ The audit daemon must be restarted for the changes to take effect.
 - no_ovirt
 {{%- endif %}}
 {{% endmacro %}}
+
+{{#
+    Describe how to configure Grub2 to add an argument to the default kernel command line.
+    The parameter should be in form `parameter=value`.
+#}}
+{{%- macro describe_grub2_argument(arg_name_value) -%}}
+{{%- if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product -%}}
+To ensure that <tt>{{{ arg_name_value }}}</tt> is added as a kernel command line
+argument to newly installed kernels, ad <tt>{{{ arg_name_value }}}</tt> to the
+default Grub2 command line for Linux operating systems.  Modify the line within
+<tt>/etc/default/grub</tt> as shown below:
+<pre>GRUB_CMDLINE_LINUX="... {{{ arg_name_value }}} ..."</pre>
+Run the following command to update command line for already installed kernels:
+{{%- if 'ubuntu' in product -%}}
+<pre># update-grub</pre>
+{{%- else -%}}
+<pre># grubby --update-kernel=ALL --args="{{{ arg_name_value }}}"</pre>
+{{%- endif -%}}
+{{%- else -%}}
+Configure the default Grub2 kernel command line to contain {{{ arg_name_value }}} as follows:
+<pre># grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) {{{ arg_name_value }}}"</pre>
+{{%- endif -%}}
+{{%- endmacro -%}}
+
+{{#
+    Provide OCIL for checking if an argument for kernel command line is configured with Grub2.
+    The parameter should have form `parameter=value`.
+#}}
+{{%- macro ocil_grub2_argument(arg_name_value) -%}}
+{{%- if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product -%}}
+Inspect the form of default GRUB 2 command line for the Linux operating system
+in <tt>/etc/default/grub</tt>. If it includes <tt>{{{ arg_name_value }}}</tt>,
+then auditinng will be enabled for newly installed kernels.
+First check if the GRUB recovery is enabled:
+<pre>$ grep 'GRUB_DISABLE_RECOVERY' /etc/default/grub</pre>
+If this option is set to true, then check that a line is output by the following command:
+<pre>$ grep 'GRUB_CMDLINE_LINUX_DEFAULT.*{{{ arg_name_value }}}.*' /etc/default/grub</pre>
+If the recovery is disabled, check the line with
+<pre>$ grep 'GRUB_CMDLINE_LINUX.*{{{ arg_name_value }}}.*' /etc/default/grub</pre>.
+{{%- if 'ubuntu' in product -%}}
+Moreover, current Grub2 config file in <tt>/etc/grub2/grub.cfg</tt> must be checked.
+<pre># grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v '{{{ arg_name_value }}}'</pre>
+This command should not return any output.
+{{%- else -%}}
+Moreover, command line parameters for currently installed kernels should be checked as well.
+Run the following command:
+<pre># grubby --info=ALL | grep args | grep -v '{{{ arg_name_value }}}'</pre>
+The command should not return any output.
+{{%- endif -%}}
+{{%- else -%}}
+Inspect the form of default GRUB 2 command line for the Linux operating system
+in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. If they include <tt>{{{ arg_name_value }}}</tt>, then auditing
+is enabled at boot time.
+<pre># grep 'kernelopts.*{{{ arg_name_value }}}.*' {{{ grub2_boot_path }}}/grubenv</pre>
+{{%- endif -%}}
+{{%- endmacro -%}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1671,7 +1671,12 @@ The command should not return any output.
 {{%- endif -%}}
 {{%- else -%}}
 Inspect the form of default GRUB 2 command line for the Linux operating system
-in <tt>{{{ grub2_boot_path }}}/grubenv</tt>. If they include <tt>{{{ arg_name_value }}}</tt>, then the parameter
+{{% if grub2_boot_path == grub2_uefi_boot_path or not grub2_uefi_boot_path -%}}
+in <tt>{{{ grub2_boot_path }}}/grubenv</tt>.
+{{%- else -%}}
+in <tt>grubenv</tt> that can be found either in <tt>{{{ grub2_boot_path }}}</tt> in case of legacy BIOS systems, or in <tt>{{{ grub2_uefi_boot_path }}}</tt> in case of UEFI systems.
+{{%- endif %}}
+If they include <tt>{{{ arg_name_value }}}</tt>, then the parameter
 is configured at boot time.
 <pre># grep 'kernelopts.*{{{ arg_name_value }}}.*' {{{ grub2_boot_path }}}/grubenv</pre>
 {{%- endif -%}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1660,7 +1660,7 @@ If this option is set to true, then check that a line is output by the following
 If the recovery is disabled, check the line with
 <pre>$ grep 'GRUB_CMDLINE_LINUX.*{{{ arg_name_value }}}.*' /etc/default/grub</pre>.
 {{%- if 'ubuntu' in product -%}}
-Moreover, current Grub2 config file in <tt>/etc/grub2/grub.cfg</tt> must be checked.
+Moreover, current Grub2 config file in <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> must be checked.
 <pre># grep vmlinuz {{{ grub2_boot_path }}}/grub.cfg | grep -v '{{{ arg_name_value }}}'</pre>
 This command should not return any output.
 {{%- else -%}}


### PR DESCRIPTION
#### Description:

- create new Jinja macros for dewscription and ocil_clause of Grub2 related rules
- apply these macros in appropriate rules
- remove warnings about /boot/grub2/grub.cfg needing to be regenerated asi this should happen automatically

#### Rationale:

- align descriptions and ocils with checks and remediations