### PR TITLE
Add XCCDF variable support in grub2_bootlader_argument

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -369,6 +369,9 @@ they must be of the same length.
 
     -   **arg_value** - argument value, eg. `'1'`
 
+    -   **arg_variable** - the variable used as the value for the argument, eg. `'var_slub_debug_options'`
+        This parameter is mutually exclusive with **arg_value**.
+
 -   Languages: Ansible, Bash, OVAL, Blueprint
 
 #### grub2_bootloader_argument_absent

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/rule.yml
@@ -42,4 +42,4 @@ template:
     name: grub2_bootloader_argument
     vars:
         arg_name: slub_debug
-        arg_value: P
+        arg_variable: var_slub_debug_options

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/tests/correct_value.pass.sh
@@ -1,3 +1,0 @@
-# platform = multi_platform_all
-
-{{{ grub2_bootloader_argument_remediation(ARG_NAME, "slub_debug=P") }}}

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/tests/correct_value.pass.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_all
+
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, "slub_debug=P") }}}

--- a/linux_os/guide/system/permissions/restrictions/poisoning/var_slub_debug_options.var
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/var_slub_debug_options.var
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'slub_debug - debug options'
+
+description: |-
+    Defines the debug options to use in <tt>slub_debug</tt> kernel command line argument.
+
+interactive: true
+
+type: string
+
+operator: equals
+
+options:
+    default: P
+    F: F
+    Z: Z
+    P: P
+    FZ: FZ
+    FZP: FZP

--- a/products/rhel7/profiles/ospp.profile
+++ b/products/rhel7/profiles/ospp.profile
@@ -113,6 +113,7 @@ selections:
     - grub2_audit_argument
     - grub2_audit_backlog_limit_argument
     - grub2_slub_debug_argument
+    - var_slub_debug_options=P
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
 

--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -130,6 +130,7 @@ selections:
     - grub2_audit_argument
     - grub2_audit_backlog_limit_argument
     - grub2_slub_debug_argument
+    - var_slub_debug_options=P
     - grub2_page_poison_argument
     - grub2_vsyscall_argument
     - grub2_vsyscall_argument.role=unscored

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -312,6 +312,7 @@ selections:
 
     # RHEL-08-010423
     - grub2_slub_debug_argument
+    - var_slub_debug_options=P
 
     # RHEL-08-010430
     - sysctl_kernel_randomize_va_space

--- a/shared/templates/grub2_bootloader_argument/ansible.template
+++ b/shared/templates/grub2_bootloader_argument/ansible.template
@@ -4,5 +4,10 @@
 # complexity = medium
 # disruption = low
 
+{{% if ARG_VARIABLE %}}
+{{{ ansible_instantiate_variables(ARG_VARIABLE) }}}
+{{% set ARG_NAME_VALUE= ARG_NAME ~ "=\"{{" ~ ARG_VARIABLE ~ "}}\""%}}
+{{% endif %}}
+
 - name: Update grub defaults and the bootloader menu
   command: /sbin/grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"

--- a/shared/templates/grub2_bootloader_argument/ansible.template
+++ b/shared/templates/grub2_bootloader_argument/ansible.template
@@ -6,7 +6,7 @@
 
 {{% if ARG_VARIABLE %}}
 {{{ ansible_instantiate_variables(ARG_VARIABLE) }}}
-{{% set ARG_NAME_VALUE= ARG_NAME ~ "=\"{{" ~ ARG_VARIABLE ~ "}}\""%}}
+{{% set ARG_NAME_VALUE = ARG_NAME ~ "={{ " ~ ARG_VARIABLE ~ " }}" %}}
 {{% endif %}}
 
 - name: Update grub defaults and the bootloader menu

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -3,5 +3,9 @@
    See the OVAL template for more comments.
    Product-specific categorization should be synced across all template content types
 -#}}
+{{%- if ARG_VARIABLE %}}
+{{{- bash_instantiate_variables(ARG_VARIABLE) }}}
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=$" ~ ARG_VARIABLE %}}
+{{%- endif %}}
 
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/shared/templates/grub2_bootloader_argument/blueprint.template
+++ b/shared/templates/grub2_bootloader_argument/blueprint.template
@@ -1,4 +1,6 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
-
+{{%- if ARG_VARIABLE %}}
+{{%- set ARG_NAME_VALUE = ARG_NAME ~ "=(blueprint-populate " ~ ARG_VARIABLE ~ ")" -%}}
+{{%- endif %}}
 [customizations.kernel]
 append = "{{{ ARG_NAME_VALUE }}}"

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -179,9 +179,28 @@
 {{%- endif %}}
 {{%- endif %}}
 
