### PR TITLE
Like the docs requirments GitPod should also use https vs the lagecy git protocol

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -18,7 +18,7 @@ tasks:
         recommonmark==0.6.0 \
         sphinx \
         sphinx-rtd-theme \
-        git+git://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain
+        git+https://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain
       [ -z "$PRODUCT" ] && PRODUCT="fedora"
       [ -z "$CONTAINER" ] && CONTAINER="fedora:34"
       [ -z "$CPE" ] && CPE="cpe:/o:fedoraproject:fedora:34"


### PR DESCRIPTION
#### Description:

Similar to #8402 fix GitPod's requirements to use https vs git. 

#### Rationale:
Pip doesn't support `git+git` anymore.