### PR TITLE
Set Benchmark's resolved attribute to true

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -912,7 +912,7 @@ class Benchmark(XCCDFEntity):
         root.set('xsi:schemaLocation',
                  'http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd')
         root.set('style', 'SCAP_1.1')
-        root.set('resolved', 'false')
+        root.set('resolved', 'true')
         root.set('xml:lang', 'en-US')
         status = ET.SubElement(root, 'status')
         status.set('date', datetime.date.today().strftime("%Y-%m-%d"))


### PR DESCRIPTION


#### Description:
As we generate an XCCDF that is in a resolved form since its creation we should set the resolved element to true.

#### Rationale:

Produces warning `WARNING: Processing an unresolved XCCDF document. This may have unexpected results.`, but shouldn't have any impact.
