### PR TITLE
no iptables.service in sle15

### DIFF
--- a/controls/cis_sle_15.yml
+++ b/controls/cis_sle_15.yml
@@ -531,7 +531,7 @@ controls:
       - l1_workstation
     automated: partially # Missing Rules
     rules:
-      - service_timesyncd_enabled
+      - service_chronyd_enabled
 
   - id: 2.2.1.3
     title: Ensure chrony is configured (Automated)
@@ -1049,8 +1049,6 @@ controls:
     status: automated
     rules:
       - package_iptables_installed
-      - service_iptables_enabled
-      - service_ip6tables_enabled
 
   - id: 3.5.3.1.2
     title: Ensure nftables is not installed (Automated)


### PR DESCRIPTION
SUSE SLES 15 does not provide or support iptables.service or
ip6tables.service. So remove rules from cis control file for sle.

#### Description:

- remove service_iptables_enabled and service_ip6tables_enabled from controls/cis_sle_15.yml

#### Rationale:

- Rules that don't apply to sle15 should not be in the sle15 cis profile.

