### PR TITLE
Update OVAL content for grub2_admin_username

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
@@ -4,9 +4,6 @@
               "The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
-      {{% if product not in ["ol8", "rhel8"] %}}
-      {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
-      {{% endif %}}
       <criterion comment="Superuser is defined in {{{ grub2_boot_path }}}/grub.cfg and it isn't
             root, admin, administrator nor equal to any system username"
             test_ref="test_bootloader_superuser_differ_from_other_users"/>
@@ -21,10 +18,6 @@
           including all system usernames">
     <object_component item_field="username" object_ref="object_user_accounts"/>
   </local_variable>
-
-  {{% if product not in ["ol8", "rhel8"] %}}
-  {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
-  {{% endif %}}
 
   <ind:textfilecontent54_state id="state_bootloader_superuser_differ_from_other_users" 
           version="1">

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
@@ -4,7 +4,9 @@
               "The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
+      {{% if product!= "ol8" %}}
       {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
+      {{% endif %}}
       <criterion comment="Superuser is defined in {{{ grub2_boot_path }}}/grub.cfg and it isn't
             root, admin, administrator nor equal to any system username"
             test_ref="test_bootloader_superuser_differ_from_other_users"/>
@@ -20,7 +22,9 @@
     <object_component item_field="username" object_ref="object_user_accounts"/>
   </local_variable>
 
+  {{% if product!= "ol8" %}}
   {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
+  {{% endif %}}
 
   <ind:textfilecontent54_state id="state_bootloader_superuser_differ_from_other_users" 
           version="1">

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
@@ -4,7 +4,7 @@
               "The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
-      {{% if product!= "ol8" %}}
+      {{% if product not in ["ol8", "rhel8"] %}}
       {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
       {{% endif %}}
       <criterion comment="Superuser is defined in {{{ grub2_boot_path }}}/grub.cfg and it isn't
@@ -22,7 +22,7 @@
     <object_component item_field="username" object_ref="object_user_accounts"/>
   </local_variable>
 
-  {{% if product!= "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
   {{% endif %}}
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/tests/no-grub.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/tests/no-grub.pass.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-. $SHARED/grub2.sh
-
-rm -f "$GRUB_CFG_ROOT/grub.cfg"
-


### PR DESCRIPTION
#### Description:

- Remove the OVAL criterion that allow the absence of  grub.cfg file

#### Rationale:

- DISA's STIG profile expects to have a superuser defined with certain characteristics, from there can be inferred that the file is needed so it defines the superuser correctly
