### PR TITLE
SUSE enable bash remediation for accounts_logon_fail_delay

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ol,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_accounts_fail_delay") }}}
 


### PR DESCRIPTION
#### Description:

- add multi_platform_sle to accounts-session/accounts_logon_fail_delay/bash/shared.sh

#### Rationale:

- sle12/15 supported for ansible remediation, and we would like to have equivalent bash and ansible remediations.

