### PR TITLE
Add no_empty_passwords_etc_shadow rule to SLE stig profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
@@ -1,0 +1,14 @@
+# platform = multi_platform_all
+
+- name: Collect users with no password
+  command: >
+    awk -F: '!$2 {print $1}' /etc/shadow
+  register: users_nopasswd
+
+- name: Lock users with no password
+  command: >
+    passwd -l {{ item }}
+  with_items: "{{ users_nopasswd.stdout_lines }}"
+  when: users_nopasswd.stdout_lines | length > 0
+
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
@@ -1,4 +1,8 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
 
 - name: Collect users with no password
   command: >

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ol
+# platform = multi_platform_ol,multi_platform_sle
 
 readarray -t users_with_empty_pass < <(sudo awk -F: '!$2 {print $1}' /etc/shadow)
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -21,11 +21,17 @@ rationale: |-
 
 severity: high
 
+identifiers:
+    cce@sle15: CCE-91155-2
+    cce@sle12: CCE-83249-3
+
 references:
     disa: CCI-000366
     nist: CM-6(b),CM-6.1(iv)
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-010291
+    stigid@sle12: SLES-12-010221
+    stigid@sle15: SLES-15-020181
 
 ocil_clause: 'Blank or NULL passwords can be used'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -22,8 +22,8 @@ rationale: |-
 severity: high
 
 identifiers:
-    cce@sle15: CCE-91155-2
     cce@sle12: CCE-83249-3
+    cce@sle15: CCE-91155-2
 
 references:
     disa: CCI-000366

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -203,6 +203,7 @@ selections:
     - mount_option_nosuid_removable_partitions
     - network_sniffer_disabled
     - no_empty_passwords
+    - no_empty_passwords_etc_shadow
     - no_files_unowned_by_user
     - no_host_based_files
     - no_shelllogin_for_systemaccounts

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -213,6 +213,7 @@ selections:
     - mount_option_nosuid_removable_partitions
     - network_sniffer_disabled
     - no_empty_passwords
+    - no_empty_passwords_etc_shadow
     - no_files_unowned_by_user
     - no_host_based_files
     - no_shelllogin_for_systemaccounts


### PR DESCRIPTION


#### Description:

- Add no_empty_passwords_etc_shadow rule to SLE stig profile update to match STIG IDs SLES-15-020181 and SLES-12-010221 

#### Rationale:

- Add no_empty_passwords_etc_shadow rule to sle12 and sle15 profile
- Add ansible remediation for the rule
- Assigned SLE CCE ids and added DISA STIG reference IDs