### PR TITLE
bugfix: no_shelllogin_for_systemaccounts: value parsing fixes

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/oval/shared.xml
@@ -45,7 +45,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
     <!-- Last (uncommented) instance od UID_MIN directive -->
-    <ind:pattern operation="pattern match">.*\n(?!#|SYS_)(UID_MIN[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:pattern operation="pattern match">.*(?:^|\n)\s*(UID_MIN[\s]+[\d]+)\s*(?:$|\n)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -55,7 +55,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
     <!-- Last (uncommented) instance of SYS_UID_MIN directive -->
-    <ind:pattern operation="pattern match">.*\n[^#]*(SYS_UID_MIN[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:pattern operation="pattern match">.*(?:^|\n)\s*(SYS_UID_MIN[\s]+[\d]+)\s*(?:$|\n)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -64,7 +64,7 @@
     <ind:behaviors singleline="true" />
     <ind:filepath>/etc/login.defs</ind:filepath>
     <!-- Last (uncommented) instance of SYS_UID_MAX directive -->
-    <ind:pattern operation="pattern match">.*\n[^#]*(SYS_UID_MAX[\s]+[\d]+)\s*\n</ind:pattern>
+    <ind:pattern operation="pattern match">.*(?:^|\n)\s*(SYS_UID_MAX[\s]+[\d]+)\s*(?:$|\n)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_max.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_max.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=SYS_UID_MAX
+
+# Add key as 1st line, drop others
+sed -Ei '
+1{i\
+'"$key"' 999
+}
+/^'"$key"'/d;
+' /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_min.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=SYS_UID_MIN
+
+# Add key as 1st line, drop others
+sed -Ei '
+1{i\
+'"$key"' 201
+}
+/^'"$key"'/d;
+' /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_uid_min.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=UID_MIN
+
+# Add key as 1st line, drop others
+sed -Ei '
+1{i\
+'"$key"' 1000
+}
+/^(SYS_)?UID_(MIN|MAX)/d;
+' /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_max.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_max.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=SYS_UID_MAX
+
+# Add bogus key as 2nd last and valid last line w/o nl
+printf "%s 2000\n%s 999" "$key" "$key" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_min.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=SYS_UID_MIN
+
+# Add bogus key as 2nd last and valid last line w/o nl
+printf "%s 2000\n%s 201" "$key" "$key" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_uid_min.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=UID_MIN
+
+# Add bogus key as 2nd last and valid last line w/o nl
+# drop SYS_UID so it does not mess
+sed -Ei '/^SYS_UID_(MIN|MAX)/d;' /etc/login.defs
+printf "%s 2000\n%s 1000" "$key" "$key" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/space_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/space_uid_min.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# remediation = none
+
+useradd --system --shell /sbin/nologin -u 999 sysuser
+useradd -u 1000 testuser
+
+key=UID_MIN
+
+# Add bogus key as 2nd last and valid last line w/o nl
+# drop SYS_UID so it does not mess
+sed -Ei '/^SYS_UID_(MIN|MAX)/d;' /etc/login.defs
+printf "%s 2000\n\t%s 1000\n" "$key" "$key" >> /etc/login.defs


### PR DESCRIPTION
#### Description:

Fix parsing login.defs 

#### Rationale:

fix start of file w/o \n at start
fix end of file w/o \n at end
fix space before key

also always generate testuser

man login.defs(5)
...
       This file is a readable text file, each line of the file describing one configuration parameter. The lines consist of a configuration name and value, separated by
       whitespace. Blank lines and comment lines are ignored. Comments are introduced with a "#" pound sign and the pound sign must be the first non-white character of the
       line.
...

So regexps to get values from login.defs use format because of:
    <ind:behaviors singleline="true" />

.* - target last key
(?:^|\n) - allow key to start at beginning of the file or after newline
\s* - allow "selarated by whitespace"
(UID_MIN[\s]+[\d]+) - key whitespace value
\s* - as before
(?:$|\n) - allow to end at EOF or EOL

There is no need to specially target # or have other tricks.

- testsuite ensures there is 1 system user and one normal user
