### PR TITLE
Extend package_pam_pwquality_installed rule for RHEL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -1,19 +1,22 @@
 documentation_complete: true
 
-prodtype: ubuntu2004
+prodtype: rhel7,rhel8,rhel9,ubuntu2004
 
 title: 'Install pam_pwquality Package'
 
 description: |-
+    {{% if 'ubuntu' not in product %}}
+    {{{ describe_package_install(package="libpwquality") }}}
+    {{% else %}}
     {{{ describe_package_install(package="libpam-pwquality") }}}
+    {{% endif %}}
 
 rationale: |-
     Use of a complex password helps to increase the time and resources required
     to compromise the password. Password complexity, or strength, is a measure
     of the effectiveness of a password in resisting attempts at guessing and
     brute-force attacks. "pwquality" enforces complex password construction
-    configuration and has the ability to limit brute-force attacks on the
-    system.
+    configuration and has the ability to limit brute-force attacks on the system.
 
 severity: medium
 
@@ -24,9 +27,14 @@ references:
 
 ocil_clause: 'the package is not installed'
 
-ocil: '{{{ ocil_package(package="libpam-pwquality") }}}'
+{{% if 'ubuntu' not in product %}}
+{{{ complete_ocil_entry_package(package="libpwquality") }}}
+{{% else %}}
+{{{ complete_ocil_entry_package(package="libpam-pwquality") }}}
+{{% endif %}}
 
 template:
     name: package_installed
     vars:
-        pkgname: libpam-pwquality
+        pkgname: libpwquality
+        pkgname@ubuntu2004: libpam-pwquality

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -638,7 +638,7 @@ zypper install -y "{{{ package }}}"
 {{%- if pkg_manager == "yum" or pkg_manager == "dnf" -%}}
 if rpm -q --quiet "{{{ package }}}" ; then
 {{% if SSG_TEST_SUITE_ENV %}}
-    {{{ pkg_manager }}} remove -y --setopt protected_packages= "{{{ package }}}"
+    rpm -e --nodeps "{{{ package }}}"
 {{% else %}}
     {{{ pkg_manager }}} remove -y "{{{ package }}}"
 {{% endif %}}


### PR DESCRIPTION
Extend the `rule package_pam_pwquality_installed` to be also applicable for RHEL.

This rule checks if the package which brings the `pam_pwquality.so` module is installed.
