### PR TITLE
SLE 12 and 15 merge auditd file modification rules STIG IDs

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
@@ -59,8 +59,8 @@ references:
     stigid@ol8: OL08-00-030540
     stigid@rhel7: RHEL-07-030410
     stigid@rhel8: RHEL-08-030490
-    stigid@sle12: SLES-12-020470
-    stigid@sle15: SLES-15-030300
+    stigid@sle12: SLES-12-020460
+    stigid@sle15: SLES-15-030290
     stigid@ubuntu2004: UBTU-20-010153
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -59,8 +59,8 @@ references:
     stigid@ol8: OL08-00-030530
     stigid@rhel7: RHEL-07-030410
     stigid@rhel8: RHEL-08-030490
-    stigid@sle12: SLES-12-020480
-    stigid@sle15: SLES-15-030310
+    stigid@sle12: SLES-12-020460
+    stigid@sle15: SLES-15-030290
     stigid@ubuntu2004: UBTU-20-010154
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -64,8 +64,8 @@ references:
     stigid@ol8: OL08-00-030470
     stigid@rhel7: RHEL-07-030510
     stigid@rhel8: RHEL-08-030420
-    stigid@sle12: SLES-12-020520
-    stigid@sle15: SLES-15-030160
+    stigid@sle12: SLES-12-020490
+    stigid@sle15: SLES-15-030150
     stigid@ubuntu2004: UBTU-20-010158
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -67,8 +67,8 @@ references:
     stigid@ol8: OL08-00-030460
     stigid@rhel7: RHEL-07-030510
     stigid@rhel8: RHEL-08-030420
-    stigid@sle12: SLES-12-020510
-    stigid@sle15: SLES-15-030320
+    stigid@sle12: SLES-12-020490
+    stigid@sle15: SLES-15-030150
     stigid@ubuntu2004: UBTU-20-010157
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/rule.yml
@@ -61,8 +61,8 @@ references:
     stigid@ol8: OL08-00-030450
     stigid@rhel7: RHEL-07-030510
     stigid@rhel8: RHEL-08-030420
-    stigid@sle12: SLES-12-020540
-    stigid@sle15: SLES-15-030180
+    stigid@sle12: SLES-12-020490
+    stigid@sle15: SLES-15-030150
     stigid@ubuntu2004: UBTU-20-010160
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -67,8 +67,8 @@ references:
     stigid@ol8: OL08-00-030430
     stigid@rhel7: RHEL-07-030510
     stigid@rhel8: RHEL-08-030420
-    stigid@sle12: SLES-12-020530
-    stigid@sle15: SLES-15-030170
+    stigid@sle12: SLES-12-020490
+    stigid@sle15: SLES-15-030150
     stigid@ubuntu2004: UBTU-20-010159
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
 
 title: 'Record Unsuccessul Delete Attempts to Files - rename'
 
@@ -30,6 +30,7 @@ identifiers:
     cce@rhcos4: CCE-82648-7
     cce@rhel7: CCE-81108-3
     cce@rhel8: CCE-80973-1
+    cce@sle12: CCE-83251-9
     cce@sle15: CCE-85701-1
 
 references:
@@ -47,7 +48,8 @@ references:
     ospp: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000468-GPOS-00212
