### PR TITLE
Fix for bug 1195523

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,ubuntu2004
 
 title: 'Enforce usage of pam_wheel for su authentication'
 
@@ -25,8 +25,6 @@ identifiers:
 references:
     cis@rhel7: "5.7"
     cis@rhel8: "5.7"
-    cis@sle12: "5.7"
-    cis@sle15: "5.6"
     cis@ubuntu2004: "5.6"
     ospp: FMT_SMF_EXT.1.1
     srg: 'SRG-OS-000373-GPOS-00156,SRG-OS-000312-GPOS-00123'


### PR DESCRIPTION
#### Description:
use_pam_wheel_for_su. As SUSE is not using the wheel group, should not enable this test for SUSE.

#### Rationale:
- Fixes # bug 1195523: https://bugzilla.suse.com/show_bug.cgi?id=1195523
