### PR TITLE
Fix same shadow field bug in tests

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/home_dir_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/home_dir_present.pass.sh
@@ -5,6 +5,6 @@ useradd -m $USER
 
 # This is to make sure that any possible user create in the test environment has also
 # a home dir created on the system.
-for user in $(awk -F':' '{ if ($4 >= {{{ uid_min }}} && $4 != 65534) print $1}' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $1}' /etc/passwd); do
     mkhomedir_helper $user 0077;
 done


### PR DESCRIPTION
My fix from #8398 was incomplete as I hadn't noticed the same bug in the
SSG test suite. This is now fixed.

`Signed-off-by: Alexander Scheel <alexander.m.scheel@gmail.com>`