### PR TITLE
Update SRG-OS-000032-GPOS-00013 for RHEL9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000032-GPOS-00013.yml
+++ b/controls/stig_rhel9/SRG-OS-000032-GPOS-00013.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000032-GPOS-00013
         levels:
             - medium
-        title: The operating system must monitor remote access methods.
+        title: {{{ full_name }}} must monitor remote access methods.
         rules:
             - sshd_set_loglevel_verbose
             - rsyslog_remote_access_monitoring

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/rule.yml
@@ -41,6 +41,9 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="no", option="LogLevel", value="VERBOSE") }}}
 
+fix: |-
+    {{{ sshd_lineinfile_fix('LogLevel', 'VERBOSE', False) }}}
+
 template:
     name: sshd_lineinfile
     vars:

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/rule.yml
@@ -43,3 +43,12 @@ ocil: |-
     <pre>grep -rE '(auth.\*|authpriv.\*|daemon.\*)' /etc/rsyslog.*</pre>
     The output should contain <tt>auth.*</tt>, <tt>authpriv.*</tt>, and <tt>daemon.*</tt>
     pointing to a log file.
+
+fix: |-
+    add or update the following lines to the "/etc/rsyslog.conf" file:
+
+    auth.*;authpriv.*;daemon.* /var/log/secure
+
+    The "rsyslog" service must be restarted for the changes to take effect. To restart the "rsyslog" service, run the following command:
+
+    $ sudo systemctl restart rsyslog.service

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1708,3 +1708,28 @@ Fill in <tt>GRUBENV_FILE_LOCATION</tt> based on information above.
 
     $ sudo dconf update
 {{%- endmacro -%}}
+
+{{#
+    Describe how to fix an ssh configure
+    :param parameter: parameter to set
+    :type parameter: str
+    :parameter value: Value to set
+    :type value: str
+    :param config_is_distributed: Should the value go in 00-complianceascode-hardening.conf vs the main sshd config file
+
+#}}
+{{%- macro sshd_lineinfile_fix(parameter, value, config_is_distributed) -%}}
+{{%- if config_is_distributed -%}}
+{{%- set path = "/etc/ssh/sshd_config.d/00-complianceascode-hardening.conf" -%}}
+{{%- else -%}}
+{{%- set path = "/etc/ssh/sshd_config" -%}}
+{{%- endif -%}}
+    To configure the system add or modify the following line in "{{{ path }}}".
+
+    {{{parameter}}}={{{value}}}
+
+    Restart the SSH daemon for the settings to take effect:
+
+    $ sudo systemctl restart sshd.service
+
+{{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

- Add a macro for now to fix sshd config
- Update SRG-OS-000032-GPOS-00013
- Add fix text for sshd_set_loglevel_verbose
- Add fix text for  rsyslog_remote_access_monitoring

#### Rationale:

RHEL9 STIG
