### PR TITLE
Turn all wireless interfaces off

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_all
 
-nmcli radio wifi off
+nmcli radio all off

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/rule.yml
@@ -19,7 +19,7 @@ description: |-
     {{% else %}}
     Configure the system to disable all wireless network interfaces with the
     following command:
-    <pre>$ sudo nmcli radio wifi off</pre>
+    <pre>$ sudo nmcli radio all off</pre>
     {{% endif %}}
 
 rationale: |-


### PR DESCRIPTION
#### Description:

- Update bash remediation for `wireless_disable_interfaces` so that both WIFI and WWAN wireless interfaces are turned off

#### Rationale:

- This is an effort to align the `wireless_disable_interfaces` rule with the DISA STIG OL08-00-040110 requirement
