### PR TITLE
SUSE add multi_platform_sle to audit_rules_file_deletion_events/bash.…

### DIFF
--- a/shared/templates/audit_rules_file_deletion_events/bash.template
+++ b/shared/templates/audit_rules_file_deletion_events/bash.template
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
 
 # First perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system


### PR DESCRIPTION
…template

sle was added to the ansible template, but not the bash template and
we want to support bash remediation as well as ansible

#### Description:

- add sle to platform spec for audit_rules_file_deletion_events/bash.template

#### Rationale:

- We want to provide bash remediation in all cases where we support ansible remediation.
