### PR TITLE
Buildsystem optimization

### DIFF
--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -15,6 +15,10 @@ try:
 except ImportError:
     from yaml import SafeLoader as yaml_SafeLoader
 
+try:
+    from yaml import CDumper as yaml_Dumper
+except ImportError:
+    from yaml import Dumper as yaml_Dumper
 
 def _bool_constructor(self, node):
     return self.construct_scalar(node)
@@ -121,7 +125,7 @@ def open_raw(yaml_file):
     return yaml_contents
 
 
-def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+def ordered_load(stream, Loader=yaml_SafeLoader, object_pairs_hook=OrderedDict):
     """
     Drop-in replacement for yaml.load(), but preserves order of dictionaries
     """
@@ -137,7 +141,7 @@ def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
     return yaml.load(stream, OrderedLoader)
 
 
-def ordered_dump(data, stream=None, Dumper=yaml.Dumper, **kwds):
+def ordered_dump(data, stream=None, Dumper=yaml_Dumper, **kwds):
     """
     Drop-in replacement for yaml.dump(), but preserves order of dictionaries
     """

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -169,6 +169,10 @@ def ordered_dump(data, stream=None, Dumper=yaml_Dumper, **kwds):
     unformatted_yaml = yaml.dump(data, None, OrderedDumper, **kwds)
     formatted_yaml = re.sub(r"[\n]+([\s]*)- name", r"\n\n\1- name", unformatted_yaml)
 
+    # Fix CDumper issue where it adds yaml document ending '...'
+    # in some templated ansible remediations
+    formatted_yaml = re.sub(r"\n\s*\.\.\.\s*", r"\n", formatted_yaml)
+
     if stream is not None:
         return stream.write(formatted_yaml)
     else:

--- a/ssg/yaml.py
+++ b/ssg/yaml.py
@@ -16,6 +16,11 @@ except ImportError:
     from yaml import SafeLoader as yaml_SafeLoader
 
 try:
+    from yaml import CLoader as yaml_Loader
+except ImportError:
+    from yaml import Loader as yaml_Loader
+
+try:
     from yaml import CDumper as yaml_Dumper
 except ImportError:
     from yaml import Dumper as yaml_Dumper
@@ -125,7 +130,7 @@ def open_raw(yaml_file):
     return yaml_contents
 
 
-def ordered_load(stream, Loader=yaml_SafeLoader, object_pairs_hook=OrderedDict):
+def ordered_load(stream, Loader=yaml_Loader, object_pairs_hook=OrderedDict):
     """
     Drop-in replacement for yaml.load(), but preserves order of dictionaries
     """

--- a/utils/build_profiler_report.py
+++ b/utils/build_profiler_report.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
 """Compare and present build times to user and generate an HTML interactive graph"""
-from inspect import trace
 import sys
 import argparse
-import re
 
 
 def load_log_file(file) -> dict:
@@ -17,8 +15,8 @@ def load_log_file(file) -> dict:
 
     # an issue appeared with new versions of cmake where the targets are duplicated with a relative
     # and absolute path and therefore they must be filtered here; filters comments too
-    lines = [line for line in lines if not line.strip().split()[3].startswith('/') and not 
-            line.startswith('#')]
+    lines = [line for line in lines if not line.strip().split()[3].startswith('/') and not
+             line.startswith('#')]
     splitLines = [line.strip().split() for line in lines]
 
     # calculate target compilation duration and add it to dict
@@ -156,7 +154,8 @@ def print_report(current_dict: dict, baseline_dict: dict = None) -> None:
         if baseline_dict and target not in baseline_dict.keys():
             line.append("Not in baseline")
 
-        # if target has multiple output files, print them on separate lines (times only at the last)
+        # if target has multiple output files, print them on separate lines
+        # (times only on the last line)
         if(';' in target):
             print("\n".join(target.rsplit(';', 1)[0].split(';')))
             split_target = target.rsplit(';', 1)[1]

--- a/utils/build_profiler_report.py
+++ b/utils/build_profiler_report.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 """Compare and present build times to user and generate an HTML interactive graph"""
+from inspect import trace
 import sys
 import argparse
 import re
@@ -13,18 +14,34 @@ def load_log_file(file) -> dict:
 
     # {Target: duration} dict
     target_duration_dict = {}
