### PR TITLE
SUSE enable remediiation for grub2_disable_interactive_boot

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
@@ -14,6 +14,16 @@
 - name: Verify that Interactive Boot is Disabled (runtime)
   command: /usr/bin/grub2-editenv - unset systemd.confirm_spawn
 
+- name: Veify GRUB_DISABLE_RECOVERY=true
+  lineinfile:
+    path: /etc/default/grub
+    regexp: '^GRUB_DISABLE_RECOVERY=.*'
+    line: 'GRUB_DISABLE_RECOVERY=true'
+    state: present
+
+- name: Verify that Recovery Boot is Disabled (runtime)
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+
 {{% else %}}
 
 - name: Verify that Interactive Boot is Disabled in /etc/default/grub

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
@@ -4,27 +4,12 @@
 # complexity = low
 # disruption = low
 
-{{% if 'sle' in product %}}
-- name: Verify that Interactive Boot is Disabled in /usr/bin/grub2-editenv
-  replace:
-    dest: /etc/default/grub
-    regexp: systemd.confirm_spawn=(1|yes|true|on) 
-    replace: systemd.confirm_spawn=no
-
-- name: Verify that Interactive Boot is Disabled (runtime)
-  command: /usr/bin/grub2-editenv - unset systemd.confirm_spawn
-
-- name: Veify GRUB_DISABLE_RECOVERY=true
+- name: Verify GRUB_DISABLE_RECOVERY=true
   lineinfile:
     path: /etc/default/grub
     regexp: '^GRUB_DISABLE_RECOVERY=.*'
     line: 'GRUB_DISABLE_RECOVERY=true'
     state: present
-
-- name: Verify that Recovery Boot is Disabled (runtime)
-  command: grub2-mkconfig -o /boot/grub2/grub.cfg
-
-{{% else %}}
 
 - name: Verify that Interactive Boot is Disabled in /etc/default/grub
   replace:
@@ -32,7 +17,18 @@
     regexp: systemd.confirm_spawn=(1|yes|true|on)
     replace: systemd.confirm_spawn=no
 
+{{% if 'sle' in product %}}
+- name: Verify that Interactive Boot is Disabled (runtime)
+  command: /usr/bin/grub2-editenv - unset systemd.confirm_spawn
+
+- name: Verify that Recovery Boot is Disabled (runtime)
+  command: grub2-mkconfig -o /boot/grub2/grub.cfg
+
+{{% else %}}
+
 - name: Verify that Interactive Boot is Disabled (runtime)
   command: /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
 
+- name: Verify that Recovery Boot is Disabled (runtime)
+  command: sudo grubby --update-kernel=ALL --args="GRUB_DISABLE_RECOVERY=true"
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/ansible/shared.yml
@@ -20,15 +20,10 @@
 {{% if 'sle' in product %}}
 - name: Verify that Interactive Boot is Disabled (runtime)
   command: /usr/bin/grub2-editenv - unset systemd.confirm_spawn
-
-- name: Verify that Recovery Boot is Disabled (runtime)
-  command: grub2-mkconfig -o /boot/grub2/grub.cfg
-
 {{% else %}}
-
 - name: Verify that Interactive Boot is Disabled (runtime)
   command: /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
-
-- name: Verify that Recovery Boot is Disabled (runtime)
-  command: sudo grubby --update-kernel=ALL --args="GRUB_DISABLE_RECOVERY=true"
 {{% endif %}}
+
+- name: Regen grub.cfg handle updated GRUB_DISABLE_RECOVERY and confirm_spawn
+  command: grub2-mkconfig -o  {{{ grub2_boot_path }}}/grub.cfg

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/bash/shared.sh
@@ -11,5 +11,22 @@ if grep -q "\(GRUB_CMDLINE_LINUX\|GRUB_CMDLINE_LINUX_DEFAULT\)" /etc/default/gru
 then
 	sed -i "s/${CONFIRM_SPAWN_YES}/${CONFIRM_SPAWN_NO}/" /etc/default/grub
 fi
