### PR TITLE
Use the correct command in bash to list fingerprint of RHEL9 gpg keys

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/bash/shared.sh
@@ -13,7 +13,7 @@ if [ "${RPM_GPG_DIR_PERMS}" -le "755" ]
 then
   # If they are safe, try to obtain fingerprints from the key file
   # (to ensure there won't be e.g. CRC error).
-{{% if product in ["rhel8", "rhv4"] %}}
+{{% if product in ["rhel8", "rhel9", "rhv4"] %}}
   readarray -t GPG_OUT < <(gpg --show-keys --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep -A1 "^pub" | grep "^fpr" | cut -d ":" -f 10)
 {{% else %}}
   readarray -t GPG_OUT < <(gpg --with-fingerprint --with-colons "$REDHAT_RELEASE_KEY" | grep "^fpr" | cut -d ":" -f 10)


### PR DESCRIPTION


#### Description:
- Use the correct command in bash to list fingerprint of RHEL9 gpg keys
  - The second command would print a warning in the RHEL9 machine, so let's
use the correct invocation.

#### Rationale:

- no warnings as:

```
$ gpg --with-fingerprint --with-colons /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release | grep "^fpr" | cut -d ":" -f 10
gpg: WARNING: no command supplied.  Trying to guess what you mean ...
567E347AD0044ADE55BA8A5F199E2F91FD431D51
7E4624258C406535D56D6F135054E4A45A6340B3
```
