### PR TITLE
SUSE audit_rules_privileged_commands_kmod add bash remediation SLE12/15

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/sle12.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/sle12.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_watch_rule("auditctl", "/usr/bin/kmod", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/usr/bin/kmod", "x", "modules") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/sle15.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/bash/sle15.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_sle
+
+# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+{{{ bash_fix_audit_watch_rule("auditctl", "/usr/bin/kmod", "x", "modules") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", "/usr/bin/kmod", "x", "modules") }}}


### PR DESCRIPTION
Ansible remediations existed, but not bash.

#### Description:

- Bash remediations were missing.

#### Rationale:

- Ansible is not officially support on all sle instamces
