### PR TITLE
Fix bash remediation of disable_users_coredumps

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -1,8 +1,10 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 SECURITY_LIMITS_FILE="/etc/security/limits.conf"
 
-if grep -qE '\*\s+hard\s+core' $SECURITY_LIMITS_FILE; then
+if grep -qE '^\s*\*\s+hard\s+core' $SECURITY_LIMITS_FILE; then
         sed -ri 's/(hard\s+core\s+)[[:digit:]]+/\1 0/' $SECURITY_LIMITS_FILE
 else
         echo "*     hard   core    0" >> $SECURITY_LIMITS_FILE
 fi
+
+sudo sed -ri '/^\s*\*\s+hard\s+core/d' /etc/security/limits.d/*.conf

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -7,4 +7,6 @@ else
         echo "*     hard   core    0" >> $SECURITY_LIMITS_FILE
 fi
 
-sed -ri '/^\s*\*\s+hard\s+core/d' /etc/security/limits.d/*.conf
+if ls /etc/security/limits.d/*.conf > /dev/null; then
+        sed -ri '/^\s*\*\s+hard\s+core/d' /etc/security/limits.d/*.conf
+fi

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -7,4 +7,4 @@ else
         echo "*     hard   core    0" >> $SECURITY_LIMITS_FILE
 fi
 
-sudo sed -ri '/^\s*\*\s+hard\s+core/d' /etc/security/limits.d/*.conf
+sed -ri '/^\s*\*\s+hard\s+core/d' /etc/security/limits.d/*.conf


### PR DESCRIPTION
#### Description:

- Update regex in sed command to differentiate commented lines. And included another sed command to remove unnecesary conf lines

#### Rationale:

- When the confline were commented out, the previous version fix the line but keeps it commented. Also avoid that limits.d/*.conf files override main configuration
