### PR TITLE
Gitpod: Build OpenSCAP 1.3.6 so it can build OCP4 and EKS content

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,10 +1,12 @@
 FROM gitpod/workspace-full
+ENV PYTHONUSERBASE=/workspace/.pip-modules
+ENV PATH=$PYTHONUSERBASE/bin:$PATH
+ENV PIP_USER=yes
 USER gitpod
 RUN sudo apt-get update -q && \
-    sudo apt-get install -yq \
+        sudo apt-get install -yq \
         cmake \
         ninja-build \
-        libopenscap8 \
         libxml2-utils \
         expat \
         xsltproc \
@@ -15,11 +17,22 @@ RUN sudo apt-get update -q && \
         python3-github \
         bats \
         python3-pytest \
-        python3-pytest-cov
+        python3-pytest-cov \
+        libdbus-1-dev libdbus-glib-1-dev libcurl4-openssl-dev \
+        libgcrypt20-dev libselinux1-dev libxslt1-dev libgconf2-dev libacl1-dev libblkid-dev \
+        libcap-dev libxml2-dev libldap2-dev libpcre3-dev python3-dev swig libxml-parser-perl \
+        libxml-xpath-perl libperl-dev libbz2-dev librpm-dev g++ libapt-pkg-dev libyaml-dev \
+        libxmlsec1-dev libxmlsec1-openssl \
+        shellcheck \
+        bats \
+        yamllint
 
-RUN pip install docker ansible
+RUN wget https://github.com/OpenSCAP/openscap/releases/download/1.3.6/openscap-1.3.6.tar.gz
 
-RUN wget https://raw.githubusercontent.com/OpenSCAP/openscap/maint-1.3/utils/oscap-ssh && \
-      sudo chmod 755 oscap-ssh && \
-      sudo mv -v oscap-ssh /usr/local/bin && \
-      sudo chown root:root /usr/local/bin/oscap-ssh
+RUN tar -zxvf openscap-1.3.6.tar.gz
+
+RUN cd openscap-1.3.6 && \
+        mkdir -p build && cd build && \
+        cmake -DCMAKE_INSTALL_PREFIX=/ .. && \
+        sudo make install && \
+        cd ../..

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,13 +4,21 @@ image:
 
 vscode:
   extensions:
-    - ggbecker.content-navigator
-    - ms-vscode.live-server
+    - ggbecker.content-navigator # useful extension for the ComplianceAsCode/content project
+    - ms-vscode.live-server # HTML preview
     - rogalmic.bash-debug # support bashdb debug configurations
+    - eamodio.gitlens # cool git extension with a bunch of extra features
+    - twxs.cmake # support to CMakeLists.txt syntax highlighting and more
 
 tasks:
   - name: Prepare Env
     init: |
+      pip install docker ansible json2html docutils==0.17.1 \
+        commonmark \
+        recommonmark==0.6.0 \
+        sphinx \
+        sphinx-rtd-theme \
+        git+git://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain
       [ -z "$PRODUCT" ] && PRODUCT="fedora"
       [ -z "$CONTAINER" ] && CONTAINER="fedora:34"
       [ -z "$CPE" ] && CPE="cpe:/o:fedoraproject:fedora:34"


### PR DESCRIPTION


#### Description:
- Gitpod: Build OpenSCAP 1.3.6 so it can build OCP4 and EKS content.
- Install optional dependencies of CaC/content so it can build/test every single aspect of CaC/content
- Additionally installs more useful VSCode extensions such as gitlens.
- pip install command had to be moved to the .gitpod.yml file because the packages for some reason were not being shown/installed in the environment. I couldn't find any relevant issue on gitpod other than how to persist the pip packages across workspace reloads.
