### PR TITLE
Remove nonexistent package rules in recent distro releases

### DIFF
--- a/products/ol8/profiles/ospp.profile
+++ b/products/ol8/profiles/ospp.profile
@@ -201,7 +201,6 @@ selections:
     - package_abrt-addon-kerneloops_removed
     - package_abrt-addon-python_removed
     - package_abrt-addon-ccpp_removed
-    - package_abrt-plugin-logger_removed
     - package_abrt-plugin-sosreport_removed
     - package_abrt-cli_removed
     - package_abrt_removed

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -937,8 +937,6 @@ selections:
     - package_abrt-addon-kerneloops_removed
     - package_abrt-addon-python_removed
     - package_abrt-cli_removed
-    - package_abrt-plugin-logger_removed
-    - package_abrt-plugin-rhtsupport_removed
     - package_abrt-plugin-sosreport_removed
 
     # OL08-00-040002

--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -208,8 +208,6 @@ selections:
     - package_abrt-addon-kerneloops_removed
     - package_python3-abrt-addon_removed
     - package_abrt-addon-ccpp_removed
-    - package_abrt-plugin-rhtsupport_removed
-    - package_abrt-plugin-logger_removed
     - package_abrt-plugin-sosreport_removed
     - package_abrt-cli_removed
     - package_abrt_removed

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -930,8 +930,6 @@ selections:
     - package_abrt-addon-kerneloops_removed
     - package_python3-abrt-addon_removed
     - package_abrt-cli_removed
-    - package_abrt-plugin-logger_removed
-    - package_abrt-plugin-rhtsupport_removed
     - package_abrt-plugin-sosreport_removed
 
     # RHEL-08-040002

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -132,8 +132,6 @@ selections:
 - package_abrt-addon-ccpp_removed
 - package_abrt-addon-kerneloops_removed
 - package_abrt-cli_removed
-- package_abrt-plugin-logger_removed
-- package_abrt-plugin-rhtsupport_removed
 - package_abrt-plugin-sosreport_removed
 - package_abrt_removed
 - package_aide_installed

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -283,8 +283,6 @@ selections:
 - package_abrt-addon-ccpp_removed
 - package_abrt-addon-kerneloops_removed
 - package_abrt-cli_removed
-- package_abrt-plugin-logger_removed
-- package_abrt-plugin-rhtsupport_removed
 - package_abrt-plugin-sosreport_removed
 - package_abrt_removed
 - package_aide_installed

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -294,8 +294,6 @@ selections:
 - package_abrt-addon-ccpp_removed
 - package_abrt-addon-kerneloops_removed
 - package_abrt-cli_removed
-- package_abrt-plugin-logger_removed
-- package_abrt-plugin-rhtsupport_removed
 - package_abrt-plugin-sosreport_removed
 - package_abrt_removed
 - package_aide_installed


### PR DESCRIPTION


#### Description:

- Remove nonexistent package rules in recent distro releases.
#### Rationale:

- These package have their name changed and are not applicable anymore to
the profiles. They should be replaced by new rules with correct package
name.

- Workaround for #8286