### PR TITLE
SUSE no_empty_passwords enable bash remediation.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/bash/shared.sh
@@ -3,9 +3,15 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
+{{% if 'sle' in product %}}
+PAM_PATH="/etc/pam.d/"
+NULLOK_FILES=$(grep -rl ".*pam_unix\\.so.*nullok.*" ${PAM_PATH})
+for FILE in ${NULLOK_FILES}; do
+   sed --follow-symlinks -i 's/\<nullok\>//g' ${FILE}
+done
+{{% else %}}
 SYSTEM_AUTH="/etc/pam.d/system-auth"
 PASSWORD_AUTH="/etc/pam.d/password-auth"
-
 if [ -f /usr/bin/authselect ]; then
     if authselect check; then
         authselect enable-feature without-nullok
@@ -22,3 +28,4 @@ else
     sed --follow-symlinks -i 's/\<nullok\>//g' $SYSTEM_AUTH
     sed --follow-symlinks -i 's/\<nullok\>//g' $PASSWORD_AUTH
 fi
+{{% endif %}}


### PR DESCRIPTION
Ansible remediation was updated to support sle12/15.
That code needed to be ported to the bash remediation.

#### Description:

- Ansible remediation was updated to support sle12/15.
That code needed to be ported to the bash remediation.

#### Rationale:

- Want to have equivalent bash and ansible remediation. Since sle12 and sle15 don't include ansible in the product.

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
