### PR TITLE
Update grub2_uefi_password & grub2_uefi_admin_username

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
@@ -4,7 +4,6 @@
               "The grub2 boot loader superuser should have a username that is hard to guess.") }}}
 
     <criteria operator="OR">
-      {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
       <criterion comment="Superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg and it
             isn't root, admin, administrator nor equal to any system username"
             test_ref="test_bootloader_uefi_superuser_differ_from_other_users"/>
@@ -19,8 +18,6 @@
           including all system usernames">
     <object_component item_field="username" object_ref="object_uefi_user_accounts"/>
   </local_variable>
-
-  {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
 
   <ind:textfilecontent54_state id="state_bootloader_uefi_superuser_differ_from_other_users"
           version="1">

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/tests/no-grub.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/tests/no-grub.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-. $SHARED/grub2.sh
-
-set_grub_uefi_root
-
-rm -f "$GRUB_CFG_ROOT/grub.cfg"
-

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
@@ -6,7 +6,6 @@
       {{% if product in ["ol8", "rhel8"] %}}
       <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" test_ref="test_grub2_uefi_password_usercfg" />
       {{% else %}}
-      {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
           <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" test_ref="test_grub2_uefi_password_usercfg" />
@@ -17,9 +16,6 @@
       {{% endif %}}
     </criteria>
   </definition>
-
-  {{% if product not in ["ol8", "rhel8"] %}}
-  {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
   
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg." id="test_bootloader_uefi_superuser" version="2">
     <ind:object object_ref="object_bootloader_uefi_superuser" />
@@ -29,7 +25,6 @@
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  {{% endif %}}
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_grub2_uefi_password_usercfg" version="1">
     <ind:object object_ref="object_grub2_uefi_password_usercfg" />

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("The UEFI grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
-      {{% if product == "ol8" %}}
+      {{% if product in ["ol8", "rhel8"] %}}
       <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" test_ref="test_grub2_uefi_password_usercfg" />
       {{% else %}}
       {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
@@ -18,7 +18,7 @@
     </criteria>
   </definition>
 
-  {{% if product != "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
   
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg." id="test_bootloader_uefi_superuser" version="2">
@@ -40,7 +40,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   
-  {{% if product != "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_grub2_uefi_password_grubcfg" version="1">
     <ind:object object_ref="object_grub2_uefi_password_grubcfg" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
@@ -3,6 +3,9 @@
     {{{ oval_metadata("The UEFI grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
+      {{% if product == "ol8" %}}
+      <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" test_ref="test_grub2_uefi_password_usercfg" />
+      {{% else %}}
       {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
       <criteria operator="AND">
         <criteria comment="check both files to account for procedure change in documenation" operator="OR">
@@ -11,11 +14,13 @@
         </criteria>
         <criterion comment="make sure a superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
       </criteria>
+      {{% endif %}}
     </criteria>
   </definition>
 
+  {{% if product != "ol8" %}}
   {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
-
+  
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg." id="test_bootloader_uefi_superuser" version="2">
     <ind:object object_ref="object_bootloader_uefi_superuser" />
   </ind:textfilecontent54_test>
@@ -24,6 +29,7 @@
     <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_grub2_uefi_password_usercfg" version="1">
     <ind:object object_ref="object_grub2_uefi_password_usercfg" />
@@ -33,7 +39,8 @@
     <ind:pattern operation="pattern match">^[\s]*GRUB2_PASSWORD=grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-
+  
+  {{% if product != "ol8" %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_grub2_uefi_password_grubcfg" version="1">
     <ind:object object_ref="object_grub2_uefi_password_grubcfg" />
   </ind:textfilecontent54_test>
@@ -42,4 +49,5 @@
     <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
@@ -3,29 +3,10 @@
     {{{ oval_metadata("The UEFI grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
-      {{% if product in ["ol8", "rhel8"] %}}
       <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" test_ref="test_grub2_uefi_password_usercfg" />
-      {{% else %}}
-      <criteria operator="AND">
-        <criteria comment="check both files to account for procedure change in documenation" operator="OR">
-          <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" test_ref="test_grub2_uefi_password_usercfg" />
-          <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_grub2_uefi_password_grubcfg" />
-        </criteria>
-        <criterion comment="make sure a superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
-      </criteria>
-      {{% endif %}}
     </criteria>
   </definition>
   
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg." id="test_bootloader_uefi_superuser" version="2">
-    <ind:object object_ref="object_bootloader_uefi_superuser" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_bootloader_uefi_superuser" version="2">
-    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_grub2_uefi_password_usercfg" version="1">
     <ind:object object_ref="object_grub2_uefi_password_usercfg" />
   </ind:textfilecontent54_test>
@@ -34,15 +15,5 @@
     <ind:pattern operation="pattern match">^[\s]*GRUB2_PASSWORD=grub\.pbkdf2\.sha512.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  
-  {{% if product not in ["ol8", "rhel8"] %}}
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/grub.cfg" id="test_grub2_uefi_password_grubcfg" version="1">
-    <ind:object object_ref="object_grub2_uefi_password_grubcfg" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_grub2_uefi_password_grubcfg" version="1">
-    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-  {{% endif %}}
+
 </def-group>

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/tests/no-grub.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/tests/no-grub.pass.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-. $SHARED/grub2.sh
-
-set_grub_uefi_root
-
-rm -f "$GRUB_CFG_ROOT/grub.cfg"

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -17,6 +17,7 @@ pkg_version: "ad986da3"
 release_key_fingerprint: "76FD3DB13AB67410B89DB10E82562EA9AD986DA3"
 
 dconf_gdm_dir: "local.d"
+grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 


### PR DESCRIPTION
#### Description:

- Removed for all products the criterion that allows OVAL to pass if <grub2_boot_path>/grub.cfg is missing. And remove unnecessary test accordingly.
- Update OVAL criteria for OL8 and RHEL8 to only look for the GRUB2_PASSWORD configuration in the file <grub2_boot_path>/user.cfg
- Set grub2_uefi_boot_path in OL8 product.yml

#### Rationale:

- The absence of grub.cfg only make sense if grub is not installed, this situation is already managed by the grub CPE
- For grub2_uefi_password:
  - It is better to check only the user.cfg file since this is the one generated by the command grub2-setpassword
  - The existence and validity of superusers is already addressed by Update grub2_uefi_admin_username and it is not required in the STIG IDs that grub2_uefi_password covers
-  The default grub2_uefi_boot_path was wrong
