### PR TITLE
Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,11 +1,11 @@
 # Products
 
-/products/rhel*/product.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+/products/rhel*/product.yml @ComplianceAsCode/red-hatters
 
 # Product Specific Profiles
 
-/products/rhel*/profiles/ @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
-/controls/cis_rhel7.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
-/controls/cis_rhel8.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
-/controls/stig_rhel8.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
-/controls/stig_rhel9* @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+/products/rhel*/profiles/ @ComplianceAsCode/red-hatters
+/controls/cis_rhel7.yml @ComplianceAsCode/red-hatters
+/controls/cis_rhel8.yml @ComplianceAsCode/red-hatters
+/controls/stig_rhel8.yml @ComplianceAsCode/red-hatters
+/controls/stig_rhel9* @ComplianceAsCode/red-hatters

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,11 @@
+# Products
+
+/products/rhel*/product.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+
+# Product Specific Profiles
+
+/products/rhel*/profiles/ @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+/controls/cis_rhel7.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+/controls/cis_rhel8.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+/controls/stig_rhel8.yml @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato
+/controls/stig_rhel9* @dahaic @evgenyz @ggbecker @jan-cerny @Mab879 @marcusburghardt @matejak @matusmarhefka @mildas @vojtapolasek @yuumasato

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,4 +8,3 @@
 /controls/cis_rhel7.yml @ComplianceAsCode/red-hatters
 /controls/cis_rhel8.yml @ComplianceAsCode/red-hatters
 /controls/stig_rhel8.yml @ComplianceAsCode/red-hatters
-/controls/stig_rhel9* @ComplianceAsCode/red-hatters


### PR DESCRIPTION
Code owners are automatically requested for review when someone opens a
pull request that modifies code that they own. Optionally, the
repository can be configured to require an approval from a code owner
before merging a PR that modifies code that they own.

See:
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Related to https://github.com/ComplianceAsCode/content/pull/8359
