### PR TITLE
Introduce rule no_empty_passwords_etc_shadow to meet STIG OL07-00-010291

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_ol
+
+readarray -t users_with_empty_pass < <(sudo awk -F: '!$2 {print $1}' /etc/shadow)
+
+for user_with_empty_pass in "${users_with_empty_pass[@]}"
+do
+    passwd -l $user_with_empty_pass
+done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/oval/shared.xml
@@ -1,0 +1,19 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The file /etc/shadow show that there aren't empty passwords") }}}
+    <criteria>
+      <criterion comment="make sure there aren't blank or null passwords in /etc/shadow"
+      test_ref="test_no_empty_passwords_etc_shadow" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+  id="test_no_empty_passwords_etc_shadow"
+  comment="make sure there aren't blank or null passwords in /etc/shadow">
+    <ind:object object_ref="obj_no_empty_passwords_etc_shadow" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_no_empty_passwords_etc_shadow" version="1">
+    <ind:filepath>/etc/shadow</ind:filepath>
+    <ind:pattern operation="pattern match">^[^:]+::.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("The file /etc/shadow show that there aren't empty passwords") }}}
+    {{{ oval_metadata("The file /etc/shadow shows that there aren't empty passwords") }}}
     <criteria>
       <criterion comment="make sure there aren't blank or null passwords in /etc/shadow"
       test_ref="test_no_empty_passwords_etc_shadow" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -1,0 +1,42 @@
+documentation_complete: true
+
+title: 'Ensure There Are No Accounts With Blank or Null Passwords'
+
+description: |-
+    Check the "/etc/shadow" file for blank passwords with the
+    following command:
+    <pre>$ sudo awk -F: '!$2 {print $1}' /etc/shadow</pre>
+    If the command returns any results, this is a finding.
+    Configure all accounts on the system to have a password or lock
+    the account with the following commands:
+    Perform a password reset:
+    <pre>$ sudo passwd [username]</pre>
+    Lock an account:
+    <pre>$ sudo passwd -l [username]</pre>
+
+rationale: |-
+    If an account has an empty password, anyone could log in and
+    run commands with the privileges of that account. Accounts with
+    empty passwords should never be used in operational environments.
+
+severity: high
+
+references:
+    disa: CCI-000366
+    nist: CM-6(b),CM-6.1(iv)
+    srg: SRG-OS-000480-GPOS-00227
+    stigid@ol7: OL07-00-010291
+
+ocil_clause: 'Blank or NULL passwords can be used'
+
+ocil: |-
+    To verify that null passwords cannot be used, run the following command:
+    <pre>$ sudo awk -F: '!$2 {print $1}' /etc/shadow</pre>
+    If this produces any output, it may be possible to log into accounts
+    with empty passwords.
+    Configure all accounts on the system to have a password or lock
+    the account with the following commands:
+    Perform a password reset:
+    <pre>$ sudo passwd [username]</pre>
+    Lock an account:
+    <pre>$ sudo passwd -l [username]</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/an_empty_pass_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/an_empty_pass_present.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+useradd new_user_with_empty_password
+passwd -d new_user_with_empty_password

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/an_empty_pass_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/an_empty_pass_present.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-
+# packages = passwd
 useradd new_user_with_empty_password
 passwd -d new_user_with_empty_password

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/no_empty_password_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/no_empty_password_present.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+readarray -t users_with_empty_pass < <(sudo awk -F: '!$2 {print $1}' /etc/shadow)
+
+for user_with_empty_pass in "${users_with_empty_pass[@]}"
+do
+    passwd -l $user_with_empty_pass
+done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/no_empty_password_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/tests/no_empty_password_present.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# packages = passwd
 readarray -t users_with_empty_pass < <(sudo awk -F: '!$2 {print $1}' /etc/shadow)
 
 for user_with_empty_pass in "${users_with_empty_pass[@]}"

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -316,3 +316,4 @@ selections:
     - selinux_context_elevation_for_sudo
     - sudoers_default_includedir
     - disallow_bypass_password_sudo
+    - no_empty_passwords_etc_shadow


### PR DESCRIPTION
#### Description:

- Introduced rule no_empty_passwords_etc_shadow with OVAL, bash and tests

#### Rationale:

- This is intended to meet DISA's STIG OL07-00-010291 requirement, part of v2r6 of this profile

