### PR TITLE
Add Dockerfiles for OL7 and OL8

### DIFF
--- a/Dockerfiles/test_suite-ol7
+++ b/Dockerfiles/test_suite-ol7
@@ -1,0 +1,23 @@
+# This Dockerfile is a minimal example for a OL7-based SSG test suite target container.
+FROM oraclelinux:7.9
+
+ENV AUTH_KEYS=/root/.ssh/authorized_keys
+
+ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
+
+# Install Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
+RUN true \
+        && yum install -y openssh-clients openssh-server openscap-scanner \
+        python tar \
+        $ADDITIONAL_PACKAGES \
+        && true
+
+RUN true \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && mkdir -p /root/.ssh \
+        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+&& true

--- a/Dockerfiles/test_suite-ol8
+++ b/Dockerfiles/test_suite-ol8
@@ -1,0 +1,23 @@
+# This Dockerfile is a minimal example for a OL8-based SSG test suite target container.
+FROM oraclelinux:8.5
+
+ENV AUTH_KEYS=/root/.ssh/authorized_keys
+
+ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
+
+# Install Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
+RUN true \
+        && yum install -y openssh-clients openssh-server openscap-scanner \
+        python3 tar \
+        $ADDITIONAL_PACKAGES \
+        && true
+
+RUN true \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && mkdir -p /root/.ssh \
+        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+&& true


### PR DESCRIPTION
Signed-off-by: Federico Ramirez <federico.r.ramirez@oracle.com>

#### Description:

- Add Dockerfiles for the OL7 and OL8 products

#### Rationale:

- Oracle Linux content maintenance efforts
