### PR TITLE
RHEL7 - exclude the user 'nfsnobody' from accounts_users_home_files_*

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
@@ -10,11 +10,20 @@
   <unix:password_object id="object_accounts_users_home_files_groupownership_objects" version="1">
     <unix:username datatype="string" operation="not equal">nobody</unix:username>
     <filter action="include">state_accounts_users_home_files_groupownership_interactive_gids</filter>
+{{%- if product == 'rhel7' %}}
+    <filter action="exclude">state_accounts_users_home_files_groupownership_nfsnobody</filter>
+{{%- endif %}}
   </unix:password_object>
 
   <unix:password_state id="state_accounts_users_home_files_groupownership_interactive_gids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:user_id>
   </unix:password_state>
+
+{{%- if product == 'rhel7' %}}
+  <unix:password_state id="state_accounts_users_home_files_groupownership_nfsnobody" version="1">
+    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  </unix:password_state>
+{{%- endif %}}
 
   <local_variable id="var_accounts_users_home_files_groupownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
@@ -10,11 +10,20 @@
   <unix:password_object id="object_accounts_users_home_files_ownership_objects" version="1">
     <unix:username datatype="string" operation="not equal">nobody</unix:username>
     <filter action="include">state_accounts_users_home_files_ownership_interactive_uids</filter>
+{{%- if product == 'rhel7' %}}
+    <filter action="exclude">state_accounts_users_home_files_ownership_nfsnobody</filter>
+{{%- endif %}}
   </unix:password_object>
 
   <unix:password_state id="state_accounts_users_home_files_ownership_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
+
+{{%- if product == 'rhel7' %}}
+  <unix:password_state id="state_accounts_users_home_files_ownership_nfsnobody" version="1">
+    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  </unix:password_state>
+{{%- endif %}}
 
   <local_variable id="var_accounts_users_home_files_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
@@ -12,11 +12,20 @@
   <unix:password_object id="object_accounts_users_home_files_permissions_objects" version="1">
     <unix:username datatype="string" operation="not equal">nobody</unix:username>
     <filter action="include">state_accounts_users_home_files_permissions_interactive_uids</filter>
+{{%- if product == 'rhel7' %}}
+    <filter action="exclude">state_accounts_users_home_files_permissions_nfsnobody</filter>
+{{%- endif %}}
   </unix:password_object>
 
   <unix:password_state id="state_accounts_users_home_files_permissions_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
+
+{{%- if product == 'rhel7' %}}
+  <unix:password_state id="state_accounts_users_home_files_permissions_nfsnobody" version="1">
+    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  </unix:password_state>
+{{%- endif %}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_accounts_users_home_files_permissions_dirs" datatype="string" version="1"


### PR DESCRIPTION
#### Description:

- Adds a filter to exclude the user `nfsnobody` on RHEL7 systems.

#### Rationale:

- Although we already exclude the user with username 'nobody', in some systems (RHEL7) the user 'nobody' has UID 99, and the user 'nfsnobody' has UID 65534.

- Fixes #8352

Interesting reference: https://fedoraproject.org/wiki/Changes/RenameNobodyUser