### PR TITLE
Move mount_option_proc_hidepid to related rule

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -230,10 +230,6 @@ controls:
     - mount_option_home_nosuid
     - mount_option_home_noexec
 
-    # /proc hidepid = 2 Contains process information and the system
-    - mount_option_proc_hidepid
-    - var_mount_option_proc_hidepid=2
-
     # /usr nodev Contains the majority of utilities and system files
     - partition_for_usr
 
@@ -251,6 +247,11 @@ controls:
     - partition_for_var_tmp
     - mount_option_var_tmp_nosuid
     - mount_option_var_tmp_noexec
+
+    related_rules:
+    # /proc hidepid = 2 Contains process information and the system
+    - mount_option_proc_hidepid
+    - var_mount_option_proc_hidepid=2
 
   - id: R13
     levels:

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/rule.yml
@@ -23,6 +23,14 @@ rationale: |-
     related to their own processes in a system. Otherwise, sensitive information from
     other users could be seem.
 
+warnings:
+    - functionality: |-
+        Hiding the <tt>pid</tt> of processes may lead to problems with <tt>PolicyKit</tt> and <tt>D-Bus</tt>,
+        it may also convey a false sense of security.
+        {{% if 'rhel' in product %}}
+        Proceed to {{{ weblink(link="https://access.redhat.com/solutions/6704531") }}} for more details.
+        {{% endif %}}
+
 {{{ complete_ocil_entry_mount_option("/proc", "hidepid=value") }}}
 
 severity: low


### PR DESCRIPTION


#### Description:

- Let's not select `mount_option_proc_hidepid` by default.
  It will still be available in the DS for people to tailor it in.

#### Rationale:

- Setting 'hidepid=2' on /proc may cause problems in other applications and each use case should be analyzed before configuring it.
