### PR TITLE
Ansible: When 'file_regex` is set, only operate on files

### DIFF
--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -24,6 +24,7 @@
   file:
     path: "{{ item.path }}"
     group: "{{{ FILEGID }}}"
+    state: file
   when: item.gid != {{{ FILEGID }}}
   with_items:
     - "{{ files_found.files }}"

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -24,6 +24,7 @@
   file:
     path: "{{ item.path }}"
     owner: "{{{ FILEUID }}}"
+    state: file
   when: item.uid != {{{ FILEUID }}}
   with_items:
     - "{{ files_found.files }}"

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -24,6 +24,7 @@
   file:
     path: "{{ item.path }}"
     mode: "{{{ FILEMODE }}}"
+    state: file
   when: item.mode != '{{{ FILEMODE}}}'
   with_items:
     - "{{ files_found.files }}"


### PR DESCRIPTION
#### Description:

- In templates `file_owner`, file_groupwoner` and  `file_permissions` ensure that the Ansible task acts on regular files when `file_regex` is set.
  The task fails when trying to change hardlinks.

`failed: [rhel9] (item={'path': '/lib/locale/en_AG/LC_COLLATE', 'mode': '0644', 'isdir': False, 'ischr': False, 'isblk': False, 'isreg': True, 'isfifo': False, 'islnk': False, 'issock': False, 'uid': 0, 'gid': 0, 'size': 2586930, 'inode': 33735145, 'dev': 64768, 'nlink': 18, 'atime': 1648146988.540588, 'mtime':1633112517.0, 'ctime': 1637841862.7420955, 'gr_name': 'root', 'pw_name': 'root', 'wusr': True, 'rusr': True, 'xusr': False, 'wgrp': False, 'rgrp': True, 'xgrp': False, 'woth': False, 'roth': True, 'xoth': False, 'isuid': False, 'isgid': False}) => {"ansible_loop_var": "item", "changed": false, "item": {"atime": 1648146988.540588, "ctime": 1637841862.7420955, "dev": 64768, "gid": 0, "gr_name": "root", "inode": 33735145, "isblk": false, "ischr": false, "isdir": false, "isfifo": false, "isgid": false, "islnk": false, "isreg": true, "issock": false, "isuid": false, "mode": "0644", "mtime": 1633112517.0, "nlink": 18, "path": "/lib/locale/en_AG/LC_COLLATE", "pw_name": "root", "rgrp": true, "roth": true, "rusr": true, "size": 2586930, "uid": 0, "wgrp": false, "woth": false, "wusr": true, "xgrp": false, "xoth": false, "xusr": false}, "msg": "src is required for creating new hardlinks"}`
- This adds `state: file` so that the task acts on regular files.

#### Rationale:

- When rule `file_permissions_library_dirs' travels down `/lib` it finds hardlinks that cause the Ansible task to fail.
  The task should act on the actual file, not the hardlink, so lets skip the hardlinks.
```
[root@localhost ~]# ls -i /lib/locale/en_AG/LC_COLLATE
33735145 /lib/locale/en_AG/LC_COLLATE

[root@localhost ~]# 
[root@localhost ~]# find / -inum 33735145
/usr/lib/locale/en_AG/LC_COLLATE
/usr/lib/locale/en_AU.utf8/LC_COLLATE
/usr/lib/locale/en_BW.utf8/LC_COLLATE
/usr/lib/locale/en_DK.utf8/LC_COLLATE
/usr/lib/locale/en_GB.utf8/LC_COLLATE
/usr/lib/locale/en_HK.utf8/LC_COLLATE
/usr/lib/locale/en_IE.utf8/LC_COLLATE
/usr/lib/locale/en_IL/LC_COLLATE
/usr/lib/locale/en_IN/LC_COLLATE
/usr/lib/locale/en_NG/LC_COLLATE
/usr/lib/locale/en_NZ.utf8/LC_COLLATE
/usr/lib/locale/en_PH.utf8/LC_COLLATE
/usr/lib/locale/en_SC.utf8/LC_COLLATE
/usr/lib/locale/en_SG.utf8/LC_COLLATE
/usr/lib/locale/en_US.utf8/LC_COLLATE
/usr/lib/locale/en_ZA.utf8/LC_COLLATE
/usr/lib/locale/en_ZM/LC_COLLATE
/usr/lib/locale/en_ZW.utf8/LC_COLLATE
```
