### PR TITLE
Remove remaining "oscap xccdf resolve" calls

### DIFF
--- a/build-scripts/add_stig_references.py
+++ b/build-scripts/add_stig_references.py
@@ -8,18 +8,17 @@ import ssg.build_stig
 
 def parse_args():
     parser = argparse.ArgumentParser(description='Add STIG references to XCCDF files.')
-    parser.add_argument("--disa-stig", help="DISA STIG Reference XCCDF file",
-                        dest="reference")
-    parser.add_argument("--unlinked-xccdf", help="unlinked SSG XCCDF file",
-                        dest="destination")
+    parser.add_argument("reference", help="DISA STIG Reference XCCDF file")
+    parser.add_argument("input", help="Input XCCDF file path")
+    parser.add_argument("output", help="Output XCCDF file path")
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
 
-    target_root = ssg.build_stig.add_references(args.reference, args.destination)
-    target_root.write(args.destination)
+    target_root = ssg.build_stig.add_references(args.input, args.reference)
+    target_root.write(args.output)
 
 
 if __name__ == "__main__":

--- a/build-scripts/unselect_empty_xccdf_groups.py
+++ b/build-scripts/unselect_empty_xccdf_groups.py
@@ -94,11 +94,6 @@ def main():
             "a benchmark!"
         )
 
-    if root_element.get("resolved") not in ["1", "true"]:
-        raise RuntimeError(
-            "Make sure the input file is a resolved XCCDF Benchmark."
-        )
-
     affected_profiles = []
     group_elements = root_element.findall(".//{%s}Group" % (XCCDF11_NS))
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -151,7 +151,7 @@ macro(ssg_build_xccdf_unlinked_stig PRODUCT STIG_REFERENCE_FILE)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
         COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf resolve -o "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/add_stig_references.py" --disa-stig "${STIG_REFERENCE_FILE}" --unlinked-xccdf "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/add_stig_references.py" "${STIG_REFERENCE_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
         DEPENDS ${PRODUCT}-shorthand.xml-ocil-unlinked.xml
         COMMENT "[${PRODUCT}-content] generating xccdf-unlinked-resolved.xml"
     )

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -128,49 +128,30 @@ macro(ssg_build_shorthand_xml PRODUCT)
     )
 endmacro()
 
-# Apply the XSLT transformation to the shorthand to generate the intermediate
-# XCCDF document. Here, unlinked refers to the fact that we don't yet have
-# knowledge of the remediations and OVAL content present in the repo and thus
-# haven't removed extraneous <oval/> elements &c. There's two versions of this
-# macro depending on whether this product has a STIG guide.
-macro(ssg_build_xccdf_unlinked_no_stig PRODUCT)
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
-        COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf resolve -o "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
-        DEPENDS ${PRODUCT}-shorthand.xml-ocil-unlinked.xml
-        COMMENT "[${PRODUCT}-content] generating xccdf-unlinked-resolved.xml"
-    )
-    add_custom_target(
-        generate-internal-${PRODUCT}-xccdf-unlinked-resolved.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
-    )
-endmacro()
-
-# See above.
-macro(ssg_build_xccdf_unlinked_stig PRODUCT STIG_REFERENCE_FILE)
-    add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
-        COMMAND "${OPENSCAP_OSCAP_EXECUTABLE}" xccdf resolve -o "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/add_stig_references.py" "${STIG_REFERENCE_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
-        DEPENDS ${PRODUCT}-shorthand.xml-ocil-unlinked.xml
-        COMMENT "[${PRODUCT}-content] generating xccdf-unlinked-resolved.xml"
-    )
-    add_custom_target(
-        generate-internal-${PRODUCT}-xccdf-unlinked-resolved.xml
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
-    )
-endmacro()
-
-macro(ssg_build_xccdf_unlinked PRODUCT)
+macro(ssg_build_xccdf_with_stig_references PRODUCT)
     file(GLOB STIG_REFERENCE_FILE_LIST "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-*-xccdf-manual.xml")
     list(APPEND STIG_REFERENCE_FILE_LIST "not-found")
     list(GET STIG_REFERENCE_FILE_LIST 0 STIG_REFERENCE_FILE)
 
     if (STIG_REFERENCE_FILE STREQUAL "not-found")
