### PR TITLE
Add docuemntion for Pandas dependancy

### DIFF
--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -155,6 +155,18 @@ apt-get install python3-sphinx
 pip install -r docs/requirements.txt
 ```
 
+### Pandas (SRG Export HTML)
+
+Install `pandas` if you want to run `utils/create_srg_export.py`:
+
+```bash
+# Fedora/RHEL
+yum install python3-pandas
+
+# Ubuntu/Debian
+apt-get install python3-pandas
+```
+
 ## Downloading the source code
 
 Download and extract a tarball from the [list of releases](https://github.com/ComplianceAsCode/content/releases):


### PR DESCRIPTION
#### Description:

Adds new section in the how to build docs for Pandas.

#### Rationale:

So that people know about it.
