### PR TITLE
Remove one "oscap xccdf resolve" step

### DIFF
--- a/build-scripts/unselect_empty_xccdf_groups.py
+++ b/build-scripts/unselect_empty_xccdf_groups.py
@@ -99,9 +99,6 @@ def main():
             "Make sure the input file is a resolved XCCDF Benchmark."
         )
 
-    # force another oscap resolve to fix namespace prefixes
-    root_element.set("resolved", "0")
-
     affected_profiles = []
     group_elements = root_element.findall(".//{%s}Group" % (XCCDF11_NS))
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -465,7 +465,6 @@ macro(ssg_build_xccdf_final PRODUCT)
         COMMAND "${SED_EXECUTABLE}" -i "s/oval-linked.xml/ssg-${PRODUCT}-oval.xml/g" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMAND "${SED_EXECUTABLE}" -i "s/ocil-linked.xml/ssg-${PRODUCT}-ocil.xml/g" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/unselect_empty_xccdf_groups.py" --input "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf resolve -o "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-internal-${PRODUCT}-linked-xccdf-oval-ocil.xml
         COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-xccdf.xml"


### PR DESCRIPTION
In this step the "oscap xccdf resolve" is superfluous because it
doesn't do any significant changes there.

What the removed "oscap xccdf resolve" does:
* shuffles XML namespace prefixes, but that doesn't change the actual
  namespace, so we don't need it
* orders attributes of some elements, but ordering of attributes doesn't
  matter in XML
* sets explicitly the reboot attribute of xccdf:fix element to its
  default value (false), but as it's the default we don't need it
* sets the resolved attribute back to true which was changed forcefully
  to false in unselect_empty_xccdf_groups.py to trick the oscap command,
  so we can instead remove that from unselect_empty_xccdf_groups.py)

Other XCCDF resolving steps are not effective in this build phase.

Notice that there still remain other occurrences of "oscap xccdf
resolve" elsewhere.


