### PR TITLE
Use correct aide path variable in the rule descriptions and ocil

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -6,7 +6,11 @@ title: 'Build and Test AIDE Database'
 
 description: |-
     Run the following command to generate a new database:
+    {{% if 'ubuntu' in product %}}
+    <pre>$ sudo aideinit</pre>
+    {{% else %}}
     <pre>$ sudo {{{ aide_bin_path }}} --init</pre>
+    {{% endif %}}
     By default, the database will be written to the file
     {{% if 'ubuntu' in product or 'sle' in product %}}
     <tt>/var/lib/aide/aide.db.new</tt>.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -6,11 +6,7 @@ title: 'Build and Test AIDE Database'
 
 description: |-
     Run the following command to generate a new database:
-    {{% if 'sle' in product %}}
-    <pre>$ sudo /usr/bin/aide --init</pre>
-    {{% else %}}
-    <pre>$ sudo /usr/sbin/aide --init</pre>
-    {{% endif %}}
+    <pre>$ sudo {{{ aide_bin_path }}} --init</pre>
     By default, the database will be written to the file
     {{% if 'ubuntu' in product or 'sle' in product %}}
     <tt>/var/lib/aide/aide.db.new</tt>.
@@ -18,11 +14,7 @@ description: |-
     <tt>/var/lib/aide/aide.db.new.gz</tt>.
     {{% endif %}}
     Storing the database, the configuration file <tt>/etc/aide.conf</tt>, and the binary
-    {{% if 'sle' in product %}}
-    <tt>/usr/bin/aide</tt>
-    {{% else %}}
-    <tt>/usr/sbin/aide</tt>
-    {{% endif %}}
+    <tt>{{{ aide_bin_path }}}</tt>
     (or hashes of these files), in a secure location (such as on read-only media) provides additional assurance about their integrity.
     The newly-generated database can be installed as follows:
     {{% if 'ubuntu' in product or 'sle' in product %}}
@@ -31,11 +23,7 @@ description: |-
     <pre>$ sudo cp /var/lib/aide/aide.db.new.gz /var/lib/aide/aide.db.gz</pre>
     {{% endif %}}
     To initiate a manual check, run the following command:
-    {{% if 'sle' in product %}}
-    <pre>$ sudo /usr/bin/aide --check</pre>
-    {{% else %}}
-    <pre>$ sudo /usr/sbin/aide --check</pre>
-    {{% endif %}}
+    <pre>$ sudo {{{ aide_bin_path }}} --check</pre>
     If this check produces any unexpected output, investigate.
 
 rationale: |-
@@ -70,5 +58,5 @@ references:
 ocil_clause: 'there is no database file'
 
 ocil: |-
-    To find the location of the AIDE databse file, run the following command:
+    To find the location of the AIDE database file, run the following command:
     <pre>$ sudo ls -l <i>DBDIR</i>/<i>database_file_name</i></pre>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -1,3 +1,7 @@
+{{% if 'ubuntu' in product %}}
+{{% set config_command_line="--config {{{ aide_conf_path }}} " %}}
+{{% endif %}}
+
 documentation_complete: true
 
 prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
@@ -7,17 +11,9 @@ title: 'Configure Periodic Execution of AIDE'
 description: |-
     At a minimum, AIDE should be configured to run a weekly scan.
     To implement a daily execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:
-    {{%- if 'ubuntu' not in product %}}
-    <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
-    {{%- else %}}
-    <pre>05 4 * * * root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
-    {{%- endif %}}
+    <pre>05 4 * * * root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>
     To implement a weekly execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:
-    {{%- if 'ubuntu' not in product %}}
-    <pre>05 4 * * 0 root {{{ aide_bin_path }}} --check</pre>
-    {{%- else %}}
-    <pre>05 4 * * 0 root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
-    {{%- endif %}}
+    <pre>05 4 * * 0 root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>
     AIDE can be executed periodically through other means; this is merely one example.
     The usage of cron's special time codes, such as  <tt>@daily</tt> and
     <tt>@weekly</tt> is acceptable.
@@ -78,11 +74,7 @@ ocil: |-
     To determine that periodic AIDE execution has been scheduled, run the following command:
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
-    {{%- if 'ubuntu' not in product %}}
-    <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
-    {{%- else %}}
-    <pre>05 4 * * * root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
-    {{%- endif %}}
+    <pre>05 4 * * * root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.
 
