### PR TITLE
Audit changes to rsyslogd binary

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
@@ -18,7 +18,11 @@
 {{% set auditfiles = auditfiles + ["/usr/sbin/audispd"] %}}
 {{% endif %}}
 
-{{% if 'rhel' not in product %}}
+{{% if product == 'ol8' %}}
+{{% set auditfiles = auditfiles + ["/usr/sbin/rsyslogd"] %}}
+{{% endif %}}
+
+{{% if 'rhel' not in product and product != 'ol8' %}}
 {{% set configString = 'p+i+n+u+g+s+b+acl+selinux+xattrs+sha512' %}}
 {{% else %}}
 {{% set configString = "p+i+n+u+g+s+b+acl+xattrs+sha512" %}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -8,15 +8,18 @@
       <criterion comment="ausearch is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_ausearch" />
       <criterion comment="aureport is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_aureport" />
       <criterion comment="autrace is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_autrace" />
-      {{% if 'rhel' not in product %}}
+      {{% if 'rhel' not in product and product != 'ol8' %}}
       <criterion comment="audispd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_audispd" />
+      {{% endif %}}
+      {{% if product == 'ol8' %}}
+      <criterion comment="rsyslogd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_rsyslogd" />
       {{% endif %}}
       <criterion comment="augenrules is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_augenrules" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_state id="state_aide_check_attributes" version="1">
-    {{% if 'rhel' not in product and 'ubuntu' not in product %}}
+    {{% if 'rhel' not in product and 'ubuntu' not in product and product != 'ol8' %}}
     <ind:subexpression operation="equals">p+i+n+u+g+s+b+acl+selinux+xattrs+sha512</ind:subexpression>
     {{% else %}}
     <ind:subexpression operation="pattern match">p\+i\+n\+u\+g\+s\+b\+acl(|\+selinux)\+xattrs\+sha512</ind:subexpression>
@@ -114,7 +117,6 @@
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-
   <ind:textfilecontent54_test id="test_aide_verify_augenrules"
   comment="augenrules is checked in {{{ aide_conf_path }}}" check="all"
   check_existence="all_exist" version="1">
@@ -127,6 +129,5 @@
     <ind:pattern operation="pattern match">^/usr/sbin/augenrules\s+([^\n]+)$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
-
 
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -48,7 +48,7 @@ references:
 
 ocil_clause: 'integrity checks of the audit tools are missing or incomplete'
 
-{{% if 'rhel' not in product and 'ubuntu' not in product %}}
+{{% if 'rhel' not in product and 'ubuntu' not in product and product != 'ol8' %}}
 {{% set aide_string = 'p+i+n+u+g+s+b+acl+selinux+xattrs+sha512' %}}
 {{% else %}}
 {{% set aide_string = 'p+i+n+u+g+s+b+acl+xattrs+sha512' %}}
@@ -65,7 +65,8 @@ ocil: |-
     /usr/sbin/ausearch {{{ aide_string }}}
     /usr/sbin/aureport {{{ aide_string }}}
     /usr/sbin/autrace {{{ aide_string }}}
-    {{% if 'rhel' not in product %}}/usr/sbin/audispd {{{ aide_string }}}{{% endif %}}
+    {{% if 'rhel' not in product and product != 'ol8' %}}/usr/sbin/audispd {{{ aide_string }}}{{% endif %}}
+    {{% if product == 'ol8' %}}/usr/sbin/rsyslogd {{{ aide_string }}}{{% endif %}}
     /usr/sbin/augenrules {{{ aide_string }}}</pre>
 
     If AIDE is configured properly to protect the integrity of the audit tools,


### PR DESCRIPTION
#### Description:

- Add rsyslogd to the list of binaries audited with AIDE.
- Updated both to the OVAL checks and the bash remediation.
- Changes applied to OL8 only.

#### Rationale:

- This is an effort to align the `aide_check_audit_tools` rule with the DISA STIG OL08-00-030650 requirement
