### PR TITLE
fix require_singleuser_auth for sle12/sle15

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -10,7 +10,7 @@
       create: yes
       dest: /usr/lib/systemd/system/rescue.service
       regexp: "^#?ExecStart="
-      {{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
+      {{% if product in ["fedora", "rhel8", "rhel9", "ol8", "sle12", "sle15"] -%}}
       line: "ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue"
       {{% elif product in ["rhel7"] %}}
       line: 'ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -1,10 +1,10 @@
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_all
 
 {{% if init_system == "systemd" -%}}
 
 service_file="/usr/lib/systemd/system/rescue.service"
 
-{{% if product in ["fedora", "rhel8", "rhel9", "ol8"] -%}}
+{{% if product in ["fedora", "rhel8", "rhel9", "ol8", "sle12", "sle15"] -%}}
 sulogin="/usr/lib/systemd/systemd-sulogin-shell rescue"
 {{%- elif product in ["rhel7"] -%}}
 sulogin='/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -22,7 +22,7 @@
   {{%- if init_system == "systemd" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
-    {{% if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4"] -%}}
+    {{% if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4", "sle12", "sle15"] -%}}
     /usr/lib/systemd/systemd-sulogin-shell
     {{%- else -%}}
     /sbin/sulogin
@@ -34,7 +34,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service" version="1">
     <ind:filepath>/usr/lib/systemd/system/rescue.service</ind:filepath>
-    {{%- if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4"] -%}}
+    {{%- if product in ["fedora", "rhel8", "rhel9", "ol8", "rhcos4", "sle12", "sle15"] -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-.*/usr/lib/systemd/systemd-sulogin-shell[ ]+rescue</ind:pattern>
     {{%- else -%}}
     <ind:pattern operation="pattern match">^ExecStart=\-/bin/sh[\s]+-c[\s]+\"(/usr)?/sbin/sulogin;[\s]+/usr/bin/systemctl[\s]+--fail[\s]+--no-block[\s]+default\"</ind:pattern>


### PR DESCRIPTION
sle12/15 has /usr/lib/systemd/systemd-sulogin-shell
not /sbin/sulogin.

#### Description:

-  Updated require_singleuser_auth rule and remediation to use /usr/lib/systemd/systemd-sulogin-shell
Also make bash remediation  multi_platform_all to match ansible remediation.

#### Rationale:

- Correct require_singleuser_auth for sle12/15