@@ -90,10 +82,6 @@ fixtext: |-
     Configure the file integrity to run at least weekly.
     Edit "/etc/crontab" and add or edit the following line:
 
-    {{% if 'ubuntu' not in product %}}
-    <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
-    {{% else %}}
-    <pre>05 4 * * * root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
-    {{% endif %}}
+    <pre>05 4 * * * root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>
 
 srg_requirement: '{{{ full_name }}} must notify the system administrator when Advanced Intrusion Detection Environment (AIDE) discovers anomalies in the operation of any security functions.'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -7,9 +7,17 @@ title: 'Configure Periodic Execution of AIDE'
 description: |-
     At a minimum, AIDE should be configured to run a weekly scan.
     To implement a daily execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:
-    <pre>05 4 * * * root {{{ aide_path }}} --check</pre>
+    {{%- if 'ubuntu' not in product %}}
+    <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
+    {{%- else %}}
+    <pre>05 4 * * * root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    {{%- endif %}}
     To implement a weekly execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:
-    <pre>05 4 * * 0 root {{{ aide_path }}} --check</pre>
+    {{%- if 'ubuntu' not in product %}}
+    <pre>05 4 * * 0 root {{{ aide_bin_path }}} --check</pre>
+    {{%- else %}}
+    <pre>05 4 * * 0 root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    {{%- endif %}}
     AIDE can be executed periodically through other means; this is merely one example.
     The usage of cron's special time codes, such as  <tt>@daily</tt> and
     <tt>@weekly</tt> is acceptable.
@@ -70,11 +78,11 @@ ocil: |-
     To determine that periodic AIDE execution has been scheduled, run the following command:
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
-    {{% if 'ubuntu' not in product %}}
-    <pre>05 4 * * * root {{{ aide_path }}} --check</pre>
-    {{% else %}}
+    {{%- if 'ubuntu' not in product %}}
+    <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
+    {{%- else %}}
     <pre>05 4 * * * root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
-    {{% endif %}}
+    {{%- endif %}}
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -10,13 +10,13 @@ description: |-
     {{%- if 'ubuntu' not in product %}}
     <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
     {{%- else %}}
-    <pre>05 4 * * * root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    <pre>05 4 * * * root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
     {{%- endif %}}
     To implement a weekly execution of AIDE at 4:05am using cron, add the following line to <tt>/etc/crontab</tt>:
     {{%- if 'ubuntu' not in product %}}
     <pre>05 4 * * 0 root {{{ aide_bin_path }}} --check</pre>
     {{%- else %}}
-    <pre>05 4 * * 0 root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    <pre>05 4 * * 0 root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
     {{%- endif %}}
     AIDE can be executed periodically through other means; this is merely one example.
     The usage of cron's special time codes, such as  <tt>@daily</tt> and
@@ -81,7 +81,7 @@ ocil: |-
     {{%- if 'ubuntu' not in product %}}
     <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
     {{%- else %}}
-    <pre>05 4 * * * root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    <pre>05 4 * * * root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
     {{%- endif %}}
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.
@@ -91,9 +91,9 @@ fixtext: |-
     Edit "/etc/crontab" and add or edit the following line:
 
     {{% if 'ubuntu' not in product %}}
-    <pre>05 4 * * * root {{{ aide_path }}} --check</pre>
+    <pre>05 4 * * * root {{{ aide_bin_path }}} --check</pre>
     {{% else %}}
-    <pre>05 4 * * * root /usr/bin/aide.wrapper --config /etc/aide/aide.conf --check</pre>
+    <pre>05 4 * * * root /usr/bin/aide.wrapper --config {{{ aide_conf_path }}} --check</pre>
     {{% endif %}}
 
 srg_requirement: '{{{ full_name }}} must notify the system administrator when Advanced Intrusion Detection Environment (AIDE) discovers anomalies in the operation of any security functions.'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
@@ -3,12 +3,6 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-{{% if product in ["sle12", "sle15"] %}}
-    {{% set aide_path = "/usr/bin/aide" %}}
-{{% else %}}
-    {{% set aide_path = "/usr/sbin/aide" %}}
-{{% endif %}}
-
 - (xccdf-var var_aide_scan_notification_email)
 
 - name: "Ensure AIDE is installed"
