### PR TITLE
File owners, groupowners, permissions should be able to recurse and file_regex

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -259,6 +259,8 @@
 
     -   **filepath** - File path to be checked. If the file path ends
         with `/` it describes a directory. Can also be a list of paths.
+        If **file_regex** is not specified, the rule will only check
+        and remediate directories.
 
     -   **filepath_is_regex** - If set to `"true"` the OVAL will
         consider the value of **filepath** as a regular expression.
@@ -294,6 +296,8 @@ they must be of the same length.
 
     -   **filepath** - File path to be checked. If the file path ends
         with `/` it describes a directory. Can also be a list of paths.
+        If **file_regex** is not specified, the rule will only check
+        and remediate directories.
 
     -   **filepath_is_regex** - If set to `"true"` the OVAL will
         consider the value of **filepath** as a regular expression.
@@ -329,6 +333,8 @@ they must be of the same length.
 
     -   **filepath** - File path to be checked. If the file path ends
         with `/` it describes a directory. Can also be a list of paths.
+        If **file_regex** is not specified, the rule will only check
+        and remediate directories.
 
     -   **filepath_is_regex** - If set to `"true"` the OVAL will
         consider the value of **filepath** as a regular expression.

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/rule.yml
@@ -69,5 +69,6 @@ template:
             - /lib64/
             - /usr/lib/
             - /usr/lib64/
+        recursive: 'true'
         file_regex: ^.*$
         fileuid: '0'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+
+useradd user_test
+
+TESTDIR="/usr/lib/dir/"
+
+mkdir $TESTDIR
+touch $TESTDIR/test_me
+chown user_test $TESTDIR/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_symlink.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_symlink.fail.sh
@@ -1,0 +1,16 @@
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+
+useradd user_test
+
+TESTDIR="/usr/lib/"
+
+# The remediation performs a 'find' followed by a 'chwon'
+# While 'find' doesn't follow symlinks by default, 'chown' does follow,
+# so 'chown' will try to change owner of a non existent file while 'find'
+# pointed out that the symlink has wrong owner.
+ln -s $TESTDIR/mising_test_file $TESTDIR/faulty_symlink
+chown -h user_test $TESTDIR/faulty_symlink
+
+# The Check ignores symlink, so we need to put a reason to run the remediations
+touch $TESTDIR/test_me
+chown user_test $TESTDIR/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -70,5 +70,6 @@ template:
             - /lib64/
             - /usr/lib/
             - /usr/lib64/
+        recursive: 'true'
         file_regex: ^.*$
         filemode: '0755'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
@@ -2,6 +2,5 @@
 
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
-    find "$dirPath" -type d -exec chmod go-w '{}' \;
     find "$dirPath" -type f -exec chmod go+w '{}' \;
 done

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -5,13 +5,18 @@
 # disruption = low
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if IS_DIRECTORY %}}
+{{% if FILE_REGEX %}}
 
-- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
+
   find:
     paths: "{{{ path }}}"
     patterns: {{{ FILE_REGEX[loop.index0] }}}
     use_regex: yes
+{{% if RECURSIVE %}}
+    recurse: yes
+{{% endif %}}
     hidden: yes
   register: files_found
 
@@ -22,15 +27,18 @@
   with_items:
     - "{{ files_found.files }}"
 
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% else %}}
 
-- name: Ensure group owner on {{{ path }}} recursively
+- name: Ensure group owner on {{{ path }}}{{% if RECURSIVE %}} recursively{{% endif %}}
   file:
     path: "{{{ path }}}"
     state: directory
+{{% if RECURSIVE %}}
     recurse: yes
+{{% endif %}}
     group: "{{{ FILEGID }}}"
 
+{{% endif %}}
 {{% else %}}
 
 - name: Test for existence {{{ path }}}

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -24,6 +24,7 @@
   file:
     path: "{{ item.path }}"
     group: "{{{ FILEGID }}}"
