### PR TITLE
Update SRG-OS-000031-GPOS-00012 for RHEL9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000031-GPOS-00012.yml
+++ b/controls/stig_rhel9/SRG-OS-000031-GPOS-00012.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000031-GPOS-00012
         levels:
             - medium
-        title: The operating system must conceal, via the session lock, information previously
+        title: {{{ full_name }}} must conceal, via the session lock, information previously
             visible on the display with a publicly viewable image.
         rules:
             - configure_bashrc_exec_tmux

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -81,4 +81,8 @@ ocil: |-
     <pre>$ grep picture-uri /etc/dconf/db/local.d/locks/*</pre>
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/picture-uri</tt>
 
+fix: |-
+    {{{ dconf_ini_file_fix("org/gnome/desktop/screensaver", "picture-uri", "''") }}}
+
+
 platform: machine


### PR DESCRIPTION
#### Description:
- Update SRG-OS-000031-GPOS-00012 for RHEL9 STIG
- Add fix text to dconf_gnome_screensaver_mode_blank

#### Rationale:

RHEL9 STIG
