### PR TITLE
Fix index page generation for guides artifacts.

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -2,6 +2,8 @@ name: Github Pages
 on:
   push:
     branches: [ 'master' ]
+  pull_request:
+    branches: [ 'master' ]
 jobs:
   publish:
     name: Publish stats, tables and guides
@@ -29,7 +31,10 @@ jobs:
       - name: Generate HTML pages
         run: utils/generate_html_pages.sh $PAGES_DIR
         shell: bash
+        env:
+          PYTHONPATH: ${{ github.workspace }}
       - name: Deploy
+        if: ${{ github.event_name == 'push' }}
         uses: JamesIves/github-pages-deploy-action@v4.2.3
         with:
           branch: gh-pages # The branch the action should deploy to.

--- a/utils/generate_html_pages.sh
+++ b/utils/generate_html_pages.sh
@@ -50,7 +50,11 @@ echo "</html>" >> $STATS_DIR/index.html
 mkdir -p $PAGES_DIR/guides
 cp -rf build/guides $PAGES_DIR
 utils/gen_html_guides_index.py . $PAGES_DIR/guides/index.html
-
+retVal=$?
+if [ $retVal -ne 0 ]; then
+    echo "Something wrong happened while generating the HTML Guides Index page"
+    exit 1
+fi
 
 # Generate Mapping Tables page
 pushd build/tables

--- a/utils/generate_html_pages.sh
+++ b/utils/generate_html_pages.sh
@@ -70,6 +70,27 @@ echo "</body>" >> index.html
 echo "</html>" >> index.html
 popd
 
+# Generate SRG Mapping Tables
+mkdir -p $PAGES_DIR/srg_mapping
+pushd $PAGES_DIR/srg_mapping
+touch index.html
+echo "<html>" > index.html
+echo "<header>" >> index.html
+echo "<h1>SRG Mapping Tables</h1>" >> index.html
+echo "</header>" >> index.html
+echo "<body>" >> index.html
+echo "<ul>" >> index.html
+srg_products="rhel9" # space separated list of products
+for product in $srg_products
+do
+echo "<li><a href=\"srg-mapping-${product}.html\">srg-mapping-${product}.html</a></li>" >> index.html
+echo "<li><a href=\"srg-mapping-${product}.xlsx\">srg-mapping-${product}.xlsx</a></li>" >> index.html
+done
+echo "</ul>" >> index.html
+echo "</body>" >> index.html
+echo "</html>" >> index.html
+popd
+
 pushd $PAGES_DIR
 touch index.html
 echo "<html>" > index.html
@@ -81,7 +102,7 @@ echo "<ul>" >> index.html
 echo "<li><a href=\"statistics/index.html\">Statistics</a></li>" >> index.html
 echo "<li><a href=\"guides/index.html\">Guides</a></li>" >> index.html
 echo "<li><a href=\"tables/index.html\">Mapping Tables</a></li>" >> index.html
-echo "<li><a href=\"srg_mapping/\">SRG Mapping Tables</a></li>" >> index.html
+echo "<li><a href=\"srg_mapping/index.html\">SRG Mapping Tables</a></li>" >> index.html
 echo "</ul>" >> index.html
 echo "</body>" >> index.html
 echo "</html>" >> index.html


### PR DESCRIPTION
#### Description:

- An attempt to fix (the code should run on this pull request and we will know if it works before merging it):

```
  utils/generate_html_pages.sh $PAGES_DIR
  shell: bash --noprofile --norc -e -o pipefail {0}
  env:
    PAGES_DIR: __pages
Traceback (most recent call last):
  File "/__w/content/content/utils/gen_html_guides_index.py", line 10, in <module>
    import ssg.jinja
ModuleNotFoundError: No module named 'ssg'
```

from https://github.com/ComplianceAsCode/content/runs/5990100490?check_suite_focus=true
