### PR TITLE
Simply mask services that should be disabled

### DIFF
--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -6,16 +6,13 @@
 {{%- if init_system == "systemd" %}}
 - name: Disable service {{{ SERVICENAME }}}
   block:
-  - name: Gather the service facts
-    service_facts:
-
   - name: Disable service {{{ SERVICENAME }}}
     systemd:
       name: "{{{ DAEMONNAME }}}.service"
       enabled: "no"
       state: "stopped"
       masked: "yes"
-    when: '"{{{ DAEMONNAME }}}.service" in ansible_facts.services'
+    ignore_errors: 'yes'
 
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
   command: systemctl list-unit-files {{{ DAEMONNAME }}}.socket


### PR DESCRIPTION


#### Description:

- Fixes fatal errors when trying to disable them:
```
TASK [Gather the service facts] ************************************************
ok: [192.168.122.34]

TASK [Disable service autofs] **************************************************
fatal: [192.168.122.34]: FAILED! => {"changed": false, "msg": "Could not find the requested service autofs.service: host"}

PLAY RECAP *********************************************************************
192.168.122.34             : ok=200  changed=55   unreachable=0    failed=1    skipped=67   rescued=0    ignored=0   
```
- I think the aim of the template is to also mask any service that the profile would like to have disabled.
  So let's not even check if the service exists in the system, let's just mask it and ignore the error saying the service doesn't exist.
  Not an excuse, but the [Bash remediations](https://github.com/yuumasato/scap-security-guide/blob/1c054ed40a4dbc2a48ffe7720d018c317cad8105/shared/templates/service_disabled/bash.template#L12) do it as well.

#### Rationale:

- At some point Ansible started to return much more services in `ansible_facts.services`, including services that are not installed.
  This caused the task to think that the service exists, attempt to stop and mask the service.
  But systemd module fatal errors on non existing services, although the module ends up masking the service in question.
```
ok: [localhost] => {
    "ansible_facts": {
        "services": {
...
            "autofs.service": {
                "name": "autofs.service",
                "source": "systemd",
                "state": "stopped",
                "status": "not-found"
            },
```
- The bash remediations simply mask the service, even if it is not installed.
Let's do the same with Ansible, mask the service and ignore errors.
