### PR TITLE
Fix handling of literal dollars in macros

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1026,7 +1026,8 @@ printf '%s\n' "{{{ message | replace('"', '\\"') }}}" >&2
 
 {{%- macro set_config_file(path, parameter, value, create, insert_after, insert_before, insensitive=true, separator=" ", separator_regex="\s\+", prefix_regex="^\s*", sed_path_separator="/") -%}}
     {{%- set new_line = parameter+separator+value -%}}
-    {{%- set line_regex = prefix_regex + ((parameter | escape_regex) | replace("/", "\/")) + separator_regex -%}}
+    {{#- An escaped dollar in the parameter is escaped because of its significance for the shell, so when making a regex out of the parameter, we remove the shell escape, as the regex escape will do its thing. -#}}
+    {{%- set line_regex = prefix_regex + ((parameter | replace("\\$", "$") | escape_regex) | replace("/", "\/")) + separator_regex -%}}
 if [ -e "{{{ path }}}" ] ; then
     {{{ lineinfile_absent(path, line_regex, insensitive, sed_path_separator=sed_path_separator) | indent(4) }}}
 else

--- a/tests/unit/bash/test_set_config_file.bats.jinja
+++ b/tests/unit/bash/test_set_config_file.bats.jinja
@@ -10,6 +10,10 @@ function call_set_config_file {
     {{{ set_config_file("$1", "Compression", "no", True) | indent(4) }}}
 }
 
+function call_set_config_file_rsyslog {
+	{{{ set_config_file(path="$1",
+                    parameter="\$DefaultNetstreamDriver", value="gtls", create=true, separator=" ", separator_regex=" ") }}}
+}
 
 @test "Basic value remediation" {
     tmp_file="$(mktemp)"
@@ -175,6 +179,20 @@ function call_set_config_file {
     expected_output='something=$value'"\n"
 
     {{{ bash_shell_file_set("$tmp_file", "something", '$value', no_quotes=true) | indent(4) }}}
+
+    run diff -U2 "$tmp_file" <(printf "$expected_output")
+    echo "$output"
+    [ "$status" -eq 0 ]
+
+    rm "$tmp_file"
+}
+
+@test "set_config_file - handle escaped dollar" {
+    tmp_file="$(mktemp)"
+    printf "%s\n" '$DefaultNetstreamDriver bad' > "$tmp_file"
+    expected_output='$DefaultNetstreamDriver gtls'"\n"
+
+    call_set_config_file_rsyslog "$tmp_file"
 
     run diff -U2 "$tmp_file" <(printf "$expected_output")
     echo "$output"


### PR DESCRIPTION
Before, the dollar got double-escaped, because as it is initially escaped for the shell.
Then, the regex escape process escaped the escape and the dollar as well.