### PR TITLE
Fix spacing issue on ansible lint check

### DIFF
--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -33,7 +33,7 @@
     mode: "{{{ FILEMODE }}}"
     state: file
   with_items:
-    - "{{ files_found.stdout_lines}}"
+    - "{{ files_found.stdout_lines }}"
 
 {{% else %}}
 


### PR DESCRIPTION


#### Description:
- Fix spacing issue on ansible lint check.
  - Spaces are required between variables and brackets.
