### PR TITLE
Revert changes from OL8 STIG profile that cause conflict with master

### DIFF
--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -935,11 +935,9 @@ selections:
     - package_abrt_removed
     - package_abrt-addon-ccpp_removed
     - package_abrt-addon-kerneloops_removed
-    - package_python3-abrt-addon_removed
+    - package_abrt-addon-python_removed
     - package_abrt-cli_removed
     - package_abrt-plugin-sosreport_removed
-    - package_libreport-plugin-rhtsupport_removed
-    - package_libreport-plugin-logger_removed
 
     # OL08-00-040002
     - package_sendmail_removed


### PR DESCRIPTION
#### Description:

- Revert changes from OL8 STIG profile that cause conflict with master.