+  when: item.gid != {{{ FILEGID }}}
   with_items:
     - "{{ files_found.files }}"
 

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -9,7 +9,7 @@
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chgrp {{{ FILEGID }}} "$file"
+        chgrp -h {{{ FILEGID }}} "$file"
     fi
 done
 {{% elif IS_DIRECTORY and RECURSIVE %}}

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -4,17 +4,25 @@
 # complexity = low
 # disruption = low
 
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
+
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}} ! -gid {{{ FILEGID }}})
+{{%- if IS_DIRECTORY %}}
+{{%- if FILE_REGEX %}}
+readarray -t files < <(find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} ! -gid {{{ FILEGID }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
         chgrp -h {{{ FILEGID }}} "$file"
     fi
 done
-{{% elif IS_DIRECTORY and RECURSIVE %}}
-find -L {{{ path }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
 {{% else %}}
+find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
+{{%- endif %}}
+{{%- else %}}
 chgrp {{{ FILEGID }}} {{{ path }}}
-{{% endif %}}
+{{%- endif %}}
 {{% endfor %}}

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -6,7 +6,7 @@
 
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}})
+readarray -t files < <(find {{{ path }}} ! -gid {{{ FILEGID }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
         chgrp -h {{{ FILEGID }}} "$file"

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -9,7 +9,7 @@
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chgrp {{{ FILEGID }}} $file
+        chgrp {{{ FILEGID }}} "$file"
     fi
 done
 {{% elif IS_DIRECTORY and RECURSIVE %}}

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -33,7 +33,7 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       {{%- if RECURSIVE %}}
-      <unix:path operation="pattern match">{{{ filepath[:-1] }}}</unix:path>
+      <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
       {{%- else %}}
       <unix:path>{{{ filepath[:-1] }}}</unix:path>
       {{%- endif %}}

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -32,14 +32,14 @@
   </unix:file_state>
   <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
-      {{%- if FILE_REGEX %}}
-      <unix:path>{{{ filepath[:-1] }}}</unix:path>
-      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
-      {{%- elif RECURSIVE %}}
+      {{%- if RECURSIVE %}}
       <unix:path operation="pattern match">{{{ filepath[:-1] }}}</unix:path>
-      <unix:filename xsi:nil="true" />
       {{%- else %}}
       <unix:path>{{{ filepath[:-1] }}}</unix:path>
+      {{%- endif %}}
+      {{%- if FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
+      {{%- else %}}
       <unix:filename xsi:nil="true" />
       {{%- endif %}}
     {{%- else %}}

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -24,6 +24,7 @@
   file:
     path: "{{ item.path }}"
     owner: "{{{ FILEUID }}}"
+  when: item.uid != {{{ FILEUID }}}
   with_items:
     - "{{ files_found.files }}"
 

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -5,32 +5,40 @@
 # disruption = low
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if IS_DIRECTORY %}}
+{{% if FILE_REGEX %}}
 
-- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
+
   find:
     paths: "{{{ path }}}"
     patterns: {{{ FILE_REGEX[loop.index0] }}}
     use_regex: yes
+{{% if RECURSIVE %}}
+    recurse: yes
+{{% endif %}}
     hidden: yes
   register: files_found
 
-- name: Ensure group owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
+- name: Ensure owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
   file:
     path: "{{ item.path }}"
     owner: "{{{ FILEUID }}}"
   with_items:
     - "{{ files_found.files }}"
 
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% else %}}
 
-- name: Ensure owner on {{{ path }}} recursively
+- name: Ensure owner on directory {{{ path }}}{{% if RECURSIVE %}} recursively{{% endif %}}
   file:
     path: "{{{ path }}}"
     state: directory
+{{% if RECURSIVE %}}
     recurse: yes
+{{% endif %}}
     owner: "{{{ FILEUID }}}"
 
+{{% endif %}}
 {{% else %}}
 
 - name: Test for existence {{{ path }}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -4,17 +4,25 @@
 # complexity = low
 # disruption = low
 
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
+
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}} ! -uid {{{ FILEUID }}})
+{{%- if IS_DIRECTORY %}}
+{{%- if FILE_REGEX %}}
+readarray -t files < <(find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} ! -uid {{{ FILEUID }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
         chown -h {{{ FILEUID }}} "$file"
     fi
 done
-{{% elif IS_DIRECTORY and RECURSIVE %}}
-find -L {{{ path }}} -type d -exec chown {{{ FILEUID }}} {} \;
-{{% else %}}
+{{%- else %}}
+find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown {{{ FILEUID }}} {} \;
+{{%- endif %}}
+{{%- else %}}
 chown {{{ FILEUID }}} {{{ path }}}
-{{% endif %}}
+{{%- endif %}}
 {{% endfor %}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -9,7 +9,7 @@
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chown {{{ FILEUID }}} $file
+        chown {{{ FILEUID }}} "$file"
     fi
 done
 {{% elif IS_DIRECTORY and RECURSIVE %}}

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -6,7 +6,7 @@
 
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}})
+readarray -t files < <(find {{{ path }}} ! -uid {{{ FILEUID }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
         chown -h {{{ FILEUID }}} "$file"

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -9,7 +9,7 @@
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chown {{{ FILEUID }}} "$file"
+        chown -h {{{ FILEUID }}} "$file"
     fi
 done
 {{% elif IS_DIRECTORY and RECURSIVE %}}

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -31,14 +31,14 @@
   </unix:file_state>
   <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
-      {{%- if FILE_REGEX %}}
-      <unix:path>{{{ filepath[:-1] }}}</unix:path>
-      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
-      {{%- elif RECURSIVE %}}
+      {{%- if RECURSIVE %}}
       <unix:path operation="pattern match">{{{ filepath[:-1] }}}</unix:path>
-      <unix:filename xsi:nil="true" />
       {{%- else %}}
       <unix:path>{{{ filepath[:-1] }}}</unix:path>
+      {{%- endif %}}
+      {{%- if FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
+      {{%- else %}}
       <unix:filename xsi:nil="true" />
       {{%- endif %}}
     {{%- else %}}

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -32,7 +32,7 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       {{%- if RECURSIVE %}}
-      <unix:path operation="pattern match">{{{ filepath[:-1] }}}</unix:path>
+      <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
       {{%- else %}}
       <unix:path>{{{ filepath[:-1] }}}</unix:path>
       {{%- endif %}}

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -24,6 +24,7 @@
   file:
     path: "{{ item.path }}"
     mode: "{{{ FILEMODE }}}"
+  when: item.mode != {{{ FILEMODE}}}
   with_items:
     - "{{ files_found.files }}"
 

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -5,13 +5,18 @@
 # disruption = low
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if IS_DIRECTORY %}}
+{{% if FILE_REGEX %}}
 
-- name: Find {{{ path }}} file(s)
+- name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
+
   find:
     paths: "{{{ path }}}"
     patterns: {{{ FILE_REGEX[loop.index0] }}}
     use_regex: yes
+{{% if RECURSIVE %}}
+    recurse: yes
+{{% endif %}}
     hidden: yes
   register: files_found
 
@@ -22,15 +27,18 @@
   with_items:
     - "{{ files_found.files }}"
 
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% else %}}
 
-- name: Set permissions for {{{ path }}} recursively
+- name: Set permissions for {{{ path }}}{{% if RECURSIVE %}} recursively{{% endif %}}
   file:
     path: "{{{ path }}}"
     state: directory
+{{% if RECURSIVE %}}
     recurse: yes
+{{% endif %}}
     mode: "{{{ FILEMODE }}}"
 
+{{% endif %}}
 {{% else %}}
 
 - name: Test for existence {{{ path }}}

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -24,7 +24,7 @@
   file:
     path: "{{ item.path }}"
     mode: "{{{ FILEMODE }}}"
-  when: item.mode != {{{ FILEMODE}}}
+  when: item.mode != '{{{ FILEMODE}}}'
   with_items:
     - "{{ files_found.files }}"
 

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -9,7 +9,7 @@
 readarray -t files < <(find {{{ path }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chmod {{{ FILEMODE }}} $file
+        chmod {{{ FILEMODE }}} "$file"
     fi    
 done
 {{% elif IS_DIRECTORY and RECURSIVE %}}

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -4,17 +4,25 @@
 # complexity = low
 # disruption = low
 
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
+
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}})
+{{%- if IS_DIRECTORY %}}
+{{%- if FILE_REGEX %}}
+readarray -t files < <(find {{{ path }}} {{{ FIND_RECURSE_ARGS }}})
 for file in "${files[@]}"; do
     if basename $file | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
         chmod {{{ FILEMODE }}} "$file"
     fi    
 done
-{{% elif IS_DIRECTORY and RECURSIVE %}}
-find -L {{{ path }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
-{{% else %}}
+{{%- else %}}
+find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
+{{%- endif %}}
+{{%- else %}}
 chmod {{{ FILEMODE }}} {{{ path }}}
-{{% endif %}}
+{{%- endif %}}
 {{% endfor %}}

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -46,7 +46,7 @@
 
     {{%- if IS_DIRECTORY %}}
       {{%- if RECURSIVE %}}
-      <unix:path operation="pattern match">{{{ filepath[:-1] }}}</unix:path>
+      <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
       {{%- else %}}
       <unix:path>{{{ filepath[:-1] }}}</unix:path>
       {{%- endif %}}

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -45,14 +45,14 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
 
     {{%- if IS_DIRECTORY %}}
-      {{%- if FILE_REGEX %}}
-      <unix:path>{{{ filepath[:-1] }}}</unix:path>
-      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
-      {{%- elif RECURSIVE %}}
+      {{%- if RECURSIVE %}}
       <unix:path operation="pattern match">{{{ filepath[:-1] }}}</unix:path>
-      <unix:filename xsi:nil="true" />
       {{%- else %}}
       <unix:path>{{{ filepath[:-1] }}}</unix:path>
+      {{%- endif %}}
+      {{%- if FILE_REGEX %}}
+      <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
+      {{%- else %}}
       <unix:filename xsi:nil="true" />
       {{%- endif %}}
     {{%- else %}}


### PR DESCRIPTION
#### Description:

- Rules `file_ownership_library_dirs` and `file_permissions_library_dirs` should recurse and check files down in the tree.
  The rules were only checking the first level of directory.
- Fix handling of symlinks in the remdiation.
  Now it doesn't try to de-reference the symlink, and remediation changes ownership of the symlink.
- Fix handling of files with spaces.

#### Rationale:

- `recurse` and `file_regex` are not mutually exclusive.
- Fixes #8303


#### Notes
- This was found because in RHEL7, the first level of `/lib' doesn't have any file, only directories:
```
[root@localhost ~]# ls /lib
binfmt.d  debug  dracut  firewalld  firmware  games  grub  kbd  kde3  kde4  kdump  kernel  locale  modprobe.d  modules  modules-load.d  NetworkManager  polkit-1  python2.7  rpm  sendmail  sendmail.postfix  sse2  sysctl.d  systemd  tmpfiles.d  tuned  udev  yum-plugins
```