### PR TITLE
Exclude user `nfsnobody` when checking home directories

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
@@ -8,22 +8,18 @@
   </definition>
 
   <unix:password_object id="object_accounts_users_home_files_groupownership_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
     <filter action="include">state_accounts_users_home_files_groupownership_interactive_gids</filter>
-{{%- if product == 'rhel7' %}}
-    <filter action="exclude">state_accounts_users_home_files_groupownership_nfsnobody</filter>
-{{%- endif %}}
+    <filter action="exclude">state_accounts_users_home_files_groupownership_user_list</filter>
   </unix:password_object>
 
   <unix:password_state id="state_accounts_users_home_files_groupownership_interactive_gids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:user_id>
   </unix:password_state>
 
-{{%- if product == 'rhel7' %}}
-  <unix:password_state id="state_accounts_users_home_files_groupownership_nfsnobody" version="1">
-    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  <unix:password_state id="state_accounts_users_home_files_groupownership_user_list" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
   </unix:password_state>
-{{%- endif %}}
 
   <local_variable id="var_accounts_users_home_files_groupownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
@@ -8,22 +8,18 @@
   </definition>
 
   <unix:password_object id="object_accounts_users_home_files_ownership_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
     <filter action="include">state_accounts_users_home_files_ownership_interactive_uids</filter>
-{{%- if product == 'rhel7' %}}
-    <filter action="exclude">state_accounts_users_home_files_ownership_nfsnobody</filter>
-{{%- endif %}}
+    <filter action="exclude">state_accounts_users_home_files_ownership_user_list</filter>
   </unix:password_object>
 
   <unix:password_state id="state_accounts_users_home_files_ownership_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
 
-{{%- if product == 'rhel7' %}}
-  <unix:password_state id="state_accounts_users_home_files_ownership_nfsnobody" version="1">
-    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  <unix:password_state id="state_accounts_users_home_files_ownership_user_list" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
   </unix:password_state>
-{{%- endif %}}
 
   <local_variable id="var_accounts_users_home_files_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
@@ -10,22 +10,18 @@
   <!-- For detailed comments about logic used in this OVAL, check the
        "file_ownership_home_directories" rule. -->
   <unix:password_object id="object_accounts_users_home_files_permissions_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
     <filter action="include">state_accounts_users_home_files_permissions_interactive_uids</filter>
-{{%- if product == 'rhel7' %}}
-    <filter action="exclude">state_accounts_users_home_files_permissions_nfsnobody</filter>
-{{%- endif %}}
+    <filter action="exclude">state_accounts_users_home_files_permissions_user_list</filter>
   </unix:password_object>
 
   <unix:password_state id="state_accounts_users_home_files_permissions_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
 
-{{%- if product == 'rhel7' %}}
-  <unix:password_state id="state_accounts_users_home_files_permissions_nfsnobody" version="1">
-    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  <unix:password_state id="state_accounts_users_home_files_permissions_user_list" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
   </unix:password_state>