+{{% if 'sle' in product %}}
+#Verify that Interactive Boot is Disabled (runtime)
+/usr/bin/grub2-editenv - unset systemd.confirm_spawn
+
+# make sure GRUB_DISABLE_RECOVERY=true
+if grep -q '^GRUB_DISABLE_RECOVERY=.*'  '/etc/default/grub' ; then
+       # modify the GRUB command-line if an GRUB_DISABLE_RECOVERY= arg already exists
+       sed -i 's/GRUB_DISABLE_RECOVERY=.*/GRUB_DISABLE_RECOVERY=true/' /etc/default/grub
+else
+       # no GRUB_DISABLE_RECOVERY=arg is present, append it to file
+       echo "GRUB_DISABLE_RECOVERY=true"  >> '/etc/default/grub'
+fi
+grub2-mkconfig -o /boot/grub2/grub.cfg
+
+{{% else %}}
+
 # Remove 'systemd.confirm_spawn' kernel argument also from runtime settings
 /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/bash/shared.sh
@@ -4,6 +4,7 @@
 # complexity = low
 # disruption = low
 
+# Verify that Interactive Boot is Disabled in /etc/default/grub
 CONFIRM_SPAWN_YES="systemd.confirm_spawn=\(1\|yes\|true\|on\)"
 CONFIRM_SPAWN_NO="systemd.confirm_spawn=no"
 
@@ -11,9 +12,6 @@ if grep -q "\(GRUB_CMDLINE_LINUX\|GRUB_CMDLINE_LINUX_DEFAULT\)" /etc/default/gru
 then
 	sed -i "s/${CONFIRM_SPAWN_YES}/${CONFIRM_SPAWN_NO}/" /etc/default/grub
 fi
-{{% if 'sle' in product %}}
-#Verify that Interactive Boot is Disabled (runtime)
-/usr/bin/grub2-editenv - unset systemd.confirm_spawn
 
 # make sure GRUB_DISABLE_RECOVERY=true
 if grep -q '^GRUB_DISABLE_RECOVERY=.*'  '/etc/default/grub' ; then
@@ -23,10 +21,19 @@ else
        # no GRUB_DISABLE_RECOVERY=arg is present, append it to file
        echo "GRUB_DISABLE_RECOVERY=true"  >> '/etc/default/grub'
 fi
+
+
+{{% if 'sle' in product %}}
+#Verify that Interactive Boot is Disabled (runtime)
+/usr/bin/grub2-editenv - unset systemd.confirm_spawn
+
+#Verify that GRUB_DISABLE_RECOVERY is Disabled (runtime)
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
 {{% else %}}
-
 # Remove 'systemd.confirm_spawn' kernel argument also from runtime settings
 /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
+
+#Verify that GRUB_DISABLE_RECOVERY is Disabled (runtime)
+/sbin/grubby --update-kernel=ALL --args="GRUB_DISABLE_RECOVERY=true"
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/bash/shared.sh
@@ -26,14 +26,10 @@ fi
 {{% if 'sle' in product %}}
 #Verify that Interactive Boot is Disabled (runtime)
 /usr/bin/grub2-editenv - unset systemd.confirm_spawn
-
-#Verify that GRUB_DISABLE_RECOVERY is Disabled (runtime)
-grub2-mkconfig -o /boot/grub2/grub.cfg
-
 {{% else %}}
 # Remove 'systemd.confirm_spawn' kernel argument also from runtime settings
 /sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"
-
-#Verify that GRUB_DISABLE_RECOVERY is Disabled (runtime)
-/sbin/grubby --update-kernel=ALL --args="GRUB_DISABLE_RECOVERY=true"
 {{% endif %}}
+
+#Regen grub.cfg handle updated GRUB_DISABLE_RECOVERY and confirm_spawn
+grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -13,7 +13,11 @@ description: |-
     Remove any instance of <pre>systemd.confirm_spawn=(1|yes|true|on)</pre> from
     the kernel arguments in that file to disable interactive boot. It is also
     required to change the runtime configuration, run:
+    {{% if 'sle' in product %}}
+    <pre>/usr/bin/grub2-editenv - unset systemd.confirm_spawn></pre>
+    {{% else %}}
     <pre>/sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"</pre>
+    {{% endif %}}
 
 rationale: |-
     Using interactive boot, the console user could disable auditing, firewalls,

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -20,7 +20,7 @@ description: |-
     {{% else %}}
     <pre>/sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"</pre>
     {{% endif %}}
-    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
+    <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg
 
 rationale: |-
     Using interactive or recovery boot, the console user could disable auditing, firewalls,

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -17,11 +17,10 @@ description: |-
     It is also required to change the runtime configuration, run:
     {{% if 'sle' in product %}}
     <pre>/usr/bin/grub2-editenv - unset systemd.confirm_spawn></pre>
-    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{% else %}}
     <pre>/sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"</pre>
