### PR TITLE
OCP: cluster version history bug fix

### DIFF
--- a/applications/openshift/integrity/cluster_version_operator_verify_integrity/rule.yml
+++ b/applications/openshift/integrity/cluster_version_operator_verify_integrity/rule.yml
@@ -18,7 +18,7 @@ identifiers:
 references:
   nist: SA-10(1)
 
-{{% set jqfilter = '[.status.history[] | .verified]' %}}
+{{% set jqfilter = '[.status.history[0:-1]|.[]|.verified]' %}}
 {{% set apipath = '/apis/config.openshift.io/v1/clusterversions/version' %}}
 
 ocil_clause: 'Cluster image is not verified'
@@ -34,6 +34,7 @@ warnings:
 - general: |-
     {{{ openshift_filtered_cluster_setting({apipath: jqfilter}) | indent(4) }}}
 
+
 template:
   name: yamlfile_value
   vars:
@@ -41,6 +42,7 @@ template:
     filepath: |-
       {{{ openshift_filtered_path(apipath, jqfilter) }}}
     yamlpath: "[:]"
+    check_existence: any_exist
     entity_check: "all"
     values:
       - value: "true"

--- a/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/allverfied_three_entries.pass.sh
+++ b/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/allverfied_three_entries.pass.sh
@@ -77,7 +77,7 @@ cat << EOF > $kube_apipath$apipath
                 "image": "registry.build01.ci.openshift.org/ci-ln-vhslt2k/release@sha256:cd38c2c90e01b6c3461afbc6f44743242b9e62fcb4a0c8b7593d7c459a164636",
                 "startedTime": "2021-12-15T03:23:17Z",
                 "state": "Completed",
-                "verified": true,
+                "verified": false,
                 "version": "4.10.0-0.ci-2021-12-15-195801"
             }
         ],
@@ -87,7 +87,7 @@ cat << EOF > $kube_apipath$apipath
 }
 EOF
 
-jq_filter='[.status.history[] | .verified]'
+jq_filter='[.status.history[0:-1]|.[]|.verified]'
 
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$apipath#$(echo -n "$apipath$jq_filter" | sha256sum | awk '{print $1}')"

--- a/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/inital_install.pass.sh
+++ b/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/inital_install.pass.sh
@@ -61,14 +61,6 @@ cat << EOF > $kube_apipath$apipath
                 "image": "registry.build01.ci.openshift.org/ci-ln-vhslt2k/release@sha256:cd38c2c90e01b6c3461afbc6f44743242b9e62fcb4a0c8b7593d7c459a164636",
                 "startedTime": "2021-12-16T06:23:17Z",
                 "state": "Completed",
-                "verified": true,
-                "version": "4.10.0-0.ci-2021-12-15-195801"
-            },
-            {
-                "completionTime": "2021-12-15T06:44:42Z",
-                "image": "registry.build01.ci.openshift.org/ci-ln-vhslt2k/release@sha256:cd38c2c90e01b6c3461afbc6f44743242b9e62fcb4a0c8b7593d7c459a164636",
-                "startedTime": "2021-12-15T06:23:17Z",
-                "state": "Completed",
                 "verified": false,
                 "version": "4.10.0-0.ci-2021-12-15-195801"
             }
@@ -79,7 +71,7 @@ cat << EOF > $kube_apipath$apipath
 }
 EOF
 
-jq_filter='[.status.history[] | .verified]'
+jq_filter='[.status.history[0:-1]|.[]|.verified]'
 
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$apipath#$(echo -n "$apipath$jq_filter" | sha256sum | awk '{print $1}')"

--- a/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/ocp4/e2e.yml
+++ b/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: FAIL
+default_result: PASS

--- a/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/one_upgrade.pass.sh
+++ b/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/one_upgrade.pass.sh
@@ -63,6 +63,14 @@ cat << EOF > $kube_apipath$apipath
                 "state": "Completed",
                 "verified": true,
                 "version": "4.10.0-0.ci-2021-12-15-195801"
+            },
+            {
+                "completionTime": "2021-12-15T06:44:42Z",
+                "image": "registry.build01.ci.openshift.org/ci-ln-vhslt2k/release@sha256:cd38c2c90e01b6c3461afbc6f44743242b9e62fcb4a0c8b7593d7c459a164636",
+                "startedTime": "2021-12-15T06:23:17Z",
+                "state": "Completed",
+                "verified": false,
+                "version": "4.10.0-0.ci-2021-12-15-195801"
             }
         ],
         "observedGeneration": 2,
@@ -71,7 +79,7 @@ cat << EOF > $kube_apipath$apipath
 }
 EOF
 
-jq_filter='[.status.history[] | .verified]'
+jq_filter='[.status.history[0:-1]|.[]|.verified]'
 
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$apipath#$(echo -n "$apipath$jq_filter" | sha256sum | awk '{print $1}')"

--- a/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/someverified_three_entries.fail.sh
+++ b/applications/openshift/integrity/cluster_version_operator_verify_integrity/tests/someverified_three_entries.fail.sh
@@ -77,7 +77,7 @@ cat << EOF > $kube_apipath$apipath
                 "image": "registry.build01.ci.openshift.org/ci-ln-vhslt2k/release@sha256:cd38c2c90e01b6c3461afbc6f44743242b9e62fcb4a0c8b7593d7c459a164636",
                 "startedTime": "2021-12-15T03:23:17Z",
                 "state": "Completed",
-                "verified": true,
+                "verified": false,
                 "version": "4.10.0-0.ci-2021-12-15-195801"
             }
         ],
@@ -87,7 +87,7 @@ cat << EOF > $kube_apipath$apipath
 }
 EOF
 
-jq_filter='[.status.history[] | .verified]'
+jq_filter='[.status.history[0:-1]|.[]|.verified]'
 
 # Get file path. This will actually be read by the scan
 filteredpath="$kube_apipath$apipath#$(echo -n "$apipath$jq_filter" | sha256sum | awk '{print $1}')"


### PR DESCRIPTION
This pr is to address BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2053602, the rule was failing because the initial OpenShift install will always have verified as false, and this pr addresses the issue by skipping the first entry in the history list.