### PR TITLE
SUSE disable_users_coredumps enable bash remediation for sle.

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle
 SECURITY_LIMITS_FILE="/etc/security/limits.conf"
 
 if grep -qE '^\s*\*\s+hard\s+core' $SECURITY_LIMITS_FILE; then


### PR DESCRIPTION
sle system were supported for ansible remediation through
platform = multi_platform_all

But not for bash, which had:

so just added multi_platform_sle  to the platform list in
disable_users_coredumps/bash/shared.sh

#### Description:

- Enable bash remediation for sle systems in disable_users_coredumps enable 

#### Rationale:

- Parity between bash and ansible remediations