+{{% if ARG_VALUE %}}
   <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
   version="1">
     <ind:subexpression datatype="string" operation="pattern match">^(?:.*\s)?{{{ ESCAPED_ARG_NAME_VALUE }}}(?:\s.*)?$</ind:subexpression>
   </ind:textfilecontent54_state>
+{{% else %}}
+  <ind:textfilecontent54_state id="state_grub2_{{{ SANITIZED_ARG_NAME }}}_argument"
+  version="1">
+    <ind:subexpression datatype="string" operation="pattern match" var_ref="local_var_regex_{{{ ARG_NAME }}}_{{{ ARG_VARIABLE }}}" />
+  </ind:textfilecontent54_state>
+
+  <local_variable id="local_var_regex_{{{ SANITIZED_ARG_NAME }}}_{{{ ARG_VARIABLE }}}"
+  comment="Regex that matches {{{ ARG_NAME }}} with value {{{ ARG_VARIABLE }}}"
+  datatype="string" version="1">
+    <concat>
+      <literal_component>^(?:.*\s)?{{{ ARG_NAME }}}=</literal_component>
+      <variable_component var_ref="{{{ ARG_VARIABLE }}}" />
+      <literal_component>(?:\s.*)?$</literal_component>
+    </concat>
+  </local_variable>
+
+  <external_variable comment="Variable defining the value the argument should have" datatype="string" id="{{{ ARG_VARIABLE }}}" version="1" />
+{{% endif %}}
 
 </def-group>

--- a/shared/templates/grub2_bootloader_argument/template.py
+++ b/shared/templates/grub2_bootloader_argument/template.py
@@ -2,7 +2,17 @@ import ssg.utils
 
 
 def preprocess(data, lang):
-    data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
+    if 'arg_value' in data and 'arg_variable' in data:
+        raise RuntimeError(
+                "ERROR: The template should not set both 'arg_value' and 'arg_variable'.\n"
+                "arg_name: {0}\n"
+                "arg_variable: {1}".format(data['arg_value'], data['arg_variable']))
+
+    if 'arg_variable' in data:
+        data["arg_name_value"] = data["arg_name"]
+    else:
+        data["arg_name_value"] = data["arg_name"] + "=" + data["arg_value"]
+
     if lang == "oval":
         # escape dot, this is used in oval regex
         data["escaped_arg_name_value"] = data["arg_name_value"].replace(".", "\\.")

--- a/shared/templates/grub2_bootloader_argument/tests/correct_value.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/correct_value.pass.sh
@@ -1,3 +1,7 @@
 # platform = multi_platform_all
+{{%- if ARG_VARIABLE %}}
+# variables = {{{ ARG_VARIABLE }}}=correct_value
+{{%- set ARG_NAME_VALUE= ARG_NAME ~ "=correct_value" %}}
+{{%- endif %}}
 
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -653,7 +653,7 @@ def expand_xccdf_subs(fix, remediation_type):
     elif remediation_type == "kubernetes":
         return
     elif remediation_type == "blueprint":
-        return
+        pattern = r'\(blueprint-populate\s*(\S+)\)'
     elif remediation_type == "ansible":
 
         if "(ansible-populate " in fix_text:

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -245,6 +245,7 @@ selections:
 - var_password_pam_difok=4
 - var_password_pam_maxrepeat=3
 - var_password_pam_maxclassrepeat=4
+- var_slub_debug_options=P
 - var_auditd_flush=incremental_async
 - var_accounts_max_concurrent_login_sessions=10
 - var_password_pam_unix_remember=5

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -448,6 +448,7 @@ selections:
 - login_banner_text=dod_banners
 - var_system_crypto_policy=fips
 - var_sudo_timestamp_timeout=always_prompt
+- var_slub_debug_options=P
 platforms: !!set {}
 cpe_names: !!set {}
 platform: null

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -457,6 +457,7 @@ selections:
 - login_banner_text=dod_banners
 - var_system_crypto_policy=fips
 - var_sudo_timestamp_timeout=always_prompt
+- var_slub_debug_options=P
 platforms: !!set {}
 cpe_names: !!set {}
 platform: null


### PR DESCRIPTION
#### Description:

- Improve the template to support checking and remediating values using
XCCDF variables.
  The arg_name and arg_variable are mutually exclusive.
- Parametrize rule `grub2_slub_debug_argument` so that it allows checking/remediating with other values.

#### Rationale:

- The template doesn't allow other values for boot arguments other than the ones hardcoded.
