### PR TITLE
fix grub2 remediations for sle12 and sle15

### DIFF
--- a/shared/macros/bash.jinja
+++ b/shared/macros/bash.jinja
@@ -1688,14 +1688,17 @@ fi
     Remediation for grub2 bootloader arguments
 #}}
 {{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
+{{% set grub_helper_args = ["--update-kernel=ALL", "--args= {{{ ARG_NAME_VALUE }}}"] -%}}
 {{% if 'ubuntu' in product %}}
 	{{% set grub_helper_executable = "update-grub" -%}}
+{{% elif product in ["sle12", "sle15"] %}}
+{{% set grub_helper_executable = "grub2-mkconfig" -%}}
+{{% set grub_helper_args = ["-o {{{ grub2_boot_path }}}/grub2.cfg"] -%}}
 {{% else %}}
 	{{% set grub_helper_executable = "grubby" -%}}
 {{% endif -%}}
-{{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE] -%}}
 
-{{% if 'ubuntu' in product or product in ['rhel7', 'ol7'] %}}
+{{% if 'ubuntu' in product or product in ['rhel7', 'ol7', 'sle12', 'sle15'] %}}
 {{{ update_etc_default_grub_manually(ARG_NAME, ARG_NAME_VALUE) }}}
 {{% endif -%}}
 

--- a/shared/macros/bash.jinja
+++ b/shared/macros/bash.jinja
@@ -1688,7 +1688,7 @@ fi
     Remediation for grub2 bootloader arguments
 #}}
 {{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
-{{% set grub_helper_args = ["--update-kernel=ALL", "--args= ~ ARG_NAME_VALUE"] -%}}
+{{% set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ ARG_NAME_VALUE ] -%}}
 {{% if 'ubuntu' in product %}}
 	{{% set grub_helper_executable = "update-grub" -%}}
 {{% elif product in ["sle12", "sle15"] %}}

--- a/shared/macros/bash.jinja
+++ b/shared/macros/bash.jinja
@@ -1688,7 +1688,7 @@ fi
     Remediation for grub2 bootloader arguments
 #}}
 {{% macro grub2_bootloader_argument_remediation(ARG_NAME, ARG_NAME_VALUE) %}}
-{{% set grub_helper_args = ["--update-kernel=ALL", "--args= {{{ ARG_NAME_VALUE }}}"] -%}}
+{{% set grub_helper_args = ["--update-kernel=ALL", "--args= ~ ARG_NAME_VALUE"] -%}}
 {{% if 'ubuntu' in product %}}
 	{{% set grub_helper_executable = "update-grub" -%}}
 {{% elif product in ["sle12", "sle15"] %}}

--- a/shared/templates/grub2_bootloader_argument/ansible.template
+++ b/shared/templates/grub2_bootloader_argument/ansible.template
@@ -9,7 +9,7 @@
 {{% set ARG_NAME_VALUE = ARG_NAME ~ "={{ " ~ ARG_VARIABLE ~ " }}" %}}
 {{% endif %}}
 
-{{% if 'ubuntu' in product or product in ['rhel7', 'ol7'] %}}
+{{% if 'ubuntu' in product or product in ['rhel7', 'ol7', 'sle12', 'sle15'] %}}
 - name: Check {{{ ARG_NAME }}} argument exists
   command: grep 'GRUB_CMDLINE_LINUX.*{{{ ARG_NAME }}}=' /etc/default/grub
   failed_when: False
@@ -29,5 +29,11 @@
       replace: '\1 {{{ ARG_NAME_VALUE }}}"'
   when: argcheck.rc != 0
 {{% endif -%}}
+
+{{% if product in ['sle12', 'sle15'] %}}
+- name: Update grub defaults and the bootloader menu
+  command: /usr/sbin/grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg
+{{% else %}}
 - name: Update grub defaults and the bootloader menu
   command: /sbin/grubby --update-kernel=ALL --args="{{{ ARG_NAME_VALUE }}}"
+{{% endif -%}}


### PR DESCRIPTION
grubby is not not avaiable for sl12 and sle15.
sle12/15 uses grub2-mkconfig.

since grub2-mkconfig use different set grub_helper_args,
move current setting to top of macro and reset for sle12/15.

This fix remedtaion on sle12/15 for rules:
grub2_audit_backlog_limit_argument
grub2_audit_argument
grub2_ipv6_disable_argument

#### Description:

- sle12/15 uses grub2-mkconfig not grubby
since grub2-mkconfig use different set grub_helper_args,

In bash move current setting to top of macro and reset for sle12/15.

This fixes remediation on sle12/15 for rules:
grub2_audit_backlog_limit_argument
grub2_audit_argument
grub2_ipv6_disable_argument

#### Rationale:

- Enable more remediations for sle12/15