-    stigid@sle15: SLES-15-030710
+    stigid@sle12: SLES-12-020411
+    stigid@sle15: SLES-15-030740
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 
 {{{ complete_ocil_entry_audit_syscall(syscall="rename") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - rename'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -1,11 +1,11 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
 
 title: 'Record Unsuccessul Delete Attempts to Files - renameat'
 
 description: |-
-    {{% if product not in ["sle15"] %}}
+    {{% if product not in ["sle12", "sle15"] %}}
     The audit system should collect unsuccessful file deletion
     attempts for all users and root. If the <tt>auditd</tt> daemon is configured
     to use the <tt>augenrules</tt> program to read audit rules during daemon
@@ -41,6 +41,7 @@ identifiers:
     cce@rhcos4: CCE-82649-5
     cce@rhel7: CCE-82082-9
     cce@rhel8: CCE-80974-9
+    cce@sle12: CCE-83252-7
     cce@sle15: CCE-85702-9
 
 references:
@@ -58,7 +59,8 @@ references:
     ospp: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000468-GPOS-00212
-    stigid@sle15: SLES-15-030720
+    stigid@sle12: SLES-12-020411
+    stigid@sle15: SLES-15-030740
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 
 {{{ complete_ocil_entry_audit_syscall(syscall="renameat") }}}
@@ -69,7 +71,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        {{% if product not in ["sle15"] %}}
+        {{% if product not in ["sle12", "sle15"] %}}
         <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
         {{% else %}}
         <pre>
@@ -79,7 +81,7 @@ warnings:
         {{% endif %}} 
      
 template:
-    {{% if product not in ["sle15"] %}}
+    {{% if product not in ["sle12", "sle15"] %}}
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: renameat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - renameat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
@@ -28,7 +28,7 @@ references:
     disa: CCI-000172
     nist@sle15: AU-12(c),AU-12.1(iv)
     srg: SRG-OS-000468-GPOS-00212
-    stigid@sle15: SLES-15-030730
+    stigid@sle15: SLES-15-030740
 
 {{{ complete_ocil_entry_audit_syscall(syscall="renameat2") }}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -66,8 +66,8 @@ references:
     stigid@ol8: OL08-00-030420
     stigid@rhel7: RHEL-07-030510
     stigid@rhel8: RHEL-08-030420
-    stigid@sle12: SLES-12-020500
-    stigid@sle15: SLES-15-030610
+    stigid@sle12: SLES-12-020490
+    stigid@sle15: SLES-15-030150
     stigid@ubuntu2004: UBTU-20-010156
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - unlink'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -1,11 +1,11 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
 
 title: 'Record Unsuccessul Delete Attempts to Files - unlink'
 
 description: |-
-    {{% if product not in ["sle15"] %}}
+    {{% if product not in ["sle12", "sle15"] %}}
     The audit system should collect unsuccessful file deletion
     attempts for all users and root. If the <tt>auditd</tt> daemon is configured
     to use the <tt>augenrules</tt> program to read audit rules during daemon
@@ -44,6 +44,7 @@ identifiers:
     cce@rhcos4: CCE-82652-9
     cce@rhel7: CCE-81106-7
     cce@rhel8: CCE-80971-5
+    cce@sle12: CCE-83254-3
     cce@sle15: CCE-85703-7
 
 references:
@@ -61,6 +62,7 @@ references:
     ospp: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000468-GPOS-00212
+    stigid@sle12: SLES-12-020411
     stigid@sle15: SLES-15-030740
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 
@@ -72,7 +74,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        {{% if product not in ["sle15"] %}}
+        {{% if product not in ["sle12", "sle15"] %}}
         <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
         {{% else %}}
         <pre>
@@ -81,7 +83,7 @@ warnings:
         {{% endif %}} 
 
 template:
-    {{% if product not in ["sle15"] %}}
+    {{% if product not in ["sle12", "sle15"] %}}
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: unlink

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Record Unsuccessul Delete Attempts to Files - unlinkat'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -1,11 +1,11 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15,sle12
 
 title: 'Record Unsuccessul Delete Attempts to Files - unlinkat'
 
 description: |-
-    {{% if product not in ["sle15"] %}}
+    {{% if product not in ["sle12", "sle15"] %}}
     The audit system should collect unsuccessful file deletion
     attempts for all users and root. If the <tt>auditd</tt> daemon is configured
     to use the <tt>augenrules</tt> program to read audit rules during daemon
@@ -44,6 +44,7 @@ identifiers:
     cce@rhcos4: CCE-82653-7
     cce@rhel7: CCE-81104-2
     cce@rhel8: CCE-80972-3
+    cce@sle12: CCE-83253-5
     cce@sle15: CCE-85704-5
 
 references:
@@ -61,7 +62,8 @@ references:
     ospp: FAU_GEN.1.1.c
     pcidss: Req-10.2.4,Req-10.2.1
     srg: SRG-OS-000064-GPOS-00033,SRG-OS-000392-GPOS-00172,SRG-OS-000458-GPOS-00203,SRG-OS-000461-GPOS-00205,SRG-OS-000468-GPOS-00212
-    stigid@sle15: SLES-15-030750
+    stigid@sle12: SLES-12-020411
+    stigid@sle15: SLES-15-030740
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000461-VMM-001830
 
 {{{ complete_ocil_entry_audit_syscall(syscall="unlinkat") }}}
@@ -72,7 +74,7 @@ warnings:
         number of ways while still achieving the desired effect. Here the system calls
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
-        {{% if product not in ["sle15"] %}}
+        {{% if product not in ["sle12", "sle15"] %}}
         <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
         {{% else %}}
         <pre>
@@ -81,7 +83,7 @@ warnings:
         {{% endif %}} 
 
 template:
-    {{% if product not in ["sle15"] %}}
+    {{% if product not in ["sle12", "sle15"] %}}
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: unlinkat

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -125,7 +125,11 @@ selections:
     - audit_rules_unsuccessful_file_modification_open
     - audit_rules_unsuccessful_file_modification_openat
     - audit_rules_unsuccessful_file_modification_open_by_handle_at
+    - audit_rules_unsuccessful_file_modification_rename
+    - audit_rules_unsuccessful_file_modification_renameat
     - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_unsuccessful_file_modification_unlink
+    - audit_rules_unsuccessful_file_modification_unlinkat
     - audit_rules_usergroup_modification_group
     - audit_rules_usergroup_modification_gshadow
     - audit_rules_usergroup_modification_opasswd


### PR DESCRIPTION
#### Description:

- SLE 12 and 15 update STIG ID refs of file modification rules

#### Rationale:

- Map rules for:
   - rename, renameat, renameat2, unlink, unlinkat
   - create, ftruncate, open, openat, open_by_handle_at, truncate
   - fchmod, fchmodat
  to new STIG IDs based on definitions in "SCAP STIG SLE12 v2.r6" and "SCAP STIG SLE15 v1.r5"