### PR TITLE
Define CPE and detection logic for OCP4 on HyperShift

### DIFF
--- a/products/ocp4/product.yml
+++ b/products/ocp4/product.yml
@@ -126,6 +126,10 @@ cpes:
       title: "Red Hat OpenShift Container Platform 4 on SDN"
       check_id: installed_app_is_ocp4_on_openshiftsdn
 
+  - ocp4-on-hypershift:
+      name: "cpe:/a:redhat:openshift_container_platform_on_hypershift:4"
+      title: "Red Hat OpenShift Container Platform 4 on HyperShift"
+      check_id: installed_app_is_ocp4_on_hypershift
 
 # Requirement string, see: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing
 # requires: "openscap>=1.3.4"

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -168,5 +168,49 @@
       </ind:value>
   </ind:yamlfilecontent_state>
 {{% endfor %}}
-</def-group>
 
+  <!-- Check for OpenShift Container Platform 4 on HyperShift -->
+  <definition class="inventory" id="installed_app_is_ocp4_on_hypershift" version="1">
+    <metadata>
+      <title>Red Hat OpenShift Container Platform</title>
+      <affected family="unix">
+        <platform>Red Hat OpenShift Container Platform 4 on HyperShift</platform>
+      </affected>
+      <reference ref_id="cpe:/a:redhat:openshift_container_platform_on_hypershift:4" source="CPE" />
+      <description>The application installed installed on the system is OpenShift 4 on HyperShift.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="cluster is OpenShift 4" test_ref="test_ocp4_hypershift" />
+      <criterion comment="Make sure OCP4 clusteroperators file is present" test_ref="test_file_for_ocp4_hypershift"/>
+    </criteria>
+  </definition>
+
+  <ind:yamlfilecontent_test id="test_ocp4_hypershift" check="at least one" comment="Find one match" version="1">
+      <ind:object object_ref="object_ocp4_hypershift"/>
+      <ind:state state_ref="state_ocp4_hypershift"/>
+  </ind:yamlfilecontent_test>
+
+  <local_variable id="hypershift_hosted_cluster_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
+    <literal_component>/kubernetes-api-resources/apis/apiextensions.k8s.io/v1/customresourcedefinitions/hostedclusters.hypershift.openshift.io</literal_component>
+  </local_variable>
+
+  <unix:file_test id="test_file_for_ocp4_hypershift" check="only one" comment="Find the actual file to be scanned." version="1">
+      <unix:object object_ref="object_file_for_ocp4_hypershift"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_file_for_ocp4_hypershift" version="1">
+      <unix:filepath var_ref="hypershift_hosted_cluster_location"/>
+  </unix:file_object>
+
+  <ind:yamlfilecontent_object id="object_ocp4_hypershift" version="1">
+      <ind:filepath var_ref="hypershift_hosted_cluster_location"/>
+      <ind:yamlpath>.status.acceptedNames.kind</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+  <ind:yamlfilecontent_state id="state_ocp4_hypershift" version="1">
+      <ind:value datatype="record">
+          <field name="#" datatype="string" operation="pattern match">HostedCluster</field>
+      </ind:value>
+  </ind:yamlfilecontent_state>
+
+</def-group>


### PR DESCRIPTION
#### Description:

- Add platform definition and detection logic for HyperShift management cluster

#### Rationale:

OpenShift clusters can be deployed as a hosted cluster, one of the variations of OpenShift installation, using [HyperShift](https://github.com/openshift/hypershift) technology.  HyperShift can create a hosted cluster not only on an OpenShift cluster but also on a vanilla Kubernetes cluster. If the underlying cluster is vanilla Kubernetes, Compliance Operator does not perform any OCP4-related check (because the underlying cluster does not contain OpenShift version resource `/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver`) while it hosts OpenShift components such as API server, kubelet and Etcd inside of a hosted cluster namespace.

This PR provides a new platform definition called `ocp4-on-hypershift`. The trigger of the definition is existence of a custom resource of HyperShift `/kubernetes-api-resources/apis/apiextensions.k8s.io/v1/customresourcedefinitions/hostedclusters.hypershift.openshift.io`. When this CRD exists in the cluster, then the platform is marked as `ocp4-on-hypershift`, as an variation of OpenShift, and OCP4-related rules will be ignited.
