### PR TITLE
Update package names of abrt according to distros

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-python_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-python_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7
+prodtype: ol7,rhel7
 
 title: 'Uninstall abrt-addon-python Package'
 

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,rhel7,rhel8
 
-title: 'Uninstall abrt-plugin-logger Package'
+title: 'Uninstall libreport-plugin-logger Package'
 
 description: |-
-    {{{ describe_package_remove(package="abrt-plugin-logger") }}}
+    {{{ describe_package_remove(package="libreport-plugin-logger") }}}
 
 rationale: |-
-    <tt>abrt-plugin-logger</tt> is an ABRT plugin which writes a report
+    <tt>libreport-plugin-logger</tt> is an ABRT plugin which writes a report
     to a specified file.
 
 severity: low
@@ -24,9 +24,9 @@ references:
     stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
-{{{ complete_ocil_entry_package(package="abrt-plugin-logger") }}}
+{{{ complete_ocil_entry_package(package="libreport-plugin-logger") }}}
 
 template:
     name: package_removed
     vars:
-        pkgname: abrt-plugin-logger
+        pkgname: libreport-plugin-logger

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
@@ -2,13 +2,13 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,rhel7,rhel8
 
-title: 'Uninstall abrt-plugin-rhtsupport Package'
+title: 'Uninstall libreport-plugin-rhtsupport Package'
 
 description: |-
-    {{{ describe_package_remove(package="abrt-plugin-rhtsupport") }}}
+    {{{ describe_package_remove(package="libreport-plugin-rhtsupport") }}}
 
 rationale: |-
-    <tt>abrt-plugin-rhtsupport</tt> is a ABRT plugin to report bugs into the
+    <tt>libreport-plugin-rhtsupportt</tt> is a ABRT plugin to report bugs into the
     Red Hat Support system.
 
 severity: low
@@ -24,9 +24,9 @@ references:
     stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
-{{{ complete_ocil_entry_package(package="abrt-plugin-rhtsupport") }}}
+{{{ complete_ocil_entry_package(package="libreport-plugin-rhtsupport") }}}
 
 template:
     name: package_removed
     vars:
-        pkgname: abrt-plugin-rhtsupport
+        pkgname: libreport-plugin-rhtsupport

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol8,rhel8
 
 title: 'Uninstall abrt-plugin-sosreport Package'
 
@@ -13,7 +13,6 @@ rationale: |-
 severity: low
 
 identifiers:
-    cce@rhel7: CCE-82911-9
     cce@rhel8: CCE-82910-1
     cce@rhel9: CCE-83515-7
 

--- a/products/ol8/profiles/ospp.profile
+++ b/products/ol8/profiles/ospp.profile
@@ -199,7 +199,7 @@ selections:
     - package_nfs-utils_removed
     - package_krb5-workstation_removed
     - package_abrt-addon-kerneloops_removed
-    - package_abrt-addon-python_removed
+    - package_python3-abrt-addon_removed
     - package_abrt-addon-ccpp_removed
     - package_abrt-plugin-logger_removed
     - package_abrt-plugin-sosreport_removed

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -935,7 +935,7 @@ selections:
     - package_abrt_removed
     - package_abrt-addon-ccpp_removed
     - package_abrt-addon-kerneloops_removed
-    - package_abrt-addon-python_removed
+    - package_python3-abrt-addon_removed
     - package_abrt-cli_removed
     - package_abrt-plugin-logger_removed
     - package_abrt-plugin-rhtsupport_removed


### PR DESCRIPTION
#### Description:

- Update package names of abrt according to distros.

#### Rationale:

- Usually these rules will pass because if a wrong package name is checked if it is not installed, it will always pass. But templated tests that force certain situation where the package would be installed, will fail because the package doesn't exist. This is an attempt to make these templated tests pass on specific distros.

- Fixes #8286
