### PR TITLE
Oval updatein rule sshd_set_idle_timeout

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -33,7 +33,7 @@
           test_ref="test_sshd_idle_timeout_config_dir" />
           {{%- endif %}}
         </criteria>
-        {{%- if product != "ol8" %}}
+        {{%- if product not in ["ol8", "rhel8"] %}}
         <extend_definition comment="The SSH ClientAliveCountMax is set to zero" definition_ref="sshd_set_keepalive" />
         {{% endif %}}
       </criteria>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -33,7 +33,9 @@
           test_ref="test_sshd_idle_timeout_config_dir" />
           {{%- endif %}}
         </criteria>
+        {{%- if product != "ol8" %}}
         <extend_definition comment="The SSH ClientAliveCountMax is set to zero" definition_ref="sshd_set_keepalive" />
+        {{% endif %}}
       </criteria>
     </criteria>
   </definition>


### PR DESCRIPTION
#### Description:

- Removed criterion from OVAL in rule `sshd_set_idle_timeout`

#### Rationale:

- This criterion is covered in other rule, `sshd_set_keepalive_0`, which is actually referenced in the `requires` section of rule.yml file (except for ubuntu2004). This was found reviewing OL8 OL08-00-010201 an then equivalent for RHEL, but it could apply to all products(might only excluding ubuntu2004).
