### PR TITLE
Update grub2_bootloader_argument template for ol8

### DIFF
--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -16,7 +16,7 @@
 {{% set system_with_expanded_kernel_options_in_loader_entries = true %}}
 {{%- endif -%}}
 
-{{% if product in ["rhel8"] -%}}
+{{% if product in ["ol8","rhel8"] -%}}
 {{% set system_with_referenced_kernel_options_in_loader_entries = true %}}
 {{% set system_with_kernel_options_in_grubenv = true %}}
 {{%- endif -%}}


### PR DESCRIPTION
#### Description:

- Include ol8 in jinja conditional where previously was only rhel8 present

#### Rationale:

- OL8 also need this conditional to be present, so it is compliant with DISA requirements as in:

  * grub2_page_poison_argument (OL08-00-010421)
  * grub2_vsyscall_argument (OL08-00-010422)
  * grub2_slub_debug_argument (OL08-00-010423)
  * grub2_pti_argument  OL08-00-040004
  * grub2_audit_backlog_limit_argument OL08-00-030602
  * grub2_audit_argument OL08-00-030601
