### PR TITLE
Update SRG-OS-000122-GPOS-00063 for RHEL9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000122-GPOS-00063.yml
+++ b/controls/stig_rhel9/SRG-OS-000122-GPOS-00063.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000122-GPOS-00063
         levels:
             - medium
-        title: The operating system must provide an audit reduction capability that supports
+        title: {{{ full_name }}} must provide an audit reduction capability that supports
             on-demand reporting requirements.
         rules:
             - package_audit_installed


### PR DESCRIPTION
#### Description:
Update SRG-OS-000122-GPOS-00063 for RHEL9 STIG

#### Rationale:
RHEL 9 STIG. The rule have been already updated by other PRs.
