### PR TITLE
Add sudoers_default_includedir rule support to SLE12 and SLE15 platforms

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/ansible/shared.yml
@@ -13,7 +13,7 @@
     contains: '^#include(dir)?\s.*$'
   register: sudoers_d_includes
 
-- name: "Remove found occurrences of file and directory inclues from /etc/sudoers.d/* files"
+- name: "Remove found occurrences of file and directory includes from /etc/sudoers.d/* files"
   lineinfile:
     path: "{{ item.path }}"
     regexp: '^#include(dir)?\s.*$'

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Ensure sudo only includes the default configuration directory'
 
@@ -24,6 +24,8 @@ identifiers:
     cce@rhel7: CCE-86277-1
     cce@rhel8: CCE-86377-9
     cce@rhel9: CCE-86477-7
+    cce@sle12: CCE-83255-0
+    cce@sle15: CCE-91151-1
 
 references:
     disa: CCI-000366
@@ -31,6 +33,8 @@ references:
     stigid@ol7: OL07-00-010339
     stigid@rhel7: RHEL-07-010339
     stigid@rhel8: RHEL-08-010379
+    stigid@sle12: SLES-12-010109
+    stigid@sle15: SLES-15-020099
 
 ocil_clause: "the /etc/sudoers doesn't include /etc/sudores.d or includes other directories?"
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -266,6 +266,7 @@ selections:
     - sudo_remove_nopasswd
     - sudo_require_reauthentication
     - sudo_restrict_privilege_elevation_to_authorized
+    - sudoers_default_includedir
     - sudoers_validate_passwd
     - susefirewall2_ddos_protection
     - susefirewall2_only_required_services

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -268,6 +268,7 @@ selections:
     - sudo_restrict_privilege_elevation_to_authorized
     - sudo_require_authentication
     - sudo_require_reauthentication
+    - sudoers_default_includedir
     - sudoers_validate_passwd
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_randomize_va_space


### PR DESCRIPTION
#### Description:

- Add sudoers_default_includedir rule support to SLE12 and SLE15 platforms

#### Rationale:

- Map DISA STIG definitions SLES-12-010109, SLES-15-020099 to the rule 'Ensure sudo only includes the default configuration directory' rule
- Fixed small typo in ansible rule description
