### PR TITLE
Delete test scenario that removes SSH keys from machine

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing_file_test.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/missing_file_test.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-#
-
-mkdir -p /etc/ssh/keys
-mv /etc/ssh/*_key /etc/ssh/keys
-sed -i "s#HostKey /etc/ssh/#HostKey /etc/ssh/keys/#g" /etc/ssh/sshd_config
-systemctl restart sshd
-rm -f /etc/ssh/*_key # systemctl restart sshd always regenerate keys in the /etc/ssh if they are not there


### PR DESCRIPTION
#### Description:
Removal of SSH keys can't be tested because then it's not possible to connect to it.

```
INFO - xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key
INFO - Script correct_permissions.pass.sh using profile (all) OK
INFO - Script lenient_permissions.fail.sh using profile (all) OK
ERROR - Script missing_file_test.pass.sh using profile (all) found issue:
ERROR - Rule xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key has not been evaluated! Wrong profile selected in test scenario?
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_file_permissions_sshd_private_key'.
```
Logs:
```
kex_exchange_identification: read: Connection reset by peer
Connection reset by 192.168.122.170 port 22
Failed to connect!
```