### PR TITLE
Update SRG-OS-000480-GPOS-00229 for RHEL9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000480-GPOS-00229.yml
+++ b/controls/stig_rhel9/SRG-OS-000480-GPOS-00229.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000480-GPOS-00229
         levels:
             - medium
-        title: The operating system must not allow an unattended or automatic logon to the
+        title: {{{ full_name }}} must not allow an unattended or automatic logon to the
             system.
         rules:
             - disable_host_auth

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
@@ -55,6 +55,9 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="yes", option="HostbasedAuthentication", value="no") }}}
 
+fix: |-
+    {{{ sshd_lineinfile_fix("HostbasedAuthentication", "no") }}}
+
 template:
     name: sshd_lineinfile
     vars:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
@@ -61,6 +61,9 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="yes", option="PermitEmptyPasswords", value="no") }}}
 
+fix: |-
+    {{{ sshd_lineinfile_fix("PermitEmptyPasswords", "no") }}}
+
 template:
     name: sshd_lineinfile
     vars:

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -55,6 +55,9 @@ references:
 
 {{{ complete_ocil_entry_sshd_option(default="yes", option="PermitUserEnvironment", value="no") }}}
 
+fix: |-
+    {{{ sshd_lineinfile_fix("PermitUserEnvironment", "no") }}}
+
 template:
     name: sshd_lineinfile
     vars:

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_automatic_login/rule.yml
@@ -50,4 +50,7 @@ ocil: |-
     <pre>[daemon]
     AutomaticLoginEnable=false</pre>
 
+fix: |-
+    {{{ dconf_ini_file_fix("daemon", "AutomaticLoginEnable", "false") }}}
+
 platform: machine


### PR DESCRIPTION
#### Description:

* Add fix to sshd_do_not_permit_user_env
* Add fix text to sshd_disable_empty_passwords
* Add to fix disable_host_auth
* Update SRG-OS-000480-GPOS-00229 for RHEL9 STIG

#### Rationale:

RHEL9 STIG