### PR TITLE
Introduce usbguard cpe and apply it to configure_usbguard_auditbackend

### DIFF
--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
@@ -29,6 +29,8 @@ references:
     stigid@ol8: OL08-00-030603
     stigid@rhel8: RHEL-08-030603
 
+platform: usbguard
+
 ocil_clause: 'AuditBackend is not set to LinuxAudit'
 
 ocil: |-

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -112,6 +112,12 @@ cpes:
       bash_conditional: {{{ bash_pkg_conditional("tftp-server") }}}
       ansible_conditional: {{{ ansible_pkg_conditional("tftp-server") }}}
 
+  - usbguard:
+      name: "cpe:/a:usbguard"
+      title: "Package usbguard is installed"
+      check_id: installed_env_has_usbguard_package
+      bash_conditional: {{{ bash_pkg_conditional("usbguard") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("usbguard") }}}
   - yum:
       name: "cpe:/a:yum"
       title: "Package yum is installed"

--- a/shared/checks/oval/installed_env_has_usbguard_package.xml
+++ b/shared/checks/oval/installed_env_has_usbguard_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_usbguard_package" version="1">
+    <metadata>
+      <title>Package usbguard is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package usbguard is installed.</description>
+      <reference ref_id="cpe:/a:usbguard" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package usbguard is installed" test_ref="test_env_has_usbguard_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_usbguard_installed" version="1"
+  comment="system has package usbguard installed">
+    <linux:object object_ref="obj_env_has_usbguard_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_usbguard_installed" version="1">
+    <linux:name>usbguard</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_usbguard_installed" version="1"
+  comment="system has package usbguard installed">
+    <linux:object object_ref="obj_env_has_usbguard_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_usbguard_installed" version="1">
+    <linux:name>usbguard</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>


### PR DESCRIPTION
#### Description:

- Created usbguard cpe
- Selected usbguard platform in the rule configure_usbguard_auditbackend

#### Rationale:

-  As DISA states in OL08-00-030603 & RHEL-08-030603 this rule should be marked as not applicable if usbguard is not installed (The enabeled part wasn't implemented as no precedent was found for that in the project)
