### PR TITLE
Enable API resource customization using distinct objPath and dumpPath

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysAdmit/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Disable the AlwaysAdmit Admission Control Plugin'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure OpenShift only responses to requests explicitly allowed by the
     admission control plugin. Check that the <code>config</code> ConfigMap object does not
@@ -35,16 +41,15 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "none satisfy"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    check_existence: "none_exist"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"AlwaysAdmit"'
+    - value: '^AlwaysAdmit$'
       operation: "pattern match"
-      type: "string"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -63,10 +63,9 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "none satisfy"
+    check_existence: "none_exist"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"AlwaysPullImages"'
+    - value: '^AlwaysPullImages$'
       operation: "pattern match"
-      type: "string"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure that the Admission Control Plugin AlwaysPullImages is not set'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
      The <tt>AlwaysPullImages</tt> admission control plugin should be disabled,
      since it can introduce new failure modes for control plane components if an

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -64,7 +64,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "none satisfy"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"AlwaysPullImages"'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_AlwaysPullImages/rule.yml
@@ -57,7 +57,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Enable the NamespaceLifecycle Admission Control Plugin'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -54,3 +54,4 @@ template:
     values:
     - value: '^NamespaceLifecycle$'
       operation: "pattern match"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -50,8 +50,7 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"NamespaceLifecycle"'
+    - value: '^NamespaceLifecycle$'
       operation: "pattern match"
-      type: "string"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Enable the NamespaceLifecycle Admission Control Plugin'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     OpenShift enables the <tt>NamespaceLifecycle</tt> plugin by default.
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -42,7 +42,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NamespaceLifecycle/rule.yml
@@ -49,7 +49,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"NamespaceLifecycle"'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Enable the NodeRestriction Admission Control Plugin'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To limit the <tt>Node</tt> and <tt>Pod</tt> objects that a kubelet could modify,
     ensure that the <tt>NodeRestriction</tt> plugin on kubelets is enabled in

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -45,7 +45,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Enable the NodeRestriction Admission Control Plugin'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -57,3 +57,4 @@ template:
     values:
     - value: '^NodeRestriction$'
       operation: "pattern match"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -52,7 +52,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"NodeRestriction"'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_NodeRestriction/rule.yml
@@ -53,8 +53,7 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"NodeRestriction"'
+    - value: '^NodeRestriction$'
       operation: "pattern match"
-      type: "string"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -53,9 +53,7 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"security.openshift.io/SecurityContextConstraint"'
+    - value: '^security.openshift.io/SecurityContextConstraint$'
       operation: "pattern match"
-      type: "string"
-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -45,7 +45,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Enable the SecurityContextConstraint Admission Control Plugin'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -57,3 +57,4 @@ template:
     values:
     - value: '^security.openshift.io/SecurityContextConstraint$'
       operation: "pattern match"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Enable the SecurityContextConstraint Admission Control Plugin'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
    To ensure pod permissions are managed, make sure that the
    <tt>SecurityContextConstraint</tt> admission control plugin is used.

--- a/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_Scc/rule.yml
@@ -52,7 +52,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"security.openshift.io/SecurityContextConstraint"'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     Instead of using a customized SecurityContext for pods, a Pod Security
     Policy (PSP) or a SecurityContextConstraint should be used. These are

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -49,7 +49,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -55,7 +55,7 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"SecurityContextDeny"'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_SecurityContextDeny/rule.yml
@@ -55,10 +55,9 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
+    check_existence: "none_exist"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"SecurityContextDeny"'
+    - value: '^SecurityContextDeny$'
       operation: "pattern match"
-      type: "string"
-      entity_check: "none satisfy"

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -52,7 +52,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"enable-admission-plugins":\[[^]]*"ServiceAccount"'

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -53,8 +53,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
     values:
-    - value: '"enable-admission-plugins":\[[^]]*"ServiceAccount"'
+    - value: '^ServiceAccount$'
       operation: "pattern match"
-      type: "string"
+      

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -45,7 +45,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Enable the ServiceAccount Admission Control Plugin'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure <tt>ServiceAccount</tt> objects must be created and granted
     before pod creation is allowed, follow the documentation and create

--- a/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_ServiceAccount/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Enable the ServiceAccount Admission Control Plugin'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -57,4 +57,4 @@ template:
     values:
     - value: '^ServiceAccount$'
       operation: "pattern match"
-      
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -59,8 +59,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["audit-log-maxbackup"][:]'
     values:
-    - value: '"apiServerArguments":{.*"audit-log-maxbackup":\["10"\]'
+    - value: '10'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the Kubernetes API Server Maximum Retained Audit Logs'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -64,3 +64,4 @@ template:
     - value: '10'
       operation: "pattern match"
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Kubernetes API Server Maximum Retained Audit Logs'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To configure how many rotations of audit logs are retained,
     edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -58,7 +58,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"apiServerArguments":{.*"audit-log-maxbackup":\["10"\]'

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure Kubernetes API Server Maximum Audit Log Size'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To rotate audit logs upon reaching a maximum size,
     edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -59,8 +59,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["audit-log-maxsize"][:]'
     values:
-    - value: '"apiServerArguments":{.*"audit-log-maxsize":\["100"\]'
+    - value: '100'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure Kubernetes API Server Maximum Audit Log Size'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -64,3 +64,4 @@ template:
     - value: '100'
       operation: "pattern match"
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -58,7 +58,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"apiServerArguments":{.*"audit-log-maxsize":\["100"\]'

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the Audit Log Path'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -57,9 +57,10 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.apiServerArguments["audit-log-path"][:]'
-        check_existence: "at_least_one_exists"
+        yamlpath: '.apiServerArguments["audit-log-path"][:]'
+        entity_check: "at least one"
         values:
             - value: '.+'
               type: "string"
               operation: "pattern match"
+              entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Audit Log Path'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To enable auditing on the Kubernetes API Server, the audit log path must be set.
     Edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -57,9 +57,9 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["audit-log-path"][:]'
         check_existence: "at_least_one_exists"
         values:
-            - value: '\"audit-log-path\"\s*:\s*\[\s*\".+\"\s*\]'
+            - value: '.+'
               type: "string"
               operation: "pattern match"

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -56,7 +56,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         check_existence: "at_least_one_exists"
         values:

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -50,7 +50,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -2,6 +2,12 @@ prodtype: ocp4
 
 title: The authorization-mode cannot be AlwaysAllow
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: 'Do not always authorize all requests.'
 
 rationale: |-

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -42,10 +42,10 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "none exist"
+    check_existence: "none_exist"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["authorization-mode"][:]'
     values:
-    - value: '"authorization-mode":\[[^]]*"AlwaysAllow"'
+    - value: 'AlwaysAllow'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -36,7 +36,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -43,7 +43,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "none exist"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"authorization-mode":\[[^]]*"AlwaysAllow"'

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -45,8 +45,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["authorization-mode"][:]'
     values:
-    - value: '"authorization-mode":\[[^]]*"Node"'
+    - value: 'Node'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -37,7 +37,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -44,7 +44,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"authorization-mode":\[[^]]*"Node"'

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -2,6 +2,12 @@ prodtype: ocp4
 
 title: Ensure authorization-mode Node is configured
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: 'Restrict kubelet nodes to reading only objects associated with them.'
 
 rationale: |-

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -2,8 +2,8 @@ prodtype: ocp4
 
 title: Ensure authorization-mode Node is configured
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -50,3 +50,4 @@ template:
     - value: 'Node'
       operation: "pattern match"
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -50,8 +50,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["authorization-mode"][:]'
     values:
-    - value: '"authorization-mode":\[[^]]*"RBAC"'
+    - value: 'RBAC'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -49,7 +49,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"authorization-mode":\[[^]]*"RBAC"'

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -2,6 +2,12 @@ prodtype: ocp4
 
 title: Ensure authorization-mode RBAC is configured
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
   To ensure OpenShift restricts different identities to a defined set
   of operations they are allowed to perform, check that the API server's

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -42,7 +42,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -2,8 +2,8 @@ prodtype: ocp4
 
 title: Ensure authorization-mode RBAC is configured
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -55,3 +55,4 @@ template:
     - value: 'RBAC'
       operation: "pattern match"
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Disable basic-auth-file for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson | .apiServerArguments | keys]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | keys ]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -62,7 +62,7 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '[:]'
+        yamlpath: '.apiServerArguments[:]'
         check_existence: "none_exist"
         values:
             - key: 'basic-auth-file'

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -61,7 +61,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         entity_check: "none satisfy"
         values:

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Disable basic-auth-file for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson | .apiServerArguments | keys]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | keys ]' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -62,9 +62,9 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.data["config.yaml"]'
-        entity_check: "none satisfy"
+        yamlpath: '[:]'
+        check_existence: "none_exist"
         values:
