### PR TITLE
fix require_emergency_target_auth for sle12/sle15

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/ansible/shared.yml
@@ -9,7 +9,7 @@
       create: yes
       dest: /usr/lib/systemd/system/emergency.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
+      {{% if product in ["fedora", "rhel8", "rhel9", "ol8","sle12", "sle15"] -%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell emergency"
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/bash/shared.sh
@@ -1,8 +1,8 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_all
 
 service_file="/usr/lib/systemd/system/emergency.service"
 
-{{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
+{{% if product in ["fedora", "rhel8", "rhel9", "ol8", "sle12", "sle15"] -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell emergency"
 {{%- else -%}}
 sulogin='/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -12,7 +12,7 @@
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
+    {{% if product in ["fedora", "rhel8", "rhel9", "ol8", "sle12", "sle15"] -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -24,7 +24,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_emergency_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/emergency.service</ind:filepath>
-    {{%- if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
+    {{%- if product in ["fedora", "rhel8", "rhel9", "ol8", "sle12", "sle15"] -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/usr/lib/systemd/systemd-sulogin-shell[\s]+emergency</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>


### PR DESCRIPTION
sle12/15 has /usr/lib/systemd/systemd-sulogin-shell
not /sbin/sulogin.

Updated rule and remediation to reflect this.
Also make bash remidtaion multi_platform_all to
match ansible remediation.

#### Description:

- sle12/15 has /usr/lib/systemd/systemd-sulogin-shell
   not /sbin/sulogin.

Updated rule and remediation to reflect this.
Also make bash remediation multi_platform_all to
match ansible remediation.

#### Rationale:

- fix and enable require_emergency_target_auth for sle12/15

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
