### PR TITLE
rsyslog: Fix array creation when path has wildcard

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -5,8 +5,8 @@
 RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
-readarray -t RSYSLOG_INCLUDE_CONFIG < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
-readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+readarray -t RSYSLOG_INCLUDE_CONFIG < <(printf '%s\n' $(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2))
+readarray -t RSYSLOG_INCLUDE < <(printf '%s\n' $(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf))
 
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -5,8 +5,10 @@
 RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
-readarray -t RSYSLOG_INCLUDE_CONFIG < <(printf '%s\n' $(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2))
-readarray -t RSYSLOG_INCLUDE < <(printf '%s\n' $(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf))
+readarray -t OLD_INC < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
+readarray -t RSYSLOG_INCLUDE_CONFIG < <(for INCPATH in "${OLD_INC[@]}"; do eval printf '%s\\n' "${INCPATH}"; done)
+readarray -t NEW_INC < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+readarray -t RSYSLOG_INCLUDE < <(for INCPATH in "${NEW_INC[@]}"; do eval printf '%s\\n' "${INCPATH}"; done)
 
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_IncludeConfig_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_IncludeConfig_perms_0601.fail.sh
@@ -50,4 +50,8 @@ cat << EOF > $RSYSLOG_CONF
 include(file="${test_conf}")
 
 \$IncludeConfig ${test_conf2}
+
+include(file="${RSYSLOG_TEST_DIR}/*.conf" mode="optional")
+
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
 EOF


### PR DESCRIPTION
This patch fixes the issue that the array is expanded to wildcard path instead of its elements.

#### Description:

- A simple test case as follows:

    /etc/rsyslog.conf
    include(file="/etc/rsyslog.d/*.conf" mode="optional")

    /etc/rsyslog.d/custom1.conf
    local1.*    /tmp/local1.out

    /etc/rsyslog.d/custom2.conf
    local2.*    /tmp/local2.out

#### Rationale:

- With current code, the RSYSLOG_INCLUDE or RSYSLOG_INCLUDE_CONFIG will be read as a string '/etc/rsyslog.d/*.conf' in the `for` loop.
- This patch ensures the wildcard path is expanded to suitable files and then added to the array.
