### PR TITLE
Introduce CPE for tftp-server

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/rule.yml
@@ -22,6 +22,8 @@ medium
 high
 {{%- endif %}}
 
+platform: tftp-server
+
 identifiers:
     cce@rhel7: CCE-80214-0
     cce@rhel8: CCE-82434-2

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -105,6 +105,13 @@ cpes:
       bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
       ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}
 
+  - tftp-server:
+      name: "cpe:/a:tftp-server"
+      title: "Package tftp-server is installed"
+      check_id: installed_env_has_tftp_server_package
+      bash_conditional: {{{ bash_pkg_conditional("tftp-server") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("tftp-server") }}}
+
   - yum:
       name: "cpe:/a:yum"
       title: "Package yum is installed"

--- a/shared/checks/oval/installed_env_has_tftp_server_package.xml
+++ b/shared/checks/oval/installed_env_has_tftp_server_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_tftp_server_package" version="1">
+    <metadata>
+      <title>Package tftp-server is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package tftp-server is installed.</description>
+      <reference ref_id="cpe:/a:tftp-server" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package tftp-server is installed" test_ref="test_env_has_tftp_server_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_tftp_server_installed" version="1"
+  comment="system has package tftp-server installed">
+    <linux:object object_ref="obj_env_has_tftp_server_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_tftp_server_installed" version="1">
+    <linux:name>tftp-server</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_tftp_server_installed" version="1"
+  comment="system has package tftp-server installed">
+    <linux:object object_ref="obj_env_has_tftp_server_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_tftp_server_installed" version="1">
+    <linux:name>tftp-server</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>


### PR DESCRIPTION
#### Description:

- Introduce CPE for tftp-server
- Apply the CPE to rule tftpd_uses_secure_mode

#### Rationale:

- This because DISA requires this rule to not be applicable when tftp-server is not installed. This in
  - OL08-00-040350
  - RHEL-08-040350
  - OL07-00-040720
  - RHEL-07-040720