### PR TITLE
Remove -F euid=0 parameter from audit_rules_suid_privilege_function for ol8

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/bash/shared.sh
@@ -7,7 +7,11 @@
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	{{% if product == "ol8" %}}
+	OTHER_FILTERS="-C uid!=euid"
+	{{% else %}}
 	OTHER_FILTERS="-C uid!=euid -F euid=0"
+	{{% endif %}}
 	AUID_FILTERS=""
 	SYSCALL="execve"
 	KEY="setuid"
@@ -20,7 +24,11 @@ done
 for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
+	{{% if product == "ol8" %}}
+	OTHER_FILTERS="-C gid!=egid"
+	{{% else %}}
 	OTHER_FILTERS="-C gid!=egid -F egid=0"
+	{{% endif %}}
 	AUID_FILTERS=""
 	SYSCALL="execve"
 	KEY="setgid"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
@@ -30,7 +30,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_uid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -39,7 +43,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_uid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -48,7 +56,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_uid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -57,7 +69,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_uid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]uid!=euid[\s]+-F[\s]euid=0[\s]+(-k[\s]+|-F[\s]+key=)setuid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -66,7 +82,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_gid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -75,7 +95,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_gid_privileged_function_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -84,7 +108,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_gid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -93,7 +121,11 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_gid_privileged_function_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
+    {{% if product == "ol8" %}}
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+(?:-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b64[\s]+-S[\s]+execve[\s]+-C[\s]gid!=egid[\s]+-F[\s]egid=0[\s]+(-k[\s]+|-F[\s]+key=)setgid[\s]*$</ind:pattern>
+    {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -8,10 +8,17 @@ description: |-
     Verify the system generates an audit record when privileged functions are executed.
     <pre># grep -iw execve <tt>/etc/audit/audit.rules</tt></pre>
 
+    {{% if product == "ol8" %}}
+    <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
+    <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
+    <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>
+    <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -k setgid</pre>
+    {{% else %}}
     <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
     <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
     <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+    {{% endif %}}
 
     If both the "b32" and "b64" audit rules for "SUID" files are not defined, this is a finding.
     If both the "b32" and "b64" audit rules for "SGID" files are not defined, this is a finding.
@@ -56,10 +63,17 @@ ocil_clause: 'it is not the case'
 ocil: |-
       Add or update the following rules in "<tt>/etc/audit/rules.d/audit.rules</tt>":
 
+      {{% if product == "ol8" %}}
+      <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -k setuid</pre>
+      <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -k setuid</pre>
+      <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -k setgid</pre>
+      <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -k setgid</pre>
+      {{% else %}}
       <pre>-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
       <pre>-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid</pre>
       <pre>-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
       <pre>-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid</pre>
+      {{% endif %}}
 
       The audit daemon must be restarted for the changes to take effect.
 


### PR DESCRIPTION
#### Description:

- Update auditd filter fot OL8 in `audit_rules_suid_privilege_function` rule

#### Rationale:

- DISA, in its STIG profile(STIG ID OL08-00-030000 referenced in this rule) doesn't mention the presence of -F euid=0 for this auditd rule
