### PR TITLE
Update accounts_umask_etc_profile remediation regex to handle comments

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: Replace user umask in /etc/profile
   replace:
     path: /etc/profile
-    regexp: "umask.*"
+    regexp: '^[^#]*umask'
     replace: "umask {{ var_accounts_user_umask }}"
   register: umask_replace
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/bash/shared.sh
@@ -2,7 +2,7 @@
 
 {{{ bash_instantiate_variables("var_accounts_user_umask") }}}
 
-grep -q umask /etc/profile && \
+grep -qE '^[^#]*umask' /etc/profile && \
   sed -i "s/umask.*/umask $var_accounts_user_umask/g" /etc/profile
 if ! [ $? -eq 0 ]; then
     echo "umask $var_accounts_user_umask" >> /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/commented_out.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/tests/commented_out.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# make sure umask commented out in /etc/profile
+sed -i '/umask/d' /etc/profile
+echo "#umask 777" >> /etc/profile
+umask 000


### PR DESCRIPTION
The current regex in the bash and ansible remediation won't fire
if the umask line is commented out.

#### Description:

- Handle cases when umask line is commented out.

#### Rationale:

- Should remediate if umask line is missing or commented out.

