### PR TITLE
Bad use of double quotes in rsyslog_files_permissions/bash/shared.sh (second try)

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -12,7 +12,7 @@ readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(i
 declare -a LOG_FILE_PATHS
 
 declare -a RSYSLOG_CONFIGS
-RSYSLOG_CONFIGS+=(${RSYSLOG_ETC_CONFIG} ${RSYSLOG_INCLUDE_CONFIG[@]} ${RSYSLOG_INCLUDE[@]})
+RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
 
 # Get full list of files to be checked
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -12,11 +12,17 @@ readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(i
 declare -a LOG_FILE_PATHS
 
 declare -a RSYSLOG_CONFIGS
-RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
+RSYSLOG_CONFIGS+=(${RSYSLOG_ETC_CONFIG} ${RSYSLOG_INCLUDE_CONFIG[@]} ${RSYSLOG_INCLUDE[@]})
 
-# Browse each file selected above as containing paths of log files
+# Get full list of files to be checked
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
-for LOG_FILE in "${RSYSLOG_CONFIGS[@]}"
+for ENTRY in "${RSYSLOG_CONFIGS[@]}"
+do
+     RSYSLOG_FILES+=("${RSYSLOG_FILES}" $(find $(dirname "${ENTRY}") -maxdepth 1 -name $(basename "${ENTRY}")))
+done
+
+# Check file and fix if needed.
+for LOG_FILE in "${RSYSLOG_FILES[@]}"
 do
 	# From each of these files extract just particular log file path(s), thus:
 	# * Ignore lines starting with space (' '), comment ('#"), or variable syntax ('$') characters,

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -16,9 +16,11 @@ RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYS
 
 # Get full list of files to be checked
 # ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
+declare -a RSYSLOG_FILES
 for ENTRY in "${RSYSLOG_CONFIGS[@]}"
 do
-     RSYSLOG_FILES+=("${RSYSLOG_FILES}" $(find $(dirname "${ENTRY}") -maxdepth 1 -name $(basename "${ENTRY}")))
+     mapfile -t FINDOUT < <(find $(dirname "${ENTRY}") -maxdepth 1 -name $(basename "${ENTRY}"))
+     RSYSLOG_FILES+=("${RSYSLOG_FILES[@]}" "${FINDOUT[@]}")
 done
 
 # Check file and fix if needed.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -19,7 +19,7 @@ RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYS
 declare -a RSYSLOG_FILES
 for ENTRY in "${RSYSLOG_CONFIGS[@]}"
 do
-     mapfile -t FINDOUT < <(find "$(dirname ${ENTRY}\")" -maxdepth 1 -name "$(basename \"${ENTRY})")
+     mapfile -t FINDOUT < <(find "$(dirname "${ENTRY}")" -maxdepth 1 -name "$(basename "${ENTRY}")")
      RSYSLOG_FILES+=("${RSYSLOG_FILES[@]}" "${FINDOUT[@]}")
 done
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -19,7 +19,7 @@ RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYS
 declare -a RSYSLOG_FILES
 for ENTRY in "${RSYSLOG_CONFIGS[@]}"
 do
-     mapfile -t FINDOUT < <(find $(dirname "${ENTRY}") -maxdepth 1 -name $(basename "${ENTRY}"))
+     mapfile -t FINDOUT < <(find "$(dirname ${ENTRY}\")" -maxdepth 1 -name "$(basename \"${ENTRY})")
      RSYSLOG_FILES+=("${RSYSLOG_FILES[@]}" "${FINDOUT[@]}")
 done
 

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -11,18 +11,18 @@ readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(i
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS
 
-declare -a RSYSLOG_CONFIGS
-RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
+RSYSLOG_CONFIGS=()
+RSYSLOG_CONFIGS=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
 
 # Get full list of files to be checked
 # RSYSLOG_CONFIGS may contain globs such as 
 # /etc/rsyslog.d/*.conf /etc/rsyslog.d/*.frule
 # So, loop over the entries in RSYSLOG_CONFIGS and use find to get the list of included files.
-declare -a RSYSLOG_FILES
+RSYSLOG_FILES=()
 for ENTRY in "${RSYSLOG_CONFIGS[@]}"
 do
      mapfile -t FINDOUT < <(find "$(dirname "${ENTRY}")" -maxdepth 1 -name "$(basename "${ENTRY}")")
-     RSYSLOG_FILES=("${RSYSLOG_FILES[@]}" "${FINDOUT[@]}")
+     RSYSLOG_FILES+=("${FINDOUT[@]}")
 done
 
 # Check file and fix if needed.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -15,12 +15,14 @@ declare -a RSYSLOG_CONFIGS
 RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
 
 # Get full list of files to be checked
-# ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
+# RSYSLOG_CONFIGS may contain globs such as 
+# /etc/rsyslog.d/*.conf /etc/rsyslog.d/*.frule
+# So, loop over the entries in RSYSLOG_CONFIGS and use find to get the list of included files.
 declare -a RSYSLOG_FILES
 for ENTRY in "${RSYSLOG_CONFIGS[@]}"
 do
      mapfile -t FINDOUT < <(find "$(dirname "${ENTRY}")" -maxdepth 1 -name "$(basename "${ENTRY}")")
-     RSYSLOG_FILES+=("${RSYSLOG_FILES[@]}" "${FINDOUT[@]}")
+     RSYSLOG_FILES=("${RSYSLOG_FILES[@]}" "${FINDOUT[@]}")
 done
 
 # Check file and fix if needed.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_glob_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_glob_perms_0600.pass.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0600 from $IncludeConfig passes.
+# test $IncludeConfig with wildcard (*.conf)
+
+source $SHARED/rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
+EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_glob_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/IncludeConfig_glob_perms_0601.fail.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0601 from $IncludeConfig fails.
+# test $IncludeConfig with wildcard (*.conf)
+
+source $SHARED/rsyslog_log_utils.sh
+
+PERMS_PASS=0600
+PERMS_FAIL=0601
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[1]}
+
+# create test configuration file
+test_conf=${RSYSLOG_TEST_DIR}/test1.conf
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*      ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
+EOF


### PR DESCRIPTION
In our testing the log files specified in /etc/rsyslog.d/ were not getting remediated.
The issue is with line:
    RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
which produces a RSYSLOG_CONFIGS of
    /etc/rsyslog.conf /run/rsyslog/additional-log-sockets.conf /etc/rsyslog.d/*.conf /etc/rsyslog.d/*.frule

line:
    RSYSLOG_CONFIGS+=(${RSYSLOG_ETC_CONFIG} ${RSYSLOG_INCLUDE_CONFIG[@]} ${RSYSLOG_INCLUDE[@]})
poduces:
    /etc/rsyslog.conf /run/rsyslog/additional-log-sockets.conf /etc/rsyslog.d/21-cloudinit.conf /etc/rsyslog.d/remote.conf /etc/rsyslog.d/acpid.frule /etc/rsyslog.d/firewall.frule /etc/rsyslog.d/NetworkManager.frule

Use find to capture effected conf and frule files.

#### Description:

- recode config file handle to use find as opposed to shell expansion for getting list of config files.

#### Rationale:

- current *.conf and *.frule handling not working
-
