### PR TITLE
Remove RHEL7 platform from invalid_rescue.pass.sh

### DIFF
--- a/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/invalid_rescue.pass.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 9
+# platform = Red Hat Enterprise Linux 9
 # packages = grub2,grubby
 
 {{{ grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) }}}


### PR DESCRIPTION
#### Description:
In RHEL7, boot loader entries are not checked.

#### Rationale:
Boot loader entries are not created on RHEL7
```
ERROR - Terminating due to error: Return code of 'cd /root/ssgts/grub2_audit_argument; SHARED=/root/ssgts/shared bash -x invalid_rescue.pass.sh' on root@192.168.122.69 is 1: Warning: Permanently added '192.168.122.69' (ECDSA) to the list of known hosts.
+ grubby --update-kernel=ALL --args=audit=1
+ echo 'I am an invalid boot entry, but nobody should care, because I am rescue'
invalid_rescue.pass.sh: line 8: /boot/loader/entries/trololol-rescue.conf: No such file or directory
```