### PR TITLE
Update SRG-OS-000078-GPOS-00046 for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000078-GPOS-00046.yml
+++ b/controls/srg_gpos/SRG-OS-000078-GPOS-00046.yml
@@ -7,4 +7,6 @@ controls:
             - accounts_password_pam_enforce_root
             - accounts_password_pam_minlen
             - accounts_password_minlen_login_defs
+            - var_password_pam_minlen=15
+            - var_accounts_password_minlen_login_defs=15
         status: automated

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -62,6 +62,13 @@ ocil: |-
     <pre>$ grep minlen /etc/security/pwquality.conf</pre>
     Your output should contain <tt>minlen = {{{ xccdf_value("var_password_pam_minlen") }}}</tt>
 
+fixtext: |-
+    Configure {{{ full_name }}} to enforce a minimum 15-character password length.
+
+    Add the following line to "/etc/security/pwquality.conf" (or modify the line to have the required value):
+
+    minlen = {{{ xccdf_value("var_password_pam_minlen") }}}
+
 platform: pam
 
 template:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
@@ -55,4 +55,11 @@ ocil: |-
     <pre>$ grep PASS_MIN_LEN /etc/login.defs</pre>
     The DoD requirement is <tt>15</tt>.
 
+fixtext: |-
+    Configure {{{ full_name }}} to enforce a minimum 15-character password length for new user accounts.
+
+    Add, or modify the following line in the "/etc/login.defs" file:
+
+    PASS_MIN_LEN {{{ xccdf_value("var_accounts_password_minlen_login_defs") }}}
+
 platform: login_defs


### PR DESCRIPTION
#### Description:

* Add `fixtext` to 
  * accounts_password_pam_minlen
  * accounts_password_minlen_login_def
* Add variables to to support the rules in the SRG

#### Rationale:

RHEL 9 STIG
