### PR TITLE
update SLE CIS profiles to specify cron service

### DIFF
--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -1311,7 +1311,7 @@ controls:
     - l1_workstation
     automated: yes
     rules:
-    - service_crond_enabled
+    - service_cron_enabled
 
   - id: 5.2.2
     title: Ensure permissions on /etc/crontab are configured (Automated)

--- a/controls/cis_sle_15.yml
+++ b/controls/cis_sle_15.yml
@@ -1480,7 +1480,7 @@ controls:
       - l1_workstation
     automated: yes
     rules:
-      - service_crond_enabled
+      - service_cron_enabled
 
   - id: 5.1.2
     title: Ensure permissions on /etc/crontab are configured (Automated)


### PR DESCRIPTION
SUSE uses the cron service not the crond service. Update
the cis entries to reflect this.

#### Description:
- since SLE12 and SLE15 use the cron service and not the crond service the CIS profiles for this should use reference service_cron_enabled and not service_crond_enabled

#### Rationale:

- Running check with cis profile fails on rule  service_crond_enabled
