### PR TITLE
tests/ds_unselect_rules.sh: make unselecting of rules more robust

### DIFF
--- a/tests/ds_unselect_rules.sh
+++ b/tests/ds_unselect_rules.sh
@@ -16,7 +16,7 @@ DS="/tmp/$(basename $DS)"
 
 printf 'Unselecting rules listed in the %s from the %s\n' "$UNSELECT_LIST" "$DS"
 for rule in $(cat $UNSELECT_LIST); do
-	sed -i "/<.*Rule id=\"$rule/s/selected=\"true\"/selected=\"false\"/g" $DS || exit 1
-	sed -i "/<.*select idref=\"$rule/s/selected=\"true\"/selected=\"false\"/g" $DS || exit 1
+	sed -i "/<.*Rule.*id=\"$rule/s/selected=\"true\"/selected=\"false\"/g" $DS || exit 1
+	sed -i "/<.*select.*idref=\"$rule/s/selected=\"true\"/selected=\"false\"/g" $DS || exit 1
 done
 printf "Done\n"


### PR DESCRIPTION
Script assumed that `id`/`idref` attributes inside `Rule`/`select`
elements will always be first attributes which might not be true
all the time, for example in the latest RHEL9 data stream the `Rule`
elements look like this:

```
<xccdf-1.2:Rule selected="true" id="xccdf_org.ssgproject.content_rule_package_aide_installed" severity="medium">
```