### PR TITLE
file_owner, file_groupowner, file_permission changed to no follow symlinks

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_symlink.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_symlink.pass.sh
@@ -5,5 +5,5 @@ useradd user_test
 TESTDIR="/usr/lib/"
 
 # The check ignores this symlink and results in pass
-ln -s $TESTDIR/mising_test_file $TESTDIR/faulty_symlink
+ln -s $TESTDIR/missing_test_file $TESTDIR/faulty_symlink
 chown -h user_test $TESTDIR/faulty_symlink

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_dir_perm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_dir_perm.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+useradd user_test
+TESTDIR="/usr/lib/"
+
+# Ensure everything is all right
+chmod -R u-s,g-ws,o-wt /lib /lib64 /usr/lib /usr/lib64
+
+# Let's setup a symlink to a directory,whose permissions are incompliant
+
+# Directory with incorrect perms
+mkdir /home/user_test/directory
+chmod 0766 /home/user_test/directory
+
+# File with correct perms
+touch /home/user_test/directory/test_file
+chmod 0755 /home/user_test/directory/test_file
+
+ln -s /home/user_test $TESTDIR/user_test_home

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_file_perm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_file_perm.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+useradd user_test
+TESTDIR="/usr/lib/"
+
+# Ensure everything is all right
+chmod -R u-s,g-ws,o-wt /lib /lib64 /usr/lib /usr/lib64
+
+# Let's setup a symlink to a directory that contains an incomplient file
+
+# Directory with correct perms
+mkdir /home/user_test/directory
+chmod 0755 /home/user_test/directory
+
+# File with incorrect perms
+touch /home/user_test/directory/test_file
+chmod 0766 /home/user_test/directory/test_file
+
+ln -s /home/user_test $TESTDIR/user_test_home

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/file_symlink_incorrect_target_perm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/file_symlink_incorrect_target_perm.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+useradd user_test
+TESTDIR="/usr/lib/"
+
+# Ensure everything is all right
+chmod -R u-s,g-ws,o-wt /lib /lib64 /usr/lib /usr/lib64
+
+# Let's setup a symlink to a file, whose permissions are incompliant
+
+# File with incorrect perms
+touch /home/user_test/test_file
+chmod 0766 /home/user_test/test_file
+
+ln -s /home/user_test/test_file $TESTDIR/user_test_home

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: 'find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
+  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -15,7 +15,7 @@
 {{%- if FILE_REGEX %}}
 find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ FILEGID }}} {} \;
 {{% else %}}
-find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
 {{%- endif %}}
 {{%- else %}}
 chgrp {{{ FILEGID }}} {{{ path }}}

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -22,10 +22,9 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       {{%- if RECURSIVE %}}
-      <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
-      {{%- else %}}
-      <unix:path>{{{ filepath[:-1] }}}</unix:path>
+      <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
       {{%- endif %}}
+      <unix:path>{{{ filepath[:-1] }}}</unix:path>
       {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
       {{%- else %}}

--- a/shared/templates/file_owner/ansible.template
+++ b/shared/templates/file_owner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: 'find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
+  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_owner/bash.template
+++ b/shared/templates/file_owner/bash.template
@@ -15,7 +15,7 @@
 {{%- if FILE_REGEX %}}
 find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -uid {{{ FILEUID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chown {{{ FILEUID }}} {} \;
 {{%- else %}}
-find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown {{{ FILEUID }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chown {{{ FILEUID }}} {} \;
 {{%- endif %}}
 {{%- else %}}
 chown {{{ FILEUID }}} {{{ path }}}

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -22,10 +22,9 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY -%}}
       {{%- if RECURSIVE %}}
-      <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
-      {{%- else %}}
-      <unix:path>{{{ filepath[:-1] }}}</unix:path>
+      <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
       {{%- endif %}}
+      <unix:path>{{{ filepath[:-1] }}}</unix:path>
       {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
       {{%- else %}}

--- a/shared/templates/file_permissions/ansible.template
+++ b/shared/templates/file_permissions/ansible.template
@@ -21,7 +21,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s){{% if RECURSIVE %}} recursively{{% endif %}}
-  command: 'find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex "{{{ FILE_REGEX[loop.index0] }}}"'
+  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False

--- a/shared/templates/file_permissions/bash.template
+++ b/shared/templates/file_permissions/bash.template
@@ -19,9 +19,9 @@
 {{% for path in FILEPATH %}}
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
-find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chmod {{{ FILEMODE }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type f -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chmod {{{ FILEMODE }}} {} \;
 {{%- else %}}
-find -L {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} {{{ PERMS }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
 {{%- endif %}}
 {{%- else %}}
 chmod {{{ FILEMODE }}} {{{ path }}}

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -26,10 +26,9 @@
   <unix:file_object comment="{{{ filepath }}}" id="object_file_permissions{{{ FILEID }}}_{{{ loop.index0 }}}" version="1">
     {{%- if IS_DIRECTORY %}}
       {{%- if RECURSIVE %}}
-      <unix:path operation="pattern match">^{{{ filepath[:-1] }}}</unix:path>
-      {{%- else %}}
-      <unix:path>{{{ filepath[:-1] }}}</unix:path>
+      <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
       {{%- endif %}}
+      <unix:path>{{{ filepath[:-1] }}}</unix:path>
       {{%- if FILE_REGEX %}}
       <unix:filename operation="pattern match">{{{ FILE_REGEX[loop.index0] }}}</unix:filename>
       {{%- else %}}


### PR DESCRIPTION
#### Description:
- 6a3f401aec68db0510ca9e1006ae29196473951c Fixes the remediations so they don't follow symlinks, this fix is similar to https://github.com/ComplianceAsCode/content/pull/8420, but on the `find` command level.
  - The fix was inadvertently undone in https://github.com/ComplianceAsCode/content/commit/2cb3907832b1d25ce7c0174c01cdac8123f5be7e
- https://github.com/ComplianceAsCode/content/commit/2cb3907832b1d25ce7c0174c01cdac8123f5be7e Adds tests to assert and ensure that OVAL behavior regarding symlinks.
- 6df9c35235c70707d2a8d7105a4f57c2485c690e Fixes OVAL's "recurse down but on on symlinks" behavior.

#### Rationale:

- Given the symlinks and hardlinks we can find in `/lib`, `/lib64`, `/usr/lib` and `/usr/lib64` I believe these templates should not follow symlinks (may be arguable for other paths).

- Fixes #8412
