### PR TITLE
Update configure_ssh_crypto_policy regex

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/ansible/shared.yml
@@ -8,4 +8,4 @@
   lineinfile:
     dest: /etc/sysconfig/sshd
     state: absent
-    regexp: ^\s*CRYPTO_POLICY.*$
+    regexp: ^\s*(?i)CRYPTO_POLICY.*$

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/bash/shared.sh
@@ -2,4 +2,4 @@
 
 SSH_CONF="/etc/sysconfig/sshd"
 
-sed -i "/^\s*CRYPTO_POLICY.*$/d" $SSH_CONF
+sed -i "/^\s*CRYPTO_POLICY.*$/Id" $SSH_CONF

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/oval/shared.xml
@@ -15,7 +15,7 @@
 
   <ind:textfilecontent54_object id="object_configure_ssh_crypto_policy" version="1">
     <ind:filepath>/etc/sysconfig/sshd</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*CRYPTO_POLICY\s*=.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*(?i)CRYPTO_POLICY\s*=.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/case_insensitive_present.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/case_insensitive_present.fail.sh
@@ -4,4 +4,5 @@
 
 SSH_CONF="/etc/sysconfig/sshd"
 
-sed -i "/^\s*CRYPTO_POLICY.*$/d" $SSH_CONF
+sed -i "/^\s*CRYPTO_POLICY.*$/Id" $SSH_CONF
+echo "CrYpTo_PoLiCy=" >> $SSH_CONF

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/comment.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/comment.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/no_config_file.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/no_config_file.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/overrides.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/tests/overrides.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 SSH_CONF="/etc/sysconfig/sshd"
 


### PR DESCRIPTION
#### Description:

- Changed regexes in configure_ssh_crypto_policy rule so it is case insensitive

#### Rationale:

- DISA, in STIG ID OL08-00-010287, mentions this conf in lower case. Also sshd related man pages mention case inensitiveness
