### PR TITLE
For sle systems the etc shadow is group shadow

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Verify Group Who Owns shadow File'
 
-{{% if "ubuntu" in product or "debian" in product %}}
+{{% if "ubuntu" in product or "debian" in product or "sle" in product %}}
     {{% set target_group="shadow" %}}
 {{% else %}}
     {{% set target_group="root" %}}
@@ -48,10 +48,10 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/shadow
+{{% if "sle" in product %}}
+        filegid: '15'
+{{% elif "ubuntu" in product or "debian" in product %}}
+        filegid: '42'
+{{% else %}}
         filegid: '0'
-        filegid@debian9: '42'
-        filegid@debian10: '42'
-        filegid@debian11: '42'
-        filegid@ubuntu1604: '42'
-        filegid@ubuntu1804: '42'
-        filegid@ubuntu2004: '42'
+{{% endif %}}


### PR DESCRIPTION
For sle systems the etc shadow file is group shadow
with a gid of 15.

#### Description:

- fix file_groupowner_etc_shadow to work for SUSE

#### Rationale:

- current code does not match group ownership for sle systems.

