### PR TITLE
Drop Anaconda remediations from rules not applicable to RHV

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/anaconda/shared.anaconda
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/anaconda/shared.anaconda
@@ -1,3 +1,3 @@
-# platform = multi_platform_all
+# platform = multi_platform_fedora,multi_platform_ol,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 9
 
 package --remove=xorg-x11-server-Xorg --remove=xorg-x11-server-common --remove=xorg-x11-server-utils {{{ "--remove=xorg-x11-server-Xwayland" if product not in ["rhel7", "ol7"] }}}

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/rule.yml
@@ -36,4 +36,4 @@ template:
     vars:
         pkgname: gssproxy
     backends:
-        anaconda: "off"
+        anaconda@rhel8: "off"

--- a/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
@@ -39,6 +39,8 @@ template:
     name: package_removed
     vars:
         pkgname: krb5-workstation
+    backends:
+        anaconda@rhel8: "off"
 
 fixtext: |-
     {{{ describe_package_remove(package="krb5-workstation") }}}

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/rule.yml
@@ -38,3 +38,5 @@ template:
     name: package_removed
     vars:
         pkgname: tuned
+    backends:
+        anaconda@rhel8: "off"

--- a/shared/applicability/virtualization.yml
+++ b/shared/applicability/virtualization.yml
@@ -17,8 +17,12 @@ cpes:
       name: "cpe:/a:no_ovirt"
       title: "oVirt is not installed (no Host nor Manager)"
       check_id: installed_env_has_no_ovirt
+      bash_conditional: '! ( rpm --quiet -q ovirt-engine || rpm --quiet -q ovirt-host )'
+      ansible_conditional: 'not ("ovirt-engine" in ansible_facts.packages or "ovirt-host" in ansible_facts.packages)'
 
   - ovirt:
       name: "cpe:/a:ovirt"
       title: "oVirt is installed (Host or Manager)"
       check_id: installed_env_has_ovirt
+      bash_conditional: 'rpm --quiet -q ovirt-engine || rpm --quiet -q ovirt-host'
+      ansible_conditional: '"ovirt-engine" in ansible_facts.packages or "ovirt-host" in ansible_facts.packages'

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -420,8 +420,6 @@ XCCDF_PLATFORM_TO_PACKAGE = {
   "s390x_arch": None,
   "not_aarch64_arch": None,
   "aarch64_arch": None,
-  "ovirt": None,
-  "no_ovirt": None,
 }
 
 # _version_name_map = {


### PR DESCRIPTION
#### Description:

- In RHEL8, drop Anaconda remediations not applicable for RHV
  - They are breaking hardened install with oscap-anaconda-addon
-  Add  remediation conditonals for `ovirt` and `no_ovirt` CPEs
   - This prevents these remediations from being applied in systems with RHV installed.

#### Rationale:

- This should fix hardened install of RHVH with STIG profile.
  - Remediations for rules not applicable to RHV were being applied.
- The `oscap-anaconda-addon` doesn't honor the CPEs in the rules, so we drop the anaconda remediations and let the post install phase handle it. In the post install phase we can guard the rules and remediations with applicability checks.
- Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2075508