### PR TITLE
OCP4: Remove oval check from file_groupowner_proxy_kubeconfig and fil…

### DIFF
--- a/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_proxy_kubeconfig/rule.yml
@@ -6,8 +6,6 @@ platform: ocp4-on-sdn
 
 title: 'Verify Group Who Owns The Worker Proxy Kubeconfig File'
 
-{{%- set kubeletconf_path = "/config/kube-proxy-config.yaml" %}}
-
 description: |-
   To ensure the Kubernetes ConfigMap is mounted into the sdn daemonset pods with the
   correct ownership, make sure that the <tt>sdn-config</tt> ConfigMap is mounted using
@@ -51,9 +49,3 @@ ocil: |-
      done
   </pre>
   The output should be <tt>root:root</tt>
-
-template:
-    name: file_groupowner
-    vars:
-        filepath: {{{ kubeletconf_path }}}
-        filegid: '0'

--- a/applications/openshift/worker/file_groupowner_proxy_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/worker/file_groupowner_proxy_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: PASS
+default_result: MANUAL

--- a/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_owner_proxy_kubeconfig/rule.yml
@@ -6,7 +6,6 @@ platform: ocp4-on-sdn
 
 title: 'Verify User Who Owns The Worker Proxy Kubeconfig File'
 
-{{%- set kubeletconf_path = "/config/kube-proxy-config.yaml" %}}
 
 description: |-
   To ensure the Kubernetes ConfigMap is mounted into the sdn daemonset pods with the
@@ -51,9 +50,3 @@ ocil: |-
      done
   </pre>
   The output should be <tt>root:root</tt>
-
-template:
-    name: file_owner
-    vars:
-        filepath: {{{ kubeletconf_path }}}
-        fileuid: '0'

--- a/applications/openshift/worker/file_owner_proxy_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/worker/file_owner_proxy_kubeconfig/tests/ocp4/e2e.yml
@@ -1,2 +1,2 @@
 ---
-default_result: PASS
+default_result: MANUAL


### PR DESCRIPTION
We need to remove the oval check from `file_groupowner_proxy_kubeconfig` and `file_owner_proxy_kubeconfig` because it was meant to check a file on the node instead of inside a pod. The oval check won't work on checking file permission inside a pod.
