### PR TITLE
Override dconf_gdm_dir for OL8

### DIFF
--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/oval/shared.xml
@@ -53,12 +53,17 @@
       <extend_definition comment="dconf installed" definition_ref="package_dconf_installed" negate="true" />
       <criteria comment="check that all DBs in question are up-to-date" operator="AND">
         {{{ check_db_criterion(dconf_gdm_dir.split(".")[0]) }}}
-        {{{ check_db_criterion("local") }}}
+        {{% if dconf_gdm_dir.split(".")[0] != "local" %}}
+          {{{ check_db_criterion("local") }}}
+        {{% endif %}}
       </criteria>
     </criteria>
   </definition>
 
   {{{ check_db_is_up_to_date(dconf_gdm_dir.split(".")[0]) }}}
-  {{{ check_db_is_up_to_date("local") }}}
+  {{% if dconf_gdm_dir.split(".")[0] != "local" %}}
+    {{{ check_db_is_up_to_date("local") }}}
+  {{% endif %}}
+
 
 </def-group>

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -16,6 +16,8 @@ pkg_version: "ad986da3"
 
 release_key_fingerprint: "76FD3DB13AB67410B89DB10E82562EA9AD986DA3"
 
+dconf_gdm_dir: "local.d"
+
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../../shared/applicability"


### PR DESCRIPTION
#### Description:

- Override dconf_gdm_dir for OL8
- Also add jinja conditional in dconf_db_up_to_date OVAL content to avoid duplicated object IDs.

#### Rationale:

- This is an effort to align the dconf rules with the DISA STIG requirements for OL8.