-{{%- endif %}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_accounts_users_home_files_permissions_dirs" datatype="string" version="1"

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
@@ -14,11 +14,20 @@
   <unix:password_object id="object_file_groupownership_home_directories_objects" version="1">
     <unix:username datatype="string" operation="not equal">nobody</unix:username>
     <filter action="include">state_file_groupownership_home_directories_interactive_gids</filter>
+  {{%- if product == 'rhel7' %}}
+    <filter action="exclude">state_file_permissions_groupownership_nfsnobody</filter>
+  {{%- endif %}}
   </unix:password_object>
 
   <unix:password_state id="state_file_groupownership_home_directories_interactive_gids" version="1">
     <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
   </unix:password_state>
+
+{{%- if product == 'rhel7' %}}
+  <unix:password_state id="state_file_permissions_groupownership_nfsnobody" version="1">
+    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  </unix:password_state>
+{{%- endif %}}
 
   <!-- #### prepare for test_file_groupownership_home_directories #### -->
   <local_variable id="var_file_groupownership_home_directories_dirs" datatype="string" version="1"

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
@@ -12,22 +12,18 @@
   <!-- For detailed comments about logic used in this OVAL, check the
        "file_ownership_home_directories" rule. -->
   <unix:password_object id="object_file_groupownership_home_directories_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
     <filter action="include">state_file_groupownership_home_directories_interactive_gids</filter>
-  {{%- if product == 'rhel7' %}}
-    <filter action="exclude">state_file_permissions_groupownership_nfsnobody</filter>
-  {{%- endif %}}
+    <filter action="exclude">state_file_permissions_groupownership_user_list</filter>
   </unix:password_object>
 
   <unix:password_state id="state_file_groupownership_home_directories_interactive_gids" version="1">
     <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
   </unix:password_state>
 
-{{%- if product == 'rhel7' %}}
-  <unix:password_state id="state_file_permissions_groupownership_nfsnobody" version="1">
-    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  <unix:password_state id="state_file_permissions_groupownership_user_list" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
   </unix:password_state>
-{{%- endif %}}
 
   <!-- #### prepare for test_file_groupownership_home_directories #### -->
   <local_variable id="var_file_groupownership_home_directories_dirs" datatype="string" version="1"

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
@@ -21,11 +21,9 @@
     create local variables composed by UIDs e Home Dirs.
   -->
   <unix:password_object id="object_file_ownership_home_directories_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
     <filter action="include">state_file_ownership_home_directories_interactive_uids</filter>
-  {{%- if product == 'rhel7' %}}
-    <filter action="exclude">state_file_ownership_home_directories_nfsnobody</filter>
-  {{%- endif %}}
+    <filter action="exclude">state_file_ownership_home_directories_user_list</filter>
   </unix:password_object>
 
   <!--
@@ -37,11 +35,9 @@
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
 
-{{%- if product == 'rhel7' %}}
-  <unix:password_state id="state_file_ownership_home_directories_nfsnobody" version="1">
-    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  <unix:password_state id="state_file_ownership_home_directories_user_list" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
   </unix:password_state>
-{{%- endif %}}
 
   <!-- 
     #### prepare for test_file_groupownership_home_directories ####

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
@@ -23,6 +23,9 @@
   <unix:password_object id="object_file_ownership_home_directories_objects" version="1">
     <unix:username datatype="string" operation="not equal">nobody</unix:username>
     <filter action="include">state_file_ownership_home_directories_interactive_uids</filter>
+  {{%- if product == 'rhel7' %}}
+    <filter action="exclude">state_file_ownership_home_directories_nfsnobody</filter>
+  {{%- endif %}}
   </unix:password_object>
 
   <!--
@@ -33,6 +36,12 @@
   <unix:password_state id="state_file_ownership_home_directories_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
+
+{{%- if product == 'rhel7' %}}
+  <unix:password_state id="state_file_ownership_home_directories_nfsnobody" version="1">
+    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  </unix:password_state>
+{{%- endif %}}
 
   <!-- 
     #### prepare for test_file_groupownership_home_directories ####

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
@@ -12,11 +12,20 @@
   <unix:password_object id="object_file_permissions_home_directories_objects" version="1">
     <unix:username datatype="string" operation="not equal">nobody</unix:username>
     <filter action="include">state_file_permissions_home_directories_interactive_uids</filter>
+  {{%- if product == 'rhel7' %}}
+    <filter action="exclude">state_file_permissions_home_files_permissions_nfsnobody</filter>
+  {{%- endif %}}
   </unix:password_object>
 
   <unix:password_state id="state_file_permissions_home_directories_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
+
+{{%- if product == 'rhel7' %}}
+  <unix:password_state id="state_file_permissions_home_files_permissions_nfsnobody" version="1">
+    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  </unix:password_state>
+{{%- endif %}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_file_permissions_home_directories_dirs" datatype="string" version="1"

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
@@ -10,22 +10,18 @@
   <!-- For detailed comments about logic used in this OVAL, check the
        "file_ownership_home_directories" rule. -->
   <unix:password_object id="object_file_permissions_home_directories_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
     <filter action="include">state_file_permissions_home_directories_interactive_uids</filter>
-  {{%- if product == 'rhel7' %}}
-    <filter action="exclude">state_file_permissions_home_files_permissions_nfsnobody</filter>
-  {{%- endif %}}
+    <filter action="exclude">state_file_permissions_home_files_permissions_user_list</filter>
   </unix:password_object>
 
   <unix:password_state id="state_file_permissions_home_directories_interactive_uids" version="1">
     <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
   </unix:password_state>
 
-{{%- if product == 'rhel7' %}}
-  <unix:password_state id="state_file_permissions_home_files_permissions_nfsnobody" version="1">
-    <unix:username datatype="string" operation="equals">nfsnobody</unix:username>
+  <unix:password_state id="state_file_permissions_home_files_permissions_user_list" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
   </unix:password_state>
-{{%- endif %}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_file_permissions_home_directories_dirs" datatype="string" version="1"

--- a/shared/macros-oval.jinja
+++ b/shared/macros-oval.jinja
@@ -902,3 +902,12 @@
   {{%- endif %}}
 </def-group>
 {{%- endmacro %}}
+
+{{#
+  User list in form of regex that are excluded when checking user home directory permissions and ownerships.
+#}}
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set user_list="(nobody|nfsnobody)" %}}
+{{%- else %}}
+  {{%- set user_list="nobody" %}}
+{{%- endif %}}


### PR DESCRIPTION
#### Description:
Filter user `nfsnobody` on RHEL7 systems.

#### Rationale:
Similar to #8393 fix

Fixes #8419 

