### PR TITLE
typo: kernel_config_slub_debug Enale -> Enable

### DIFF
--- a/linux_os/guide/system/kernel_build_config/kernel_config_slub_debug/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_slub_debug/rule.yml
@@ -6,7 +6,7 @@ description: |-
     SLUB has extensive debug support features and this allows the allocator validation checking to
     be enabled.
 
-    {{{ kernel_build_config_describe_config("CONFIG_SLUB_DEBUG", "n") | indent(4) }}}
+    {{{ kernel_build_config_describe_config("CONFIG_SLUB_DEBUG", "y") | indent(4) }}}
 
 rationale: |-
     This activates the checking of the memory allocator structures and resets to zero the zones
@@ -25,11 +25,11 @@ identifiers:
 ocil_clause: 'the kernel was not built with the required value'
 
 ocil: |-
-    {{{ kernel_build_config_ocil("CONFIG_SLUB_DEBUG", "n") | indent(4) }}}
+    {{{ kernel_build_config_ocil("CONFIG_SLUB_DEBUG", "y") | indent(4) }}}
 
 template:
     name: kernel_build_config
     vars:
         config: CONFIG_SLUB_DEBUG
-        value: 'n'
+        value: 'y'
 

--- a/linux_os/guide/system/kernel_build_config/kernel_config_slub_debug/rule.yml
+++ b/linux_os/guide/system/kernel_build_config/kernel_config_slub_debug/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Enale SLUB debugging support'
+title: 'Enable SLUB debugging support'
 
 description: |-
     SLUB has extensive debug support features and this allows the allocator validation checking to


### PR DESCRIPTION
#### Description:

Typo and change checked value to match what is wanted, aka CONFIG_SLUB_DEBUG should be enabled (y).

#### Rationale:

Typo and fix of logic.