### PR TITLE
Align kernel_module_loading remediations

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -3,7 +3,13 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-#
+
+{{% if product in ["ol8", "rhel8"] %}}
+{{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
+{{% else %}}
+{{% set auid_filters = "" %}}
+{{% endif %}}
+
 # What architecture are we on?
 #
 - name: Set architecture for audit tasks
@@ -18,7 +24,7 @@
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
       other_filters="",
-      auid_filters="",
+      auid_filters=auid_filters,
       syscalls=audit_syscalls,
       key="modules",
       syscall_grouping=audit_syscalls,
@@ -26,7 +32,7 @@
     {{{ ansible_audit_auditctl_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
       other_filters="",
-      auid_filters="",
+      auid_filters=auid_filters,
       syscalls=audit_syscalls,
       key="modules",
       syscall_grouping=audit_syscalls,
@@ -37,7 +43,7 @@
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",
       other_filters="",
-      auid_filters="",
+      auid_filters=auid_filters,
       syscalls=audit_syscalls,
       key="modules",
       syscall_grouping=audit_syscalls,
@@ -45,7 +51,7 @@
     {{{ ansible_audit_auditctl_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",
       other_filters="",
-      auid_filters="",
+      auid_filters=auid_filters,
       syscalls=audit_syscalls,
       key="modules",
       syscall_grouping=audit_syscalls,

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
@@ -12,7 +12,11 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
         OTHER_FILTERS=""
+        {{% if product in ["ol8", "rhel8"] %}}
+        AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+        {{% else %}}
         AUID_FILTERS=""
+        {{% endif %}}
         SYSCALL="init_module finit_module delete_module"
         KEY="modules"
         SYSCALL_GROUPING="init_module finit_module delete_module"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -7,5 +7,5 @@ sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/sys
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed '1,10d' test_audit.rules > /etc/audit/audit.rules
-sed -i '5,8d' /etc/audit/audit.rules
+sed '1,8d' test_audit.rules > /etc/audit/audit.rules
+sed -i '4,7d' /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -9,3 +9,6 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,8d' test_audit.rules > /etc/audit/audit.rules
 sed -i '4,7d' /etc/audit/audit.rules
+{{% if product in ["ol8", "rhel8"] %}}
+sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -7,4 +7,4 @@ sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/sys
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed '1,13d' test_audit.rules > /etc/audit/audit.rules
+sed '1,12d' test_audit.rules > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -8,3 +8,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '1,12d' test_audit.rules > /etc/audit/audit.rules
+{{% if product in ["ol8", "rhel8"] %}}
+sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -8,3 +8,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '8,15d' test_audit.rules > /etc/audit/audit.rules
+{{% if product in ["ol8", "rhel8"] %}}
+sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -7,4 +7,4 @@ sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/sys
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed '11,18d' test_audit.rules > /etc/audit/audit.rules
+sed '8,15d' test_audit.rules > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
@@ -7,4 +7,4 @@ sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/sys
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed -e '11,18d' -e '/.*init.*/d' test_audit.rules > /etc/audit/audit.rules
+sed -e '7,15d' -e '/.*init.*/d' test_audit.rules > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
@@ -6,3 +6,6 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,8d' test_audit.rules > /etc/audit/rules.d/test.rules
 sed -i '4,7d' /etc/audit/rules.d/test.rules
+{{% if product in ["ol8", "rhel8"] %}}
+sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
@@ -4,5 +4,5 @@
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed '1,10d' test_audit.rules > /etc/audit/rules.d/test.rules
-sed -i '5,8d' /etc/audit/rules.d/test.rules
+sed '1,8d' test_audit.rules > /etc/audit/rules.d/test.rules
+sed -i '4,7d' /etc/audit/rules.d/test.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
@@ -4,4 +4,4 @@
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed '1,13d' test_audit.rules > /etc/audit/rules.d/test.rules
+sed '1,12d' test_audit.rules > /etc/audit/rules.d/test.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
@@ -5,3 +5,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '1,12d' test_audit.rules > /etc/audit/rules.d/test.rules
+{{% if product in ["ol8", "rhel8"] %}}
+sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
@@ -4,3 +4,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '8,15d' test_audit.rules > /etc/audit/rules.d/test.rules
+{{% if product in ["ol8", "rhel8"] %}}
+sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
@@ -3,4 +3,4 @@
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed '11,18d' test_audit.rules > /etc/audit/rules.d/test.rules
+sed '8,15d' test_audit.rules > /etc/audit/rules.d/test.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line_one_missing.fail.sh
@@ -3,4 +3,4 @@
 rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
-sed -e '11,18d' -e '/.*init.*/d' test_audit.rules > /etc/audit/rules.d/test.rules
+sed -e '7,15d' -e '/.*init.*/d' test_audit.rules > /etc/audit/rules.d/test.rules


### PR DESCRIPTION

#### Description:

- Rules 'audit_rules_kernel_module_loading' and 'audit_rules_kernel_module_loading_*' are closely tied.
  The check for the former uses the same definitions as the second rules.
  So the remediations of both rules need to be aligned.

#### Rationale:

- Follow up from #8327 
- Fixes #8526 
