### PR TITLE
Update the podman build command in OCP unit tests guide

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1217,7 +1217,7 @@ is intended to run.
 To build the container, from the project's root
 directory, execute the following command:
 
-    podman build --build-arg CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub) -t ssg_test_suite -f Dockerfiles/test_suite-fedora
+    podman build --build-arg CLIENT_PUBLIC_KEY="$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite -f test_suite-fedora Dockerfiles
 
 Unit tests reside en each rule's `tests/` directory. Tests are
 simply bash scripts that set up the required environment


### PR DESCRIPTION
The OCP4 unit tests require you to build a container with dependencies
required to test the rules, like the openscap-scanner. The documentation
tells you how to do this, but running the command verbatim fails for two
reasons.

First, The --build-arg for the CLIENT_PUBLIC_KEY isn't quoted. This
argument is supposed to be the contents of a public key, which consists
of three different pieces ($algorithm $key $name) and are delimited by
spaces. Without proper quoting, `podman build` will accept the $key and
$name as arguments, causing it to fail with something like:

  Error: accepts at most 1 arg(s), received 2

The second error is due to a missing directory (typically `.` if you're
running podman from the directory containing the Dockerfiles), where it
complains about a missing context.

This commit updates the command to include a target directory and proper
quoting.

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
