### PR TITLE
Fix OCIL macro call for some kernel build config rules

### DIFF
--- a/linux_os/guide/system/kernel_build_config/kernel_config_debug_wx/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_debug_wx/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_DEBUG_WX", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_DEBUG_WX", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_fortify_source/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_fortify_source/rule.yml
@@ -26,7 +26,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_FORTIFY_SOURCE", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_FORTIFY_SOURCE", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_hardened_usercopy/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_hardened_usercopy/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_HARDENED_USERCOPY", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_HARDENED_USERCOPY", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_none/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_none/rule.yml
@@ -26,7 +26,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_LEGACY_VSYSCALL_NONE", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_LEGACY_VSYSCALL_NONE", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_refcount_full/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_refcount_full/rule.yml
@@ -30,7 +30,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_REFCOUNT_FULL", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_REFCOUNT_FULL", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_retpoline/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_retpoline/rule.yml
@@ -26,7 +26,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_RETPOLINE", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_RETPOLINE", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_sched_stack_end_check/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_sched_stack_end_check/rule.yml
@@ -28,7 +28,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_SCHED_STACK_END_CHECK", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_SCHED_STACK_END_CHECK", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config

--- a/linux_os/guide/system/kernel_build_config/kernel_config_vmap_stack/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_vmap_stack/rule.yml
@@ -25,7 +25,7 @@ identifiers:
 ocil_clause: 'the kernel was built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_VMAP_STACK", "Y") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_VMAP_STACK", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config


### PR DESCRIPTION
#### Description:

- The value in the `/boot/config-*` is `y`, not `Y`.

#### Rationale:

- Fix typo in option
