### PR TITLE
Add CPE to OCP profile filter

### DIFF
--- a/products/ocp4/profiles/high-node.profile
+++ b/products/ocp4/profiles/high-node.profile
@@ -41,7 +41,7 @@ description: |-
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
 extends: cis-node
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms'
+filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
 
 selections:
     - nist_ocp4:all:high

--- a/products/ocp4/profiles/high.profile
+++ b/products/ocp4/profiles/high.profile
@@ -37,7 +37,7 @@ description: |-
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms'
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms'
 
 # CM-6 CONFIGURATION SETTINGS
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION

--- a/products/ocp4/profiles/moderate-node.profile
+++ b/products/ocp4/profiles/moderate-node.profile
@@ -39,7 +39,7 @@ description: |-
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
 extends: cis-node
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms'
+filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
 
 selections:
     - nist_ocp4:all:moderate

--- a/products/ocp4/profiles/moderate.profile
+++ b/products/ocp4/profiles/moderate.profile
@@ -36,7 +36,7 @@ description: |-
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms'
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
 
 # CM-6 CONFIGURATION SETTINGS
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION

--- a/products/ocp4/profiles/pci-dss-node.profile
+++ b/products/ocp4/profiles/pci-dss-node.profile
@@ -15,7 +15,7 @@ title: 'PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform
 description: |-
     Ensures PCI-DSS v3.2.1 security configuration settings are applied.
 
-filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms'
+filter_rules: '"ocp4-node" in platforms or "ocp4-master-node" in platforms or "ocp4-node-on-sdn" in platforms or "ocp4-node-on-ovn" in platforms'
 
 # Req-2.2
 extends: cis-node


### PR DESCRIPTION
We didn't add CPE to OCP profile filter, and as a result some nodes/platform rules were in all the profiles, this PR addresses the issue