### PR TITLE
Remove RHEL-08-010200 and RHEL-08-010201 from RHEL8 and RHEL9 STIG

### DIFF
--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -51,7 +51,7 @@ selections:
     - var_password_pam_lcredit=1
     - var_password_pam_retry=3
     - var_password_pam_minlen=15
-    - var_sshd_set_keepalive=0
+    # - var_sshd_set_keepalive=0
     - sshd_approved_macs=stig
     - sshd_approved_ciphers=stig
     - sshd_idle_timeout_value=10_minutes
@@ -170,11 +170,13 @@ selections:
     # RHEL-08-010190
     - dir_perms_world_writable_sticky_bits
 
-    # RHEL-08-010200
-    - sshd_set_keepalive_0
-
-    # RHEL-08-010201
-    - sshd_set_idle_timeout
+    # These two items don't behave as they used to in RHEL8.6 and RHEL9
+    # anymore. They will be disabled for now until an alternative
+    # solution is found.
+    # # RHEL-08-010200
+    # - sshd_set_keepalive_0
+    # # RHEL-08-010201
+    # - sshd_set_idle_timeout
 
     # RHEL-08-010210
     - file_permissions_var_log_messages

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -52,7 +52,7 @@ selections:
     - var_password_pam_lcredit=1
     - var_password_pam_retry=3
     - var_password_pam_minlen=15
-    - var_sshd_set_keepalive=0
+    # - var_sshd_set_keepalive=0
     - sshd_approved_macs=stig
     - sshd_approved_ciphers=stig
     - sshd_idle_timeout_value=10_minutes
@@ -171,11 +171,13 @@ selections:
     # RHEL-08-010190
     - dir_perms_world_writable_sticky_bits
 
-    # RHEL-08-010200
-    - sshd_set_keepalive_0
-
-    # RHEL-08-010201
-    - sshd_set_idle_timeout
+    # These two items don't behave as they used to in RHEL8.6 and RHEL9
+    # anymore. They will be disabled for now until an alternative
+    # solution is found.
+    # # RHEL-08-010200
+    # - sshd_set_keepalive_0
+    # # RHEL-08-010201
+    # - sshd_set_idle_timeout
 
     # RHEL-08-010210
     - file_permissions_var_log_messages

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -353,8 +353,6 @@ selections:
 - sshd_enable_warning_banner
 - sshd_print_last_log
 - sshd_rekey_limit
-- sshd_set_idle_timeout
-- sshd_set_keepalive_0
 - sshd_use_strong_rng
 - sshd_x11_use_localhost
 - sssd_certificate_verification
@@ -423,7 +421,6 @@ selections:
 - var_password_pam_ucredit=1
 - var_password_pam_lcredit=1
 - var_password_pam_retry=3
-- var_sshd_set_keepalive=0
 - sshd_approved_macs=stig
 - sshd_approved_ciphers=stig
 - sshd_idle_timeout_value=10_minutes

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -364,8 +364,6 @@ selections:
 - sshd_enable_warning_banner
 - sshd_print_last_log
 - sshd_rekey_limit
-- sshd_set_idle_timeout
-- sshd_set_keepalive_0
 - sshd_use_strong_rng
 - sshd_x11_use_localhost
 - sssd_certificate_verification
@@ -432,7 +430,6 @@ selections:
 - var_password_pam_ucredit=1
 - var_password_pam_lcredit=1
 - var_password_pam_retry=3
-- var_sshd_set_keepalive=0
 - sshd_approved_macs=stig
 - sshd_approved_ciphers=stig
 - sshd_idle_timeout_value=10_minutes


### PR DESCRIPTION
#### Description:
- Remove RHEL-08-010200 and RHEL-08-010201 from RHEL8 and RHEL9 STIG.
  - These two items don't behave as they used to in RHEL8.6 and RHEL9
anymore. They will be disabled for now until an alternative
solution is found.

Mitigates: https://bugzilla.redhat.com/show_bug.cgi?id=2038977 and https://bugzilla.redhat.com/show_bug.cgi?id=2038978