### PR TITLE
Update OVAL in sshd_disable_compression for ol8

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
@@ -17,7 +17,9 @@
         <criterion comment="Check Compression in /etc/ssh/sshd_config"
         test_ref="test_sshd_disable_compression" />
       </criteria>
+      {{% if product != "ol8" %}}
       <extend_definition comment="OpenSSH version 7.4 or higher contains fix for authentication Compression exploit" definition_ref="sshd_version_equal_or_higher_than_74" />
+      {{% endif %}}
     </criteria>
   </definition>
 


### PR DESCRIPTION
#### Description:

- Removed criterion that allows the rule to pass just by reviewing the version of OpenSSH, for OL8

#### Rationale:

- As mentioned in [the PR this criterion was introduced](https://github.com/ComplianceAsCode/content/pull/6453) 
> Pre-auth compression support has been disabled by
   default for >10 years. Support remains in the client.

- So this change comes with the intention to not rely in default behavior. Also DISA doesn't mention this condition in its OL08-00-010510 requirement