### PR TITLE
Introduce CPE for aarch64 and make package_rear_installed n/a aarch64.

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_rear_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rear_installed/rule.yml
@@ -25,6 +25,10 @@ ocil: '{{{ ocil_package(package="rear") }}}'
 # The package is not available for s309x on RHEL<8.5
 # platform: not_s390x_arch
 
+{{%- if product == "rhel9" %}}
+platform: not_aarch64_arch
+{{%- endif %}}
+
 template:
     name: package_installed
     vars:

--- a/shared/applicability/arch.yml
+++ b/shared/applicability/arch.yml
@@ -12,3 +12,15 @@ cpes:
       check_id: proc_sys_kernel_osrelease_arch_s390x
       bash_conditional: 'grep -q s390x /proc/sys/kernel/osrelease'
 
+  - not_aarch64_arch:
+      name: "cpe:/a:not_aarch64_arch"
+      title: "System architecture is not AARCH64"
+      check_id: proc_sys_kernel_osrelease_arch_not_aarch64
+      bash_conditional: "! grep -q aarch64 /proc/sys/kernel/osrelease"
+
+  - aarch64_arch:
+      name: "cpe:/a:aarch64_arch"
+      title: "System architecture is AARCH64"
+      check_id: proc_sys_kernel_osrelease_arch_aarch64
+      bash_conditional: 'grep -q aarch64 /proc/sys/kernel/osrelease'
+

--- a/shared/checks/oval/proc_sys_kernel_osrelease_arch_aarch64.xml
+++ b/shared/checks/oval/proc_sys_kernel_osrelease_arch_aarch64.xml
@@ -1,0 +1,33 @@
+<def-group>
+  <definition class="inventory" id="proc_sys_kernel_osrelease_arch_aarch64"
+  version="1">
+    <metadata>
+      <title>Test that the architecture is aarch64</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check that architecture of kernel in /proc/sys/kernel/osrelease is aarch64</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Architecture is aarch64"
+      test_ref="test_proc_sys_kernel_osrelease_arch_aarch64" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="proc_sys_kernel is for aarch64 architecture"
+      id="test_proc_sys_kernel_osrelease_arch_aarch64"
+  version="1">
+    <ind:object object_ref="object_proc_sys_kernel_osrelease_arch_aarch64" />
+    <ind:state state_ref="state_proc_sys_kernel_osrelease_arch_aarch64" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_proc_sys_kernel_osrelease_arch_aarch64" version="1">
+    <ind:filepath>/proc/sys/kernel/osrelease</ind:filepath>
+    <ind:pattern operation="pattern match">^.*\.(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_proc_sys_kernel_osrelease_arch_aarch64" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^aarch64$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/shared/checks/oval/proc_sys_kernel_osrelease_arch_not_aarch64.xml
+++ b/shared/checks/oval/proc_sys_kernel_osrelease_arch_not_aarch64.xml
@@ -1,0 +1,16 @@
+<def-group>
+  <definition class="inventory" id="proc_sys_kernel_osrelease_arch_not_aarch64"
+  version="1">
+    <metadata>
+      <title>Test for different architecture than aarch64</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Check that architecture of kernel in /proc/sys/kernel/osrelease is not aarch64</description>
+    </metadata>
+    <criteria>
+      <extend_definition comment="Architecture is not aarch64"
+      definition_ref="proc_sys_kernel_osrelease_arch_aarch64" negate="true"/>
+    </criteria>
+  </definition>
+</def-group>

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -424,6 +424,8 @@ XCCDF_PLATFORM_TO_PACKAGE = {
   "non-uefi": None,
   "not_s390x_arch": None,
   "s390x_arch": None,
+  "not_aarch64_arch": None,
+  "aarch64_arch": None,
   "ovirt": None,
   "no_ovirt": None,
 }


### PR DESCRIPTION
#### Description:
- Introduce CPE for aarch64 and make package_rear_installed n/a aarch64.

#### Rationale:

- This rule is not applicable for RHEL9 only.
