### PR TITLE
Add Centos Stream 8/9 support in install_vm script

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -26,7 +26,7 @@ def parse_args():
         "--distro",
         dest="distro",
         required=True,
-        choices=['fedora', 'rhel7', 'centos7', 'rhel8', 'rhel9'],
+        choices=['fedora', 'rhel7', 'centos7', 'centos8', 'centos9', 'rhel8', 'rhel9'],
         help="What distribution to install."
     )
     parser.add_argument(
@@ -144,6 +144,12 @@ def main():
             data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/os"
         elif data.distro == "centos7":
             data.url = "http://mirror.centos.org/centos/7/os/x86_64"
+        elif data.distro == "centos8":
+            data.url = "http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/"
+            data.extra_repo = "http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/"
+        elif data.distro == "centos9":
+            data.url = "http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/"
+            data.extra_repo = "http://mirror.stream.centos.org/9-stream/AppStream/x86_64/os/"
     if not data.url:
         sys.stderr.write("For the '{}' distro the `--url` option needs to be provided.\n".format(data.distro))
         return 1


### PR DESCRIPTION
#### Description:

- It adds a predefined set of URLs to centos 8/9 to point to their
repository so one can easily install the operating system by just using
the distro option.

#### Rationale:

- Easily install centos 8/9
