### PR TITLE
Update RHEL9 auxiliary gpg key to auxiliary key 3

### DIFF
--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -22,11 +22,11 @@ dconf_gdm_dir: "distro.d"
 # The fingerprints below are retrieved from https://access.redhat.com/security/team/key
 pkg_release: "4ae0493b"
 pkg_version: "fd431d51"
-aux_pkg_release: "5b32db75"
-aux_pkg_version: "d4082792"
+aux_pkg_release: "6229229e"
+aux_pkg_version: "5a6340b3"
 
 release_key_fingerprint: "567E347AD0044ADE55BA8A5F199E2F91FD431D51"
-auxiliary_key_fingerprint: "6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792"
+auxiliary_key_fingerprint: "7E4624258C406535D56D6F135054E4A45A6340B3"
 oval_feed_url: "https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml.bz2"
 
 cpes_root: "../../shared/applicability"


### PR DESCRIPTION


#### Description:
- Update RHEL9 auxiliary gpg key to auxiliary key 3.
  - Key fingerprint: DA7F68E3872D6E7BDCE05225E7EB5F3ACDD9699F
