### PR TITLE
Use UID field for bash remediation of homedirs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/bash/shared.sh
@@ -4,6 +4,6 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($4 >= {{{ uid_min }}} && $4 != 65534) print $1}' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $1}' /etc/passwd); do
     mkhomedir_helper $user 0077;
 done


### PR DESCRIPTION
Per documentation, /etc/passwd has the first field as the username, the
second field as the password, the third as UID, and the fourth as GID.
The existing bash remediation used the fourth field (GID) as the UID_MIN
check, which while likely nominally functional, isn't necessarily
correct. Instead, the third field (UID) should be used for comparison.

See also: https://docs.oracle.com/cd/E86824_01/html/E54775/passwd-4.html

```
Signed-off-by: Alexander Scheel <alex.scheel@hashicorp.com>
```