### PR TITLE
Align pam_faillock bash macros to ansible macros

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/bash/shared.sh
@@ -1,8 +1,6 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
-if [ -f /usr/bin/authselect ]; then
-    {{{ bash_enable_pam_faillock_with_authselect() }}}
-fi
-
 {{{ bash_instantiate_variables("var_accounts_passwords_pam_faillock_deny") }}}
-{{{ bash_set_faillock_option("deny", "$var_accounts_passwords_pam_faillock_deny") }}}
+
+{{{ bash_pam_faillock_enable() }}}
+{{{ bash_pam_faillock_parameter_value("deny", "$var_accounts_passwords_pam_faillock_deny") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/bash/shared.sh
@@ -1,7 +1,4 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
-if [ -f /usr/bin/authselect ]; then
-    {{{ bash_enable_pam_faillock_with_authselect() }}}
-fi
-
-{{{ bash_set_faillock_option("even_deny_root", "") }}}
+{{{ bash_pam_faillock_enable() }}}
+{{{ bash_pam_faillock_parameter_value("even_deny_root", "") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
-{{{ bash_enable_pam_faillock_with_authselect() }}}
-{{{ bash_set_faillock_option("local_users_only", "") }}}
+{{{ bash_pam_faillock_enable() }}}
+{{{ bash_pam_faillock_parameter_value("local_users_only", "") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/bash/shared.sh
@@ -1,8 +1,6 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
-if [ -f /usr/bin/authselect ]; then
-    {{{ bash_enable_pam_faillock_with_authselect() }}}
-fi
-
 {{{ bash_instantiate_variables("var_accounts_passwords_pam_faillock_fail_interval") }}}
-{{{ bash_set_faillock_option("fail_interval", "$var_accounts_passwords_pam_faillock_fail_interval") }}}
+
+{{{ bash_pam_faillock_enable() }}}
+{{{ bash_pam_faillock_parameter_value("fail_interval", "$var_accounts_passwords_pam_faillock_fail_interval") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/bash/shared.sh
@@ -1,8 +1,6 @@
 # platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
-if [ -f /usr/bin/authselect ]; then
-    {{{ bash_enable_pam_faillock_with_authselect() }}}
-fi
-
 {{{ bash_instantiate_variables("var_accounts_passwords_pam_faillock_unlock_time") }}}
-{{{ bash_set_faillock_option("unlock_time", "$var_accounts_passwords_pam_faillock_unlock_time") }}}
+
+{{{ bash_pam_faillock_enable() }}}
+{{{ bash_pam_faillock_parameter_value("unlock_time", "$var_accounts_passwords_pam_faillock_unlock_time") }}}

--- a/shared/macros-bash.jinja
+++ b/shared/macros-bash.jinja
@@ -1003,6 +1003,31 @@ fi
 {{%- endmacro -%}}
 
 {{#
+    Enable pam_faillock.so PAM module by directly editing PAM files.
+    This option is only recommended when authselect tool is not available for the system.
+#}}
+{{%- macro bash_enable_pam_faillock_directly_in_pam_files() -%}}
+AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
+for pam_file in "${AUTH_FILES[@]}"
+do
+    if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+(preauth silent|authfail).*$' "$pam_file" ; then
+        sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent' "$pam_file"
+        sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        required      pam_faillock.so authfail' "$pam_file"
+        sed -i --follow-symlinks '/^account.*required.*pam_unix.so.*/i account     required      pam_faillock.so' "$pam_file"
+    fi
+    sed -Ei 's/(auth.*)(\[default=die\])(.*pam_faillock.so)/\1required     \3/g' "$pam_file"
+done
+{{%- endmacro -%}}
+
+{{%- macro bash_pam_faillock_enable() -%}}
+if [ -f /usr/bin/authselect ]; then
+    {{{ bash_enable_pam_faillock_with_authselect() }}}
+else
+    {{{ bash_enable_pam_faillock_directly_in_pam_files() }}}
+fi
+{{%- endmacro -%}}
+
+{{#
     Sets PAM faillock module options and values.
     It also adds pam_faillock.so as required module for account.
 
@@ -1010,26 +1035,7 @@ fi
 :param value: value of option
 
 #}}
-{{%- macro bash_set_faillock_option(option, value) -%}}
-AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
-
-for pam_file in "${AUTH_FILES[@]}"
-do
-    {{{ bash_pam_faillock_enable("$pam_file") | indent(4) }}}
-    {{{ bash_pam_faillock_parameter_value("$pam_file", option, value) | indent(4) }}}
-done
-{{%- endmacro -%}}
-
-{{%- macro bash_pam_faillock_enable(pam_file) -%}}
-if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+(preauth silent|authfail).*$' "{{{ pam_file }}}" ; then
-    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent' "{{{ pam_file }}}"
-    sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        required      pam_faillock.so authfail' "{{{ pam_file }}}"
-    sed -i --follow-symlinks '/^account.*required.*pam_unix.so.*/i account     required      pam_faillock.so' "{{{ pam_file }}}"
-fi
-sed -Ei 's/(auth.*)(\[default=die\])(.*pam_faillock.so)/\1required     \3/g' "{{{ pam_file }}}"
-{{%- endmacro -%}}
-
-{{%- macro bash_pam_faillock_parameter_value(pam_file, option, value='') -%}}
+{{%- macro bash_pam_faillock_parameter_value(option, value='') -%}}
 FAILLOCK_CONF="/etc/security/faillock.conf"
 if [ -f $FAILLOCK_CONF ]; then
     {{%- if value == '' %}}
@@ -1049,22 +1055,26 @@ if [ -f $FAILLOCK_CONF ]; then
     fi
     {{%- endif %}}
 else
-    if ! grep -qE '^\s*auth.*pam_faillock.so (preauth|authfail).*{{{ option }}}' "{{{ pam_file }}}"; then
+    AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
+    for pam_file in "${AUTH_FILES[@]}"
+    do
+        if ! grep -qE '^\s*auth.*pam_faillock.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
+            {{%- if value == '' %}}
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}/' "$pam_file"
+            {{%- else %}}
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            {{%- endif %}}
         {{%- if value == '' %}}
-        sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}/' "{{{ pam_file }}}"
-        sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}/' "{{{ pam_file }}}"
+        fi
         {{%- else %}}
-        sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "{{{ pam_file }}}"
-        sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "{{{ pam_file }}}"
+        else
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+        fi
         {{%- endif %}}
-    {{%- if value == '' %}}
-    fi
-    {{%- else %}}
-    else
-        sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "{{{ pam_file }}}"
-        sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "{{{ pam_file }}}"
-    fi
-    {{%- endif %}}
+    done
 fi
 {{%- endmacro -%}}
 


### PR DESCRIPTION
Recently pam_faillock.so remediation were refactored to remove code duplication with macros.
That time Ansible macros were developed and bash macros were slightly changed.
Now the bash macros were also refactored to be more aligned to Ansible macros using similar functions.
It is now less prone to discrepancies between Ansible and Bash remediation.
