### PR TITLE
Enforce rounds parameter presence

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/oval/shared.xml
@@ -3,10 +3,12 @@
     {{{ oval_metadata("The number of rounds for password hashing should be set correctly.") }}}
     <criteria comment="Check if rounds option of pam_unix is as expected" operator="OR">
         <criterion comment="The value of rounds is set correctly in pam_unix.so" test_ref="test_password_auth_pam_unix_rounds_is_set" />
+        {{% if product != "ol8" %}}
         <criteria comment="The value of rounds is no set, in this case the system default is used" operator="AND">
             <criterion comment="The default value of rounds is used in pam_unix.so" test_ref="test_password_auth_pam_unix_rounds_is_default" />
             <criterion comment="The target value of rounds is the default" test_ref="test_password_auth_default_pam_unix_rounds_var" />
         </criteria>
+        {{% endif %}}
     </criteria>
   </definition>
 
@@ -15,12 +17,7 @@
     <ind:object object_ref="object_password_auth_pam_unix_rounds" />
     <ind:state state_ref="state_password_auth_pam_unix_rounds" />
   </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_test id="test_password_auth_pam_unix_rounds_is_default" check="all" check_existence="none_exist"
-  comment="Test if rounds attribute of pam_unix.so is not set in /etc/pam.d/password-auth" version="1">
-    <ind:object object_ref="object_password_auth_pam_unix_rounds" />
-  </ind:textfilecontent54_test>
-
+  
   <ind:textfilecontent54_object id="object_password_auth_pam_unix_rounds" version="1">
     <ind:filepath operation="pattern match">^/etc/pam.d/password-auth$</ind:filepath>
     <ind:pattern operation="pattern match">^\s*password\s+(?:(?:sufficient)|(?:required))\s+pam_unix\.so.*rounds=([0-9]*).*$</ind:pattern>
@@ -31,6 +28,12 @@
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_unix_rounds" />
   </ind:textfilecontent54_state>
 
+  {{% if product != "ol8" %}}
+  <ind:textfilecontent54_test id="test_password_auth_pam_unix_rounds_is_default" check="all" check_existence="none_exist"
+  comment="Test if rounds attribute of pam_unix.so is not set in /etc/pam.d/password-auth" version="1">
+    <ind:object object_ref="object_password_auth_pam_unix_rounds" />
+  </ind:textfilecontent54_test>
+
   <ind:variable_test check="all" check_existence="all_exist" id="test_password_auth_default_pam_unix_rounds_var" version="1"
       comment="Check if value of var_password_pam_unix_rounds is the system's default">
     <ind:object object_ref="object_password_auth_default_pam_unix_rounds_var" />
@@ -38,17 +41,18 @@
   </ind:variable_test>
 
   <ind:variable_object comment="All modified times of all keyfiles" id="object_password_auth_default_pam_unix_rounds_var" version="1">
-     <ind:var_ref>var_password_pam_unix_rounds</ind:var_ref>
-   </ind:variable_object>
+    <ind:var_ref>var_password_pam_unix_rounds</ind:var_ref>
+  </ind:variable_object>
 
   <ind:variable_state id="state_password_auth_default_pam_unix_rounds_var" version="1">
     <ind:value datatype="int" operation="equals" var_check="all" var_ref="var_password_auth_default_hashing_rounds" />
   </ind:variable_state>
 
   <local_variable id="var_password_auth_default_hashing_rounds" datatype="int" version="1" comment="Default number of password hashing rounds">
-      <literal_component>5000</literal_component>
+    <literal_component>5000</literal_component>
   </local_variable>
-
+  {{% endif %}}
+  
   <external_variable comment="number of passwords hashing rounds" datatype="int" id="var_password_pam_unix_rounds" version="1" />
 
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/oval/shared.xml
@@ -3,10 +3,12 @@
     {{{ oval_metadata("The number of rounds for password hashing should be set correctly.") }}}
     <criteria comment="Check if rounds option of pam_unix is as expected" operator="OR">
         <criterion comment="The value of rounds is set correctly in pam_unix.so" test_ref="test_system_auth_pam_unix_rounds_is_set" />
+        {{% if product != "ol8" %}}
         <criteria comment="The value of rounds is no set, in this case the system default is used" operator="AND">
             <criterion comment="The default value of rounds is used in pam_unix.so" test_ref="test_system_auth_pam_unix_rounds_is_default" />
             <criterion comment="The target value of rounds is the default" test_ref="test_system_auth_default_pam_unix_rounds_var" />
         </criteria>
+        {{% endif %}}
     </criteria>
   </definition>
 
@@ -14,11 +16,6 @@
   comment="Test if rounds attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth" version="1">
     <ind:object object_ref="object_system_auth_pam_unix_rounds" />
     <ind:state state_ref="state_system_auth_pam_unix_rounds" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_test id="test_system_auth_pam_unix_rounds_is_default" check="all" check_existence="none_exist"
-  comment="Test if rounds attribute of pam_unix.so is not set in /etc/pam.d/system-auth" version="1">
-    <ind:object object_ref="object_system_auth_pam_unix_rounds" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_system_auth_pam_unix_rounds" version="1">
@@ -30,6 +27,12 @@
   <ind:textfilecontent54_state id="state_system_auth_pam_unix_rounds" version="1">
     <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_unix_rounds" />
   </ind:textfilecontent54_state>
+
+  {{% if product != "ol8" %}}
+  <ind:textfilecontent54_test id="test_system_auth_pam_unix_rounds_is_default" check="all" check_existence="none_exist"
+  comment="Test if rounds attribute of pam_unix.so is not set in /etc/pam.d/system-auth" version="1">
+    <ind:object object_ref="object_system_auth_pam_unix_rounds" />
+  </ind:textfilecontent54_test>
 
   <ind:variable_test check="all" check_existence="all_exist" id="test_system_auth_default_pam_unix_rounds_var" version="1"
       comment="Check if value of var_password_pam_unix_rounds is the system's default">
@@ -48,6 +51,7 @@
   <local_variable id="var_system_auth_default_hashing_rounds" datatype="int" version="1" comment="Default number of password hashing rounds">
       <literal_component>5000</literal_component>
   </local_variable>
+  {{% endif %}}
 
   <external_variable comment="number of passwords hashing rounds" datatype="int" id="var_password_pam_unix_rounds" version="1" />
 


### PR DESCRIPTION
#### Description:

- Modified accounts_password_pam_unix_rounds_password_auth & accounts_password_pam_unix_rounds_system_auth OVAL so it doesn't allow to pass with default settings

#### Rationale:

- Enforce explicit parameter declaration and not rely on default
