### PR TITLE
SUSE Group init_module and finit_module audit rules.

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -54,8 +54,8 @@ references:
     stigid@ol8: OL08-00-030360
     stigid@rhel7: RHEL-07-030820
     stigid@rhel8: RHEL-08-030360
-    stigid@sle12: SLES-12-020750
-    stigid@sle15: SLES-15-030540
+    stigid@sle12: SLES-12-020740
+    stigid@sle15: SLES-15-030530
     stigid@ubuntu2004: UBTU-20-010179
     vmmsrg: SRG-OS-000477-VMM-001970
 


### PR DESCRIPTION


#### Description:

- init_module and finit_module now have the same STIG id according to latest DISA STIG release
