### PR TITLE
Add SRG mapping text to the STIG mapping table

### DIFF
--- a/shared/transforms/shared_xccdf2table-stig.xslt
+++ b/shared/transforms/shared_xccdf2table-stig.xslt
@@ -75,6 +75,7 @@
 				<td>CCI</td>
 				<td>CAT</td>
 				<td>Title</td>
+				<td>SRG</td>
 			</xsl:otherwise>
 			</xsl:choose>
 				<td>Description</td>
@@ -112,6 +113,7 @@
 				<!--<td> <xsl:value-of select="cdf:title" /></td>-->
 				<td> <xsl:value-of select="cdf:Rule/@severity" /></td>
 				<td> <xsl:value-of select="cdf:Rule/cdf:title" /></td>
+				<td> <xsl:value-of select="cdf:title/node()" /></td>
 			</xsl:otherwise>
 			</xsl:choose>
 			<td> <pre> <xsl:call-template name="extract-vulndiscussion"><xsl:with-param name="desc" select="cdf:Rule/cdf:description"/></xsl:call-template> </pre> </td>


### PR DESCRIPTION
#### Description:

- Add SRG mapping text to the STIG mapping table.

#### Rationale:

- We can easily access the mapped SRG a STIG item has and it will be available in e.g.: https://complianceascode.github.io/content/tables/table-rhel8-stig-manual.html

![Screenshot from 2022-04-05 13-03-34](https://user-images.githubusercontent.com/18730394/161740384-27414f93-2918-4d5e-91e8-9ffdaf865409.png)

