### PR TITLE
Optimize library dirs rules

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/lenient_permissions.fail.sh
@@ -2,5 +2,7 @@
 
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
-    find "$dirPath" -type f -exec chmod go+w '{}' \;
+    # Limit the test changes to a subset of file in the directory
+    # Remediation the whole library dirs is very time consuming
+    find "$dirPath" -type f -regex ".*\.txt" -exec chmod go+w '{}' \;
 done

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}'"
+  command: 'find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -8,26 +8,26 @@
 {{% if IS_DIRECTORY %}}
 {{% if FILE_REGEX %}}
 
-- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
 
-  find:
-    paths: "{{{ path }}}"
-    patterns: {{{ FILE_REGEX[loop.index0] }}}
-    use_regex: yes
-{{% if RECURSIVE %}}
-    recurse: yes
-{{% endif %}}
-    hidden: yes
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
+  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}'"
   register: files_found
+  changed_when: False
+  failed_when: False
+  check_mode: no
 
 - name: Ensure group owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
   file:
-    path: "{{ item.path }}"
+    path: "{{ item }}"
     group: "{{{ FILEGID }}}"
     state: file
-  when: item.gid != {{{ FILEGID }}}
   with_items:
-    - "{{ files_found.files }}"
+    - "{{ files_found.stdout_lines }}"
 
 {{% else %}}
 

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -13,12 +13,7 @@
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}})
-for file in "${files[@]}"; do
-    if basename "$file" | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chgrp {{{ FILEGID }}} "$file"
-    fi
-done
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ FILEGID }}} {} \;
 {{% else %}}
 find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
 {{%- endif %}}

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -8,26 +8,26 @@
 {{% if IS_DIRECTORY %}}
 {{% if FILE_REGEX %}}
 
-- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
 
-  find:
-    paths: "{{{ path }}}"
-    patterns: {{{ FILE_REGEX[loop.index0] }}}
-    use_regex: yes
-{{% if RECURSIVE %}}
-    recurse: yes
-{{% endif %}}
-    hidden: yes
+- name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
+  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}'"
   register: files_found
+  changed_when: False
+  failed_when: False
+  check_mode: no
 
 - name: Ensure owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
   file:
-    path: "{{ item.path }}"
+    path: "{{ item }}"
     owner: "{{{ FILEUID }}}"
     state: file
-  when: item.uid != {{{ FILEUID }}}
   with_items:
-    - "{{ files_found.files }}"
+    - "{{ files_found.stdout_lines }}"
 
 {{% else %}}
 

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}'"
+  command: 'find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -13,12 +13,7 @@
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}})
-for file in "${files[@]}"; do
-    if basename "$file" | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chown {{{ FILEUID }}} "$file"
-    fi
-done
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown {{{ FILEUID }}} {} \;
 {{%- else %}}
 find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown {{{ FILEUID }}} {} \;
 {{%- endif %}}

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -8,26 +8,33 @@
 {{% if IS_DIRECTORY %}}
 {{% if FILE_REGEX %}}
 
-- name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
+{{%- if RECURSIVE %}}
+{{% set FIND_RECURSE_ARGS="" %}}
+{{%- else %}}
+{{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
+{{%- endif %}}
 
-  find:
-    paths: "{{{ path }}}"
-    patterns: {{{ FILE_REGEX[loop.index0] }}}
-    use_regex: yes
-{{% if RECURSIVE %}}
-    recurse: yes
-{{% endif %}}
-    hidden: yes
+{{%- if ALLOW_STRICTER_PERMISSIONS %}}
+{{% set PERMS="-perm /" + SEARCH_MODE %}}
+{{%- else %}}
+{{% set PERMS="\! -perm " + SEARCH_MODE %}}
+{{%- endif %}}
+
+- name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
+  command: "find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}}"
   register: files_found
+  changed_when: False
+  failed_when: False
+  check_mode: no
 
 - name: Set permissions for {{{ path }}} file(s)
   file:
-    path: "{{ item.path }}"
+    path: "{{ item }}"
     mode: "{{{ FILEMODE }}}"
     state: file
   when: item.mode != '{{{ FILEMODE}}}'
   with_items:
-    - "{{ files_found.files }}"
+    - "{{ files_found.stdout_lines}}"
 
 {{% else %}}
 

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -21,7 +21,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
-  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}'"
+  command: 'find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -21,7 +21,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
-  command: "find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}}"
+  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}}"
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -32,7 +32,6 @@
     path: "{{ item }}"
     mode: "{{{ FILEMODE }}}"
     state: file
-  when: item.mode != '{{{ FILEMODE}}}'
   with_items:
     - "{{ files_found.stdout_lines}}"
 

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -21,7 +21,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
-  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}}"
+  command: "find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}'"
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -19,7 +19,7 @@
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}} -exec chmod {{{ FILEMODE }}} {} \;
+find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}} -exec chmod {{{ FILEMODE }}} {} \;
 {{%- else %}}
 find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
 {{%- endif %}}

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -10,17 +10,18 @@
 {{% set FIND_RECURSE_ARGS="-maxdepth 1" %}}
 {{%- endif %}}
 
+{{%- if ALLOW_STRICTER_PERMISSIONS %}}
+{{% set PERMS="-perm /" + SEARCH_MODE %}}
+{{%- else %}}
+{{% set PERMS="\! -perm " + SEARCH_MODE %}}
+{{%- endif %}}
+
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-readarray -t files < <(find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f)
-for file in "${files[@]}"; do
-    if basename "$file" | grep -qE '{{{ FILE_REGEX[loop.index0] }}}'; then
-        chmod {{{ FILEMODE }}} "$file"
-    fi    
-done
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}} -exec chmod {{{ FILEMODE }}} {} \;
 {{%- else %}}
