### PR TITLE
Improve pam_faillock macro remediation to fix wrong control

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_faillock_not_required_pam_files.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/pam_faillock_not_required_pam_files.fail.sh
@@ -3,8 +3,8 @@
 # packages = authconfig
 {{%- else %}}
 # packages = authselect
-{{%- endif %}}
 # remediation = none
+{{%- endif %}}
 # variables = var_accounts_passwords_pam_faillock_deny=3
 
 # This test scenario manually modify the pam_faillock.so entries in auth section from

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1026,6 +1026,7 @@ if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+(preauth silent|authfail
     sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        required      pam_faillock.so authfail' "{{{ pam_file }}}"
     sed -i --follow-symlinks '/^account.*required.*pam_unix.so.*/i account     required      pam_faillock.so' "{{{ pam_file }}}"
 fi
+sed -Ei 's/(auth.*)(\[default=die\])(.*pam_faillock.so)/\1required     \3/g' "{{{ pam_file }}}"
 {{%- endmacro -%}}
 
 {{%- macro bash_pam_faillock_parameter_value(pam_file, option, value='') -%}}


### PR DESCRIPTION
Old versions of the pam_faillock remediation created a pam_faillock.so line
with the control "[default=die]", which is not the proper control. The
remediation was already updated for new implementations but the bash
remediation was not updating the control if pam_faillock.so was once
enabled using the old remediation. This patch fix this.