### PR TITLE
SUSE SLE fix audit_rules_unsuccessful_file_modification_renameat2

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_rename/rule.yml
@@ -69,5 +69,8 @@ template:
         syscall_grouping:
           - rename
           - renameat
+          {{% if product in ['sle15'] %}}
+          - renameat2
+          {{% endif %}}
           - unlink
           - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -81,18 +81,15 @@ warnings:
         {{% endif %}} 
      
 template:
-    {{% if product not in ["sle12", "sle15"] %}}
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: renameat
         syscall_grouping:
           - rename
           - renameat
+          {{% if product in ['sle15'] %}}
+          - renameat2
+          {{% endif %}}
           - unlink
           - unlinkat
-    {{% else %}}
-    name: audit_rules_syscall_events
-    vars:
-        attr: renameat
-    {{% endif %}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
@@ -43,6 +43,12 @@ warnings:
         -a always,exit -F arch=b64 -S renameat2 -F auid>=1000 -F auid!=4294967295 -k perm_mod</pre>
 
 template:
-    name: audit_rules_syscall_events
+    name: audit_rules_unsuccessful_file_modification
     vars:
-        attr: renameat2
+        name: renameat2
+        syscall_grouping:
+          - rename
+          - renameat
+          - renameat2
+          - unlink
+          - unlinkat

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -83,18 +83,15 @@ warnings:
         {{% endif %}} 
 
 template:
-    {{% if product not in ["sle12", "sle15"] %}}
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: unlink
         syscall_grouping:
           - rename
           - renameat
+          {{% if product in ['sle15'] %}}
+          - renameat2
+          {{% endif %}}
           - unlink
           - unlinkat
-    {{% else %}}
-    name: audit_rules_syscall_events
-    vars:
-        attr: unlink
-    {{% endif %}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -83,18 +83,14 @@ warnings:
         {{% endif %}} 
 
 template:
-    {{% if product not in ["sle12", "sle15"] %}}
     name: audit_rules_unsuccessful_file_modification
     vars:
         name: unlinkat
         syscall_grouping:
           - rename
           - renameat
+          {{% if product in ['sle15'] %}}
+          - renameat2
+          {{% endif %}}
           - unlink
           - unlinkat
-    {{% else %}}
-    name: audit_rules_syscall_events
-    vars:
-        attr: unlinkat
-    {{% endif %}}
-


### PR DESCRIPTION
The rule audit_rules_unsuccessful_file_modification_renameat2
should have been using audit_rules_unsuccessful_file_modification
and not audit_rules_syscall_events. This required updates to
 audit_rules_unsuccessful_file_modification_rename
 audit_rules_unsuccessful_file_modification_renameat
 audit_rules_unsuccessful_file_modification_unlink
 audit_rules_unsuccessful_file_modification_unlinkat
Since those also used, audit_rules_syscall_events
renameat2 only applies to sle15, so the references to renameat2
in the other rules is within a jijna2 conditional.

#### Description:

- Handle renameat2 in the same way we handle audit_rules_unsuccessful_file_modification_openat.

#### Rationale:

- We should handle all audit_rules_unsuccessful_file_... rules in the same way.
