### PR TITLE
Unify grub2 bash macro and template

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1649,39 +1649,31 @@ fi
     Remediation for grub2 bootloader arguments
 #}}
 {{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
-{{% if product in ["rhel7", "ol7", "rhel9"] or 'ubuntu' in product %}}
-{{% if '/' in ARG_NAME %}}
-{{{ raise("ARG_NAME (" + ARG_NAME + ") uses sed path separator (/) in " + rule_id) }}}
-{{% elif '/' in ARG_NAME_VALUE %}}
-{{{ raise("ARG_NAME_VALUE (" + ARG_NAME_VALUE + ") uses sed path separator (/) in " + rule_id) }}}
-{{% endif %}}
+{{% set grub_helper_executable = "grubby" -%}}
+{{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
+
+{{%- macro update_etc_default_grub_manually() -%}}
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
-	# modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
+       # modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
+       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
 else
-	# no {{{ ARG_NAME }}}=arg is present, append it
-	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'
+       # no {{{ ARG_NAME }}}=arg is present, append it
+       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'
 fi
+{{%- endmacro %}}
 
 {{% if 'ubuntu' in product %}}
-update-grub
-{{% else %}}
-# Correct the form of kernel command line for each installed kernel in the bootloader
-grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
-{{% endif %}}
-{{% else %}}
-# Correct grub2 kernelopts value using grub2-editenv
-existing_kernelopts="$(grub2-editenv - list | grep kernelopts)"
-if ! printf '%s' "$existing_kernelopts" | grep -qE '^kernelopts=(.*\s)?{{{ ARG_NAME_VALUE }}}(\s.*)?$'; then
-  if test -n "$existing_kernelopts"; then
-    grub2-editenv - set "$existing_kernelopts {{{ ARG_NAME_VALUE }}}"
-  else
-    grub2-editenv - set "kernelopts={{{ ARG_NAME_VALUE }}}"
-  fi
-fi
-{{% endif %}}
+{{{ update_etc_default_grub_manually() }}}
+{{% set grub_helper_executable = "update-grub" -%}}
+{{% endif -%}}
 
+{{% if product in ["rhel8", "ol8"] %}}
+{{# Suppress the None output of append -#}}
+{{{ grub_helper_args.append("--env=/boot/grub2/grubenv") or "" -}}}
+{{% endif -%}}
+
+{{{ grub_helper_executable }}} {{{ " ".join(grub_helper_args) }}}
 {{% endmacro %}}
 
 

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1645,14 +1645,11 @@ fi
 {{%- endmacro %}}
 
 {{#
-
-    Remediation for grub2 bootloader arguments
+    Ensures that /etc/default/grub file contains the ARG_NAME_VALUE.
+:param ARG_NAME: name of the grub parameter, e.g.: "audit"
+:param ARG_NAME_VALUE: parameter together with the value to ensure, e.g.: "audit=1"
 #}}
-{{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
-{{% set grub_helper_executable = "grubby" -%}}
-{{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
-
-{{%- macro update_etc_default_grub_manually() -%}}
+{{%- macro update_etc_default_grub_manually(ARG_NAME, ARG_NAME_VALUE) -%}}
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
        # modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
@@ -1663,8 +1660,16 @@ else
 fi
 {{%- endmacro %}}
 
+{{#
+
+    Remediation for grub2 bootloader arguments
+#}}
+{{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
+{{% set grub_helper_executable = "grubby" -%}}
+{{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
+
 {{% if 'ubuntu' in product %}}
-{{{ update_etc_default_grub_manually() }}}
+{{{ update_etc_default_grub_manually(ARG_NAME, ARG_NAME_VALUE) }}}
 {{% set grub_helper_executable = "update-grub" -%}}
 {{% endif -%}}
 

--- a/shared/templates/grub2_bootloader_argument/bash.template
+++ b/shared/templates/grub2_bootloader_argument/bash.template
@@ -4,28 +4,4 @@
    Product-specific categorization should be synced across all template content types
 -#}}
 
-{{% set grub_helper_executable = "grubby" -%}}
-{{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
-
-{{%- macro update_etc_default_grub_manually() -%}}
-# Correct the form of default kernel command line in GRUB
-if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
-       # modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
-       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
-else
-       # no {{{ ARG_NAME }}}=arg is present, append it
-       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'
-fi
-{{%- endmacro %}}
-
-{{% if 'ubuntu' in product %}}
-{{{ update_etc_default_grub_manually() }}}
-{{% set grub_helper_executable = "update-grub" -%}}
-{{% endif -%}}
-
-{{% if product in ["rhel8", "ol8"] %}}
-{{# Suppress the None output of append -#}}
-{{{ grub_helper_args.append("--env=/boot/grub2/grubenv") or "" -}}}
-{{% endif -%}}
-
-{{{ grub_helper_executable }}} {{{ " ".join(grub_helper_args) }}}
+{{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}


### PR DESCRIPTION
#### Description:

- PR #7931 introduced macro `grub2_bootloader_argument_remediation()`
  - Which was aligned with the bash remediation from `grub2_bootloader_argument`, and used in the templated test scenario.
- PR #8180 updated the `grub2_bootloader_argument` template
  - And the macro got out of sync with the template.
- This PR unifies the macro with the template.