-find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
+find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
 {{%- endif %}}
 {{%- else %}}
 chmod {{{ FILEMODE }}} {{{ path }}}

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -19,7 +19,7 @@
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex {{{ FILE_REGEX[loop.index0] }}} -exec chmod {{{ FILEMODE }}} {} \;
+find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chmod {{{ FILEMODE }}} {} \;
 {{%- else %}}
 find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
 {{%- endif %}}

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -78,11 +78,23 @@ def preprocess(data, lang):
             mode_int = mode_int >> 1
 
         search_mode = ''
+        fix_mode = ''
         for k in mode_dict:
             if mode_dict[k] != '':
                 if search_mode != '':
                     search_mode += ','
                 search_mode += "{}+{}".format(k, mode_dict[k])
 
+                if data['allow_stricter_permissions']:
+                    if fix_mode != '':
+                        fix_mode += ','
+                    fix_mode += "{}-{}".format(k, mode_dict[k])
+
         data["search_mode"] = search_mode
+        if data['allow_stricter_permissions']:
+            # overwrite "filemode" with a subtractive symbolic mode
+            # e.g., if filemode was "0755", now it is "u-s,g-ws,o-wt"
+            # This allows files to keep the permission in which they are already stricter
+            data["filemode"] = fix_mode
+
     return data

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -22,6 +22,41 @@ def _file_owner_groupowner_permissions_regex(data):
     check_conflict_regex_directory(data)
 
 
+def map_symbolic_permissions(filemode, allow_stricter_permissions):
+    mode_int = int(filemode, 8)
+    fields = [
+        ('o', 'x'), ('o', 'w'), ('o', 'r'),
+        ('g', 'x'), ('g', 'w'), ('g', 'r'),
+        ('u', 'x'), ('u', 'w'), ('u', 'r'),
+        ('o', 't'), ('g', 's'), ('u', 's')
+    ]
+    mode_dict = {'u': '', 'g': '', 'o': ''}
+    for field in fields:
+        if mode_int & 0x01 == 1:
+            if not allow_stricter_permissions:
+                mode_dict[field[0]] += field[1]
+        else:
+            if allow_stricter_permissions:
+                mode_dict[field[0]] += field[1]
+        mode_int = mode_int >> 1
+    return mode_dict
+
+
+def group_symbolic_permissions(mode_dict):
+    search_mode = ''
+    fix_mode = ''
+    for k in mode_dict:
+        if mode_dict[k] != '':
+            if search_mode != '':
+                search_mode += ','
+            search_mode += "{}+{}".format(k, mode_dict[k])
+
+            if fix_mode != '':
+                fix_mode += ','
+            fix_mode += "{}-{}".format(k, mode_dict[k])
+    return search_mode, fix_mode
+
+
 def preprocess(data, lang):
     _file_owner_groupowner_permissions_regex(data)
 
@@ -60,35 +95,9 @@ def preprocess(data, lang):
         data["statemode"] = mode_str.rstrip("\n")
 
     if lang in ["bash", "ansible"]:
-        mode_int = int(data["filemode"], 8)
-        mode_dict = {'u': '', 'g': '', 'o': ''}
-        fields = [
-            ('o', 'x'), ('o', 'w'), ('o', 'r'),
-            ('g', 'x'), ('g', 'w'), ('g', 'r'),
-            ('u', 'x'), ('u', 'w'), ('u', 'r'),
-            ('o', 't'), ('g', 's'), ('u', 's')
-        ]
-        for field in fields:
-            if mode_int & 0x01 == 1:
-                if not data['allow_stricter_permissions']:
-                    mode_dict[field[0]] += field[1]
-            else:
-                if data['allow_stricter_permissions']:
-                    mode_dict[field[0]] += field[1]
-            mode_int = mode_int >> 1
 
-        search_mode = ''
-        fix_mode = ''
-        for k in mode_dict:
-            if mode_dict[k] != '':
-                if search_mode != '':
-                    search_mode += ','
-                search_mode += "{}+{}".format(k, mode_dict[k])
-
-                if data['allow_stricter_permissions']:
-                    if fix_mode != '':
-                        fix_mode += ','
-                    fix_mode += "{}-{}".format(k, mode_dict[k])
+        mode_map = map_symbolic_permissions(data["filemode"], data['allow_stricter_permissions'])
+        search_mode, fix_mode = group_symbolic_permissions(mode_map)
 
         data["search_mode"] = search_mode
         if data['allow_stricter_permissions']:


### PR DESCRIPTION
#### Description:

- Ditches use of Ansible `find` module in favor of the CLI utility `find`.
  - Main advantage of CLI `find` is that we can filter out the compliant files.
- This PR also expands `allow_stricter_permissions` to the remediations.
  - This should speed up even more the Ansible and Bash remediations.
  - Most of the files in the library dirs have permissions stricter (0644) than the rule threshold (0755).
 
#### Rationale:

- The Ansible remediation is taking hours to go through the library dirs because the Ansible `find` module returns a list of all files for the `file` module to iterate. With CLI `find` command, the `file` module only iterates through the files that need fixing.

#### Notes::
- If this approach looks good, I'll remove Ansible `find` from `file_owner` and `file_groupowner` too.
