### PR TITLE
OCP: Add vaiabled support for kubelet_configure_tls_cipher_suites

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/kubernetes/shared.yml
@@ -1,11 +1,8 @@
 ---
 # platform = multi_platform_ocp
+# {{.var_kubelet_tls_cipher_suites_regex}} we have to put variable array name here for mutilines remediation 
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 spec:
   kubeletConfig:
-    tlsCipherSuites:
-    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    tlsCipherSuites: [{{.var_kubelet_tls_cipher_suites}}]

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -27,7 +27,8 @@ description: |-
           - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     </pre>
-
+  In order to configure this rule to check alternative cipher, both var_kubelet_tls_cipher_suites_regex
+  and var_kubelet_tls_cipher_suites have to be set
 rationale: |-
   TLS ciphers have had a number of known vulnerabilities and weaknesses,
   which can reduce the protection provided by them. By default Kubernetes
@@ -63,7 +64,4 @@ template:
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".tlsCipherSuites[:]"
-    values:
-    - value: '^(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)$'
-      operation: 'pattern match'
-
+    xccdf_variable: var_kubelet_tls_cipher_suites_regex

--- a/applications/openshift/kubelet/var_kubelet_tls_cipher_suites.var
+++ b/applications/openshift/kubelet/var_kubelet_tls_cipher_suites.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Configure Kubelet use of the Strong Cryptographic Ciphers'
+
+description: 'Cryptographic Ciphers Available for Kubelet, seperated by comma'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"

--- a/applications/openshift/kubelet/var_kubelet_tls_cipher_suites_regex.var
+++ b/applications/openshift/kubelet/var_kubelet_tls_cipher_suites_regex.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Configure Kubelet use of the Strong Cryptographic Ciphers'
+
+description: 'Cryptographic Ciphers Available for Kubelet'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: "^(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)$"


### PR DESCRIPTION
User can choose which cipher to be used by setting two variable, `var_kubelet_tls_cipher_suites_regex`, and `var_kubelet_tls_cipher_suites`
