### PR TITLE
Fix docs build

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ commonmark
 recommonmark>=0.6.0
 sphinx
 sphinx-rtd-theme
-git+git://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain
+git+https://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain


### PR DESCRIPTION
#### Description:
Use https for git in doc requirements 

#### Rationale:

pip no longer supports `git+git`.
