### PR TITLE
Bad use of double quotes in rsyslog_files_permissions/bash/shared.sh

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -12,7 +12,7 @@ readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(i
 declare -a LOG_FILE_PATHS
 
 declare -a RSYSLOG_CONFIGS
-RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
+RSYSLOG_CONFIGS+=(${RSYSLOG_ETC_CONFIG} ${RSYSLOG_INCLUDE_CONFIG[@]} ${RSYSLOG_INCLUDE[@]})
 
 # Browse each file selected above as containing paths of log files
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)


### PR DESCRIPTION
#### Description:

- In our testing the log files specified in /etc/rsyslog.d/ were not getting remediated.
The issue is with line:
    RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
which produces a RSYSLOG_CONFIGS of
    /etc/rsyslog.conf /run/rsyslog/additional-log-sockets.conf /etc/rsyslog.d/*.conf /etc/rsyslog.d/*.frule

line:
    RSYSLOG_CONFIGS+=(${RSYSLOG_ETC_CONFIG} ${RSYSLOG_INCLUDE_CONFIG[@]} ${RSYSLOG_INCLUDE[@]})
poduces:
      /etc/rsyslog.conf /run/rsyslog/additional-log-sockets.conf /etc/rsyslog.d/21-cloudinit.conf /etc/rsyslog.d/remote.conf /etc/rsyslog.d/acpid.frule /etc/rsyslog.d/firewall.frule /etc/rsyslog.d/NetworkManager.frule

The double quotes in the first case is keeping the variables from expanding. This creates
errors later in the loop code, since LOG_FILE gets the values /etc/rsyslog.d/*.conf and /etc/rsyslog.d/*.frule
and the existence check fails.

#### Rationale:

- Fix bash remediation

