### PR TITLE
Add a rule to STIG profile in OL8 and RHEL8

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/oval/shared.xml
@@ -60,7 +60,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_screensaver_lock_delay_setting" version="1">
-    <ind:subexpression datatype="int" operation="equals" var_check="all" var_ref="var_screensaver_lock_delay" />
+    <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="var_screensaver_lock_delay" />
   </ind:textfilecontent54_state>
 
   <external_variable comment="screensaver lock delay variable" datatype="int"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/rule.yml
@@ -42,7 +42,9 @@ references:
     pcidss: Req-8.1.8
     srg: SRG-OS-000029-GPOS-00010
     stigid@ol7: OL07-00-010110
+    stigid@ol8: OL08-00-020031
     stigid@rhel7: RHEL-07-010110
+    stigid@rhel8: RHEL-08-020031
 
 ocil_clause: 'the screensaver lock delay is missing, or is set to a value greater than 5'
 

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -492,6 +492,10 @@ selections:
     # OL08-00-020030
     - dconf_gnome_screensaver_lock_enabled
 
+    # OL08-00-020031
+    - dconf_gnome_screensaver_lock_delay
+    - var_screensaver_lock_delay=5_seconds
+
     # OL08-00-020039
     - package_tmux_installed
 

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -492,7 +492,7 @@ selections:
     # OL08-00-020030
     - dconf_gnome_screensaver_lock_enabled
 
-    # OL08-00-020031
+    # OL08-00-020031, OL08-00-020080
     - dconf_gnome_screensaver_lock_delay
     - var_screensaver_lock_delay=5_seconds
 
@@ -516,8 +516,6 @@ selections:
 
     # OL08-00-020070
     - configure_tmux_lock_after_time
-
-    # OL08-00-020080
 
     # OL08-00-020090
     - sssd_enable_certmap

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -499,6 +499,10 @@ selections:
     # RHEL-08-020030
     - dconf_gnome_screensaver_lock_enabled
 
+    # RHEL-08-020031
+    - dconf_gnome_screensaver_lock_delay
+    - var_screensaver_lock_delay=5_seconds
+
     # RHEL-08-020039
     - package_tmux_installed
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -499,7 +499,7 @@ selections:
     # RHEL-08-020030
     - dconf_gnome_screensaver_lock_enabled
 
-    # RHEL-08-020031
+    # RHEL-08-020031, RHEL-08-020080
     - dconf_gnome_screensaver_lock_delay
     - var_screensaver_lock_delay=5_seconds
 
@@ -523,8 +523,6 @@ selections:
 
     # RHEL-08-020070
     - configure_tmux_lock_after_time
-
-    # RHEL-08-020080
 
     # RHEL-08-020090
     - sssd_enable_certmap

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -179,6 +179,7 @@ selections:
 - dconf_gnome_lock_screen_on_smartcard_removal
 - dconf_gnome_login_banner_text
 - dconf_gnome_screensaver_idle_delay
+- dconf_gnome_screensaver_lock_delay
 - dconf_gnome_screensaver_lock_enabled
 - dir_group_ownership_library_dirs
 - dir_ownership_library_dirs
@@ -447,6 +448,7 @@ selections:
 - var_system_crypto_policy=fips
 - var_sudo_timestamp_timeout=always_prompt
 - var_slub_debug_options=P
+- var_screensaver_lock_delay=5_seconds
 platforms: !!set {}
 cpe_names: !!set {}
 platform: null

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -190,6 +190,7 @@ selections:
 - dconf_gnome_lock_screen_on_smartcard_removal
 - dconf_gnome_login_banner_text
 - dconf_gnome_screensaver_idle_delay
+- dconf_gnome_screensaver_lock_delay
 - dconf_gnome_screensaver_lock_enabled
 - dir_group_ownership_library_dirs
 - dir_ownership_library_dirs
@@ -456,6 +457,7 @@ selections:
 - var_system_crypto_policy=fips
 - var_sudo_timestamp_timeout=always_prompt
 - var_slub_debug_options=P
+- var_screensaver_lock_delay=5_seconds
 platforms: !!set {}
 cpe_names: !!set {}
 platform: null


### PR DESCRIPTION
#### Description:

- Update OVAL of dconf_gnome_screensaver_lock_delay so it allows values smaller than the variable(more restrictive scenarios)
- Add dconf_gnome_screensaver_lock_delay rule to OL8 and RHEL8 STIG profiles
- Update STIG IDs both in profiles and in dconf_gnome_screensaver_lock_delay rule

#### Rationale:

- the rule dconf_gnome_screensaver_lock_delay complies with OL08-00-020031 & RHEL-08-020031