@@ -25,4 +19,4 @@
     hour: 04
     weekday: 0
     user: root
-    job: '{{{aide_path}}}  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" {{ var_aide_scan_notification_email }}'
+    job: '{{{ aide_bin_path }}}  --check | /bin/mail -s "$(hostname) - AIDE Integrity Check" {{ var_aide_scan_notification_email }}'

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -2,13 +2,6 @@
 
 {{{ bash_package_install("aide") }}}
 {{{ bash_instantiate_variables("var_aide_scan_notification_email") }}}
-{{% if product in ["sle12", "sle15"] %}}
-    {{% set aide_path = "/usr/bin/aide" %}}
-{{% else %}}
-    {{% set aide_path = "/usr/sbin/aide" %}}
-{{% endif %}}
-
-
 
 CRONTAB=/etc/crontab
 CRONDIRS='/etc/cron.d /etc/cron.daily /etc/cron.weekly /etc/cron.monthly'
@@ -22,7 +15,7 @@ if [ -f /var/spool/cron/root ]; then
 	VARSPOOL=/var/spool/cron/root
 fi
 
-if ! grep -qR '^.*{{{aide_path}}}\s*\-\-check.*|.*\/bin\/mail\s*-s\s*".*"\s*.*@.*$' $CRONTAB_EXIST $VARSPOOL $CRONDIRS; then
-	echo "0 5 * * * root {{{ aide_path }}}  --check | /bin/mail -s \"\$(hostname) - AIDE Integrity Check\" $var_aide_scan_notification_email" >> $CRONTAB
+if ! grep -qR '^.*{{{ aide_bin_path }}}\s*\-\-check.*|.*\/bin\/mail\s*-s\s*".*"\s*.*@.*$' $CRONTAB_EXIST $VARSPOOL $CRONDIRS; then
+	echo "0 5 * * * root {{{ aide_bin_path }}}  --check | /bin/mail -s \"\$(hostname) - AIDE Integrity Check\" $var_aide_scan_notification_email" >> $CRONTAB
 fi
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/oval/shared.xml
@@ -1,9 +1,3 @@
-{{% if product in ["sle12", "sle15"] %}} 
-{{% set aide_bin_path = "/usr/bin/aide" %}} 
-{{% else %}} 
-{{% set aide_bin_path = "/usr/sbin/aide" %}} 
-{{% endif %}} 
-
 <def-group>
   <definition class="compliance" id="aide_scan_notification" version="1">
     {{{ oval_metadata("AIDE should notify appropriate personnel of the details

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -17,6 +17,9 @@ grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
 
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
+aide_bin_path: "/usr/bin/aide"
+aide_conf_path: "/etc/aide/aide.conf"
+
 cpes_root: "../../shared/applicability"
 cpes:
   - ubuntu1604:

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -17,7 +17,7 @@ grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
 
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
-aide_bin_path: "/usr/bin/aide"
+aide_bin_path: "/usr/bin/aide.wrapper"
 aide_conf_path: "/etc/aide/aide.conf"
 
 cpes_root: "../../shared/applicability"

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -16,6 +16,9 @@ grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
 
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
+aide_bin_path: "/usr/bin/aide"
+aide_conf_path: "/etc/aide/aide.conf"
+
 cpes_root: "../../shared/applicability"
 cpes:
   - ubuntu1804:

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -16,7 +16,7 @@ grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
 
 chrony_conf_path: "/etc/chrony/chrony.conf"
 
-aide_bin_path: "/usr/bin/aide"
+aide_bin_path: "/usr/bin/aide.wrapper"
 aide_conf_path: "/etc/aide/aide.conf"
 
 cpes_root: "../../shared/applicability"

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -15,6 +15,7 @@ oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.fo
 grub2_boot_path: "/boot/grub"
 grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
 
+aide_bin_path: "/usr/bin/aide"
 aide_conf_path: "/etc/aide/aide.conf"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -15,7 +15,7 @@ oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.fo
 grub2_boot_path: "/boot/grub"
 grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
 
-aide_bin_path: "/usr/bin/aide"
+aide_bin_path: "/usr/bin/aide.wrapper"
 aide_conf_path: "/etc/aide/aide.conf"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 


### PR DESCRIPTION
#### Description:

- Use correct aide path variable in the rule descriptions and ocil.

#### Rationale:

- Related to #8305
