### PR TITLE
Group chown syscall audit rules under same STIG ID dor SLE12 and SLE15

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
@@ -62,8 +62,8 @@ references:
     stigid@ol8: OL08-00-030520
     stigid@rhel7: RHEL-07-030370
     stigid@rhel8: RHEL-08-030480
-    stigid@sle12: SLES-12-020430
-    stigid@sle15: SLES-15-030260
+    stigid@sle12: SLES-12-020420
+    stigid@sle15: SLES-15-030250
     stigid@ubuntu2004: UBTU-20-010149
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
@@ -59,8 +59,8 @@ references:
     stigid@ol8: OL08-00-030510
     stigid@rhel7: RHEL-07-030370
     stigid@rhel8: RHEL-08-030480
-    stigid@sle12: SLES-12-020450
-    stigid@sle15: SLES-15-030280
+    stigid@sle12: SLES-12-020420
+    stigid@sle15: SLES-15-030250
     stigid@ubuntu2004: UBTU-20-010150
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -59,8 +59,8 @@ references:
     stigid@ol8: OL08-00-030500
     stigid@rhel7: RHEL-07-030370
     stigid@rhel8: RHEL-08-030480
-    stigid@sle12: SLES-12-020440
-    stigid@sle15: SLES-15-030270
+    stigid@sle12: SLES-12-020420
+    stigid@sle15: SLES-15-030250
     stigid@ubuntu2004: UBTU-20-010151
     vmmsrg: SRG-OS-000458-VMM-001810,SRG-OS-000474-VMM-001940
 


### PR DESCRIPTION
#### Description:

- Group chown, fchown, lchown syscall audit rules under same STIG ID dor SLE12 and SLE15
