### PR TITLE
grub2_bootloader_argument: Edit /etc/default/grub ourselves on certain systems

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1653,7 +1653,7 @@ fi
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
        # modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
-       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]*\(.*"\)/\1 {{{ ARG_NAME_VALUE }}} \2/'  '/etc/default/grub'
+       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]\+\(.*"\)/\1{{{ ARG_NAME_VALUE }}}\2/'  '/etc/default/grub'
 else
        # no {{{ ARG_NAME }}}=arg is present, append it
        sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1668,7 +1668,7 @@ fi
 {{% set grub_helper_executable = "grubby" -%}}
 {{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
 
-{{% if 'ubuntu' in product %}}
+{{% if 'ubuntu' in product or product in ['rhel7', 'ol7'] %}}
 {{{ update_etc_default_grub_manually(ARG_NAME, ARG_NAME_VALUE) }}}
 {{% set grub_helper_executable = "update-grub" -%}}
 {{% endif -%}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1653,10 +1653,10 @@ fi
 # Correct the form of default kernel command line in GRUB
 if grep -q '^GRUB_CMDLINE_LINUX=.*{{{ ARG_NAME }}}=.*"'  '/etc/default/grub' ; then
        # modify the GRUB command-line if an {{{ ARG_NAME }}}= arg already exists
-       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\){{{ ARG_NAME }}}=[^[:space:]]\+\(.*"\)/\1{{{ ARG_NAME_VALUE }}}\2/'  '/etc/default/grub'
+       sed -i "s/\(^GRUB_CMDLINE_LINUX=\".*\){{{ ARG_NAME }}}=[^[:space:]]\+\(.*\"\)/\1{{{ ARG_NAME_VALUE }}}\2/"  '/etc/default/grub'
 else
        # no {{{ ARG_NAME }}}=arg is present, append it
-       sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 {{{ ARG_NAME_VALUE }}}"/'  '/etc/default/grub'
+       sed -i "s/\(^GRUB_CMDLINE_LINUX=\".*\)\"/\1 {{{ ARG_NAME_VALUE }}}\"/"  '/etc/default/grub'
 fi
 {{%- endmacro %}}
 

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1665,12 +1665,15 @@ fi
     Remediation for grub2 bootloader arguments
 #}}
 {{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
-{{% set grub_helper_executable = "grubby" -%}}
+{{% if 'ubuntu' in product %}}
+	{{% set grub_helper_executable = "update-grub" -%}}
+{{% else %}}
+	{{% set grub_helper_executable = "grubby" -%}}
+{{% endif -%}}
 {{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
 
 {{% if 'ubuntu' in product or product in ['rhel7', 'ol7'] %}}
 {{{ update_etc_default_grub_manually(ARG_NAME, ARG_NAME_VALUE) }}}
-{{% set grub_helper_executable = "update-grub" -%}}
 {{% endif -%}}
 
 {{% if product in ["rhel8", "ol8"] %}}

--- a/shared/templates/grub2_bootloader_argument/ansible.template
+++ b/shared/templates/grub2_bootloader_argument/ansible.template
@@ -9,5 +9,25 @@
 {{% set ARG_NAME_VALUE = ARG_NAME ~ "={{ " ~ ARG_VARIABLE ~ " }}" %}}
 {{% endif %}}
 
+{{% if 'ubuntu' in product or product in ['rhel7', 'ol7'] %}}
+- name: Check {{{ ARG_NAME }}} argument exists
+  command: grep 'GRUB_CMDLINE_LINUX.*{{{ ARG_NAME }}}=' /etc/default/grub
+  failed_when: False
+  register: argcheck
+
+- name: Replace existing {{{ ARG_NAME }}} argument
+  replace:
+      path: /etc/default/grub
+      regexp: '{{{ ARG_NAME }}}=\w+'
+      replace: '{{{ ARG_NAME_VALUE }}}'
+  when: argcheck.rc == 0
+
+- name: Add {{{ ARG_NAME }}} argument
+  replace:
+      path: /etc/default/grub
+      regexp: '(GRUB_CMDLINE_LINUX=.*)"'
+      replace: '\1 {{{ ARG_NAME_VALUE }}}"'
+  when: argcheck.rc != 0
+{{% endif -%}}
 - name: Update grub defaults and the bootloader menu
   command: /sbin/grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"


### PR DESCRIPTION
#### Description:

- On RHEL7, OL7 and Ubuntu, let's add the grub2 argument in  `/etc/default/grub` "ourselves".

#### Rationale:

- On some systems `grubby` doesn't update `/etc/default/grub`, so we need to add it there.
- This is a follow up from #8180
- Fixes #8301