### PR TITLE
Update oval name resolution

### DIFF
--- a/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
@@ -2,9 +2,28 @@
   <definition class="compliance" id="network_configure_name_resolution" version="1">
     {{{ oval_metadata("Multiple Domain Name System (DNS) Servers should be configured
       in /etc/resolv.conf.") }}}
-    <criteria>
+    <criteria operator="OR">
+      {{% if product == "ol8" %}}
+      <criteria comment="If the DNS entry is found on the host's line of the /etc/nsswitch.conf
+        file, verify the operating system is configured to use two or more name servers for DNS
+        resolution."
+        operator="AND">
+        <criterion comment="check if dns is set in host line in  /etc/nsswitch.conf"
+        test_ref="test_host_line_dns_parameter_nsswitch" />
+        <criterion comment="check if more than one nameserver in /etc/resolv.conf"
+        test_ref="test_network_configure_name_resolution" />
+      </criteria>
+      <criteria comment="If the DNS entry is missing from the host's line in the /etc/nsswitch.conf
+        file, the /etc/resolv.conf file must be empty. " operator="AND">
+        <criterion comment="check that dns is not set in host line in  /etc/nsswitch.conf"
+        test_ref="test_host_line_dns_parameter_nsswitch" negate="true"/>
+        <criterion comment="check if /etc/resolv.conf is empty"
+        test_ref="test_file_empty_resolv" />
+      </criteria>
+      {{% else %}}
       <criterion comment="check if more than one nameserver in /etc/resolv.conf"
       test_ref="test_network_configure_name_resolution" />
+      {{% endif %}}
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -18,4 +37,30 @@
     <!-- Make sure we have greater than 1 nameserver in resolv.conf -->
     <ind:instance datatype="int" operation="greater than">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{% if product == "ol8" %}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="check if dns is set in host line in  /etc/nsswitch.conf"
+  id="test_host_line_dns_parameter_nsswitch" version="1">
+    <ind:object object_ref="obj_host_line_dns_parameter_nsswitch" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_host_line_dns_parameter_nsswitch" version="1">
+    <ind:filepath>/etc/nsswitch.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*hosts\s*:\s*.*dns.*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <unix:file_test id="test_file_empty_resolv" check="all" check_existence="all_exist"
+    comment="check if /etc/resolv.conf is empty" version="1">
+    <unix:object object_ref="obj_file_empty_resolv"/>
+    <unix:state state_ref="state_file_empty_resolv"/>
+  </unix:file_test>
+  <unix:file_object id="obj_file_empty_resolv" version="1">
+    <unix:filepath>/etc/resolv.conf</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_file_empty_resolv" version="1">
+    <unix:size datatype="int">0</unix:size>
+  </unix:file_state>
+
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("Multiple Domain Name System (DNS) Servers should be configured
       in /etc/resolv.conf.") }}}
     <criteria operator="OR">
-      {{% if product == "ol8" %}}
+      {{% if "ol" in product or "rhel" in product %}}
       <criteria comment="If the DNS entry is found on the host's line of the /etc/nsswitch.conf
         file, verify the operating system is configured to use two or more name servers for DNS
         resolution."
@@ -38,7 +38,7 @@
     <ind:instance datatype="int" operation="greater than">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product == "ol8" %}}
+  {{% if "ol" in product or "rhel" in product %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="check if dns is set in host line in  /etc/nsswitch.conf"
   id="test_host_line_dns_parameter_nsswitch" version="1">

--- a/linux_os/guide/system/network/network_configure_name_resolution/rule.yml
+++ b/linux_os/guide/system/network/network_configure_name_resolution/rule.yml
@@ -5,6 +5,19 @@ prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 title: 'Configure Multiple DNS Servers in /etc/resolv.conf'
 
 description: |-
+    {{% if "ol" in product or "rhel" in product %}}
+    Determine whether the system is using local or DNS name resolution with the
+    following command:
+    <pre>$ sudo grep hosts /etc/nsswitch.conf
+    hosts: files dns</pre>
+    If the DNS entry is missing from the host's line in the "/etc/nsswitch.conf"
+    file, the "/etc/resolv.conf" file must be empty.
+    Verify the "/etc/resolv.conf" file is empty with the following command:
+    <pre>$ sudo ls -al /etc/resolv.conf
+    -rw-r--r-- 1 root root 0 Aug 19 08:31 resolv.conf</pre>
+    If the DNS entry is found on the host's line of the "/etc/nsswitch.conf" file,
+    then verify the following:<br/>
+    {{% endif %}}
     Multiple Domain Name System (DNS) Servers should be configured
     in <tt>/etc/resolv.conf</tt>. This provides redundant name resolution services
     in the event that a domain server crashes. To configure the system to contain

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/commented_nameservers.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/commented_nameservers.fail.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_all
+
+source common.sh
+
+if grep -q '^\s*hosts:' "$NSSWITCHFILE"; then
+    sed -i 's/^\s*hosts:.*$/& dns/g' "$NSSWITCHFILE"
+else
+    echo "hosts: dns" >> "$NSSWITCHFILE"
+fi
+
+echo -e "#nameserver 192.168.1.2\n#nameserver 192.168.1.3\n" >> "$RESOLVFILE"

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/common.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/common.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+NSSWITCHFILE=/etc/nsswitch.conf
+RESOLVFILE=/etc/resolv.conf
+
+sed -r -i 's/(^\s*hosts:.*?)\bdns\b\s*(.*)/\1\2/g' "$NSSWITCHFILE"
+
+truncate -s 0 "$RESOLVFILE"

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_is_empty.pass.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_is_empty.pass.sh
@@ -1,0 +1,3 @@
+# platform = multi_platform_ol,multi_platform_rhel
+
+source common.sh

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_isnt_empty.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_isnt_empty.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_ol,multi_platform_rhel
 
 source common.sh
 

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_isnt_empty.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/dns_not_in_nsswitch_and_resolv_isnt_empty.fail.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+
+source common.sh
+
+echo -e "nameserver 192.168.1.2\nnameserver 192.168.1.3\n" >> "$RESOLVFILE"

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/one_nameserver.fail.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/one_nameserver.fail.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_all
+
+source common.sh
+
+if grep -q '^\s*hosts:' "$NSSWITCHFILE"; then
+    sed -i 's/^\s*hosts:.*$/& dns/g' "$NSSWITCHFILE"
+else
+    echo "hosts: dns" >> "$NSSWITCHFILE"
+fi
+
+echo -e "nameserver 192.168.1.2" >> "$RESOLVFILE"

--- a/linux_os/guide/system/network/network_configure_name_resolution/tests/two_nameserver.pass.sh
+++ b/linux_os/guide/system/network/network_configure_name_resolution/tests/two_nameserver.pass.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_all
+
+source common.sh
+
+if grep -q '^\s*hosts:' "$NSSWITCHFILE"; then
+    sed -i 's/^\s*hosts:.*$/& dns/g' "$NSSWITCHFILE"
+else
+    echo "hosts: dns" >> "$NSSWITCHFILE"
+fi
+
+echo -e "nameserver 192.168.1.2\nnameserver 192.168.1.3\n" >> "$RESOLVFILE"


### PR DESCRIPTION
#### Description:

- Update network_configure_name_resolution OVAL behavior

#### Rationale:

- These criteria introduced are part of the DISA requirements under the STIG IDs that this rule references

> stigid@ol7: OL07-00-040600
    stigid@ol8: OL08-00-010680
    stigid@rhel7: RHEL-07-040600
    stigid@rhel8: RHEL-08-010680
