### PR TITLE
OCP: Add vaiabled support for kubelet_configure_tls_cipher_suites

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/kubernetes/shared.yml
@@ -1,11 +1,8 @@
 ---
 # platform = multi_platform_ocp
+# {{.var_kubelet_tls_cipher_suites_regex}} we have to put variable array name here for mutilines remediation 
 apiVersion: machineconfiguration.openshift.io/v1
 kind: KubeletConfig
 spec:
   kubeletConfig:
-    tlsCipherSuites:
-    - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+    tlsCipherSuites: [{{.var_kubelet_tls_cipher_suites}}]

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -27,7 +27,8 @@ description: |-
           - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
           - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
     </pre>
-
+  In order to configure this rule to check for an alternative cipher, both var_kubelet_tls_cipher_suites_regex
+  and var_kubelet_tls_cipher_suites have to be set
 rationale: |-
   TLS ciphers have had a number of known vulnerabilities and weaknesses,
   which can reduce the protection provided by them. By default Kubernetes
@@ -58,12 +59,11 @@ ocil: |-
     TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
     </pre>
 
+
 template:
   name: yamlfile_value
   vars:
     filepath: /etc/kubernetes/kubelet.conf
     yamlpath: ".tlsCipherSuites[:]"
-    values:
-    - value: '^(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)$'
-      operation: 'pattern match'
-
+    xccdf_variable: var_kubelet_tls_cipher_suites_regex
+    regex_data: true

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/tests/tls_cipher.fail.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/tests/tls_cipher.fail.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# remediation = none
+
+# Create infra file for CPE to pass
+mkdir -p "/etc/kubernetes"
+
+cat <<EOF > "/etc/kubernetes/kubelet.conf"
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/kubelet-ca.crt
+  anonymous:
+    enabled: false
+cgroupDriver: systemd
+cgroupRoot: /
+clusterDNS:
+  - 10.217.4.10
+clusterDomain: cluster.local
+containerLogMaxSize: 50Mi
+maxPods: 250
+kubeAPIQPS: 50
+kubeAPIBurst: 100
+rotateCertificates: true
+serializeImagePulls: false
+staticPodPath: /etc/kubernetes/manifests
+systemCgroups: /system.slice
+systemReserved:
+  ephemeral-storage: 1Gi
+featureGates:
+  APIPriorityAndFairness: true
+  LegacyNodeRoleBehavior: false
+  NodeDisruptionExclusion: true
+  RotateKubeletServerCertificate: true
+  ServiceNodeExclusion: true
+  SupportPodPidsLimit: true
+  DownwardAPIHugePages: true
+serverTLSBootstrap: true
+tlsMinVersion: VersionTLS12
+tlsCipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+  - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+EOF

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/tests/tls_cipher.pass.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/tests/tls_cipher.pass.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# remediation = none
+
+# Create infra file for CPE to pass
+mkdir -p "/etc/kubernetes"
+
+cat <<EOF > "/etc/kubernetes/kubelet.conf"
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/kubelet-ca.crt
+  anonymous:
+    enabled: false
+cgroupDriver: systemd
+cgroupRoot: /
+clusterDNS:
+  - 10.217.4.10
+clusterDomain: cluster.local
+containerLogMaxSize: 50Mi
+maxPods: 250
+kubeAPIQPS: 50
+kubeAPIBurst: 100
+rotateCertificates: true
+serializeImagePulls: false
+staticPodPath: /etc/kubernetes/manifests
+systemCgroups: /system.slice
+systemReserved:
+  ephemeral-storage: 1Gi
+featureGates:
+  APIPriorityAndFairness: true
+  LegacyNodeRoleBehavior: false
+  NodeDisruptionExclusion: true
+  RotateKubeletServerCertificate: true
+  ServiceNodeExclusion: true
+  SupportPodPidsLimit: true
+  DownwardAPIHugePages: true
+serverTLSBootstrap: true
+tlsMinVersion: VersionTLS12
+tlsCipherSuites:
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+EOF

