### PR TITLE
Exclude package_libreport-plugin-rhtsupport_removed from stig_gui profile

### DIFF
--- a/products/rhel8/profiles/stig_gui.profile
+++ b/products/rhel8/profiles/stig_gui.profile
@@ -38,3 +38,6 @@ selections:
 
     # RHEL-08-040321
     - '!xwindows_runlevel_target'
+
+    # RHEL-08-040001
+    - '!package_libreport-plugin-rhtsupport_removed'

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -304,7 +304,6 @@ selections:
 - package_krb5-server_removed
 - package_krb5-workstation_removed
 - package_libreport-plugin-logger_removed
-- package_libreport-plugin-rhtsupport_removed
 - package_mcafeetp_installed
 - package_opensc_installed
 - package_openssh-server_installed


### PR DESCRIPTION
#### Description:
libreport-plugin-rhtsupport package is required by anaconda-gui

#### Rationale:
Not possible to install STIG with GUI when the `libreport-plugin-rhtsupport` is excluded.

Fixes #8527 