### PR TITLE
Update SRG-OS-000125-GPOS-00065 for RHEL 9 STIG

### DIFF
--- a/controls/stig_rhel9/SRG-OS-000125-GPOS-00065.yml
+++ b/controls/stig_rhel9/SRG-OS-000125-GPOS-00065.yml
@@ -2,7 +2,7 @@ controls:
     -   id: SRG-OS-000125-GPOS-00065
         levels:
             - medium
-        title: The operating system must employ strong authenticators in the establishment
+        title: {{{ full_name }}} must employ strong authenticators in the establishment
             of nonlocal maintenance and diagnostic sessions.
         rules:
             - sshd_enable_pam

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
@@ -45,4 +45,4 @@ template:
         value: 'yes'
 
 fix: |-
-    {{{ sshd_lineinfile_fix('UsePam', 'yes') }}}
+    {{{ sshd_lineinfile_fix('UsePAM', 'yes') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/rule.yml
@@ -43,3 +43,6 @@ template:
         parameter: UsePAM
         rule_id: sshd_enable_pam
         value: 'yes'
+
+fix: |-
+    {{{ sshd_lineinfile_fix('UsePam', 'yes') }}}

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/rule.yml
@@ -41,7 +41,7 @@ ocil: |-
     To verify that kernel parameter 'crypto.fips_enabled' is set properly, run the following command:
     <pre>sysctl crypto.fips_enabled</pre>
     The output should contain the following:
-    <pre>crypto.fips_enabled =  1</pre>
+    <pre>crypto.fips_enabled = 1</pre>
 
 warnings:
     - general: |-
@@ -63,3 +63,14 @@ warnings:
         party review by an accredited lab. While open source software is
         capable of meeting this, it does not meet FIPS-140 unless the vendor
         submits to this process.
+
+fix: |-
+    Configure the operating system to implement DoD-approved encryption by following the steps below:
+
+    To enable strict FIPS compliance, the fips=1 kernel option needs to be added to the kernel boot parameters during system installation so key generation is done with FIPS-approved algorithms and continuous monitoring tests in place.
+
+    Enable FIPS mode after installation (not strict FIPS compliant) with the following command:
+
+    $ sudo fips-mode-setup --enable
+
+    Reboot the system for the changes to take effect.

--- a/shared/macros.jinja
+++ b/shared/macros.jinja
@@ -1755,7 +1755,7 @@ Fill in <tt>GRUBENV_FILE_LOCATION</tt> based on information above.
 {{%- endif -%}}
     To configure the system add or modify the following line in "{{{ path }}}".
 
-    {{{parameter}}}={{{value}}}
+    {{{parameter}}} {{{value}}}
 
     Restart the SSH daemon for the settings to take effect:
 


### PR DESCRIPTION
#### Description:
* Use correct separator macro sshd_lineinfile_fix The sshd_config file doesn't use = as a separator, it uses
whitespace.
* Add fix text

#### Rationale:

RHEL 9 STIG