-    for line in lines:
-        line = line.strip()
 
-        # pattern to match target names that are an absolute path - these should be skipped
-        # --> an issue appeared with new versions of cmake where the targets are duplicated for some
-        # reason and therefore they must be filtered here
-        duplicate_pattern = re.compile("[0-9]+\s+[0-9]+\s+[0-9]+\s+/.*")
-        if not line.startswith('#') and not duplicate_pattern.match(line):
-            # calculate target compilation duration and add it to dict
-            line = line.split()
-            duration = int(line[1]) - int(line[0])
-            target_duration_dict[line[3]] = duration
+    # an issue appeared with new versions of cmake where the targets are duplicated with a relative
+    # and absolute path and therefore they must be filtered here; filters comments too
+    lines = [line for line in lines if not line.strip().split()[3].startswith('/') and not 
+            line.startswith('#')]
+    splitLines = [line.strip().split() for line in lines]
+
+    # calculate target compilation duration and add it to dict
+    hash_target_duration_dict = {}
+    for line in splitLines:
+        duration = int(line[1]) - int(line[0])
+        hash = line[2]
+        target = line[3]
+
+        # filter out lines with duplicate times and concatenate target names
+        if hash not in hash_target_duration_dict:
+            target_duration_dict[target] = duration
+            # add target,duration with new hash
+            hash_target_duration_dict[hash] = (target, duration)
+        else:
+            previous_target = hash_target_duration_dict[hash][0]
+            # concatenate previous target with same hash to this one
+            concated_target = previous_target + ";" + target
+            # remove old target entry and add concatenated target = duraiton
+            target_duration_dict[concated_target] = \
+                target_duration_dict.pop(previous_target)
+            # update target name in hash dict
+            hash_target_duration_dict[hash] = (concated_target, duration)
 
     return target_duration_dict
 
@@ -138,6 +155,12 @@ def print_report(current_dict: dict, baseline_dict: dict = None) -> None:
         # if target was not in baseline, append note
         if baseline_dict and target not in baseline_dict.keys():
             line.append("Not in baseline")
+
+        # if target has multiple output files, print them on separate lines (times only at the last)
+        if(';' in target):
+            print("\n".join(target.rsplit(';', 1)[0].split(';')))
+            split_target = target.rsplit(';', 1)[1]
+            line[0] = f'{split_target:60}'
         print(' | '.join(line))
 
     # Print time and % delta of the whole build time


### PR DESCRIPTION
#### Description:

- Speed up the build system by using C implementations of yaml Loader and Dumper in `ssg/yaml.py` used by `build-scripts/collect_remediations.py`
- Fix build profiler bug where targets with multiple outputs all added duplicate build time
- What is the difference in build time after these changes (RHEL8 build):
   - before: **~3 minutes**, collect_remediations taking up **~17%** of build time and **~30 seconds** itself
   - after: **_~2:45 minutes_**, collect_remediations taking up **_~12%_** of build time and **_~20 seconds_** itself
   - these times were measured using the profiling tool from #7832, they vary a lot and are averages from multiple builds

#### Issues:

- When using CDumper, the formatting fix on lines 150-151 in `yaml.py/ordered_dump` does not work. This is seemingly because the underlying emitter classes are different for `yaml.Dumper` and `yaml.CDumper`, and while the former contains the `increase_indent` method, the latter does not (https://github.com/yaml/pyyaml/blob/8cdff2c80573b8be8e8ad28929264a913a63aa33/yaml/_yaml.pyx and https://github.com/yaml/pyyaml/blob/8cdff2c80573b8be8e8ad28929264a913a63aa33/lib/yaml/emitter.py, respectively). I found that some people had the exact same issue here: https://github.com/yaml/libyaml/issues/224 and there was no response from the maintainers of `libyaml`. Although `yamllint` says that some ansible tasks in `build/rhel8/fixes/ansible` have invalid indentation, running the test suite on some of these ansible tasks (such as sssd_offline_cred_expiration) with the `--remediate-using ansible` option produced no errors, so I am not sure if this is actually a problem. If needed, a simple regex substitution could be added to the ordered_dump function to add the extra indentation (modifying and recompiling `libyaml` seems needlessly complicated).