### PR TITLE
Mark no_empty_passwords_etc_shadow as machine only

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -13,10 +13,6 @@ description: |-
     <tt>/etc/pam.d/system-auth</tt>
     {{% endif %}}
     to prevent logins with empty passwords.
-    Note that this rule is not applicable for systems running within a
-    container. Having user with empty password within a container is not
-    considered a risk, because it should not be possible to directly login into
-    a container anyway.
 
 rationale: |-
     If an account has an empty password, anyone could log in and
@@ -78,3 +74,7 @@ warnings:
        PAM files, the <tt>authselect</tt> integrity check will fail and the remediation will be
        aborted in order to preserve intentional changes. In this case, an informative message will
        be shown in the remediation report.
+       Note that this rule is not applicable for systems running within a
+       container. Having user with empty password within a container is not
+       considered a risk, because it should not be possible to directly login into
+       a container anyway.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/rule.yml
@@ -21,6 +21,8 @@ rationale: |-
 
 severity: high
 
+platform: machine
+
 identifiers:
     cce@sle12: CCE-83249-3
     cce@sle15: CCE-91155-2
@@ -46,3 +48,10 @@ ocil: |-
     <pre>$ sudo passwd [username]</pre>
     Lock an account:
     <pre>$ sudo passwd -l [username]</pre>
+
+warnings:
+    - general:
+       Note that this rule is not applicable for systems running within a
+       container. Having user with empty password within a container is not
+       considered a risk, because it should not be possible to directly login into
+       a container anyway.


### PR DESCRIPTION
#### Description:

Mark `no_empty_passwords_etc_shadow` same as `no_empty_passwords` as [machine only](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml#L28)


#### Rationale:
See https://bugzilla.redhat.com/show_bug.cgi?id=1856466#c16
