### PR TITLE
Add rule disallow_bypass_password_sudo to meet STIG OL07-00-010344

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/bash/shared.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ol
+
+sed -i '/pam_succeed_if/d' /etc/pam.d/sudo

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/oval/shared.xml
@@ -1,0 +1,21 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{ oval_metadata("Disallow Configuration to Bypass Password Requirements for Privilege Escalation.") }}}
+        <criteria>
+            <criterion comment="Check absence of conf pam_succeed_if in /etc/pam.d/sudo"
+            test_ref="test_disallow_bypass_password_sudo" />
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist"
+    comment="Check absence of conf pam_succeed_if in /etc/pam.d/sudo"
+    id="test_disallow_bypass_password_sudo" version="1">
+        <ind:object object_ref="obj_disallow_bypass_password_sudo" />
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_object id="obj_disallow_bypass_password_sudo" version="1">
+        <ind:filepath>/etc/pam.d/sudo</ind:filepath>
+        <ind:pattern operation="pattern match">^.*pam_succeed_if.*$</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/rule.yml
@@ -1,0 +1,33 @@
+documentation_complete: true
+
+title: Disallow Configuration to Bypass Password Requirements for Privilege Escalation
+
+description: |-
+    Verify the operating system is not configured to bypass password requirements for privilege
+    escalation. Check the configuration of the "/etc/pam.d/sudo" file with the following command:
+    <pre>$ sudo grep pam_succeed_if /etc/pam.d/sudo</pre>
+    If any occurrences of "pam_succeed_if" is returned from the command, this is a finding.
+
+
+rationale: |-
+    Without re-authentication, users may access resources or perform tasks for which they do not
+    have authorization. When operating systems provide the capability to escalate a functional
+    capability, it is critical the user re-authenticate.
+
+severity: medium
+
+references:
+    disa: CCI-002038
+    nist: IA-11
+    srg: SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158
+    stigid@ol7: OL07-00-010344     
+
+ocil_clause: |-
+    system is configured to bypass password requirements for privilege escalation
+
+ocil: |-
+    Verify the operating system is not configured to bypass password requirements for privilege
+    escalation. Check the configuration of the "/etc/pam.d/sudo" file with the following command:
+    <pre>$ sudo grep pam_succeed_if /etc/pam.d/sudo</pre>
+
+platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_absent.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_ol
+
+sed -i '/pam_succeed_if/d' /etc/pam.d/sudo

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_present.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ol
+
+if  ! grep "pam_succeed_if" /etc/pam.d/sudo ; then 
+    echo "auth required pam_succeed_if.so quiet user ingroup wheel" >> /etc/pam.d/sudo
+fi 

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -315,3 +315,4 @@ selections:
     - selinux_confine_to_least_privilege
     - selinux_context_elevation_for_sudo
     - sudoers_default_includedir
+    - disallow_bypass_password_sudo


### PR DESCRIPTION
#### Description:

- Introduced rule disallow_bypass_password_sudo with OVAL, bash and tests

#### Rationale:

- This is intended to meet DISA's STIG OL07-00-010344 requirement, part of v2r6 of this profile
