### PR TITLE
Update abrt package rules for ol8

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-ccpp_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-ccpp_removed/rule.yml
@@ -21,7 +21,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-addon-ccpp") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-kerneloops_removed/rule.yml
@@ -21,7 +21,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-addon-kerneloops") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-addon-python_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-addon-python_removed/rule.yml
@@ -19,7 +19,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-addon-python") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-cli_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-cli_removed/rule.yml
@@ -21,7 +21,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-cli") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-libs_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-libs_removed/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'Uninstall abrt-libs Package'
+
+description: |-
+    {{{ describe_package_remove(package="abrt-libs") }}}
+
+rationale: |-
+    <tt>abrt-libs</tt> provides libraries for the ABRT package.
+
+severity: medium
+
+references:
+    disa: CCI-000381
+    srg: SRG-OS-000095-GPOS-00049
+    stigid@ol8: OL08-00-040001
+
+{{{ complete_ocil_entry_package(package="abrt-libs") }}}
+
+template:
+    name: package_removed
+    vars:
+        pkgname: abrt-libs

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-logger_removed/rule.yml
@@ -21,7 +21,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-plugin-logger") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-rhtsupport_removed/rule.yml
@@ -21,7 +21,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-plugin-rhtsupport") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-plugin-sosreport_removed/rule.yml
@@ -20,7 +20,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="abrt-plugin-sosreport") }}}

--- a/linux_os/guide/system/software/system-tools/package_abrt-server-info-page_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_abrt-server-info-page_removed/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'Uninstall abrt-server-info-page Package'
+
+description: |-
+    {{{ describe_package_remove(package="abrt-server-info-page") }}}
+
+rationale: |-
+    <tt>abrt-server-info-page</tt> provides a web page with summary of ABRT services.
+
+severity: medium
+
+references:
+    disa: CCI-000381
+    srg: SRG-OS-000095-GPOS-00049
+    stigid@ol8: OL08-00-040001
+
+{{{ complete_ocil_entry_package(package="abrt-server-info-page") }}}
+
+template:
+    name: package_removed
+    vars:
+        pkgname: abrt-server-info-page

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -933,11 +933,8 @@ selections:
 
     # OL08-00-040001
     - package_abrt_removed
-    - package_abrt-addon-ccpp_removed
-    - package_abrt-addon-kerneloops_removed
-    - package_abrt-addon-python_removed
-    - package_abrt-cli_removed
-    - package_abrt-plugin-sosreport_removed
+    - package_abrt-libs_removed
+    - package_abrt-server-info-page_removed
 
     # OL08-00-040002
     - package_sendmail_removed


### PR DESCRIPTION
#### Description:

- Update abrt-packages related rules for OL8
- Remove the OL8 stig ID from several abrt-package related rules
- Introduce two new rules for the `abrt-libs` and `abrt-server-info-page` packages

#### Rationale:

- The removal of the abrt-packages currently present in the OL8 stig profile is enough to meet DISA STIG requirement OL08-00-040001
