### PR TITLE
Add sudoers_default_includedir to ol7 STIG

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,rhel7,rhel8,rhel9
 
 title: 'Ensure sudo only includes the default configuration directory'
 
@@ -28,6 +28,7 @@ identifiers:
 references:
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
+    stigid@ol7: OL07-00-010339
     stigid@rhel7: RHEL-07-010339
     stigid@rhel8: RHEL-08-010379
 

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -314,3 +314,4 @@ selections:
     - sebool_ssh_sysadm_login
     - selinux_confine_to_least_privilege
     - selinux_context_elevation_for_sudo
+    - sudoers_default_includedir


### PR DESCRIPTION
#### Description:

- Add sudoers_default_includedir rule to ol7 STIG profile and updated the references to include OL7 STIG ID

#### Rationale:

- DISA's STIG profile for OL7 requires this rule under the OL07-00-010339 requirement
