### PR TITLE
SUSE auditd_data_retention_flush enable bash remediation

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_auditd_flush") }}}
 


### PR DESCRIPTION
#### Description:

- enable bash remediation for sle12/15

#### Rationale:

- ansible remediation was enabled, but not bash.
