### PR TITLE
Update chronyd_or_ntpd_set_maxpoll to check both configs (ntpd and chronyd)

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/oval/shared.xml
@@ -2,9 +2,9 @@
   <definition class="compliance" id="chronyd_or_ntpd_set_maxpoll" version="1">
     {{{ oval_metadata("Configure the maxpoll setting in /etc/ntp.conf or chrony.conf
       to continuously poll the time source servers.") }}}
-    <criteria operator="OR">
+    <criteria operator="AND">
       <criteria operator="OR">
-        <criterion comment="check if no server or pool entry is set in /etc/chrony.conf"
+        <criterion comment="check if no server entry is set in /etc/ntp.conf"
           test_ref="test_ntp_no_server"/>
         <criteria operator="AND">
           <criterion comment="check if maxpoll is set in /etc/ntp.conf"
@@ -96,8 +96,8 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="check if all server entries have maxpoll set in /etc/ntp.conf"
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="check if no server entries in /etc/ntp.conf"
   id="test_ntp_no_server" version="1">
     <ind:object object_ref="obj_ntp_no_server_nor_pool" />
   </ind:textfilecontent54_test>


### PR DESCRIPTION
#### Description:
The rule needs to verify both - `ntp` **AND** `chrony` configs.
In both config checks, the logic is the similar - if no `server` (or `pool` for `chrony` because it allows both) directive is in the file, it is `pass`. If the directive is there, it needs to have `maxpoll` and correct value to pass.

#### Rationale:
Previous **OR** condition caused wrong result for case when `ntp` had wrong (or missing) `maxpoll` but `chrony` didn't have `server` directive at all. Because of that `ntp` part failed, `chrony` part passed and final result was `pass`.

Wrong `check_existence` caused `fail` when it was supposed to `pass` (when `server` is missing).

Got revealed by `ntp_wrong_maxpoll.fail.sh` test scenario on RHEL7:
`$ python3 tests/test_suite.py rule --libvirt qemu:///session test-suite-rhel7 --datastream build/ssg-rhel7-ds.xml --no-reports --scenario ntp_wrong_maxpoll chronyd_or_ntpd_set_maxpoll`