### PR TITLE
Store OVAL of compiled platforms as string

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -2060,7 +2060,7 @@ class Platform(XCCDFEntity):
             cpe_platform.append(cpe_test)
         else:
             cpe_platform.append(self.test.to_xml_element())
-        xmlstr = ET.tostring(cpe_platform, encoding="utf8", method="xml")
+        xmlstr = ET.tostring(cpe_platform).decode()
         return xmlstr
 
     def to_xml_element(self):


### PR DESCRIPTION
#### Description:

- change how the xml_content attribute of Platform class is encoded
- it was stored as bytes, now it is stored as string
- based on https://stackoverflow.com/a/48671499
- I chose this way because it is compatible with Python 2 and 3

#### Rationale:

- compiled platforms had xml_content attribute stored in form of byte string and therefore it was nod readable for humans.