### PR TITLE
Add custom ansible remediation for service_pcscd_enabled

### DIFF
--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Build Ansible Roles
         run: PYTHONPATH=. python3 utils/ansible_playbook_to_role.py --build-playbooks-dir ./build/ansible/ --dry-run ./build/ansible_roles
       - name: Lint Ansible Roles
-        run: ansible-lint -x 204 -x experimental ./build/ansible_roles/*
+        run: ansible-lint -x 204 -x experimental -x command-instead-of-module ./build/ansible_roles/*

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/service_pcscd_enabled/ansible/shared.yml
@@ -1,0 +1,24 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = enable
+# complexity = low
+# disruption = low
+- name: Enable service pcscd
+  block:
+  - name: Gather the package facts
+    package_facts:
+      manager: auto
+
+  - name: Start service pcscd
+    service:
+      name: "pcscd"
+      state: "started"
+      masked: "no"
+    when:
+    - '"pcsc-lite" in ansible_facts.packages'
+
+  - name: Enable service pcscd
+    ansible.builtin.command:
+      cmd: systemctl enable pcscd
+    when:
+    - '"pcsc-lite" in ansible_facts.packages'

--- a/tests/ansible-lint_config.yml
+++ b/tests/ansible-lint_config.yml
@@ -5,3 +5,4 @@ skip_list:
   - '403' # Package installs should not use latest
   - '503' # Tasks that run when changed should likely be handlers
   - no-tabs # Rule permissions_local_var_log uses explicit \t character
+  - command-instead-of-module # sometimes systemctl must be executed instead of the module


### PR DESCRIPTION


#### Description:
- Add custom ansible remediation for service_pcscd_enabled.
  - The remediation is based on the template but runs the service enablement
through the shell since the ansible module doesn't enable the service
properly in regards to OVAL check.

- Fixes #8002 
