### PR TITLE
Add disallow_bypass_password_sudo rule to SLE stig profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/ansible/shared.yml
@@ -1,0 +1,8 @@
+# platform = multi_platform_ol,multi_platform_sle
+
+- name: Check for pam_succeed_if entry
+  ansible.builtin.lineinfile:
+    path: "/etc/pam.d/sudo"
+    create: no
+    regexp: 'pam_succeed_if'
+    state: absent

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/ansible/shared.yml
@@ -1,4 +1,8 @@
 # platform = multi_platform_ol,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
 
 - name: Check for pam_succeed_if entry
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_ol
+# platform = multi_platform_ol,multi_platform_sle
 
 sed -i '/pam_succeed_if/d' /etc/pam.d/sudo

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/rule.yml
@@ -16,11 +16,17 @@ rationale: |-
 
 severity: medium
 
+identifiers:
+    cce@sle12: CCE-83250-1
+    cce@sle15: CCE-91156-0
+
 references:
     disa: CCI-002038
     nist: IA-11
     srg: SRG-OS-000373-GPOS-00156,SRG-OS-000373-GPOS-00157,SRG-OS-000373-GPOS-00158
-    stigid@ol7: OL07-00-010344     
+    stigid@ol7: OL07-00-010344
+    stigid@sle12: SLES-12-010114
+    stigid@sle15: SLES-15-020104
 
 ocil_clause: |-
     system is configured to bypass password requirements for privilege escalation

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_absent.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ol
+# platform = multi_platform_ol,multi_platform_sle
 
 sed -i '/pam_succeed_if/d' /etc/pam.d/sudo

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/tests/pam_succeed_if_present.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ol
+# platform = multi_platform_ol,multi_platform_sle
 
 if  ! grep "pam_succeed_if" /etc/pam.d/sudo ; then 
     echo "auth required pam_succeed_if.so quiet user ingroup wheel" >> /etc/pam.d/sudo

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -167,6 +167,7 @@ selections:
     - dir_system_commands_group_root_owned
     - dir_system_commands_root_owned
     - disable_ctrlaltdel_reboot
+    - disallow_bypass_password_sudo
     - display_login_attempts
     - enable_dconf_user_profile
     - encrypt_partitions

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -180,6 +180,7 @@ selections:
     - disable_ctrlaltdel_burstaction
     - disable_ctrlaltdel_reboot
     - disable_ctrlaltdel_reboot
+    - disallow_bypass_password_sudo
     - display_login_attempts
     - enable_dconf_user_profile
     - encrypt_partitions


### PR DESCRIPTION

#### Description:

- Add disallow_bypass_password_sudo rule to SLE stig profiles

#### Rationale:

- Add disallow_bypass_password_sudo rule to sle12 and sle15 profile
- Add ansible remediation for the rule
- Assigned SLE CCE ids and added DISA STIG reference IDs
