### PR TITLE
Performance improvements for file permission and ownership templates

### DIFF
--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -13,23 +13,12 @@
    {{% endif %}}
     </criteria>
   </definition>
-  {{%- if MISSING_FILE_PASS -%}}
-    {{# Any number of files can exist, from zero to any #}}
-    {{% set FILE_EXISTENCE = "any_exist" %}}
-  {{%- else -%}}
-    {{# All defined files must exist. When using regex, at least one file must match #}}
-    {{% set FILE_EXISTENCE = "all_exist" %}}
-  {{%- endif -%}}
-
 
   {{% for filepath in FILEPATH %}}
-  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing group ownership of {{{ filepath }}}" id="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+  <unix:file_test check="all" check_existence="none_exist" comment="Testing group ownership of {{{ filepath }}}" id="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     <unix:object object_ref="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />
-    <unix:state state_ref="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" />
   </unix:file_test>
-  <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" version="1">
-    <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
-  </unix:file_state>
+
   <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       {{%- if RECURSIVE %}}
@@ -46,8 +35,14 @@
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
     {{%- endif %}}
     <filter action="exclude">symlink_file_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}</filter>
+    <filter action="exclude">state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}</filter>
   </unix:file_object>
+
+  <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" version="1">
+    <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
+  </unix:file_state>
   {{% endfor %}}
+
   <unix:file_state id="symlink_file_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>

--- a/shared/templates/file_groupowner/tests/correct_groupowner.pass.sh
+++ b/shared/templates/file_groupowner/tests/correct_groupowner.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}

--- a/shared/templates/file_groupowner/tests/incorrect_groupowner.fail.sh
+++ b/shared/templates/file_groupowner/tests/incorrect_groupowner.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 groupadd group_test
 

--- a/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 {{% for path in FILEPATH %}}
     {{% if MISSING_FILE_PASS %}}

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -13,22 +13,12 @@
   {{% endif %}}
     </criteria>
   </definition>
-  {{%- if MISSING_FILE_PASS -%}}
-    {{# Any number of files can exist, from zero to any #}}
-    {{% set FILE_EXISTENCE = "any_exist" %}}
-  {{%- else -%}}
-    {{# All defined files must exist. When using regex, at least one file must match #}}
-    {{% set FILE_EXISTENCE = "all_exist" %}}
-  {{%- endif -%}}
 
   {{% for filepath in FILEPATH %}}
-  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing user ownership of {{{ filepath }}}" id="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
+  <unix:file_test check="all" check_existence="none_exist" comment="Testing user ownership of {{{ filepath }}}" id="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     <unix:object object_ref="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" />
-    <unix:state state_ref="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}_{{{ loop.index0 }}}" />
   </unix:file_test>
-  <unix:file_state id="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}_{{{ loop.index0 }}}" version="1">
-    <unix:user_id datatype="int">{{{ FILEUID }}}</unix:user_id>
-  </unix:file_state>
+
   <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       {{%- if RECURSIVE %}}
@@ -45,8 +35,14 @@
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
     {{%- endif %}}
     <filter action="exclude">symlink_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}</filter>
+    <filter action="exclude">state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}_{{{ loop.index0 }}}</filter>
   </unix:file_object>
+
+  <unix:file_state id="state_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}_{{{ loop.index0 }}}" version="1">
+    <unix:user_id datatype="int">{{{ FILEUID }}}</unix:user_id>
+  </unix:file_state>
   {{% endfor %}}
+
   <unix:file_state id="symlink_file_owner{{{ FILEID }}}_uid_{{{ FILEUID }}}" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>

--- a/shared/templates/file_owner/tests/correct_owner.pass.sh
+++ b/shared/templates/file_owner/tests/correct_owner.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}

--- a/shared/templates/file_owner/tests/incorrect_owner.fail.sh
+++ b/shared/templates/file_owner/tests/incorrect_owner.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 useradd testuser_123
 

--- a/shared/templates/file_owner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_owner/tests/missing_file_test.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 {{% for path in FILEPATH %}}
     {{% if MISSING_FILE_PASS %}}

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -1,19 +1,3 @@
-{{%- if ALLOW_STRICTER_PERMISSIONS %}}
-    {{#
-        When allowing stricter permissions, the check looks for files/directories
-        that have any extra permission bit set. The permissions mode (STATEMODE)
-        is negated (inverted) and becomes a mask for permissions that should not be set.
-    #}}
-  {{% set FILE_EXISTENCE = "at_least_one_exists" %}}
-{{%- else -%}}
-  {{%- if MISSING_FILE_PASS -%}}
-    {{# Any number of files can exist, from zero to any #}}
-    {{% set FILE_EXISTENCE = "any_exist" %}}
-  {{%- else -%}}
-    {{# All defined files must exist. When using regex, at least one file must match #}}
-    {{% set FILE_EXISTENCE = "all_exist" %}}
-  {{%- endif -%}}
-{{%- endif -%}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
   {{% if FILEPATH is not string %}}
@@ -22,28 +6,24 @@
       ") }}}
     <criteria>
   {{% for filepath in FILEPATH %}}
-      <criterion comment="Check file mode of {{{ filepath }}}" test_ref="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}"{{{ ' negate="true"' if ALLOW_STRICTER_PERMISSIONS }}}/>
+      <criterion comment="Check file mode of {{{ filepath }}}" test_ref="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}"/>
   {{% endfor %}}
   {{% else %}}
     {{{ oval_metadata("This test makes sure that " +  FILEPATH + " has mode " + FILEMODE + ".
       If the target file or directory has an extended ACL, then it will fail the mode check.
       ") }}}
     <criteria>
-      <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}"{{{ ' negate="true"' if ALLOW_STRICTER_PERMISSIONS }}}/>
+      <criterion comment="Check file mode of {{{ FILEPATH }}}" test_ref="test_file_permissions{{{ FILEID }}}"/>
   {{% endif %}}
     </criteria>
   </definition>
 
   {{% for filepath in FILEPATH %}}
-  <unix:file_test check="all" check_existence="{{{ FILE_EXISTENCE }}}" comment="Testing mode of {{{ filepath }}}" id="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="2">
+  <unix:file_test check="all" check_existence="none_exist" comment="Testing mode of {{{ filepath }}}" id="test_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="3">
     <unix:object object_ref="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" />
-    <unix:state state_ref="state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}" />
   </unix:file_test>
-  <unix:file_state id="state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_{{{ 'not_' if ALLOW_STRICTER_PERMISSIONS }}}{{{ FILEMODE }}}"{{{ ' operator="OR"' if ALLOW_STRICTER_PERMISSIONS }}} version="2">
-      {{{ STATEMODE | indent(6) }}}
-  </unix:file_state>
-  <unix:file_object comment="{{{ filepath }}}" id="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
 
+  <unix:file_object comment="{{{ filepath }}}" id="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY %}}
       {{%- if RECURSIVE %}}
       <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
@@ -58,17 +38,13 @@
     {{%- else %}}
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
     {{%- endif %}}
-
-    {{%- if ALLOW_STRICTER_PERMISSIONS %}}
-      {{#
-          This filter is required because of an issue in OpenSCAP. The issue has been fixed in:
-          https://github.com/OpenSCAP/openscap/pull/1709 but this line should be kept until the
-          fix is widely available. The fix is expected to be part of OpenSCAP >= 1.3.5.
-      #}}
-      <filter action="include">state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_not_{{{ FILEMODE }}}</filter>
-    {{%- endif %}}
       <filter action="exclude">exclude_symlinks_{{{ FILEID }}}</filter>
+      <filter action="exclude">state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_{{{ FILEMODE }}}{{{ 'or_stricter_' if ALLOW_STRICTER_PERMISSIONS }}}</filter>
   </unix:file_object>
+
+  <unix:file_state id="state_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}_mode_{{{ FILEMODE }}}{{{ 'or_stricter_' if ALLOW_STRICTER_PERMISSIONS }}}" operator="AND" version="3">
+      {{{ STATEMODE | indent(6) }}}
+  </unix:file_state>
   {{% endfor %}}
 
   <unix:file_state id="exclude_symlinks_{{{ FILEID }}}" version="1">

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -50,11 +50,8 @@ def preprocess(data, lang):
                         "<unix:" + field + " datatype=\"boolean\">true</unix:"
                         + field + ">\n" + mode_str)
             else:
-                value = "false"
-                if data['allow_stricter_permissions']:
-                    value = "true"
                 mode_str = (
-                    "<unix:" + field + " datatype=\"boolean\">{}</unix:".format(value)
+                    "<unix:" + field + " datatype=\"boolean\">false</unix:"
                     + field + ">\n" + mode_str)
             mode_int = mode_int >> 1
         data["statemode"] = mode_str.rstrip("\n")

--- a/shared/templates/file_permissions/tests/correct_permissions.pass.sh
+++ b/shared/templates/file_permissions/tests/correct_permissions.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
 
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}

--- a/shared/templates/file_permissions/tests/lenient_permissions.fail.sh
+++ b/shared/templates/file_permissions/tests/lenient_permissions.fail.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-#
 
 {{% for path in FILEPATH %}}
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
 {{% elif IS_DIRECTORY and RECURSIVE %}}
-find -L {{{ path }}} -type d -exec chmod 777 {} \;
+find -L {{{ path }}} -type d -maxdepth 1 -exec chmod 777 {} \;
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"


### PR DESCRIPTION
These templates used to hit performance issues when directories were
recursively assessed. The OVAL logic was slightly changed to improve the
performance around 50% or more for some rules.

- Fixes #8417
