### PR TITLE
install_vm.py: update default Fedora version to 35

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -141,7 +141,7 @@ def main():
 
     if not data.url:
         if data.distro == "fedora":
-            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Everything/x86_64/os"
+            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os"
         elif data.distro == "centos7":
             data.url = "http://mirror.centos.org/centos/7/os/x86_64"
         elif data.distro == "centos8":
@@ -221,7 +221,7 @@ def main():
     # The kernel option 'net.ifnames=0' is used to disable predictable network
     # interface names, for more details see:
     # https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/
-    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} {inst_opt} ksdevice=eth0 net.ifnames=0 console=ttyS0,115200" --serial pty --graphics={graphics_opt} --noautoconsole --rng /dev/random --wait={wait_opt} --location={url}'.format(**data.__dict__)
+    command = 'virt-install --connect={libvirt} --name={domain} --memory={ram} --vcpus={cpu} --network {network} --disk {disk_spec} --initrd-inject={kickstart} --extra-args="inst.ks=file:/{ks_basename} {inst_opt} inst.ks.device=eth0 net.ifnames=0 console=ttyS0,115200" --serial pty --graphics={graphics_opt} --noautoconsole --rng /dev/random --wait={wait_opt} --location={url}'.format(**data.__dict__)
     if data.uefi == "normal":
         command = command+" --boot uefi"
     if data.uefi == "secureboot":


### PR DESCRIPTION
All usage of Anaconda boot arguments without `inst.` prefix
was removed in Fedora, for more details see:

https://docs.fedoraproject.org/en-US/fedora/latest/install-guide/advanced/Boot_Options/#sect-boot-options-deprecated

Therefore, this commit also updates `ksdevice` option to
`inst.ks.device` due to `ksdevice` being deprecated and removed.
The new `inst.ks.device` option offers the same functionality as
the deprecated `ksdevice` option on both RHEL7 and RHEL8.