### PR TITLE
remove redundant rule from HIPAA profiles

### DIFF
--- a/products/rhel7/profiles/hipaa.profile
+++ b/products/rhel7/profiles/hipaa.profile
@@ -24,7 +24,6 @@ selections:
     - grub2_password
     - grub2_uefi_password
     - file_groupowner_grub2_cfg
-    - file_permissions_grub2_cfg
     - file_owner_grub2_cfg
     - grub2_disable_interactive_boot
     - no_direct_root_logins

--- a/products/rhel8/profiles/hipaa.profile
+++ b/products/rhel8/profiles/hipaa.profile
@@ -24,7 +24,6 @@ selections:
     - grub2_password
     - grub2_uefi_password
     - file_groupowner_grub2_cfg
-    - file_permissions_grub2_cfg
     - file_owner_grub2_cfg
     - grub2_disable_interactive_boot
     - no_direct_root_logins

--- a/products/rhel9/profiles/hipaa.profile
+++ b/products/rhel9/profiles/hipaa.profile
@@ -24,7 +24,6 @@ selections:
     - grub2_password
     - grub2_uefi_password
     - file_groupowner_grub2_cfg
-    - file_permissions_grub2_cfg
     - file_owner_grub2_cfg
     - grub2_disable_interactive_boot
     - no_direct_root_logins


### PR DESCRIPTION
#### Description:

- remove file_permissions_grub2_cfg from rhel hipaa profiles

#### Rationale:

- the rule is colliding with rpm_verify_permissions
- the requirement is addressed by the fact that the /boot/grub2 directory has no permissions for group or other