### PR TITLE
Add SRG references to STIG rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
@@ -22,6 +22,8 @@ identifiers:
     cce@rhel9: CCE-85878-7
 
 references:
+    disa: CCI-000366
+    srg: SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-020100
 
 ocil_clause: 'pam_pwquality.so is not enabled in password-auth'

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
@@ -22,6 +22,8 @@ identifiers:
     cce@rhel9: CCE-85873-8
 
 references:
+    disa: CCI-000366
+    srg: SRG-OS-000480-GPOS-00227
     stigid@rhel8: RHEL-08-020101
 
 ocil_clause: 'pam_pwquality.so is not enabled in system-auth'


### PR DESCRIPTION


#### Description:
- Add SRG references to STIG rules.
  - Rules accounts_password_pam_pwquality_password_auth and accounts_password_pam_pwquality_system_auth
were missing SRG required references.

#### Rationale:

- No missing SRG for STIG rules are allowed.
