### PR TITLE
Update regex to detect nfs filesystems in fstab

### DIFF
--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1390,7 +1390,7 @@ readarray -t vfstype_points < <(grep -E "[[:space:]]{{{ vfstype }}}[[:space:]]" 
 
 for vfstype_point in "${vfstype_points[@]}"
 do
-    {{{ bash_ensure_mount_option_in_fstab("$vfstype_point", mount_opt, fs_spec, type) | indent(4) }}}
+    {{{ bash_ensure_mount_option_in_fstab("${vfstype_point//\\\\/\\\\\\\\}", mount_opt, fs_spec, type) | indent(4) }}}
 done
 {{%- endmacro %}}
 

--- a/shared/templates/mount_option_remote_filesystems/oval.template
+++ b/shared/templates/mount_option_remote_filesystems/oval.template
@@ -14,7 +14,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_nfs_{{{ MOUNTOPTIONID }}}_etc_fstab" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w:-]+\]?[:=][/\w-]+\s+[/\w\\-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_no_nfs_defined_etc_fstab_{{{ MOUNTOPTIONID }}}" version="1">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*\[?[\.\w-:]+\]?:[/\w-]+\s+[/\w-]+\s+nfs[4]?\s+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[?[\.\w:-]+\]?[:=][/\w-]+\s+[/\w\\-]+\s+nfs[4]?\s+(.*)$</ind:pattern>
     <!-- the "not equal" operation below essentially means all instances of the regexp -->
     <ind:instance datatype="int" operation="not equal">0</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/mount_option_remote_filesystems/tests/correct_option.pass.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/correct_option.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [ -f "/etc/fstab" ]; then
+    sudo sed -i -E "/^\s*\S+\s+\S+\s+nfs/d" /etc/fstab
+fi
+
+echo "UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d /mount/point nfs {{{ MOUNTOPTION }}} 0 0" >> /etc/fstab
+echo "label=remote /store\040mount\011point nfs {{{ MOUNTOPTION }}} 0 0" >> /etc/fstab
+echo "host:/dir /host\040dir nfs {{{ MOUNTOPTION }}} 0 0" >> /etc/fstab

--- a/shared/templates/mount_option_remote_filesystems/tests/wrong_option.fail.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/wrong_option.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [ -f "/etc/fstab" ]; then
+    sudo sed -i -E "/^\s*\S+\s+\S+\s+nfs/d" /etc/fstab
+fi
+
+echo "UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d /mount/point nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
+echo "label=remote /store\040mount\011point nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
+echo "host:/dir /host\040dir nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
+
+sudo sed -i -E "s/(^\s*\S+\s+\S+\s+nfs.*)(,{{{ MOUNTOPTION }}}|{{{ MOUNTOPTION }}},)(.*)/\1\3/g" /etc/fstab


### PR DESCRIPTION
#### Description:

- Update regex in mount_option_remote_filesystems template OVAL

#### Rationale:

- Regex didn't match mounted filesystems with UUID= or LABEL= method.
Also needed to add the character \ to allow escaped fs files
