### PR TITLE
Update accounts_password template OVAL for ol8

### DIFF
--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -3,7 +3,12 @@
     {{{ oval_metadata("The password " + VARIABLE + " should meet minimum requirements") }}}
     <criteria operator="AND" comment="conditions for {{{ VARIABLE }}} are satisfied">
       <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
-      <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
+      <criteria operator="OR">
+        <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
+        {{% if product == "ol8" %}}
+        <criterion comment="/etc/security/pwquality.conf.d/*.conf" test_ref="test_password_pam_pwquality_d_{{{ VARIABLE }}}" />
+        {{% endif %}}
+      </criteria>
     </criteria>
   </definition>
 
@@ -19,9 +24,24 @@
 
   <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
     <ind:filepath>/etc/security/pwquality.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+  
+  {{% if product == "ol8" %}}
+  <ind:textfilecontent54_test check="all"
+  comment="check the configuration of /etc/security/pwquality.conf.d/*.conf"
+  id="test_password_pam_pwquality_d_{{{ VARIABLE }}}" version="1">
+    <ind:object object_ref="obj_password_pam_pwquality_d_{{{ VARIABLE }}}" />
+    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_password_pam_pwquality_d_{{{ VARIABLE }}}" version="1">
+    <ind:filepath operation="pattern match">^/etc/security/pwquality.conf.d/.*\.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% endif %}}
 
   <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}" version="3">
     <ind:subexpression datatype="int" operation="{{{ OPERATION }}}" var_ref="var_password_pam_{{{ VARIABLE }}}" />


### PR DESCRIPTION
#### Description:

- Update accounts_password OVAL template for OL8 so it looks for the configuration also in /etc/security/pwquality.conf.d/*.conf

#### Rationale:

- Ol8 needs to check /etc/security/pwquality.conf.d/*.conf files also, as states the STIG IDs:
  * OL08-00-020300
  * OL08-00-020280
  * OL08-00-020230
  * OL08-00-020170
  * OL08-00-020160
  * OL08-00-020150
  * OL08-00-020140
  * OL08-00-020130
  * OL08-00-020120
  * OL08-00-020110
