### PR TITLE
Update SRG-OS-000112-GPOS-00057 for RHEL9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000112-GPOS-00057.yml
+++ b/controls/stig_rhel9/SRG-OS-000112-GPOS-00057.yml
@@ -2,6 +2,17 @@ controls:
     -   id: SRG-OS-000112-GPOS-00057
         levels:
             - medium
-        title: The operating system must implement replay-resistant authentication mechanisms
+        title: {{{ full_name }}} must implement replay-resistant authentication mechanisms
             for network access to privileged accounts.
-        status: pending
+        status: inherently met
+        check: |-
+            {{{ full_name }}} supports this requirement and cannot be configured to be out of compliance.
+            {{{ full_name }}} inherently meets this requirement.
+        fix: |-
+            {{{ full_name }}} inherently meets this requirement.
+            No fix is required.
+        artifact_description: |-
+            The release notes of OpenSSH 7.6 states "OpenSSH is a 100% complete SSH protocol 2.0 implementation and includes sftp client and server support."
+            https://www.openssh.com/txt/release-7.6
+        status_justification:
+            The OpenSSH package in {{{ full_name }}} is version 8.7, which is newer than 7.6 which only supports SSH protocol 2.0 which is restraint to replay attacks.


### PR DESCRIPTION
#### Description:

Moving to inherently met since the default version is 8.7

#### Rationale:

RHEL 9 STIG. 

This PR will need some extra care when reviewing.
