### PR TITLE
fix aide_build_database rule and remediation to work with sles 12 and 15

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -11,7 +11,11 @@
     - aide
 
 - name: "Build and Test AIDE Database"
+{{% if 'sle' in product %}}
+  command: /usr/bin/aide --init
+{{% else %}}
   command: /usr/sbin/aide --init
+{{% endif %}}
   changed_when: True
 
 # mainly to allow ansible's check mode to work
@@ -22,8 +26,13 @@
 
 - name: "Stage AIDE Database"
   copy:
+{{% if 'sle' in product %}}
+    src: /var/lib/aide/aide.db.new
+    dest: /var/lib/aide/aide.db
+{{% else %}}
     src: /var/lib/aide/aide.db.new.gz
     dest: /var/lib/aide/aide.db.gz
+{{% endif %}}
     backup: yes
     remote_src: yes
   when: (aide_database_stat.stat.exists is defined and aide_database_stat.stat.exists)

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -26,7 +26,7 @@
 
 - name: "Stage AIDE Database"
   copy:
-{{% if 'sle' in product %}}
+{{% if 'ubuntu' in product or 'sle' in product %}}
     src: /var/lib/aide/aide.db.new
     dest: /var/lib/aide/aide.db
 {{% else %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/bash/shared.sh
@@ -1,6 +1,10 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 {{{ bash_package_install("aide") }}}
-
+{{% if 'sle' in product %}}
+/usr/bin/aide --init
+/bin/cp -p /var/lib/aide/aide.db.new /var/lib/aide/aide.db
+{{% else %}}
 /usr/sbin/aide --init
 /bin/cp -p /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz
+{{% endif %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/oval/shared.xml
@@ -13,6 +13,40 @@
     </criteria>
   </definition>
 
+  {{% if 'sle' in product %}}
+  <!-- OVAL object to collect filename for Aide build database -->
+  <ind:textfilecontent54_object id="object_aide_build_new_database_filename" version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^database_out=file:/([/a-z.]+)$</ind:pattern>
+    <!-- From aide.conf(5) - "If there are multiple database_out lines, then the first one is used" =>
+         therefore we will retrieve only the first instance -->
+    <ind:instance operation="equals" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- OVAL object to collect filename for Aide build database -->
+  <ind:textfilecontent54_object id="object_aide_operational_database_filename" version="1">
+    <ind:filepath>/etc/aide.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^database=file:/([/a-z.]+)$</ind:pattern>
+    <!-- From aide.conf(5) - "If there are multiple database_out lines, then the first one is used" =>
+                  therefore we will retrieve only the first instance -->
+    <ind:instance operation="equals" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <!-- OVAL variable to concatenate directory path and filename of new Aide build database file into final absolute path -->
+  <local_variable id="variable_aide_build_new_database_absolute_path" datatype="string" comment="Absolute path of Aide build database file" version="1">
+    <concat>
+      <literal_component>/</literal_component>
+      <object_component object_ref="object_aide_build_new_database_filename" item_field="subexpression" />
+    </concat>
+  </local_variable>
+
+  <!-- OVAL variable to concatenate directory path and filename of operational Aide build database file into final absolute path -->
+  <local_variable id="variable_aide_operational_database_absolute_path" datatype="string" comment="Absolute path of Aide build database file" version="1">
+    <concat>
+      <literal_component>/</literal_component>
+      <object_component object_ref="object_aide_operational_database_filename" item_field="subexpression" />
+    </concat>
+  </local_variable>
+  {{% else %}}
   <!-- OVAL object to collect directory path for Aide build database directory -->
   <ind:textfilecontent54_object id="object_aide_build_database_dirpath" version="1">
     <ind:filepath>/etc/aide.conf</ind:filepath>
@@ -55,23 +89,24 @@
       <object_component object_ref="object_aide_operational_database_filename" item_field="subexpression" />
     </concat>
   </local_variable>
+  {{% endif %}}
+
+  <unix:file_object id="object_aide_build_new_database_absolute_path" version="1">
+    <unix:filepath var_ref="variable_aide_build_new_database_absolute_path" var_check="at least one" />
+  </unix:file_object>
 
   <unix:file_test id="test_aide_build_new_database_absolute_path" check="all" check_existence="all_exist"
   comment="Testing existence of new aide database file" version="1">
     <unix:object object_ref="object_aide_build_new_database_absolute_path" />
   </unix:file_test>
 
-  <unix:file_object id="object_aide_build_new_database_absolute_path" version="1">
-    <unix:filepath var_ref="variable_aide_build_new_database_absolute_path" var_check="at least one" />
+  <unix:file_object id="object_aide_operational_database_absolute_path" version="1">
+    <unix:filepath var_ref="variable_aide_operational_database_absolute_path" var_check="at least one" />
   </unix:file_object>
 
   <unix:file_test id="test_aide_operational_database_absolute_path" check="all" check_existence="all_exist"
   comment="Testing existence of operational aide database file" version="1">
     <unix:object object_ref="object_aide_operational_database_absolute_path" />
   </unix:file_test>
-
-  <unix:file_object id="object_aide_operational_database_absolute_path" version="1">
-    <unix:filepath var_ref="variable_aide_operational_database_absolute_path" var_check="at least one" />
-  </unix:file_object>
 
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -6,18 +6,36 @@ title: 'Build and Test AIDE Database'
 
 description: |-
     Run the following command to generate a new database:
-    <pre>$ sudo /usr/sbin/aide --init</pre>
-    By default, the database will be written to the file <tt>/var/lib/aide/aide.db.new.gz</tt>.
-    Storing the database, the configuration file <tt>/etc/aide.conf</tt>, and the binary
-    <tt>/usr/sbin/aide</tt> (or hashes of these files), in a secure location (such as on read-only media) provides additional assurance about their integrity.
-    The newly-generated database can be installed as follows:
-    {{% if 'ubuntu' not in product %}}
-    <pre>$ sudo cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz</pre>
+    {{% if 'sle' in product %}}
+    <pre>$ sudo /usr/bin/aide --init</pre>
     {{% else %}}
+    <pre>$ sudo /usr/sbin/aide --init</pre>
+    {{% endif %}}
+    By default, the database will be written to the file
+    {{% if 'ubuntu' in product or 'sle' in product %}}
+    <tt>/var/lib/aide/aide.db.new</tt>.
+    {{% else %}}
+    <tt>/var/lib/aide/aide.db.new.gz</tt>.
+    {{% endif %}}
+    Storing the database, the configuration file <tt>/etc/aide.conf</tt>, and the binary
+    {{% if 'sle' in product %}}
+    <tt>/usr/bin/aide</tt>
+    {{% else %}}
+    <tt>/usr/sbin/aide</tt>
+    {{% endif %}}
+    (or hashes of these files), in a secure location (such as on read-only media) provides additional assurance about their integrity.
+    The newly-generated database can be installed as follows:
+    {{% if 'ubuntu' in product or 'sle' in product %}}
     <pre>$ sudo cp /var/lib/aide/aide.db.new /var/lib/aide/aide.db</pre>
+    {{% else %}}
+    <pre>$ sudo cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz</pre>
     {{% endif %}}
     To initiate a manual check, run the following command:
+    {{% if 'sle' in product %}}
+    <pre>$ sudo /usr/bin/aide --check</pre>
+    {{% else %}}
     <pre>$ sudo /usr/sbin/aide --check</pre>
+    {{% endif %}}
     If this check produces any unexpected output, investigate.
 
 rationale: |-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_malformed.fail.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # packages = aide
 
+{{% if 'ubuntu' in product or 'sle' in product %}}
+DB=/var/lib/aide/aide.db
+{{% else %}}
 DB=/var/lib/aide/aide.db.gz
+{{% endif %}}
 
 rm -rf $DB
 echo "not really a database" > $DB
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/tests/db_not_present.fail.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # packages = aide
 
+{{% if 'ubuntu' in product or 'sle' in product %}}
+DB=/var/lib/aide/aide.db
+{{% else %}}
 DB=/var/lib/aide/aide.db.gz
+{{% endif %}}
 
 rm -rf $DB


### PR DESCRIPTION
aide_build_database check and remediation  which is in the cis profile for sle12 and sle15 does not work for SLE 12/15.

#### Description:

- There were a number of issues:
-  oval/shared.xml
   assumeed aide.conf had:
        @@define DBDIR /path
        database_out=file:@@{DBDIR}/filename
        database=file:@@{DBDIR}/filename
SLE 12 and 15 does not use: :@@{DBDIR} it just has:
         database_out=file:/pathfile
         database=file:/path/file

- in remediation
1:  bash was not enabled for sle
2: sle uses /var/lib/aide/aide.db.new and /var/lib/aide/aide.db not /var/lib/aide/aide.db.new.gz and /var/lib/aide/aide.db.gz
3: path to aide is /usr/bin/aide as opposed to /usr/sbin/aide --init

- in the rule.yml:
   Need to make sle aware for file name and path differences.
   Since .gx nv not gz also applied to ubuntu needed to re-code some
   {{% if not in product %}} to
   {{% if 'ubuntu' in product or 'sle' in product %}}

#### Rationale:

- get aide_build_database working for sle 12/15

