### PR TITLE
Add <pre> tag HTML element to STIG mapping tables

### DIFF
--- a/shared/transforms/shared_xccdf2table-stig.xslt
+++ b/shared/transforms/shared_xccdf2table-stig.xslt
@@ -114,9 +114,9 @@
 				<td> <xsl:value-of select="cdf:Rule/cdf:title" /></td>
 			</xsl:otherwise>
 			</xsl:choose>
-			<td> <xsl:call-template name="extract-vulndiscussion"><xsl:with-param name="desc" select="cdf:Rule/cdf:description"/></xsl:call-template> </td>
-			<td> <xsl:apply-templates select="cdf:Rule/cdf:check/cdf:check-content/node()"/> </td>
-			<td> <xsl:apply-templates select="cdf:Rule/cdf:fixtext/node()"/> </td>
+			<td> <pre> <xsl:call-template name="extract-vulndiscussion"><xsl:with-param name="desc" select="cdf:Rule/cdf:description"/></xsl:call-template> </pre> </td>
+			<td> <pre> <xsl:apply-templates select="cdf:Rule/cdf:check/cdf:check-content/node()"/> </pre> </td>
+			<td> <pre> <xsl:apply-templates select="cdf:Rule/cdf:fixtext/node()"/> </pre> </td>
 			<td> <xsl:apply-templates select="cdf:Rule/cdf:version/node()"/> </td>
 			<td> <xsl:value-of select="cdf:Rule/@id"/> </td>
 			<xsl:if test='$notes'>


### PR DESCRIPTION


#### Description:
- Add `<pre>` tag HTML element to STIG mapping tables.
  - It preserves the original formatting of the text and even in HTML it's
presented with its original newlines.
- Caveat: The horizontal scroller gets bigger than what the page can fit because it doesn't know how to wrap properly the `<pre>` element

Previous
![Screenshot from 2022-03-17 10-50-15](https://user-images.githubusercontent.com/18730394/158789226-8336a2fb-725c-42f2-b074-4f293e94687d.png)

After
![Screenshot from 2022-03-17 10-48-39](https://user-images.githubusercontent.com/18730394/158789241-08373524-2ec5-4d76-a677-6120c4bf23b0.png)