-            - value: 'basic-auth'
+            - key: 'basic-auth-file'
               type: "string"
               operation: "pattern match"

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Disable basic-auth-file for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     Basic Authentication should not be used for any reason. If needed, edit API
     Edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: Ensure that the bindAddress is set to a relevant secure port
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: "The bindAddress is set by default to <tt>0.0.0.0:6443</tt>, and listening with TLS enabled."
 
 rationale: |-

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -48,8 +48,5 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
-    values:
-    - value: '"servingInfo":{.*"bindAddress":"0.0.0.0:6443"'
-      operation: "pattern match"
-      type: "string"
+    yamlpath: '.servingInfo["bindAddress"][:]'
+    xccdf_value: var_apiserver_bind_address

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -47,7 +47,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"servingInfo":{.*"bindAddress":"0.0.0.0:6443"'

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: Ensure that the bindAddress is set to a relevant secure port
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -48,5 +48,10 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.servingInfo["bindAddress"][:]'
+    yamlpath: '.servingInfo["bindAddress"]'
     xccdf_value: var_apiserver_bind_address
+    embedded_data: "true"
+    values:
+    - value: '(.+)'
+      operation: "pattern match"
+      type: "string"

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -40,7 +40,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -62,9 +62,9 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.data["config.yaml"]'
+        yamlpath: '.apiServerArguments["client-ca-file"][:]'
         entity_check: "all"
         values:
-            - value: '.apiServerArguments.*"client-ca-file":\["/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt"\]'
+            - value: '/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt'
               operation: "pattern match"
               type: "string"

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Client Certificate Authority for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     Certificates must be provided to fully setup TLS client certificate
     authentication. To ensure the API Server utilizes its own TLS certificates, the

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -61,7 +61,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         entity_check: "all"
         values:

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -62,9 +62,11 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.apiServerArguments["client-ca-file"][:]'
+        yamlpath: '.apiServerArguments["client-ca-file"]'
         entity_check: "all"
+        xccdf_variable: var_apiserver_client_ca
+        embedded_data: "true"
         values:
-            - value: '/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt'
+            - value: '(.+)'
               operation: "pattern match"
               type: "string"

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the Client Certificate Authority for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the etcd Certificate Authority for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -64,7 +64,9 @@ template:
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.apiServerArguments["etcd-cafile"][:]'
         entity_check: "all"
+        xccdf_variable: var_apiserver_etcd_ca
+        embedded_data: "true"
         values:
-            - value: '/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt'
+            - value: '(.+)'
               operation: "pattern match"
               type: "string"

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -61,7 +61,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         entity_check: "all"
         values:

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the etcd Certificate Authority for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure etcd is configured to make use of TLS encryption for client
     connections, follow the OpenShift documentation and setup the TLS

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -62,9 +62,9 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.data["config.yaml"]'
+        yamlpath: '.apiServerArguments["etcd-cafile"][:]'
         entity_check: "all"
         values:
-            - value: '.apiServerArguments.*"etcd-cafile":\["/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt"\]'
+            - value: '/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt'
               operation: "pattern match"
               type: "string"

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the etcd Certificate for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -60,7 +60,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
      - value: '"etcd-certfile":\[.*\.crt"\]'

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the etcd Certificate for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure etcd is configured to make use of TLS encryption for client
     communications, follow the OpenShift documentation and setup the TLS

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -61,8 +61,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["etcd-certfile"][:]'
     values:
-     - value: '"etcd-certfile":\[.*\.crt"\]'
+     - value: '.*\.crt'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -61,8 +61,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["etcd-keyfile"][:]'
     values:
-     - value: '"etcd-keyfile":\[.*\.key"\]'
+     - value: '.*\.key'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -60,7 +60,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
      - value: '"etcd-keyfile":\[.*\.key"\]'

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the etcd Certificate Key for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the etcd Certificate Key for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure etcd is configured to make use of TLS encryption for client
     communications, follow the OpenShift documentation and setup the TLS

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -39,7 +39,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -46,7 +46,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"apiServerArguments":{.*"kubelet-https":\["false"\]'

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Ensure that the --kubelet-https argument is set to true'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -45,11 +45,10 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.apiServerArguments["kubelet-https"]'
+    yamlpath: '.apiServerArguments[:]'
+    check_existence: "none_exist"
     values:
-    - value: 'false'
+    - key: 'kubelet-https'
       operation: "pattern match"
       type: "string"
-      entity_check: "none satisfy"

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure that the --kubelet-https argument is set to true'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     The kube-apiserver ensures https to the kubelet by default. The apiserver
     flag "--kubelet-https" is deprecated and should be either set to "true" or

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -47,9 +47,9 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["kubelet-https"]'
     values:
-    - value: '"apiServerArguments":{.*"kubelet-https":\["false"\]'
+    - value: 'false'
       operation: "pattern match"
       type: "string"
       entity_check: "none satisfy"

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Disable Use of the Insecure Bind Address'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson | .apiServerArguments | keys ]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | keys ]' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -57,9 +57,9 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "none exist"
+    check_existence: "none_exist"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '[:]'
     values:
     - value: 'insecure-bind-address'
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -51,7 +51,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -58,7 +58,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "none exist"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: 'insecure-bind-address'

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Disable Use of the Insecure Bind Address'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     OpenShift should not bind to non-loopback insecure addresses.
     Edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Disable Use of the Insecure Bind Address'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson | .apiServerArguments | keys ]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | keys ]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson | .apiServerArguments' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson | .apiServerArguments' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -59,7 +59,7 @@ template:
     ocp_data: "true"
     check_existence: "none_exist"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '[:]'
+    yamlpath: '.apiServerArguments[:]'
     values:
     - value: 'insecure-bind-address'
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Prevent Insecure Port Access'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Prevent Insecure Port Access'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     By default, traffic for the OpenShift API server is served over
     HTTPS with authentication and authorization, and the secure API endpoint

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -63,8 +63,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["insecure-port"][:]'
     values:
-    - value: '"insecure-port":\[["?]0["?]\]'
+    - value: '0'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -62,7 +62,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"insecure-port":\[["?]0["?]\]'

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -55,7 +55,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -62,8 +62,10 @@ template:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.apiServerArguments["kubelet-certificate-authority"][:]'
-        check_existence: "at_least_one_exists"
+        entity_check: "all"
+        xccdf_variable: var_apiserver_kubelet_certificate_authority
+        embedded_data: "true"
         values:
-            - value: '/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt'
-              type: "string"
+            - value: '(.+)'
               operation: "pattern match"
+              type: "string"

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -61,9 +61,9 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.data["config.yaml"]'
+        yamlpath: '.apiServerArguments["kubelet-certificate-authority"][:]'
         check_existence: "at_least_one_exists"
         values:
-            - value: '\"kubelet-certificate-authority\"\s*:\s*\[\s*\"/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt\"\s*\]'
+            - value: '/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt'
               type: "string"
               operation: "pattern match"

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -60,7 +60,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         check_existence: "at_least_one_exists"
         values:

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -54,7 +54,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the kubelet Certificate Authority for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the kubelet Certificate Authority for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure OpenShift verifies kubelet certificates before establishing
     connections, follow the OpenShift documentation and setup the TLS connection

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -61,7 +61,9 @@ template:
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.apiServerArguments["kubelet-client-certificate"][:]'
+    xccdf_variable: var_apiserver_kubelet_client_cert
+    embedded_data: "true"
     values:
-    - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt'
+    - value: '(.+)'
       type: "string"
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the kubelet Certificate File for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -59,7 +59,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt"\]'

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -52,7 +52,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the kubelet Certificate File for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To enable certificate based kubelet authentication,
     edit the <tt>config</tt> configmap in the <tt>openshift-kube-apiserver</tt>

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -60,8 +60,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["kubelet-client-certificate"][:]'
     values:
-    - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt"\]'
+    - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt'
       type: "string"
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -52,7 +52,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the kubelet Certificate Key for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -59,7 +59,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key"\]'

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the kubelet Certificate Key for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To enable certificate based kubelet authentication,
     edit the <tt>config</tt> configmap in the <tt>openshift-kube-apiserver</tt>

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -60,8 +60,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["kubelet-client-key"][:]'
     values:
-    - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key"\]'
+    - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key'
       type: "string"
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -61,7 +61,9 @@ template:
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.apiServerArguments["kubelet-client-key"][:]'
+    xccdf_variable: var_apiserver_kubelet_client_key
+    embedded_data: "true"
     values:
-    - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key'
+    - value: '(.+)'
       type: "string"
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -7,9 +7,9 @@ title: 'Ensure all admission control plugins are enabled'
 
 
 {{% set jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]' %}}
-{{% set apipath = '/apis/{{.openshift_kube_apiserver_namespace}}config.openshift.io/v1/clusterversions/version' %}}
-{{% set apipathdefault = '/apis/config.openshift.io/v1/clusterversions/version' %}}
-{{% set dump = apipathdefault ~ ',' ~ jqfilter %}}
+{{% set custom_api_path = '/apis/{{.openshift_kube_apiserver_namespace}}config.openshift.io/v1/clusterversions/version' %}}
+{{% set default_api_path = '/apis/config.openshift.io/v1/clusterversions/version' %}}
+{{% set dump_path = default_api_path ~ ',' ~ jqfilter %}}
 
 
 description: |-
@@ -45,7 +45,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({apipath: dump}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 
 template:
@@ -53,7 +53,7 @@ template:
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path(apipathdefault, jqfilter) }}}
+      {{{ openshift_filtered_path(default_api_path, jqfilter) }}}
     yamlpath: "[:]"
     check_existence: "none_exist"
     entity_check: "all"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -5,7 +5,12 @@ prodtype: ocp4
 title: 'Ensure all admission control plugins are enabled'
 
 
+
 {{% set jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]' %}}
+{{% set apipath = '/apis/{{.openshift_kube_apiserver_namespace}}config.openshift.io/v1/clusterversions/version' %}}
+{{% set apipathdefault = '/apis/config.openshift.io/v1/clusterversions/version' %}}
+{{% set dump = apipathdefault ~ ',' ~ jqfilter %}}
+
 
 description: |-
     To make sure none of them is explicitly disabled except PodSecurity, run the following command:
@@ -40,7 +45,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/api/v1/namespaces/openshift-kube-apiserver/configmaps/config': jqfilter}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({apipath: dump}) | indent(4) }}}
 
 
 template:
@@ -48,7 +53,7 @@ template:
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path('/api/v1/namespaces/openshift-kube-apiserver/configmaps/config', jqfilter) }}}
+      {{{ openshift_filtered_path(apipathdefault, jqfilter) }}}
     yamlpath: "[:]"
     check_existence: "none_exist"
     entity_check: "all"

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -4,17 +4,16 @@ prodtype: ocp4
 
 title: 'Ensure all admission control plugins are enabled'
 
