### PR TITLE
Change the OCIL clause of kernel build config rules to negative form

### DIFF
--- a/linux_os/guide/system/kernel_build_config/kernel_config_acpi_custom_method/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_acpi_custom_method/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@rhel8: CCE-86778-8
     cce@rhel9: CCE-86779-6
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_ACPI_CUSTOM_METHOD", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_compat_vdso/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_compat_vdso/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@rhel8: CCE-87256-4
     cce@rhel9: CCE-87257-2
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_COMPAT_VDSO", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_debug_fs/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_debug_fs/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@rhel8: CCE-88033-6
     cce@rhel9: CCE-89033-5
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_DEBUG_FS", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_debug_wx/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_debug_wx/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@rhel8: CCE-87032-9
     cce@rhel9: CCE-88032-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_DEBUG_WX", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_devkmem/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_devkmem/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@rhel8: CCE-86947-9
     cce@rhel9: CCE-86948-7
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_DEVKMEM", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_fortify_source/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_fortify_source/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@rhel8: CCE-86545-1
     cce@rhel9: CCE-86546-9
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_FORTIFY_SOURCE", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_hardened_usercopy/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_hardened_usercopy/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@rhel8: CCE-88299-3
     cce@rhel9: CCE-89299-2
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_HARDENED_USERCOPY", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_hardened_usercopy_fallback/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_hardened_usercopy_fallback/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@rhel8: CCE-86091-6
     cce@rhel9: CCE-86092-4
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_HARDENED_USERCOPY_FALLBACK", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_emulate/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_emulate/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@rhel8: CCE-87649-0
     cce@rhel9: CCE-87650-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_LEGACY_VSYSCALL_EMULATE", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_none/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_none/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@rhel8: CCE-87573-2
     cce@rhel9: CCE-87574-0
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_LEGACY_VSYSCALL_NONE", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_xonly/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_legacy_vsyscall_xonly/rule.yml
@@ -22,7 +22,7 @@ severity: medium
 identifiers:
     cce@rhel9: CCE-87805-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_LEGACY_VSYSCALL_XONLY", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_proc_kcore/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_proc_kcore/rule.yml
@@ -21,7 +21,7 @@ identifiers:
     cce@rhel8: CCE-87105-3
     cce@rhel9: CCE-87106-1
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_PROC_KCORE", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_refcount_full/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_refcount_full/rule.yml
@@ -27,7 +27,7 @@ identifiers:
     cce@rhel8: CCE-86422-3
     cce@rhel9: CCE-86423-1
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_REFCOUNT_FULL", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_retpoline/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_retpoline/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@rhel8: CCE-87494-1
     cce@rhel9: CCE-87495-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_RETPOLINE", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_sched_stack_end_check/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_sched_stack_end_check/rule.yml
@@ -25,7 +25,7 @@ identifiers:
     cce@rhel8: CCE-88041-9
     cce@rhel9: CCE-89041-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_SCHED_STACK_END_CHECK", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_security_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_security_dmesg_restrict/rule.yml
@@ -20,7 +20,7 @@ identifiers:
     cce@rhel8: CCE-87339-8
     cce@rhel9: CCE-87340-6
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_SECURITY_DMESG_RESTRICT", "n") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_stackprotector/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_stackprotector/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@rhel8: CCE-88055-9
     cce@rhel9: CCE-89055-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_STACKPROTECTOR", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_stackprotector_strong/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_stackprotector_strong/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@rhel8: CCE-88036-9
     cce@rhel9: CCE-89036-8
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_STACKPROTECTOR_STRONG", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_strict_kernel_rwx/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_strict_kernel_rwx/rule.yml
@@ -22,7 +22,7 @@ identifiers:
     cce@rhel8: CCE-85993-4
     cce@rhel9: CCE-86993-3
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_STRICT_KERNEL_WRX", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_vmap_stack/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_vmap_stack/rule.yml
@@ -22,7 +22,7 @@ identifiers:
     cce@rhel8: CCE-86251-6
     cce@rhel9: CCE-86252-4
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_VMAP_STACK", "y") | indent(4) }}}

--- a/linux_os/guide/system/kernel_build_config/kernel_config_x86_vsyscall_emulation/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_x86_vsyscall_emulation/rule.yml
@@ -23,7 +23,7 @@ identifiers:
     cce@rhel8: CCE-87883-5
     cce@rhel9: CCE-87884-3
 
-ocil_clause: 'the kernel was built with the required value'
+ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
     {{{ kernel_build_config_ocil("CONFIG_X86_VSYSCALL_EMULATION", "n") | indent(4) }}}


### PR DESCRIPTION
#### Description:

- Change the OCIL clause of kernel build config rules to negative form

#### Rationale:

- This is the way the OCIL questions should be worded
