### PR TITLE
Allow lines between pam_env.so and pam_pkcs11.so

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
@@ -92,7 +92,7 @@
   <local_variable id="variable_smart_card_required_smartcard_auth" datatype="string"
   comment="Regular expression to check if smartcard authentication is required in /etc/pam.d/smartcard-auth" version="1">
     <concat>
-      <literal_component>\nauth[\s]+required[\s]+pam_env.so</literal_component>
+      <literal_component>\nauth[\s]+required[\s]+pam_env.so.*</literal_component>
       <literal_component>\nauth[\s]+\[success=done[\s]ignore=ignore[\s]default=die\][\s]</literal_component>
       <literal_component>pam_pkcs11.so[\s]nodebug[\s]wait_for_card\n.*</literal_component>
       <literal_component>\npassword[\s]+required[\s]+pam_pkcs11.so\n</literal_component>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled_with_faillock.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled_with_faillock.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
+
+systemctl enable pcscd.socket
+systemctl start pcscd.socket
+
+. ./configure_pam_stack.sh
+
+
+SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
+PAM_ENV_SO="auth.*required.*pam_env.so"
+PAM_FAILLOCK_PREAUTH="auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200"
+SYSTEM_AUTH_PAM_PKCS11="auth [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_pkcs11.so nodebug"
+PAM_FAILLOCK_AUTHFAIL="auth        required      pam_faillock.so authfail deny=4 unlock_time=1200"
+sed -i --follow-symlinks -e '/^'"$PAM_ENV_SO"'/a '"$PAM_FAILLOCK_PREAUTH" "$SMARTCARD_AUTH_CONF"
+sed -i --follow-symlinks -e '/^'"$SYSTEM_AUTH_PAM_PKCS11"'/a '"$PAM_FAILLOCK_AUTHFAIL" "$SMARTCARD_AUTH_CONF"


### PR DESCRIPTION

#### Description:

- In `/etc/pam.d/smartcard-auth`, allow lines between `pam_env.so` and `pam_pkcs11.so`

#### Rationale:

- There are cases when, in /etc/pam.d/smartcard-auth, pam_pkcs11.so will not be right after pam_env.so, for example when faillock is configured.

Example section:
```
auth        required      pam_env.so
auth        required      pam_faillock.so preauth silent deny=4
unlock_time=1200
auth        [success=done ignore=ignore default=die] pam_pkcs11.so
nodebug wait_for_card
auth        required      pam_faillock.so authfail deny=4
unlock_time=1200
auth        required      pam_deny.so
```
- Fixes  #8023