### PR TITLE
Check for a CNI that supports network policies

### DIFF
--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -24,9 +24,29 @@ ocil: |-
     <pre>$ oc explain networkpolicy</pre>
     The resulting output should be an explanation of the NetworkPolicy resource.
 
+{{% set api_path = '/apis/operator.openshift.io/v1/networks/cluster' %}}
+{{% set jqfilter = '[.spec.defaultNetwork.type]' %}}
+
 references:
     cis@ocp4: 5.3.1
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-1.1.4,Req-1.2,Req-2.2
     srg: SRG-APP-000516-CTR-001325,SRG-APP-000516-CTR-001330,SRG-APP-000516-CTR-001335
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_cluster_setting({api_path: jqfilter}) | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: "true"
+    filepath: |-
+      {{{ openshift_filtered_path(api_path, jqfilter) }}}
+    yamlpath: "[:]"
+    check_existence: "any_exist"
+    entity_check: "all"
+    values:
+      - value: "OpenShiftSDN|OVN"
+        operation: "pattern match"

--- a/applications/openshift/networking/configure_network_policies/tests/ocp4/e2e.yml
+++ b/applications/openshift/networking/configure_network_policies/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/networking/configure_network_policies/tests/openshiftsdn.pass.sh
+++ b/applications/openshift/networking/configure_network_policies/tests/openshiftsdn.pass.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+
+yum install -y jq
+
+kube_filepath_root="/kubernetes-api-resources"
+api_path="/apis/operator.openshift.io/v1/networks/cluster"
+dir="$kube_filepath_root/apis/operator.openshift.io/v1/networks"
+filepath="$kube_filepath_root$api_path"
+
+mkdir -p "$dir"
+
+jq_filter="[.spec.defaultNetwork.type]"
+
+cat <<EOF > "$filepath"
+
+{
+    "apiVersion": "operator.openshift.io/v1",
+    "kind": "Network",
+    "metadata": {
+        "creationTimestamp": "2022-04-25T13:39:15Z",
+        "generation": 61,
+        "name": "cluster",
+        "resourceVersion": "24589",
+        "uid": "089e8ee9-15c4-4868-80af-773df44cafdd"
+    },
+    "spec": {
+        "clusterNetwork": [
+            {
+                "cidr": "10.128.0.0/14",
+                "hostPrefix": 23
+            }
+        ],
+        "defaultNetwork": {
+            "type": "OpenShiftSDN"
+        },
+        "disableNetworkDiagnostics": false,
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": null,
+        "operatorLogLevel": "Normal",
+        "serviceNetwork": [
+            "172.30.0.0/16"
+        ],
+        "unsupportedConfigOverrides": null
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "False",
+                "type": "ManagementStateDegraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:52:19Z",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "True",
+                "type": "Upgradeable"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:53:53Z",
+                "status": "False",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:40:00Z",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "readyReplicas": 0,
+        "version": "4.10.6"
+    }
+}
+EOF
+
+# Get the filepath. This will actually be read by the scan.
+filteredpath="$filepath#$(echo -n "$api_path$jq_filter" | sha256sum | awk '{print $1}')"
+
+jq "$jq_filter" "$filepath" > "$filteredpath"

--- a/applications/openshift/networking/configure_network_policies/tests/ovn.pass.sh
+++ b/applications/openshift/networking/configure_network_policies/tests/ovn.pass.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+
+yum install -y jq
+
+kube_filepath_root="/kubernetes-api-resources"
+api_path="/apis/operator.openshift.io/v1/networks/cluster"
+dir="$kube_filepath_root/apis/operator.openshift.io/v1/networks"
+filepath="$kube_filepath_root$api_path"
+
+mkdir -p "$dir"
+
+jq_filter="[.spec.defaultNetwork.type]"
+
+cat <<EOF > "$filepath"
+
+{
+    "apiVersion": "operator.openshift.io/v1",
+    "kind": "Network",
+    "metadata": {
+        "creationTimestamp": "2022-04-25T13:39:15Z",
+        "generation": 61,
+        "name": "cluster",
+        "resourceVersion": "24589",
+        "uid": "089e8ee9-15c4-4868-80af-773df44cafdd"
+    },
+    "spec": {
+        "clusterNetwork": [
+            {
+                "cidr": "10.128.0.0/14",
+                "hostPrefix": 23
+            }
+        ],
+        "defaultNetwork": {
+            "type": "OVN"
+        },
+        "disableNetworkDiagnostics": false,
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": null,
+        "operatorLogLevel": "Normal",
+        "serviceNetwork": [
+            "172.30.0.0/16"
+        ],
+        "unsupportedConfigOverrides": null
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "False",
+                "type": "ManagementStateDegraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:52:19Z",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "True",
+                "type": "Upgradeable"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:53:53Z",
+                "status": "False",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:40:00Z",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "readyReplicas": 0,
+        "version": "4.10.6"
+    }
+}
+EOF
+
+# Get the filepath. This will actually be read by the scan.
+filteredpath="$filepath#$(echo -n "$api_path$jq_filter" | sha256sum | awk '{print $1}')"
+
+jq "$jq_filter" "$filepath" > "$filteredpath"

--- a/applications/openshift/networking/configure_network_policies/tests/unsupported-cni.fail.sh
+++ b/applications/openshift/networking/configure_network_policies/tests/unsupported-cni.fail.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+
+yum install -y jq
+
+kube_filepath_root="/kubernetes-api-resources"
+api_path="/apis/operator.openshift.io/v1/networks/cluster"
+dir="$kube_filepath_root/apis/operator.openshift.io/v1/networks"
+filepath="$kube_filepath_root$api_path"
+
+mkdir -p "$dir"
+
+jq_filter="[.spec.defaultNetwork.type]"
+
+cat <<EOF > "$filepath"
+
+{
+    "apiVersion": "operator.openshift.io/v1",
+    "kind": "Network",
+    "metadata": {
+        "creationTimestamp": "2022-04-25T13:39:15Z",
+        "generation": 61,
+        "name": "cluster",
+        "resourceVersion": "24589",
+        "uid": "089e8ee9-15c4-4868-80af-773df44cafdd"
+    },
+    "spec": {
+        "clusterNetwork": [
+            {
+                "cidr": "10.128.0.0/14",
+                "hostPrefix": 23
+            }
+        ],
+        "defaultNetwork": {
+            "type": "UnsupportedCNI"
+        },
+        "disableNetworkDiagnostics": false,
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": null,
+        "operatorLogLevel": "Normal",
+        "serviceNetwork": [
+            "172.30.0.0/16"
+        ],
+        "unsupportedConfigOverrides": null
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "False",
+                "type": "ManagementStateDegraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:52:19Z",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "True",
+                "type": "Upgradeable"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:53:53Z",
+                "status": "False",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:40:00Z",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "readyReplicas": 0,
+        "version": "4.10.6"
+    }
+}
+EOF
+
+# Get the filepath. This will actually be read by the scan.
+filteredpath="$filepath#$(echo -n "$api_path$jq_filter" | sha256sum | awk '{print $1}')"
+
+jq "$jq_filter" "$filepath" > "$filteredpath"


### PR DESCRIPTION
Before, configure_network_policies was a manual check that told the user
to make sure they were using a CNI that supported network policies. This
information is actually available through the K8S operator API.

Let's update the rule so that we query the appropriate resource and
filter it so we can check for CNIs that support network policies.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2072431