-        ssg_build_xccdf_unlinked_no_stig(${PRODUCT})
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-with-stig-references.xml"
+            COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-with-stig-references.xml"
+            DEPENDS ${PRODUCT}-shorthand.xml-ocil-unlinked.xml
+            COMMENT "[${PRODUCT}-content] generating xccdf-with-stig-references.xml"
+        )
     else()
-        ssg_build_xccdf_unlinked_stig(${PRODUCT} ${STIG_REFERENCE_FILE})
+        add_custom_command(
+            OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-with-stig-references.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/add_stig_references.py" "${STIG_REFERENCE_FILE}" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-with-stig-references.xml"
+            DEPENDS ${PRODUCT}-shorthand.xml-ocil-unlinked.xml
+            COMMENT "[${PRODUCT}-content] generating xccdf-with-stig-references.xml"
+        )
     endif()
+    add_custom_target(
+        generate-internal-${PRODUCT}-xccdf-with-stig-references.xml
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/xccdf-with-stig-references.xml"
+    )
 endmacro()
 
 # Build all templated content using the YAML "template" key in this product's
@@ -326,9 +307,9 @@ macro(ssg_build_xccdf_with_remediations PRODUCT)
     endforeach()
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" ${PRODUCT_XSLT_LANGUAGE_PARAMS} --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked-resolved.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" ${PRODUCT_XSLT_LANGUAGE_PARAMS} --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${SSG_SHARED_TRANSFORMS}/xccdf-addremediations.xslt" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-with-stig-references.xml"
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-unlinked.xml"
-        DEPENDS generate-internal-${PRODUCT}-xccdf-unlinked-resolved.xml
+        DEPENDS generate-internal-${PRODUCT}-xccdf-with-stig-references.xml
         DEPENDS ${PRODUCT_LANGUAGE_DEPENDS}
         COMMENT "[${PRODUCT}-content] generating xccdf-unlinked.xml"
     )
@@ -788,7 +769,7 @@ macro(ssg_build_product PRODUCT)
     ssg_build_shorthand_xml(${PRODUCT})
     ssg_make_all_tables(${PRODUCT})
     ssg_build_templated_content(${PRODUCT})
-    ssg_build_xccdf_unlinked(${PRODUCT})
+    ssg_build_xccdf_with_stig_references(${PRODUCT})
     ssg_build_remediations(${PRODUCT})
 
     if ("${PRODUCT_ANSIBLE_REMEDIATION_ENABLED}" AND SSG_ANSIBLE_PLAYBOOKS_PER_RULE_ENABLED)

--- a/ssg/build_stig.py
+++ b/ssg/build_stig.py
@@ -7,18 +7,20 @@ from .xml import ElementTree as ET
 from .constants import XCCDF11_NS, stig_ns, stig_refs
 
 
-def add_references(reference, destination):
+def add_references(input_file_name, reference_file_name):
     """
-    For a given reference XCCDF file and destination file, process all
-    STIG references in the rules from destination and correctly link
+    For a given input XCCDF file and DISA STIG reference XCCDF file, process
+    all STIG references in the rules from input XCCDF file and correctly link
     them to the corresponding reference rule.
 
     Returns the updated ElementTree containing updated reference elements.
     """
     try:
-        reference_root = ET.parse(reference)
+        reference_root = ET.parse(reference_file_name)
     except IOError:
-        print("INFO: DISA STIG Reference file not found for this platform: %s" % reference)
+        print(
+            "INFO: DISA STIG Reference file not found for this platform: %s" %
+            reference_file_name)
         sys.exit(0)
 
     reference_rules = reference_root.findall('.//{%s}Rule' % XCCDF11_NS)
@@ -30,7 +32,7 @@ def add_references(reference, destination):
         if version is not None and version.text:
             dictionary[version.text] = rule.get('id')
 
-    target_root = ET.parse(destination)
+    target_root = ET.parse(input_file_name)
     target_rules = target_root.findall('.//{%s}Rule' % XCCDF11_NS)
 
     for rule in target_rules:


### PR DESCRIPTION
#### Description:
Remove remaining "oscap xccdf resolve" calls from our CMake definition. This is a follow up on PR #8351.

For more details, please read commit messages of every commit.

#### Rationale:
It turns out that the benchmark is already resolved when its generated.
