### PR TITLE
Update SRG-OS-000068-GPOS-00036 for RHEL9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000068-GPOS-00036.yml
+++ b/controls/stig_rhel9/SRG-OS-000068-GPOS-00036.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000068-GPOS-00036
         levels:
             - medium
-        title: The operating system must map the authenticated identity to the user or group
+        title: {{{ full_name }}} must map the authenticated identity to the user or group
             account for PKI-based authentication.
         rules:
             - sssd_enable_certmap

--- a/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
@@ -51,6 +51,18 @@ ocil: |-
     domains = testing.test
     </pre>
 
+fix: |-
+    Configure {{{ full_name }}} to map the authenticated identity to the user or group account by adding or modifying the certmap section of the "/etc/sssd/sssd.conf" file based on the following example:
+
+    [certmap/testing.test/rule_name]
+    matchrule =<SAN>.*EDIPI@mil
+    maprule = (userCertificate;binary={cert!bin})
+    dmains = testing.test
+
+    The "sssd" service must be restarted for the changes to take effect. To restart the "sssd" service, run the following command:
+
+    $ sudo systemctl restart sssd.service
+
 template:
     name: lineinfile
     vars:


### PR DESCRIPTION
#### Description:

- Update SRG-OS-000068-GPOS-00036
- Add fix to sssd_enable_certmap

#### Rationale:

RHEL 9 STIG