### PR TITLE
Use FQDN comparison when finding the profile in STIG tailoring

### DIFF
--- a/utils/create_scap_delta_tailoring.py
+++ b/utils/create_scap_delta_tailoring.py
@@ -31,8 +31,12 @@ def get_profile(product, profile_name):
         './/{{{scap}}}component/{{{xccdf}}}Benchmark/{{{xccdf}}}Profile'.format(
             scap=NS["scap"], xccdf=NS["xccdf-1.2"])
     )
+
+    profile_name_fqdn = "xccdf_org.ssgproject.content_profile_{profile_name}".format(
+        profile_name=profile_name)
+
     for profile in profiles:
-        if profile.attrib['id'].endswith(profile_name):
+        if profile.attrib['id'] == profile_name_fqdn:
             return profile
 
 


### PR DESCRIPTION
#### Description:
- Use FQDN comparison when finding the profile in STIG tailoring.
  - Without the full comparison it can happen that a similar profile that
ends with the same string can be used instead. For example rhelh-stig in
RHEL7.
#### Rationale:

- Fixes #8308
