### PR TITLE
Playbooks contain ansible.builtin requiring Ansible 2.9 or higher

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -120,7 +120,7 @@ OSCAP_PATH = "oscap"
 OSCAP_PROFILE_ALL_ID = "(all)"
 XCCDF11_NS = "http://checklists.nist.gov/xccdf/1.1"
 XCCDF12_NS = "http://checklists.nist.gov/xccdf/1.2"
-min_ansible_version = "2.5"
+min_ansible_version = "2.9"
 ansible_version_requirement_pre_task_name = \
     "Verify Ansible meets SCAP-Security-Guide version requirements."
 standard_profiles = ['standard', 'pci-dss', 'desktop', 'server']


### PR DESCRIPTION
#### Description:

Playbooks now container ansible.builtin task definitions which require a newer version of Ansible. The ssg min version constant is currently set to 2.5.

#### Rationale:

With the addition of ansible.builtin task definitions, a version of Ansible newer than 2.5, the current ssg min default, is required. ansible.builtin requires Ansible version 2.9 or higher.