### PR TITLE
Generalize OpenShift groups

### DIFF
--- a/applications/openshift/group.yml
+++ b/applications/openshift/group.yml
@@ -2,18 +2,20 @@ documentation_complete: true
 
 prodtype: ocp4,eks
 
-title: 'OpenShift Settings'
+title: 'Kubernetes Settings'
 
 description: |-
-    Each section of this configuration guide includes information about the default configuration
-    of an OpenShift cluster and a set of recommendations for hardening the configuration. For each
-    hardening recommendation, information on how to implement the control and/or how to verify or audit
-    the control is provided. In some cases, remediation information is also provided.
+    Each section of this configuration guide includes information about the
+    configuration of a Kubernetes cluster and a set of recommendations for
+    hardening the configuration. For each hardening recommendation, information
+    on how to implement the control and/or how to verify or audit the control
+    is provided. In some cases, remediation information is also provided.
 
-    Many of the settings in the hardening guide are in place by default. The audit information for these
-    settings is provided in order to verify that the cluster admininstrator has not made changes that
-    would be less secure than the OpenShift defaults. A small number of items require configuration.
+    Some of the settings in the hardening guide are in place by default. The
+    audit information for these settings is provided in order to verify that
+    the cluster admininstrator has not made changes that would be less secure.
+    A small number of items require configuration.
 
-    Finally, there are some recommendations that require decisions by the system operator, such as audit
-    log size, retention, and related settings.
+    Finally, there are some recommendations that require decisions by the
+    system operator, such as audit log size, retention, and related settings.
 

--- a/applications/openshift/networking/group.yml
+++ b/applications/openshift/networking/group.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4,eks
 
-title: 'Network Configuration and Firewalls'
+title: 'Kubernetes - Network Configuration and Firewalls'
 
 description: |-
     Most systems must be connected to a network of some

--- a/applications/openshift/worker/group.yml
+++ b/applications/openshift/worker/group.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ocp4,eks
 
-title: 'OpenShift - Worker Node Settings'
+title: 'Kubernetes - Worker Node Settings'
 
 description: |-
     Contains evaluations for the worker node configuration settings.


### PR DESCRIPTION
We're now starting to use some OpenShift rules for EKS checks. This
commit updates the groups for those specific rules, which contain
`prodtype: eks`, to remove OpenShift and generalize it with Kubernetes.

This commit is related to issue #8198

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