-    <pre>/sbin/grubby --update-kernel=ALL --args="GRUB_DISABLE_RECOVERY=true"</pre>
     {{% endif %}}
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
 
 rationale: |-
     Using interactive or recovery boot, the console user could disable auditing, firewalls,

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -20,7 +20,7 @@ description: |-
     {{% else %}}
     <pre>/sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"</pre>
     {{% endif %}}
-    <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg
+    <pre>grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre>
 
 rationale: |-
     Using interactive or recovery boot, the console user could disable auditing, firewalls,

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/rule.yml
@@ -11,16 +11,20 @@ description: |-
     <tt>yes</tt>, <tt>true</tt>, or <tt>on</tt> value to the
     <tt>systemd.confirm_spawn</tt> kernel argument in <tt>/etc/default/grub</tt>.
     Remove any instance of <pre>systemd.confirm_spawn=(1|yes|true|on)</pre> from
-    the kernel arguments in that file to disable interactive boot. It is also
-    required to change the runtime configuration, run:
+    the kernel arguments in that file to disable interactive boot.
+    Recovery booting must also be disabled. Confirm that
+    <tt>GRUB_DISABLE_RECOVERY=true</tt> is set in  <tt>/etc/default/grub</tt>.
+    It is also required to change the runtime configuration, run:
     {{% if 'sle' in product %}}
     <pre>/usr/bin/grub2-editenv - unset systemd.confirm_spawn></pre>
+    <pre>grub2-mkconfig -o /boot/grub2/grub.cfg</pre>
     {{% else %}}
     <pre>/sbin/grubby --update-kernel=ALL --remove-args="systemd.confirm_spawn"</pre>
+    <pre>/sbin/grubby --update-kernel=ALL --args="GRUB_DISABLE_RECOVERY=true"</pre>
     {{% endif %}}
 
 rationale: |-
-    Using interactive boot, the console user could disable auditing, firewalls,
+    Using interactive or recovery boot, the console user could disable auditing, firewalls,
     or other services, weakening system security.
 
 severity: medium
@@ -52,6 +56,7 @@ ocil: |-
     Inspect <tt>/etc/default/grub</tt> for any instances of
     <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> in the kernel boot arguments.
     Presence of a <tt>systemd.confirm_spawn=(1|yes|true|on)</tt> indicates
-    that interactive boot is enabled at boot time.
+    that interactive boot is enabled at boot time and verify that
+    <tt>GRUB_DISABLE_RECOVERY=true</tt> to disable recovery boot.
 
 platform: grub2

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/disabled_recovery_boot.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/disabled_recovery_boot.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# make sure GRUB_DISABLE_RECOVERY=true
+if grep -q '^GRUB_DISABLE_RECOVERY=.*'  '/etc/default/grub' ; then
+       # modify the GRUB command-line if an GRUB_DISABLE_RECOVERY= arg already exists
+       sed -i 's/GRUB_DISABLE_RECOVERY=.*/GRUB_DISABLE_RECOVERY=true/' /etc/default/grub
+else
+       # no GRUB_DISABLE_RECOVERY=arg is present, append it to file
+       echo "GRUB_DISABLE_RECOVERY=true"  >> '/etc/default/grub'
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/enabled_recovery_boot.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/tests/enabled_recovery_boot.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Fail GRUB_DISABLE_RECOVERY
+# if GRUB_DISABLE_RECOVERY=true, set to false
+# if not set, do nothing, since that is also a failure.
+if grep -q '^GRUB_DISABLE_RECOVERY=.*'  '/etc/default/grub' ; then
+       # modify the GRUB command-line if an GRUB_DISABLE_RECOVERY= arg already exists
+       sed -i 's/GRUB_DISABLE_RECOVERY=.*/GRUB_DISABLE_RECOVERY=false/' /etc/default/grub
+fi
+


### PR DESCRIPTION
Two issues:
1: oval requires:
   GRUB_DISABLE_RECOVERY=true
   in /etc/default/grub

   But this was not being remediated in either ansible or bash.

2: bash remediation was not updated, so it was still trying to use grubby
   which is not part of sle12/15 destribution

#### Description:

- update ansible remediation to handle make sure GRUB_DISABLE_RECOVERY=true set
- update bash remediation to match ansible remediation for sle12/15
- update rule.yml to reflect that sle does not use grubby

#### Rationale:

- enable grub2_disable_interactive_boot remediation for sle12/15.
