### PR TITLE
Update regex in no_tmux_in_shells rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_all
 
-if grep -q 'tmux$' /etc/shells ; then
-	sed -i '/tmux$/d' /etc/shells
+if grep -q 'tmux\s*$' /etc/shells ; then
+	sed -i '/tmux\s*$/d' /etc/shells
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/oval/shared.xml
@@ -12,7 +12,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_no_tmux_in_shells" version="1">
     <ind:filepath>/etc/shells</ind:filepath>
-    <ind:pattern operation="pattern match">tmux$</ind:pattern>
+    <ind:pattern operation="pattern match">tmux\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>


### PR DESCRIPTION
#### Description:

- Update regex both in OVAL and bash 

#### Rationale:

- Allow whitespaces at the end of the line and still find the shell usage
