### PR TITLE
Update grub2_password rule to be compliant with OL08-00-010150 & RHEL-08-010150

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("The grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
-      {{% if product == "ol8" %}}
+      {{% if product in ["ol8", "rhel8"] %}}
       <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
       {{% else %}}
       {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
@@ -17,11 +17,11 @@
       {{% endif %}}
     </criteria>
   </definition>
-  {{% if product != "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
   {{% endif %}}
 
-  {{% if product != "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_boot_path }}}/grub.cfg files." id="test_bootloader_superuser" version="2">
     <ind:object object_ref="object_bootloader_superuser" />
   </ind:textfilecontent54_test>
@@ -41,7 +41,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product != "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_boot_path }}}/grub.cfg" id="test_grub2_password_grubcfg" version="1">
     <ind:object object_ref="object_grub2_password_grubcfg" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
@@ -6,7 +6,6 @@
       {{% if product in ["ol8", "rhel8"] %}}
       <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
       {{% else %}}
-      {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
           <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
@@ -17,9 +16,6 @@
       {{% endif %}}
     </criteria>
   </definition>
-  {{% if product not in ["ol8", "rhel8"] %}}
-  {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
-  {{% endif %}}
 
   {{% if product not in ["ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_boot_path }}}/grub.cfg files." id="test_bootloader_superuser" version="2">

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
@@ -3,6 +3,9 @@
     {{{ oval_metadata("The grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
+      {{% if product == "ol8" %}}
+      <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
+      {{% else %}}
       {{{ oval_file_absent_criterion(grub2_boot_path + "/grub.cfg") }}}
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
@@ -11,11 +14,14 @@
         </criteria>
         <criterion comment="make sure a superuser is defined in {{{ grub2_boot_path }}}/grub.cfg" test_ref="test_bootloader_superuser"/>
       </criteria>
+      {{% endif %}}
     </criteria>
   </definition>
-
+  {{% if product != "ol8" %}}
   {{{ oval_file_absent(grub2_boot_path + "/grub.cfg") }}}
+  {{% endif %}}
 
+  {{% if product != "ol8" %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_boot_path }}}/grub.cfg files." id="test_bootloader_superuser" version="2">
     <ind:object object_ref="object_bootloader_superuser" />
   </ind:textfilecontent54_test>
@@ -24,6 +30,7 @@
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" id="test_grub2_password_usercfg" version="1">
     <ind:object object_ref="object_grub2_password_usercfg" />
@@ -34,6 +41,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  {{% if product != "ol8" %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_boot_path }}}/grub.cfg" id="test_grub2_password_grubcfg" version="1">
     <ind:object object_ref="object_grub2_password_grubcfg" />
   </ind:textfilecontent54_test>
@@ -42,4 +50,5 @@
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/no-grub.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/tests/no-grub.pass.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-. $SHARED/grub2.sh
-
-rm -f "$GRUB_CFG_ROOT/grub.cfg"


### PR DESCRIPTION
#### Description:

- Update OVAL criteria for OL8 and RHEL8 to only look for the `GRUB2_PASSWORD` configuration in the file `<grub2_boot_path>/user.cfg`
- And removed for all products the criterion that allows OVAL to pass if `<grub2_boot_path>/grub.cfg` is missing. And remove unnecessary test accordingly.

#### Rationale:

- It is better to check only the `user.cfg` file since this is the one generated by the command `grub2-setpassword`
- The existence and validity of superusers is already addressed by `grub2_admin_username` and it is not required in this STIG IDs
- The absence of `grub.cfg` only make sense if grub is not installed, this situation is already managed by the grub CPE
