### PR TITLE
Do not remove krb5-workstation package on oVirt

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
@@ -27,6 +27,12 @@ references:
     stigid@ol8: OL08-00-010162
     stigid@rhel8: RHEL-08-010162
 
+platforms:
+{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
+
+warnings:
+{{{ ovirt_rule_notapplicable_warning("RHV hosts require ipa-client package, which has dependency on krb5-workstation") | indent(4) }}}
+
 {{{ complete_ocil_entry_package(package="krb5-workstation") }}}
 
 template:


### PR DESCRIPTION
#### Description:

- Do not remove krb5-workstation package on oVirt

#### Rationale:

- RHV hosts require ipa-client package, which has dependency on krb5-workstation

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2055149
