### PR TITLE
Fix accounts_umask_etc_bashrc to work with sle12/15

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -5,16 +5,22 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
-- name: Replace user umask in /etc/bashrc
+{{% if 'sle' in product %}}
+{{% set etc_bash_rc = "/etc/bash.bashrc" %}}
+{{% else %}}
+{{% set etc_bash_rc = "/etc/bashrc" %}}
+{{% endif %}}
+
+- name: Replace user umask in {{{ etc_bash_rc }}}
   replace:
-    path: /etc/bashrc
+    path: {{{ etc_bash_rc }}}
     regexp: "umask.*"
     replace: "umask {{ var_accounts_user_umask }}"
   register: umask_replace
 
-- name: Append user umask in /etc/bashrc
+- name: Append user umask in {{{ etc_bash_rc }}}
   lineinfile:
     create: yes
-    path: /etc/bashrc
+    path: {{{ etc_bash_rc }}}
     line: "umask {{ var_accounts_user_umask }}"
   when: umask_replace is not changed

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
@@ -1,9 +1,15 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_accounts_user_umask") }}}
 
-grep -q umask /etc/bashrc && \
-  sed -i "s/umask.*/umask $var_accounts_user_umask/g" /etc/bashrc
+{{% if 'sle' in product %}}
+{{% set etc_bash_rc = "/etc/bash.bashrc" %}}
+{{% else %}}
+{{% set etc_bash_rc = "/etc/bashrc" %}}
+{{% endif %}}
+
+grep -q umask {{{ etc_bash_rc }}} && \
+  sed -i "s/umask.*/umask $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
 if ! [ $? -eq 0 ]; then
-    echo "umask $var_accounts_user_umask" >> /etc/bashrc
+    echo "umask $var_accounts_user_umask" >> {{{ etc_bash_rc }}}
 fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/oval/shared.xml
@@ -1,3 +1,8 @@
+{{% if 'sle' in product %}}
+{{% set etc_bash_rc = "/etc/bash.bashrc" %}}
+{{% else %}}
+{{% set etc_bash_rc = "/etc/bashrc" %}}
+{{% endif %}}
 <def-group>
   <definition class="compliance" id="accounts_umask_etc_bashrc" version="2">
     {{{ oval_metadata("The default umask for users of the bash shell") }}}
@@ -9,14 +14,14 @@
   </definition>
 
   <ind:textfilecontent54_object id="obj_umask_from_etc_bashrc"
-  comment="Umask value from /etc/bashrc" version="1">
-    <ind:filepath>/etc/bashrc</ind:filepath>
+  comment="Umask value from {{{ etc_bash_rc }}}" version="1">
+    <ind:filepath>{{{ etc_bash_rc }}}</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*umask[\s]+([^#\s]*)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <local_variable id="var_first_digit_of_umask_from_etc_bashrc"
-  comment="First octal digit of umask from /etc/bashrc"
+  comment="First octal digit of umask from {{{ etc_bash_rc }}}"
   datatype="int" version="1">
     <substring substring_start="1" substring_length="1">
       <object_component item_field="subexpression" object_ref="obj_umask_from_etc_bashrc" />
@@ -24,7 +29,7 @@
   </local_variable>
 
   <local_variable id="var_second_digit_of_umask_from_etc_bashrc"
-  comment="Second octal digit of umask from /etc/bashrc"
+  comment="Second octal digit of umask from {{{ etc_bash_rc }}}"
   datatype="int" version="1">
     <substring substring_start="2" substring_length="1">
       <object_component item_field="subexpression" object_ref="obj_umask_from_etc_bashrc" />
@@ -32,7 +37,7 @@
   </local_variable>
 
   <local_variable id="var_third_digit_of_umask_from_etc_bashrc"
-  comment="Third octal digit of umask from /etc/bashrc"
+  comment="Third octal digit of umask from {{{ etc_bash_rc }}}"
   datatype="int" version="1">
     <substring substring_start="3" substring_length="1">
       <object_component item_field="subexpression" object_ref="obj_umask_from_etc_bashrc" />
@@ -40,7 +45,7 @@
   </local_variable>
 
   <local_variable id="var_etc_bashrc_umask_as_number"
-  comment="/etc/bashrc umask converted from string to a number"
+  comment="{{{ etc_bash_rc }}} umask converted from string to a number"
   datatype="int" version="1">
     <arithmetic arithmetic_operation="add">
       <arithmetic arithmetic_operation="multiply">
@@ -56,7 +61,7 @@
   </local_variable>
 
   <ind:variable_test id="tst_accounts_umask_etc_bashrc" version="1" check="all"
-  comment="Test the retrieved /etc/bashrc umask value(s) match the var_accounts_user_umask requirement">
+  comment="Test the retrieved {{{ etc_bash_rc }}} umask value(s) match the var_accounts_user_umask requirement">
     <ind:object object_ref="obj_accounts_umask_etc_bashrc" />
     <ind:state state_ref="ste_accounts_umask_etc_bashrc" />
   </ind:variable_test>

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/rule.yml
@@ -4,9 +4,15 @@ prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure the Default Bash Umask is Set Correctly'
 
+{{% if 'sle' in product %}}
+{{% set etc_bash_rc = "/etc/bash.bashrc" %}}
+{{% else %}}
+{{% set etc_bash_rc = "/etc/bashrc" %}}
+{{% endif %}}
+
 description: |-
     To ensure the default umask for users of the Bash shell is set properly,
-    add or correct the <tt>umask</tt> setting in <tt>/etc/bashrc</tt> to read
+    add or correct the <tt>umask</tt> setting in <tt>{{{ etc_bash_rc }}}</tt> to read
     as follows:
     <pre>umask {{{ xccdf_value("var_accounts_user_umask") }}}</pre>
 
@@ -45,10 +51,10 @@ references:
 ocil_clause: 'the above command returns no output, or if the umask is configured incorrectly'
 
 ocil: |-
-    Verify the <tt>umask</tt> setting is configured correctly in the <tt>/etc/bashrc</tt> file by
+    Verify the <tt>umask</tt> setting is configured correctly in the <tt>{{{ etc_bash_rc }}}</tt> file by
     running the following command:
-    <pre># grep "umask" /etc/bashrc</pre>
+    <pre># grep "umask" {{{ etc_bash_rc }}}</pre>
     All output must show the value of <tt>umask</tt> set as shown below:
-    <pre># grep "umask" /etc/bashrc
+    <pre># grep "umask" {{{ etc_bash_rc }}}
     umask {{{ xccdf_value("var_accounts_user_umask") }}}
     umask {{{ xccdf_value("var_accounts_user_umask") }}}</pre>


### PR DESCRIPTION
sles 12/15 uses /etc/bash.bashrc not /etc/bashrc

#### Description:

- sles 12/15 uses /etc/bash.bashrc not /etc/bashrc

1: update tests and remediation to handle /etc/bash.bashrc
2: change platform to be multi_platform_all in bash remediation to match
   ansible code.

#### Rationale:

- get accounts_umask_etc_bashrc working for sle12/15

