### PR TITLE
Downgrade OCP4 builder image to fedora 34

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -1,5 +1,9 @@
 # This dockerfile builds the content in the current repo for OCP4
-FROM registry.fedoraproject.org/fedora-minimal:35 as builder
+#
+# We're using Fedora 34 here because we're hitting issues with Fedora 35 (e.g.,
+# https://bugzilla.redhat.com/show_bug.cgi?id=2009047). Update this when Fedora
+# 35 is fixed.
+FROM registry.fedoraproject.org/fedora-minimal:34 as builder
 
 WORKDIR /content
 


### PR DESCRIPTION
We use Quay triggers to build content on each merged PR in
ComplianceAsCode/content and we use this content for testing.

Recently, we started hitting issues building content where the build
fails because the microdnf thread can't start. This appears to be a
related issue to other things in fedora 35 [0].

  https://bugzilla.redhat.com/show_bug.cgi?id=2009047

This commit updates the build image to use fedora 34, which isn't
susceptible to this issue. At the very least we can get the automation
for building content to work and we can come back and update the build
image when we have a working fedora 35 image.
