### PR TITLE
Adjust partition sizes to acomodate a GUI install

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_enhanced-ks.cfg
@@ -100,13 +100,13 @@ volgroup VolGroup --pesize=4096 pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=6536 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
-logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition
-logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /home Located On Separate Partition
-logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=512 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var/tmp Located On Separate Partition

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_high-ks.cfg
@@ -104,13 +104,13 @@ volgroup VolGroup --pesize=4096 pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=6536 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
-logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition
-logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /home Located On Separate Partition
-logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=512 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var/tmp Located On Separate Partition

--- a/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-anssi_bp28_intermediary-ks.cfg
@@ -100,13 +100,13 @@ volgroup VolGroup --pesize=4096 pv.01
 # Create particular logical volumes (optional)
 logvol / --fstype=xfs --name=LogVol06 --vgname=VolGroup --size=3192 --grow
 # Ensure /usr Located On Separate Partition
-logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=5000 --fsoptions="nodev"
+logvol /usr --fstype=xfs --name=LogVol08 --vgname=VolGroup --size=6536 --fsoptions="nodev"
 # Ensure /opt Located On Separate Partition
-logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /opt --fstype=xfs --name=LogVol09 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /srv Located On Separate Partition
-logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid"
+logvol /srv --fstype=xfs --name=LogVol10 --vgname=VolGroup --size=512 --fsoptions="nodev,nosuid"
 # Ensure /home Located On Separate Partition
-logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=1024 --fsoptions="nodev"
+logvol /home --fstype=xfs --name=home --vgname=VolGroup --size=512 --fsoptions="nodev"
 # Ensure /tmp Located On Separate Partition
 logvol /tmp --fstype=xfs --name=tmp --vgname=VolGroup --size=1024 --fsoptions="nodev,nosuid,noexec"
 # Ensure /var/tmp Located On Separate Partition


### PR DESCRIPTION
#### Description:

- Add 1536 MB to the `/usr` partition.
  This should also give it some room for future requirement increases.
- Reduce 512 MB from `/opt`, `/srv` and`/home` partitions.

#### Rationale:

- The GUI requires more room in the `/usr` partition:
  `At least 339MB more space needed on the /usr filesystem.`
- Let's reduce size of `/opt`, `/srv` and `/home`, which should not have any data right after install.