-
-
-{{% set jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]' %}}
-{{% set custom_api_path = '/apis/{{.openshift_kube_apiserver_namespace}}config.openshift.io/v1/clusterversions/version' %}}
-{{% set default_api_path = '/apis/config.openshift.io/v1/clusterversions/version' %}}
-{{% set dump_path = default_api_path ~ ',' ~ jqfilter %}}
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | .apiServerArguments | select(has("disable-admission-plugins")) | if ."disable-admission-plugins" != ["PodSecurity"] then ."disable-admission-plugins" else empty end]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 
 
 description: |-
     To make sure none of them is explicitly disabled except PodSecurity, run the following command:
-    <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '{{{ jqfilter }}}'</pre>
+    <pre>$ oc -n openshift-kube-apiserver get configmap config -o json | jq -r '{{{ default_jqfilter }}}'</pre>
     and make sure the output is empty.
 
 rationale: |-
@@ -40,7 +39,7 @@ ocil_clause: 'No admission plugins are disabled'
 
 ocil: |-
     To verify that the list of disabled admission plugins is empty, run the following command:
-    <pre>$oc -n openshift-kube-apiserver get configmap config -o json | jq -r '{{{ jqfilter }}}'</pre>
+    <pre>$oc -n openshift-kube-apiserver get configmap config -o json | jq -r '{{{ default_jqfilter }}}'</pre>
     There should be no output.
 
 warnings:
