### PR TITLE
OCP4: Added control response for SI-4(24)

### DIFF
--- a/applications/openshift/general/compliance_notification_enabled/rule.yml
+++ b/applications/openshift/general/compliance_notification_enabled/rule.yml
@@ -18,7 +18,7 @@ identifiers:
   cce@ocp4: CCE-86032-0
 
 references:
-  nist: SI-6
+  nist: SI-6,SI-4(24)
 
 {{% set jqfilter = '[.items[] | select(.metadata.name =="compliance") | .metadata.name]' %}}
 

--- a/applications/openshift/general/file_integrity_notification_enabled/rule.yml
+++ b/applications/openshift/general/file_integrity_notification_enabled/rule.yml
@@ -15,7 +15,7 @@ identifiers:
   cce@ocp4: CCE-90572-9
 
 references:
-  nist: SI-6,SI-7(2)
+  nist: SI-6,SI-7(2),SI-4(24)
   pcidss: Req-11.5.1,Req-12.10.5
 
 {{% set jqfilter = '[.items[] | select(.metadata.name =="file-integrity") | .metadata.name]' %}}

--- a/applications/openshift/integrity/file_integrity_exists/rule.yml
+++ b/applications/openshift/integrity/file_integrity_exists/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 
 references:
   nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-007-3 R4,CIP-007-3 R4.1,CIP-007-3 R4.2
-  nist: SC-4(23),SI-6,SI-7,SI-7(1),CM-6(a),SI-7(2)
+  nist: SC-4(23),SI-6,SI-7,SI-7(1),CM-6(a),SI-7(2),SI-4(24)
   pcidss: Req-10.5.5,Req-11.5
   srg: SRG-APP-000472-CTR-001170,SRG-APP-000473-CTR-001175,SRG-APP-000474-CTR-001180
 

--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -15707,13 +15707,23 @@ controls:
   - high
   - moderate
 - id: SI-4(24)
-  status: pending
+  status: automated
   notes: |-
-    A control response for SI-4(20) is planned. Engineering progress can be
-    tracked via:
+    The OpenShift Platform provides the File Integrity Operator to do
+    integrity verification of files and information on the nodes. [1]
 
-    https://issues.redhat.com/browse/CMP-541
-  rules: []
+    The operator can be configured to perform integrity checks at user-defined
+    intervals. [2]
+    A File Integrity Operator Prometheus rule will alert organization defined personnel for any integrity check failure. 
+
+    A user can also use external antivirus engine for detecting trojans, viruses, malware & other malicious threats. 
+
+    [1] https://docs.openshift.com/container-platform/latest/security/file_integrity_operator/file-integrity-operator-installation.html
+    [2] https://docs.openshift.com/container-platform/4.6/security/file_integrity_operator/file-integrity-operator-configuring.html
+  rules:
+  - file_integrity_exists
+  - file_integrity_notification_enabled
+  - compliance_notification_enabled
   description: |-
     The information system discovers, collects, distributes, and uses indicators of compromise.
 


### PR DESCRIPTION
A control response is added for SI-4(24), rule `file_integrity_exists`, `file_integrity_notification_enabled` and `compliance_notification_enabled` are added to the control.