### PR TITLE
Fix variable path access issue

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -13,7 +13,7 @@
 
 - name: Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
   replace:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     regexp: '^[\s]*{{{ SYSCTLVAR }}}'
     replace: '#{{{ SYSCTLVAR }}}'
   loop: "{{ find_sysctl_d.files }}"


### PR DESCRIPTION
#### Description:

There is an issue in the sysctl-related tasks when the configuration already exists. The module references the item dictionary returned by the find module instead of the 'path' element in the item dictionary.

Dict returned by the find module: https://docs.ansible.com/ansible/latest/collections/ansible/builtin/find_module.html#return-values

Details in https://github.com/ComplianceAsCode/content/issues/8275

#### Rationale:

Fixes issue #8275