@@ -53,7 +52,7 @@ template:
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path(default_api_path, jqfilter) }}}
+      {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: "[:]"
     check_existence: "none_exist"
     entity_check: "all"

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the API Server Minimum Request Timeout'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -58,7 +58,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     xccdf_variable: var_api_min_request_timeout
     embedded_data: "true"

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the API Server Minimum Request Timeout'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     The API server minimum request timeout defines the minimum number of
     seconds a handler must keep a request open before timing it out. To set this,

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -59,10 +59,10 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["min-request-timeout"][:]'
     xccdf_variable: var_api_min_request_timeout
     embedded_data: "true"
     values:
-    - value: '"apiServerArguments":{.*"min-request-timeout":\["(\d*)"\]'
+    - value: '(\d*)'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -44,7 +44,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
       
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -51,7 +51,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: 'service-account-lookup.*\["true"\]'

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: Ensure that the service-account-lookup argument is set to true
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: Ensure that the service-account-lookup argument is set to true
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: Validate service account before validating token.
 
 rationale: |-

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -52,8 +52,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["service-account-lookup"][:]'
     values:
-    - value: 'service-account-lookup.*\["true"\]'
+    - value: 'true'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the Service Account Public Key for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -60,7 +60,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
      - value: '"serviceAccountPublicKeyFiles":\[.*sa-token-signing-certs",.*bound-sa-token-signing-certs"]'

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -61,8 +61,8 @@ template:
     ocp_data: "true"
     entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.serviceAccountPublicKeyFiles[:]'
     values:
-     - value: '"serviceAccountPublicKeyFiles":\[.*sa-token-signing-certs",.*bound-sa-token-signing-certs"]'
+     - value: '.+'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Service Account Public Key for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the API Server utilizes its own key pair,
     edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -61,8 +61,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["tls-cert-file"][:]'
     values:
-     - value: '"tls-cert-file":\["/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.crt"\]'
+     - value: '/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.crt'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -60,7 +60,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
      - value: '"tls-cert-file":\["/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.crt"\]'

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -62,7 +62,9 @@ template:
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.apiServerArguments["tls-cert-file"][:]'
+    xccdf_variable: var_apiserver_tls_cert
+    embedded_data: "true"
     values:
-     - value: '/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.crt'
+     - value: '(.+)'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the Certificate for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Certificate for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the API Server utilizes its own TLS certificates, the
     <tt>tls-cert-file</tt> must be configured. Verify

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -70,7 +70,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
     - value: '\"cipherSuites\":\[(\"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\"|\"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\"|\"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\"|\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\"|\"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\"|\"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\"|,| )*\]'

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -69,10 +69,10 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "at least one"
+    entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.cipherSuites[:]'
     values:
-    - value: '\"cipherSuites\":\[(\"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256\"|\"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256\"|\"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256\"|\"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\"|\"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256\"|\"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\"|,| )*\]'
+    - value: 'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
       operation: "pattern match"
       type: "string"

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -59,7 +59,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 - management: |-
     Once configured, API Server clients that cannot support modern
     cryptographic ciphers will not be able to make connections to the API

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Use Strong Cryptographic Ciphers on the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
@@ -71,7 +71,7 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.cipherSuites[:]'
+    yamlpath: '.servingInfo.cipherSuites[:]'
     values:
     - value: 'TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384'
       operation: "pattern match"

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Use Strong Cryptographic Ciphers on the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure that the API Server is configured to only use strong
     cryptographic ciphers, verify the <tt>openshift-kube-apiserver</tt>

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -60,7 +60,7 @@ template:
   vars:
     ocp_data: "true"
     entity_check: "all"
-    filepath: /api/v1/namespaces/openshift-kube-apiserver/configmaps/config
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.data["config.yaml"]'
     values:
      - value: '"tls-private-key-file":\["/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.key"\]'

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -61,8 +61,8 @@ template:
     ocp_data: "true"
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.data["config.yaml"]'
+    yamlpath: '.apiServerArguments["tls-private-key-file"][:]'
     values:
-     - value: '"tls-private-key-file":\["/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.key"\]'
+     - value: '/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.key'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -62,7 +62,9 @@ template:
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.apiServerArguments["tls-private-key-file"][:]'
+    xccdf_variable: var_apiserver_tls_private_key
+    embedded_data: "true"
     values:
-     - value: '/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls\.key'
+     - value: '(.+)'
        operation: "pattern match"
        type: "string"

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Certificate Key for the API Server'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the API Server utilizes its own TLS certificates, the
     <tt>tls-private-key-file</tt> must be configured. Verify

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Configure the Certificate Key for the API Server'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -60,9 +60,8 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: '.data["config.yaml"]'
-        entity_check: "none satisfy"
+        yamlpath: '.apiServerArguments["enable-admission-plugins"][:]'
+        check_existence: "none_exist"
         values:
-            - value: 'token-auth-file'
-              type: "string"
+            - value: '^token-auth-file$'
               operation: "pattern match"

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -59,7 +59,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         entity_check: "none satisfy"
         values:

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -53,7 +53,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Disable Token-based Authentication'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure OpenShift does not accept token-based authentication,
     follow the OpenShift documentation and configure alternate mechanisms for

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure OpenShift API Server Maximum Audit Log Size'
 
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To rotate audit logs upon reaching a maximum size,
     edit the <tt>openshift-apiserver</tt> configmap
@@ -51,10 +57,11 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-apiserver/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '.apiServerArguments["audit-log-maxsize][:]'
+    xccdf_variable: var_apiserver_audit_log_maxsize
+    embedded_data: "true"
     values:
-    - value: '"apiServerArguments":{.*"audit-log-maxsize":\["100"\]'
-      operation: "pattern match"
+    - value: '(.+)'
       type: "string"
+      operation: "pattern match"

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -58,7 +58,7 @@ template:
   vars:
     ocp_data: "true"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-    yamlpath: '.apiServerArguments["audit-log-maxsize][:]'
+    yamlpath: '.apiServerArguments["audit-log-maxsize"][:]'
     xccdf_variable: var_apiserver_audit_log_maxsize
     embedded_data: "true"
     values:

--- a/applications/openshift/api-server/var_apiserver_audit_log_maxsize.var
+++ b/applications/openshift/api-server/var_apiserver_audit_log_maxsize.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'API Server audit log max size'
+
+description: 'API Server audit log max size'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "100"

--- a/applications/openshift/api-server/var_apiserver_bind_address.var
+++ b/applications/openshift/api-server/var_apiserver_bind_address.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Bind Address of secure API endpoint'
+
+description: 'Bind Address of secure API endpoint'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "0.0.0.0:6443"

--- a/applications/openshift/api-server/var_apiserver_client_ca.var
+++ b/applications/openshift/api-server/var_apiserver_client_ca.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer client CA'
+
+description: 'OpenShift Kube APIServer client CA'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-certs/configmaps/client-ca/ca-bundle.crt"

--- a/applications/openshift/api-server/var_apiserver_etcd_ca.var
+++ b/applications/openshift/api-server/var_apiserver_etcd_ca.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer etcd CA'
+
+description: 'OpenShift Kube APIServer etcd CA'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-resources/configmaps/etcd-serving-ca/ca-bundle.crt"

--- a/applications/openshift/api-server/var_apiserver_kubelet_certificate_authority.var
+++ b/applications/openshift/api-server/var_apiserver_kubelet_certificate_authority.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer kubelet certificate authority'
+
+description: 'OpenShift Kube APIServer kubelet certificate authority'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-resources/configmaps/kubelet-serving-ca/ca-bundle.crt"

--- a/applications/openshift/api-server/var_apiserver_kubelet_client_cert.var
+++ b/applications/openshift/api-server/var_apiserver_kubelet_client_cert.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer kubelet client cert'
+
+description: 'OpenShift Kube APIServer kubelet client cert'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.crt"

--- a/applications/openshift/api-server/var_apiserver_kubelet_client_key.var
+++ b/applications/openshift/api-server/var_apiserver_kubelet_client_key.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer kubelet client key'
+
+description: 'OpenShift Kube APIServer kubelet client key'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-certs/secrets/kubelet-client/tls.key"

--- a/applications/openshift/api-server/var_apiserver_tls_cert.var
+++ b/applications/openshift/api-server/var_apiserver_tls_cert.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer TLS cert'
+
+description: 'OpenShift Kube APIServer TLS cert'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.crt"

--- a/applications/openshift/api-server/var_apiserver_tls_private_key.var
+++ b/applications/openshift/api-server/var_apiserver_tls_private_key.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer TLS private key'
+
+description: 'OpenShift Kube APIServer TLS private key'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "/etc/kubernetes/static-pod-certs/secrets/service-network-serving-certkey/tls.key"

--- a/applications/openshift/api-server/var_openshift_kube_apiserver_config.var
+++ b/applications/openshift/api-server/var_openshift_kube_apiserver_config.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube API Server config name'
+
+description: 'OpenShift Kube API Server config name'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "config"

--- a/applications/openshift/api-server/var_openshift_kube_apiserver_config_data_name.var
+++ b/applications/openshift/api-server/var_openshift_kube_apiserver_config_data_name.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube API Server config data name'
+
+description: 'OpenShift Kube API Server config data name'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "config.yaml"

--- a/applications/openshift/api-server/var_openshift_kube_apiserver_namespace.var
+++ b/applications/openshift/api-server/var_openshift_kube_apiserver_namespace.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift Kube APIServer namespace'
+
+description: 'OpenShift Kube APIServer namespace'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "openshift-kube-apiserver"

--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -4,6 +4,13 @@ prodtype: ocp4
 
 title: 'Ensure Controller insecure port argument is unset'
 
+{{% set custom_jqfilter = '{{.var_kube_controller_manager_port_zero_filter}}' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]' %}}
+{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
+
 description: |-
     To ensure the Controller Manager service is bound to secure loopback
     address and a secure port,
@@ -31,8 +38,6 @@ rationale: |-
 
 severity: low
 
-{{% set jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]' %}}
-
 identifiers:
     cce@ocp4: CCE-83578-5
 
@@ -55,14 +60,13 @@ references:
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config': jqfilter}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: |-
-      {{{ openshift_filtered_path('/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config', jqfilter) }}}
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: "[:]"
     values:
       - value: "true"

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure that the RotateKubeletServerCertificate argument is set'
 
+{{% set custom_jqfilter = '{{.var_kube_controller_manager_rotate_kubelet_server_certs_filter}}' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson | .extendedArguments["feature-gates"]' %}}
+{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To enforce kublet server certificate rotation on the Controller Manager,
     set the <tt>RotateKubeletServerCertificate</tt> option to <tt>true</tt>
@@ -43,7 +49,7 @@ identifiers:
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 - functionality: |-
     This recommendation only applies if you let kubelets get their
     certificates from the API Server. In case your certificates come from an
@@ -61,9 +67,11 @@ template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    entity_check: "at least one"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
-    - value: '\"RotateKubeletServerCertificate\=true\"'
-      operation: "pattern match"
+    - value: 'RotateKubeletServerCertificate=true'
       type: "string"
+      operation: "pattern match"
+      entity_check: "at least one"

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure Controller secure-port argument is set'
 
+{{% set custom_jqfilter = '{{.var_kube_controller_manager_secure_port_filter}}' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["secure-port"][]=="10257" then true else false end]' %}}
+{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the Controller Manager service is bound to secure loopback
     address using a secure port,
@@ -46,15 +52,16 @@ references:
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    entity_check: "at least one"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
-    - value: '(\"secure-port\":\[\"10257\"\])'
-      operation: "pattern match"
+    - value: 'true'
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Service Account Certificate Authority Key for the Controller Manager'
 
+{{% set custom_jqfilter = '{{.var_kube_controller_manager_service_account_ca_filter}}' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["root-ca-file"]!=null then true else false end]' %}}
+{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the API Server utilizes its own key pair, set the <tt>masterCA</tt>
     parameter to the public key file for service accounts in the <tt>openshift-kube-controller-manager</tt> configmap on the master
@@ -46,15 +52,16 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    entity_check: "at least one"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
-    - value: '\"root-ca-file\":\[\"/etc/kubernetes/static-pod-resources/configmaps/serviceaccount-ca/ca-bundle.crt\"\]'
-      operation: "pattern match"
+    - value: 'true'
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Service Account Private Key for the Controller Manager'
 
+{{% set custom_jqfilter = '{{.var_kube_controller_manager_service_account_private_key_filter}}' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["service-account-private-key-file"]!=null then true else false end]' %}}
+{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the API Server utilizes its own key pair, set the <tt>privateKeyFile</tt>
     parameter to the public key file for service accounts in the <tt>openshift-kube-controller-manager</tt> configmap on the master
@@ -48,15 +54,16 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
-    yamlpath: ".data['config.yaml']"
+    entity_check: "at least one"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
-    - value: "extendedArguments\":{[^}]*service-account-private-key-file\":\\[[^\\]]*\"/etc/kubernetes/static-pod-resources/secrets/service-account-private-key/service-account\\.key\"[^\\]]*\\]"
-      operation: "pattern match"
+    - value: 'true'      
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure that use-service-account-credentials is enabled'
 
+{{% set custom_jqfilter = '{{.var_kube_controller_manager_use_service_account_filter}}' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["use-service-account-credentials"][]=="true" then true else false end]' %}}
+{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure individual service account credentials are used,
     set the <tt>use-service-account-credentials</tt> option to <tt>true</tt>
@@ -51,15 +57,16 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-controller-manager/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    entity_check: "at least one"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
-    - value: '\"use-service-account-credentials\":\[\"true\"\]'
-      operation: "pattern match"
+    - value: 'true'
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/controller/var_kube_controller_manager_config_data_name.var
+++ b/applications/openshift/controller/var_kube_controller_manager_config_data_name.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config data name'
+
+description: 'Kube controller manager config data name'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "config.yaml"

--- a/applications/openshift/controller/var_kube_controller_manager_config_filepath.var
+++ b/applications/openshift/controller/var_kube_controller_manager_config_filepath.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config filepath'
+
+description: 'Kube controller manager config filepath'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config'

--- a/applications/openshift/controller/var_kube_controller_manager_port_zero_filter.var
+++ b/applications/openshift/controller/var_kube_controller_manager_port_zero_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config check - port should not be zero'
+
+description: 'Kube controller manager config check - port should not be zero'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]'

--- a/applications/openshift/controller/var_kube_controller_manager_rotate_kubelet_server_certs_filter.var
+++ b/applications/openshift/controller/var_kube_controller_manager_rotate_kubelet_server_certs_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config check - rotate kubelet server certs'
+
+description: 'Kube controller manager config check - rotate kubelet server certs'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '.data."config.yaml" | fromjson | .extendedArguments["feature-gates"]'

--- a/applications/openshift/controller/var_kube_controller_manager_secure_port_filter.var
+++ b/applications/openshift/controller/var_kube_controller_manager_secure_port_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config check - secure port'
+
+description: 'Kube controller manager config check - secure port'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."config.yaml" | fromjson | if .extendedArguments["secure-port"][]=="10257" then true else false end]'

--- a/applications/openshift/controller/var_kube_controller_manager_service_account_ca_filter.var
+++ b/applications/openshift/controller/var_kube_controller_manager_service_account_ca_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config check - service account CA'
+
+description: 'Kube controller manager config check - service account CA'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."config.yaml" | fromjson | if .extendedArguments["root-ca-file"]!=null then true else false end]'

--- a/applications/openshift/controller/var_kube_controller_manager_service_account_private_key_filter.var
+++ b/applications/openshift/controller/var_kube_controller_manager_service_account_private_key_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config check - service account private key'
+
+description: 'Kube controller manager config check - service account private key'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."config.yaml" | fromjson | if .extendedArguments["service-account-private-key-file"]!=null then true else false end]'

--- a/applications/openshift/controller/var_kube_controller_manager_use_service_account_filter.var
+++ b/applications/openshift/controller/var_kube_controller_manager_use_service_account_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube controller manager config check - use service account'
+
+description: 'Kube controller manager config check - use service account'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."config.yaml" | fromjson | if .extendedArguments["use-service-account-credentials"][]=="true" then true else false end]'

--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Disable etcd Self-Signed Certificates'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the <tt>etcd</tt> service is not using self-signed
     certificates, run the following command:
@@ -40,15 +46,15 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         entity_check: "none satisfy"
-        yamlpath: '.data["pod.yaml"]'
+        yamlpath: '[:]'
         values:
           - value: '.*auto-tls[= ]true.*'
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure That The etcd Client Certificate Is Correctly Set'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the etcd service is serving TLS to clients,
     make sure the <tt>etcd-pod*</tt> ConfigMaps in the
@@ -39,14 +45,14 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
-        yamlpath: ".data['pod.yaml']"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: "[:]"
         values:
-          - value: ".*--cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.crt \\.*"
+          - value: "--cert-file="
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Enable The Client Certificate Authentication'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the <tt>etcd</tt> service is serving TLS to clients,
     make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
@@ -37,15 +43,15 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
-        yamlpath: ".data['pod.yaml']"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: '[:]'
         values:
           - value: ".*--client-cert-auth=true \\.*"
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure That The etcd Key File Is Correctly Set'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the etcd service is serving TLS to clients,
     make sure the <tt>etcd-pod*</tt> ConfigMaps in the
@@ -39,14 +45,14 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
-        yamlpath: ".data['pod.yaml']"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: "[:]"
         values:
-          - value: ".*--key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-serving-NODE_NAME.key \\.*"
+          - value: "--key-file="
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Disable etcd Peer Self-Signed Certificates'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the <tt>etcd</tt> service is not using self-signed
     certificates, run the following command:
@@ -40,15 +46,15 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         entity_check: "none satisfy"
-        yamlpath: '.data["pod.yaml"]'
+        yamlpath: '[:]'
         values:
           - value: '.*peer-auto-tls[= ]true.*'
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure That The etcd Peer Client Certificate Is Correctly Set'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the etcd service is serving TLS to peers,
     make sure the <tt>etcd-pod*</tt> ConfigMaps in the
@@ -39,14 +45,14 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
-        yamlpath: ".data['pod.yaml']"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: '[:]'
         values:
-          - value: ".*--peer-cert-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.crt \\.*"
+          - value: "--peer-cert-file="
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Enable The Peer Client Certificate Authentication'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the <tt>etcd</tt> service is serving TLS to clients,
     make sure the <tt>etcd-pod*</tt> <tt>ConfigMaps</tt> in the
@@ -37,15 +43,14 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
-
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
-        yamlpath: ".data['pod.yaml']"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: '[:]'
         values:
-          - value: ".*--peer-client-cert-auth=true \\.*"
+          - value: '--peer-client-cert-auth=true'
             operation: "pattern match"

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure That The etcd Peer Key File Is Correctly Set'
 
+{{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the etcd service is serving TLS to peers,
     make sure the <tt>etcd-pod*</tt> ConfigMaps in the
@@ -39,14 +45,14 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: /api/v1/namespaces/openshift-etcd/configmaps/etcd-pod
-        yamlpath: ".data['pod.yaml']"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: '[:]'
         values:
-          - value: ".*--peer-key-file=/etc/kubernetes/static-pod-certs/secrets/etcd-all-[a-z]+/etcd-peer-NODE_NAME.key \\.*"
+          - value: "--peer-key-file="
             operation: "pattern match"

--- a/applications/openshift/etcd/var_etcd_argument_filter.var
+++ b/applications/openshift/etcd/var_etcd_argument_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Etcd config filter'
+
+description: 'Etcd config filter'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."pod.yaml"]'

--- a/applications/openshift/etcd/var_etcd_filepath.var
+++ b/applications/openshift/etcd/var_etcd_filepath.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Etcd config file path'
+
+description: 'Etcd config file path'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod'

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -48,7 +48,7 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: ".data['config.yaml']"
+        yamlpath: '.apiServerArguments["kubelet-client-certificate"][:]'
         values:
-          - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt"\]'
+          - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt'
             operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -47,8 +47,13 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
+        entity_check: "all"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.apiServerArguments["kubelet-client-certificate"][:]'
+        xccdf_variable: var_apiserver_kubelet_client_cert
+        embedded_data: "true"
         values:
-          - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt'
+          - value: '(.+)'
+            type: "string"
             operation: "pattern match"
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -47,7 +47,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: ".data['config.yaml']"
         values:
           - value: '"kubelet-client-certificate":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.crt"\]'

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure That The kubelet Client Certificate Is Correctly Set'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the kubelet TLS client certificate is configured, edit the
     kubelet configuration file <tt>/etc/kubernetes/kubelet.conf</tt>

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Ensure That The kubelet Client Certificate Is Correctly Set'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -41,7 +41,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Ensure That The kubelet Server Key Is Correctly Set'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the kubelet TLS private server key certificate is configured, edit the
     kubelet configuration file <tt>/etc/kubernetes/kubelet.conf</tt>

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -47,7 +47,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: ".data['config.yaml']"
         values:
           - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key"\]'

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -48,7 +48,7 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: ".data['config.yaml']"
+        yamlpath: '.apiServerArguments["kubelet-client-key"][:]'
         values:
-          - value: '"kubelet-client-key":\["/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key"\]'
+          - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key'
             operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -47,8 +47,12 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
+        entity_check: "all"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.apiServerArguments["kubelet-client-key"][:]'
+        xccdf_variable: var_apiserver_kubelet_client_key
+        embedded_data: "true"
         values:
-          - value: '/etc/kubernetes/static-pod-(resources|certs)/secrets/kubelet-client/tls.key'
+          - value: '(.+)'
+            type: "string"
             operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'Ensure That The kubelet Server Key Is Correctly Set'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -41,7 +41,7 @@ ocil: |-
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -50,7 +50,7 @@ references:
 
 warnings:
     - general: |-
-        {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-apiserver/configmaps/config") | indent(8) }}}
+        {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(8) }}}
 
 template:
     name: yamlfile_value

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -56,7 +56,7 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: ".data['config.yaml']"
         values:
           - value: '.*kubelet-read-only-port"\:\["0"\].*'

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'kubelet - Disable the Read-Only Port'
 
+{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
+{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To disable the read-only port, edit the kubelet configuration
     Edit the <tt>openshift-kube-apiserver</tt> configmap

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -57,8 +57,8 @@ template:
     vars:
         ocp_data: "true"
         filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
-        yamlpath: ".data['config.yaml']"
+        yamlpath: '.apiServerArguments["kubelet-read-only-port"][:]'
         values:
-          - value: '.*kubelet-read-only-port"\:\["0"\].*'
+          - value: '0'
             type: "string"
             operation: "pattern match"

--- a/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
+++ b/applications/openshift/kubelet/kubelet_disable_readonly_port/rule.yml
@@ -4,8 +4,8 @@ prodtype: ocp4
 
 title: 'kubelet - Disable the Read-Only Port'
 
-{{% set custom_jqfilter = '[.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson]' %}}
-{{% set default_jqfilter = '[.data."config.yaml" | fromjson]' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
 {{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Audit Log Path'
 
+{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To enable auditing on the OpenShift API Server, the audit log path must be set.
     Edit the <tt>openshift-apiserver</tt> configmap
@@ -50,10 +56,22 @@ template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: '/api/v1/namespaces/openshift-apiserver/configmaps/config'
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
         yamlpath: '.data["config.yaml"]'
         check_existence: "at_least_one_exists"
         values:
             - value: '\"audit-log-path\"\s*:\s*\[\s*\".+\"\s*\]'
               type: "string"
               operation: "pattern match"
+template:
+    name: yamlfile_value
+    vars:
+        ocp_data: "true"
+        filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+        yamlpath: '.apiServerArguments[:]'
+        check_existence: "none_exist"
+        values:
+            - key: 'basic-auth-file'
+              type: "string"
+              operation: "pattern match"
+

--- a/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
+++ b/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: Ensure that the bind-address parameter is not used
 
+{{% set custom_jqfilter = '{{.var_scheduler_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_scheduler_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
   The Scheduler API service which runs on port 10251/TCP by default is used for
   health and metrics information and is available without authentication or
@@ -40,14 +46,14 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod") | indent(4) }}}
+    {{{  openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod
-    yamlpath: '.data["pod.yaml"]'
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
       - value: "bind-address"
         operation: "pattern match"

--- a/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
+++ b/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: Ensure that the port parameter is zero
 
+{{% set custom_jqfilter = '{{.var_scheduler_argument_filter}}' %}}
+{{% set default_jqfilter = '[.data."pod.yaml"]' %}}
+{{% set custom_api_path = '{{.var_scheduler_filepath}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
   The Scheduler API service which runs on port 10251/TCP by default is used for
   health and metrics information and is available without authentication or
@@ -32,16 +38,16 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: /api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod
-    yamlpath: '.data["pod.yaml"]'
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '[:]'
     values:
-    - value: '"--port=0",'
+    - value: '--port=0'
       operation: "pattern match"
       entity_check: "all"
       type: "string"

--- a/applications/openshift/scheduler/var_scheduler_argument_filter.var
+++ b/applications/openshift/scheduler/var_scheduler_argument_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube scheduler config filter'
+
+description: 'Kube scheduler filter'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.data."pod.yaml"]'

--- a/applications/openshift/scheduler/var_scheduler_filepath.var
+++ b/applications/openshift/scheduler/var_scheduler_filepath.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Kube scheduler config file path'
+
+description: 'Kube scheduler config file path'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod'

--- a/ocp-resources/compliance-operator-catalog-source.yaml
+++ b/ocp-resources/compliance-operator-catalog-source.yaml
@@ -7,4 +7,5 @@ spec:
   displayName: Compliance Operator Upstream
   publisher: github.com/openshift/compliance-operator
   sourceType: grpc
-  image: quay.io/compliance-operator/compliance-operator-index:latest
+  image: quay.io/osco4hypershift/compliance-operator-index:latest
+

--- a/ocp-resources/compliance-operator-catalog-source.yaml
+++ b/ocp-resources/compliance-operator-catalog-source.yaml
@@ -7,5 +7,4 @@ spec:
   displayName: Compliance Operator Upstream
   publisher: github.com/openshift/compliance-operator
   sourceType: grpc
-  image: quay.io/osco4hypershift/compliance-operator-index:latest
-
+  image: quay.io/compliance-operator/compliance-operator-index:latest

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -42,31 +42,52 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
   {{% set vars = v.split(',') %}}
   {{% if vars|length == 2 %}}
     {{% set dump_path = vars[0] %}}
-    {{% set filter = vars[1] %}}
+    {{% set default_filter = vars[1] %}}
+    {{% set custom_filter = vars[1] %}}
+  {{% elif vars|length == 3 %}}
+    {{% set dump_path = vars[0] %}}
+    {{% set default_filter = vars[1] %}}
+    {{% set custom_filter = vars[2] %}}
   {{% else %}}
     {{% set dump_path = obj_path %}}
-    {{% set filter = v %}}
+    {{% set default_filter = v %}}
+    {{% set custom_filter = v %}}
   {{% endif %}}
   <li>
-    <code class="ocp-api-endpoint" id="{{{ (dump_path+filter)|sha256 }}}">{{{ obj_path }}}</code>
+    <code class="ocp-api-endpoint" id="{{{ (dump_path+default_filter)|sha256 }}}">{{{ obj_path }}}</code>
     API endpoint, filter with with the <code>jq</code> utility using the following filter
-    <code class="ocp-api-filter" id="filter-{{{ (dump_path+filter)|sha256 }}}">{{{ filter }}}</code>
+    <code class="ocp-api-filter" id="filter-{{{ (dump_path+default_filter)|sha256 }}}">{{{ custom_filter }}}</code>
     and persist it to the local
-    <code class="ocp-dump-location" id="dump-{{{ (dump_path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ dump_path.lstrip("/") }}}#{{{ (dump_path+filter)|sha256 }}}</code>
+    <code class="ocp-dump-location" id="dump-{{{ (dump_path+default_filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ dump_path.lstrip("/") }}}#{{{ (dump_path+default_filter)|sha256 }}}</code>
     file.
   </li>
 {{% endfor %}}
+
 {{% for arg in varargs %}}
-{{% for path, filter in arg.items() %}}
-  <li>
-    <code class="ocp-api-endpoint" id="{{{ (path+filter)|sha256 }}}">{{{ path }}}</code>
-    API endpoint, filter with with the <code>jq</code> utility using the following filter
-    <code class="ocp-api-filter" id="filter-{{{ (path+filter)|sha256 }}}">{{{ filter }}}</code>
-    and persist it to the local
-    <code class="ocp-dump-location" id="dump-{{{ (path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (path+filter)|sha256 }}}</code>
-    file.
-  </li>
-{{% endfor %}}
+    {{% for obj_path, v in arg.items() %}}
+  {{% set vars = v.split(',') %}}
+  {{% if vars|length == 2 %}}
+    {{% set dump_path = vars[0] %}}
+    {{% set default_filter = vars[1] %}}
+    {{% set custom_filter = vars[1] %}}
+  {{% elif vars|length == 3 %}}
+    {{% set dump_path = vars[0] %}}
+    {{% set default_filter = vars[1] %}}
+    {{% set custom_filter = vars[2] %}}
+  {{% else %}}
+    {{% set dump_path = obj_path %}}
+    {{% set default_filter = v %}}
+    {{% set custom_filter = v %}}
+  {{% endif %}}
+    <li>
+        <code class="ocp-api-endpoint" id="{{{ (dump_path+default_filter)|sha256 }}}">{{{ obj_path }}}</code>
+        API endpoint, filter with with the <code>jq</code> utility using the following filter
+        <code class="ocp-api-filter" id="filter-{{{ (dump_path+default_filter)|sha256 }}}">{{{ custom_filter }}}</code>
+        and persist it to the local
+        <code class="ocp-dump-location" id="dump-{{{ (dump_path+default_filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ dump_path.lstrip("/") }}}#{{{ (dump_path+default_filter)|sha256 }}}</code>
+        file.
+    </li>
+    {{% endfor %}}
 {{% endfor %}}
 </ul>
 {{%- endmacro %}}

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -38,13 +38,21 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the {{% i
 This rule's check operates on the cluster configuration dump.
 Therefore, you need to use a tool that can query the OCP API, retrieve the following:
 <ul>
-{{% for path, filter in path_filter_pairs.items() %}}
+{{% for obj_path, v in path_filter_pairs.items() %}}
+  {{% set vars = v.split(',') %}}
+  {{% if vars|length == 2 %}}
+    {{% set dump_path = vars[0] %}}
+    {{% set filter = vars[1] %}}
+  {{% else %}}
+    {{% set dump_path = obj_path %}}
+    {{% set filter = v %}}
+  {{% endif %}}
   <li>
-    <code class="ocp-api-endpoint" id="{{{ (path+filter)|sha256 }}}">{{{ path }}}</code>
+    <code class="ocp-api-endpoint" id="{{{ (dump_path+filter)|sha256 }}}">{{{ obj_path }}}</code>
     API endpoint, filter with with the <code>jq</code> utility using the following filter
-    <code class="ocp-api-filter" id="filter-{{{ (path+filter)|sha256 }}}">{{{ filter }}}</code>
+    <code class="ocp-api-filter" id="filter-{{{ (dump_path+filter)|sha256 }}}">{{{ filter }}}</code>
     and persist it to the local
-    <code class="ocp-dump-location" id="dump-{{{ (path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ path.lstrip("/") }}}#{{{ (path+filter)|sha256 }}}</code>
+    <code class="ocp-dump-location" id="dump-{{{ (dump_path+filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ dump_path.lstrip("/") }}}#{{{ (dump_path+filter)|sha256 }}}</code>
     file.
   </li>
 {{% endfor %}}


### PR DESCRIPTION

## Description

This PR  is the successor of #7928 and https://github.com/openshift/compliance-operator/pull/788.

The final contents of #7928 leveraged [the Compliance Operator's template substitution feature](https://github.com/openshift/compliance-operator/pull/750), but its format force rule authors write both default path (in `.template.vars.filepath`) and customized path placeholder (in `warnings`), which may increase rule authoring workload and update inconsistency.

This PR solves the issue by modifying the OpenShift cluster setting macros.  Now the macros can accept both default and customized path, and it provides simpler authoring format for the rule authors.

(Please also see the description of #7928)

#### Rationale:

- This PR expands the capability of ComplianceAsCode/content and Compliance Operator to various kinds of installations including managed OpenShift Services
