### PR TITLE
correct update-crypto-policies --set is not idempotent

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -14,8 +14,8 @@
 
 - name: Register Crypto Policy value (runtime)
   command: /usr/bin/update-crypto-policies --show
-  register: update_crypo_policies_show
+  register: update_crypto_policies_show
 
 - name: Verify that Crypto Policy is Set (runtime)
   command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
-  when: update_crypo_policies_show.stdout != var_system_crypto_policy
+  when: update_crypto_policies_show.stdout != var_system_crypto_policy

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/ansible/shared.yml
@@ -12,5 +12,10 @@
     line: "{{ var_system_crypto_policy }}"
     create: yes
 
+- name: Register Crypto Policy value (runtime)
+  command: /usr/bin/update-crypto-policies --show
+  register: update_crypo_policies_show
+
 - name: Verify that Crypto Policy is Set (runtime)
   command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
+  when: update_crypo_policies_show.stdout != var_system_crypto_policy

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -24,8 +24,8 @@
 
 - name: Register Crypto Policy value (runtime)
   command: /usr/bin/update-crypto-policies --show
-  register: update_crypo_policies_show
+  register: update_crypto_policies_show
 
 - name: Verify that Crypto Policy is Set (runtime)
   command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
-  when: update_crypo_policies_show.stdout != var_system_crypto_policy
+  when: update_crypto_policies_show.stdout != var_system_crypto_policy

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -22,5 +22,10 @@
     line: "{{ var_system_crypto_policy }}"
     create: yes
 
+- name: Register Crypto Policy value (runtime)
+  command: /usr/bin/update-crypto-policies --show
+  register: update_crypo_policies_show
+
 - name: Verify that Crypto Policy is Set (runtime)
   command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
+  when: update_crypo_policies_show.stdout != var_system_crypto_policy

--- a/tests/unit/ssg-module/test_playbook_builder_data/guide/configure_crypto_policy/ansible/shared.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/guide/configure_crypto_policy/ansible/shared.yml
@@ -14,8 +14,8 @@
 
 - name: Register Crypto Policy value (runtime)
   command: /usr/bin/update-crypto-policies --show
-  register: update_crypo_policies_show
+  register: update_crypto_policies_show
 
 - name: Verify that Crypto Policy is Set (runtime)
   command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
-  when: update_crypo_policies_show.stdout != var_system_crypto_policy
+  when: update_crypto_policies_show.stdout != var_system_crypto_policy

--- a/tests/unit/ssg-module/test_playbook_builder_data/guide/configure_crypto_policy/ansible/shared.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/guide/configure_crypto_policy/ansible/shared.yml
@@ -12,5 +12,10 @@
     line: "{{ var_system_crypto_policy }}"
     create: yes
 
+- name: Register Crypto Policy value (runtime)
+  command: /usr/bin/update-crypto-policies --show
+  register: update_crypo_policies_show
+
 - name: Verify that Crypto Policy is Set (runtime)
   command: /usr/bin/update-crypto-policies --set {{ var_system_crypto_policy }}
+  when: update_crypo_policies_show.stdout != var_system_crypto_policy


### PR DESCRIPTION
#### Description:
update-crypto-policies --set is not idempotent and will execute on subsequent runs of Ansible. Check and compare the current runtime value of update-crypto-policies by invoking update-crypto-policies --show and registering its output as a variable which can be used as a conditional on the subsequent update-crypto-policies --set

#### Rationale:
Ansible should be idempotent by providing a conditional state to compare against.