### PR TITLE
make rule enable_fips_mode check only for technical state

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/rhcos4.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/rhcos4.xml
@@ -5,7 +5,6 @@
       <extend_definition comment="check /etc/system-fips exists" definition_ref="etc_system_fips_exists" />
       <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="proc_sys_crypto_fips_enabled" />
       <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -6,7 +6,6 @@
       <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="sysctl_crypto_fips_enabled" />
       <extend_definition comment="Dracut FIPS module is enabled" definition_ref="enable_dracut_fips_module" />
       <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
-      <extend_definition comment="Installed OS is FIPS certified" definition_ref="installed_OS_is_FIPS_certified" />
       <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -13,11 +13,9 @@ description: |-
     <ul>
     <li>Setting the kernel FIPS mode flag (<tt>/proc/sys/crypto/fips_enabled</tt>) to <tt>1</tt></li>
     <li>Creating <tt>/etc/system-fips</tt></li>
-    <li>Setting the system crypto policy in <tt>/etc/crypto-policies/config</tt> to <tt>FIPS</tt></li>
+    <li>Setting the system crypto policy in <tt>/etc/crypto-policies/config</tt> to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt></li>
     <li>Loading the Dracut <tt>fips</tt> module</li>
     </ul>
-    This rule also ensures that the system policy is set to <tt>{{{ xccdf_value("var_system_crypto_policy") }}}</tt>.
-    Furthermore, the system running in FIPS mode should be FIPS certified by NIST.
 
 rationale: |-
     Use of weak or untested encryption algorithms undermines the purposes of utilizing encryption to
@@ -48,7 +46,7 @@ references:
 ocil_clause: 'FIPS mode is not enabled'
 
 ocil: |-
-    To verify that FIPS is enabled properly, run the following command:
+    To verify that FIPS mode is enabled properly, run the following command:
     <pre>fips-mode-setup --check</pre>
     The output should contain the following:
     <pre>FIPS mode is enabled.</pre>
@@ -61,19 +59,6 @@ warnings:
     - general: |-
         The system needs to be rebooted for these changes to take effect.
     - regulatory: |-
-        System Crypto Modules must be provided by a vendor that undergoes
-        FIPS-140 certifications.
-        FIPS-140 is applicable to all Federal agencies that use
-        cryptographic-based security systems to protect sensitive information
-        in computer and telecommunication systems (including voice systems) as
-        defined in Section 5131 of the Information Technology Management Reform
-        Act of 1996, Public Law 104-106. This standard shall be used in
-        designing and implementing cryptographic modules that Federal
-        departments and agencies operate or are operated for them under
-        contract. See <b>{{{ weblink(link="https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.140-2.pdf") }}}</b>
-        To meet this, the system has to have cryptographic software provided by
-        a vendor that has undergone this certification. This means providing
-        documentation, test results, design information, and independent third
-        party review by an accredited lab. While open source software is
-        capable of meeting this, it does not meet FIPS-140 unless the vendor
-        submits to this process.
+        This rule DOES NOT CHECK if the components of the operating system are FIPS certified.
+        You can find the list of FIPS certified modules at {{{ weblink(link="https://csrc.nist.rip/groups/STM/cmvp/documents/140-1/1401vend.htm") }}}.
+        This rule checks if the system is running in FIPS mode. See the rule description for more information about what it means.

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/rule.yml
@@ -60,5 +60,5 @@ warnings:
         The system needs to be rebooted for these changes to take effect.
     - regulatory: |-
         This rule DOES NOT CHECK if the components of the operating system are FIPS certified.
-        You can find the list of FIPS certified modules at {{{ weblink(link="https://csrc.nist.rip/groups/STM/cmvp/documents/140-1/1401vend.htm") }}}.
+        You can find the list of FIPS certified modules at {{{ weblink(link="https://csrc.nist.gov/projects/cryptographic-module-validation-program/validated-modules/search") }}}.
         This rule checks if the system is running in FIPS mode. See the rule description for more information about what it means.


### PR DESCRIPTION
#### Description:

- remove extend definitions from the OVAL of enable_fips_mode which determined if the OS is FIPS certified
- add warning that the rule is not determining if the OS is FIPS certified
- minor description adjustments

#### Rationale:

- the rule employed an OVAL check called installed_os_is_fips_certified. However, FIPS certification does not apply to an operating system as a whole but rather to cryptographic components. Moreover, it seems that the main goal of enable_fips_mode rule is to check if the FIPS mode (not the certification!) has been applied on the system. Note that the fact that the system is running in FIPS mode does not mean that the cryptographic components have undergone FIPS certification.