### PR TITLE
OCP4: Fix api_server_no_adm_ctrl_plugins_disabled jq filter

### DIFF
--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Ensure all admission control plugins are enabled'
 
 
-{{% set jqfilter = '[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]' %}}
+{{% set jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]' %}}
 
 description: |-
     To make sure none of them is explicitly disabled except PodSecurity, run the following command:

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/no_disabled.pass.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/no_disabled.pass.sh
@@ -27,8 +27,7 @@ cat <<EOF > "$kube_apipath$config_apipath"
 }
 EOF
 
-jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
-
+jq_filter='[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]'
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
 

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/no_disabled_null.pass.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/no_disabled_null.pass.sh
@@ -14,7 +14,7 @@ cat <<EOF > "$kube_apipath$config_apipath"
 {
     "apiVersion": "v1",
     "data": {
-        "config.yaml": "{\"apiServerArguments\":{\"allow-privileged\":[\"true\"],\"disable-admission-plugins\":[\"PodSecurity\"]}}"
+        "config.yaml": "{\"apiServerArguments\":{\"allow-privileged\":[\"true\"]}}"
     },
     "kind": "ConfigMap",
     "metadata": {
@@ -28,7 +28,6 @@ cat <<EOF > "$kube_apipath$config_apipath"
 EOF
 
 jq_filter='[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]'
-
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"
 

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/not_podsecurity.fail.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/not_podsecurity.fail.sh
@@ -27,7 +27,7 @@ cat <<EOF > "$kube_apipath$config_apipath"
 }
 EOF
 
-jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
+jq_filter='[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]'
 
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/other_than_podsecurity.fail.sh
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/tests/other_than_podsecurity.fail.sh
@@ -27,7 +27,7 @@ cat <<EOF > "$kube_apipath$config_apipath"
 }
 EOF
 
-jq_filter='[.data."config.yaml" | fromjson | select(.apiServerArguments."disable-admission-plugins"!=["PodSecurity"] and .apiServerArguments."disable-admission-plugins"!=[]) | .apiServerArguments."disable-admission-plugins"]'
+jq_filter='[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]'
 
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$config_apipath#$(echo -n "$config_apipath$jq_filter" | sha256sum | awk '{print $1}')"


### PR DESCRIPTION
The previous jq filter is outputting null instead of empty when there is no `disable-admission-plugins` present, this pr updated the jq filter, so that it will output empty instead of null.
