### PR TITLE
Enable bash remediation for SUSE smartcard_pam_enabled

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_sle,multi_platform_ubuntu
+{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '') }}}
+{{% else %}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth','sufficient', 'pam_pkcs11.so', '', '', '') }}}
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
-{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+{{% if 'ubuntu' in product %}}
 {{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '') }}}
 {{% else %}}
 {{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth','sufficient', 'pam_pkcs11.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/bash/ubuntu.sh
@@ -1,3 +1,0 @@
-# platform = multi_platform_ubuntu
-
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-auth', 'auth', '[success=2 default=ignore]', 'pam_pkcs11.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
-
+{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
 echo '# auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
+{{% else %}}
+echo '# auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/commented.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
-{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+{{% if 'ubuntu' in product %}}
 echo '# auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% else %}}
 echo '# auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 
-{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+{{% if 'ubuntu' in product %}}
 echo 'auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% else %}}
 echo 'auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/correct.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 
+{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
 echo 'auth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
+{{% else %}}
+echo 'auth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/nothing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/nothing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 
 echo > /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
+# platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 
+{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
 echo 'aauth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
+{{% else %}}
+echo 'aauth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/tests/substring.fail.sh
@@ -2,7 +2,7 @@
 # platform = multi_platform_ubuntu,multi_platform_sle
 # packages = libpam-pkcs11
 
-{{% if product in ["ubuntu1604", "ubuntu1804", "ubuntu2004"] %}}
+{{% if 'ubuntu' in product %}}
 echo 'aauth [success=2 default=ignore] pam_pkcs11.so' > /etc/pam.d/common-auth
 {{% else %}}
 echo 'aauth sufficient pam_pkcs11.so' > /etc/pam.d/common-auth


### PR DESCRIPTION
create smartcard_pam_enabled/bash/shared.sh
which includes both sle and ubuntu remediations
use jinja ifs and remove
smartcard_pam_enabled/bash/ubuntu.sh
since that is now in shared.sh

Update test code to support sle.

#### Description:

- Update bash remediation to support sle

#### Rationale:

- ansible not installed by dfault on SLE12/15

