### PR TITLE
Fix typo in accounts_password_pam_unix_remember Ubuntu bash

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_password_pam_unix_remember") }}}
 
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-password', 'password', '[success=1 default=ignore]', 'pam_unix.so', 'obsecure sha512 shadow remember', "$var_password_pam_unix_remember", "$var_password_pam_unix_remember") }}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-password', 'password', '[success=1 default=ignore]', 'pam_unix.so', 'obscure sha512 shadow remember', "$var_password_pam_unix_remember", "$var_password_pam_unix_remember") }}}


### PR DESCRIPTION
#### Description:

- Small typo in Ubuntu specific bash
