### PR TITLE
Exclude ol8 and rhel8 from require_emergency_target_auth oval criteria

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -5,7 +5,7 @@
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_emergency_service" />
-      {{%- if product != "ol8" -%}}
+      {{%- if product not in ["ol8", "rhel8"] -%}}
       <criterion test_ref="test_require_emergency_service_emergency_target" />
       <criterion test_ref="test_no_custom_emergency_target" negate="true"/>
       <criterion test_ref="test_no_custom_emergency_service" negate="true"/>
@@ -34,7 +34,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{%- if product != "ol8" -%}}
+  {{%- if product not in ["ol8", "rhel8"] -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that the systemd emergency.service is in the emergency.target"
     id="test_require_emergency_service_emergency_target" version="1">

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -5,9 +5,11 @@
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_emergency_service" />
+      {{%- if product != "ol8" -%}}
       <criterion test_ref="test_require_emergency_service_emergency_target" />
       <criterion test_ref="test_no_custom_emergency_target" negate="true"/>
       <criterion test_ref="test_no_custom_emergency_service" negate="true"/>
+      {{%- endif -%}}
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -32,6 +34,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  {{%- if product != "ol8" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that the systemd emergency.service is in the emergency.target"
     id="test_require_emergency_service_emergency_target" version="1">
@@ -66,4 +69,5 @@
     <unix:path operation="equals">/etc/systemd/system</unix:path>
     <unix:filename operation="pattern match">^emergency.target$</unix:filename>
   </unix:file_object>
+  {{%- endif -%}}
 </def-group>


### PR DESCRIPTION
#### Description:

- Removed 3 criteria for ol8 and rhel8 from rule require_emergency_target_auth oval criteria

#### Rationale:

-  These criteria are not included in STIG IDs: OL08-00-010152 and RHEL-08-010152, listed in this rule references
