### PR TITLE
Remove `sshd_set_idle_timeout` tests that check wrong `sshd_set_keepalive` configuration

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/oval/shared.xml
@@ -33,7 +33,7 @@
           test_ref="test_sshd_idle_timeout_config_dir" />
           {{%- endif %}}
         </criteria>
-        {{%- if product not in ["ol8", "rhel8"] %}}
+        {{%- if product not in ["ol8", "rhel8", "rhel9"] %}}
         <extend_definition comment="The SSH ClientAliveCountMax is set to zero" definition_ref="sshd_set_keepalive" />
         {{% endif %}}
       </criteria>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/comment.fail.sh
@@ -7,5 +7,6 @@ SSHD_CONFIG="/etc/ssh/sshd_config"
 
 . "$SHARED/utilities.sh"
 
-assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "ClientAliveInterval 10"
-assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "# ClientAliveCountMax 0"
+sed -i "/ClientAliveInterval/d" "$SSHD_CONFIG"
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveInterval "# ClientAliveInterval 10"
+assert_directive_in_file "$SSHD_CONFIG" ClientAliveCountMax "ClientAliveCountMax 0"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/line_not_there.fail.sh
@@ -3,4 +3,5 @@
 
 # The rule doesn't remediate the ClientAliveCountMax setting, we have another rule for that.
 
-sed -i "/^ClientAliveCountMax.*/d" /etc/ssh/sshd_config
+sed -i "/^ClientAliveInterval.*/d" /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/other_comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/other_comment.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 
 SSHD_CONFIG="/etc/ssh/sshd_config"
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/other_line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/other_line_not_there.fail.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 # remediation = none
 
 # The rule doesn't remediate the ClientAliveCountMax setting, we have another rule for that.
 
-sed -i "/^ClientAliveInterval.*/d" /etc/ssh/sshd_config
+sed -i "/^ClientAliveCountMax.*/d" /etc/ssh/sshd_config
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/other_wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/tests/other_wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = Red Hat Enterprise Linux 7
 # remediation = none
 
 # The rule doesn't remediate the ClientAliveCountMax setting, we have another rule for that.


### PR DESCRIPTION
#### Description:
`sshd_set_idle_timeout` tests cleanup, because it doesn't check `ClientAliveCountMax` (`sshd_set_keepalive` configuration) anymore.

#### Rationale:
Previously, the rule had `extend_definition`checking `sshd_set_keepalive`. But the definition was removed and now `sshd_set_keepalive` is as `requires`. The rule in `requires` is not checked during `oscap xccdf eval --rule`, see https://github.com/OpenSCAP/openscap/issues/1854#issuecomment-1090251235