--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/tests/tls_cipher_diff_seq.pass.sh
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/tests/tls_cipher_diff_seq.pass.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# remediation = none
+
+# Create infra file for CPE to pass
+mkdir -p "/etc/kubernetes"
+
+cat <<EOF > "/etc/kubernetes/kubelet.conf"
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+authentication:
+  x509:
+    clientCAFile: /etc/kubernetes/kubelet-ca.crt
+  anonymous:
+    enabled: false
+cgroupDriver: systemd
+cgroupRoot: /
+clusterDNS:
+  - 10.217.4.10
+clusterDomain: cluster.local
+containerLogMaxSize: 50Mi
+maxPods: 250
+kubeAPIQPS: 50
+kubeAPIBurst: 100
+rotateCertificates: true
+serializeImagePulls: false
+staticPodPath: /etc/kubernetes/manifests
+systemCgroups: /system.slice
+systemReserved:
+  ephemeral-storage: 1Gi
+featureGates:
+  APIPriorityAndFairness: true
+  LegacyNodeRoleBehavior: false
+  NodeDisruptionExclusion: true
+  RotateKubeletServerCertificate: true
+  ServiceNodeExclusion: true
+  SupportPodPidsLimit: true
+  DownwardAPIHugePages: true
+serverTLSBootstrap: true
+tlsMinVersion: VersionTLS12
+tlsCipherSuites:
+  - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+  - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+  - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+EOF

--- a/applications/openshift/kubelet/var_kubelet_tls_cipher_suites.var
+++ b/applications/openshift/kubelet/var_kubelet_tls_cipher_suites.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Configure Kubelet use of the Strong Cryptographic Ciphers'
+
+description: 'Cryptographic Ciphers Available for Kubelet, seperated by comma'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256"

--- a/applications/openshift/kubelet/var_kubelet_tls_cipher_suites_regex.var
+++ b/applications/openshift/kubelet/var_kubelet_tls_cipher_suites_regex.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Configure Kubelet use of the Strong Cryptographic Ciphers'
+
+description: 'Cryptographic Ciphers Available for Kubelet'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: "^(TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384|TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256|TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256)$"

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -818,6 +818,10 @@ The selected value can be changed in the profile (consult the actual variable fo
 
     -   **embedded_data** - if set to `"true"` and used combined with `xccdf_variable`, the data retrieved by `yamlpath`
         is considered as a blob and the field `value` has to contain a capture regex.
+   
+    -   **regex_data** - if set to `"true"` and combined with `xccdf_variable`, it will use the value of `xccdf_variable` as a regex
+        and does pattern match operation instead of equal operation.
+
 
     -   **check_existence_yamlpath** - optional YAML Path that could be set to ensure that the target sequence from `yamlpath` has all
         required sub-elements. It is helpful when the `yamlpath` is targeting a map inside a sequence, and the document could be

--- a/shared/templates/yamlfile_value/oval.template
+++ b/shared/templates/yamlfile_value/oval.template
@@ -113,7 +113,11 @@
       {{% if XCCDF_VARIABLE and not EMBEDDED_DATA %}}
       {{% set name = "#" if not VALUES else (VALUES|first).key|default("#")|escape_yaml_key %}}
       {{% set datatype = "string" if not VALUES else (VALUES|first).type|default("string") %}}
+      {{% if not REGEX_DATA %}}
       <field {{{ {'name': name, 'datatype': datatype, 'operation': 'equals'}|xmlattr }}} var_ref="{{{ XCCDF_VARIABLE }}}" />
+      {{% else %}}
+      <field {{{ {'name': "#", 'operation': 'pattern match'}|xmlattr }}} var_ref="{{{ XCCDF_VARIABLE }}}" />
+      {{% endif %}}
       {{% else %}}
       {{% for val in VALUES %}}
       <field {{{ {'name': val.key|default("#")|escape_yaml_key, 'datatype': val.type,  'operation':  val.operation, 'entity_check': val.entity_check}|xmlattr }}}>{{{ val.value }}}</field>

--- a/shared/templates/yamlfile_value/template.py
+++ b/shared/templates/yamlfile_value/template.py
@@ -6,6 +6,9 @@ def preprocess(data, lang):
     embedded_data = parse_template_boolean_value(data, parameter="embedded_data", default_value=False)
     data["embedded_data"] = embedded_data
 
+    regex_data = parse_template_boolean_value(data, parameter="regex_data", default_value=False)
+    data["regex_data"] = regex_data
+
     if data.get("xccdf_variable") and embedded_data:
         values = data.get("values", [{}])
         if len(values) > 1:


### PR DESCRIPTION
User can choose which cipher to be used by setting two variable, var_kubelet_tls_cipher_suites_regex, and var_kubelet_tls_cipher_suites