### PR TITLE
Fix bash remediations of browsers

### DIFF
--- a/products/chromium/guide/chromium/chromium_policy_file/bash/chromium.sh
+++ b/products/chromium/guide/chromium/chromium_policy_file/bash/chromium.sh
@@ -3,7 +3,8 @@ CHROME_POL_FILE="chrome_stig_policy.json"
 CHROME_POL_DIR="/etc/chromium/policies/managed/"
 
 if [ ! -d ${CHROME_POL_DIR} ] ; then
-   mkdir -p -m 755 ${CHROME_POL_DIR}
+   mkdir -p ${CHROME_POL_DIR}
+   chmod 755 ${CHROME_POL_DIR}
 fi
 
 if [ ! -f ${CHROME_POL_DIR}/${CHROME_POL_FILE} ] ; then

--- a/products/chromium/guide/chromium/var_enable_approved_plugins.var
+++ b/products/chromium/guide/chromium/var_enable_approved_plugins.var
@@ -9,4 +9,5 @@ type: string
 interactive: true
 
 options:
-    default: None
+    default: ''
+    none: ''

--- a/products/chromium/profiles/stig.profile
+++ b/products/chromium/profiles/stig.profile
@@ -23,6 +23,7 @@ selections:
     - var_extension_whitelist=none
     - var_auth_schema=negotiate
     - var_trusted_home_page=blank
+    - var_enable_approved_plugins=none
     - chromium_policy_file
     - chromium_disable_firewall_traversal
     - chromium_block_desktop_notifications

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1737,11 +1737,10 @@ Example macro invocation:
 #}}
 {{%- macro bash_chromium_pol_setting(chrome_pol_file, chrome_pol_dir, pol_setting, pol_setting_val, pol_setting_val_edit=None) %}}
 {{% if not pol_setting_val_edit %}}
-{{ pol_setting_val_edit=pol_setting_val }}
+{{% set pol_setting_val_edit = pol_setting_val %}}
 {{% endif %}}
-grep -q {{{ pol_setting }}} {{{ chrome_pol_dir }}}{{{ chrome_pol_file }}}
 
-if ! [ $? -eq 0 ] ; then
+if ! grep -q {{{ pol_setting }}} {{{ chrome_pol_dir }}}{{{ chrome_pol_file }}}; then
    sed -i -e '/{/a \  "'{{{ pol_setting }}}'": '{{{ pol_setting_val_edit }}}',' {{{ chrome_pol_dir }}}{{{ chrome_pol_file }}}
 else
    sed -i -e 's/\"'{{{ pol_setting }}}'.*/\"'{{{ pol_setting }}}'\": '{{{ pol_setting_val }}}',/g' {{{ chrome_pol_dir }}}{{{ chrome_pol_file }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -903,7 +903,8 @@ for firefox_dir in ${firefox_dirs}; do
             firefox_pref_dir="${firefox_dir}/${firefox_pref}"
         else
             firefox_pref_dir="${firefox_dir}/${firefox_preferences}"
-            mkdir -m 755 -p "${firefox_pref_dir}"
+            mkdir -p "${firefox_pref_dir}"
+            chmod 755 "${firefox_pref_dir}"
         fi
 
         # Make sure the Firefox .js file exists and has the appropriate permissions
@@ -953,10 +954,10 @@ for firefox_dir in ${firefox_dirs}; do
     if [ -d "${firefox_dir}" ]; then
         # Make sure the Firefox .cfg file exists and has the appropriate permissions
         if ! [ -f "${firefox_dir}/${firefox_cfg}" ] ; then
-            echo "//" "${firefox_dir}/${firefox_cfg}"
+            echo "//  IMPORTANT: Start your code on the 2nd line" > "${firefox_dir}/${firefox_cfg}"
             chmod 644 "${firefox_dir}/${firefox_cfg}"
-        elif ! [ $(head -1 "${firefox_dir}/${firefox_cfg}" | grep "^//$") ]; then
-            sed -i '1 i\//' "${firefox_dir}/${firefox_cfg}"
+        elif ! head -1 "${firefox_dir}/${firefox_cfg}" | grep -q "^//"; then
+            sed -i '1 i\// IMPORTANT: Start your code on the 2nd line' "${firefox_dir}/${firefox_cfg}"
         fi
 
         {{{ _put_into_firefox_cfg(config_item="lockPref", key=key, value_varname="value", where="${firefox_dir}/${firefox_cfg}", sed_separator=sed_separator) | indent(4 * 2) }}}


### PR DESCRIPTION
- `mkdir` with permission specified may be misleading, so the statement has been duplicated.
- XCCDF values make troubles during the build if the default selector is used, so a non-default has been added and specified.
- The "start on the 2nd line" is a [sample from Firefox website](https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig)