### PR TITLE
bugfix-fedora-35: (?:[\S]+,) -> (?:[^,]+,)

### DIFF
--- a/shared/templates/audit_rules_path_syscall/oval.template
+++ b/shared/templates/audit_rules_path_syscall/oval.template
@@ -36,11 +36,11 @@
 
   <!-- Access to /var/log/audit rule regex-->
   <constant_variable id="var_audit_rule_32bit_{{{ SYSCALL }}}_write_{{{ PATHID }}}_regex" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
   </constant_variable>
 
   <constant_variable id="var_audit_rule_64bit_{{{ SYSCALL }}}_write_{{{ PATHID }}}_regex" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+(?:-F[\s]+{{{ POS }}}&amp;03)[\s]+(?:-F[\s]+path={{{ PATH }}})[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>
   </constant_variable>
 
   <!-- directory access {{{ PATH }}} augenrule -->

--- a/shared/templates/audit_rules_unsuccessful_file_modification_o_creat/oval.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification_o_creat/oval.template
@@ -44,10 +44,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_32bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_64bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_creat_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>

--- a/shared/templates/audit_rules_unsuccessful_file_modification_o_trunc_write/oval.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification_o_trunc_write/oval.template
@@ -44,10 +44,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_32bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_64bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_o_trunc_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>

--- a/shared/templates/audit_rules_unsuccessful_file_modification_rule_order/oval.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification_rule_order/oval.template
@@ -44,10 +44,10 @@
 
   <!-- General rule boiler plate -->
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_order_32bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b32[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_order_64bit_head" version="1" datatype="string" comment="audit rule arch and syscal">
-      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[\S]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
+      <value>^[\s]*-a[\s]+always,exit[\s]+(?:-F[\s]+arch=b64[\s]+)(?:-S[\s]+(?:[^,]+,)*({{{ SYSCALL }}})(?:,[\S]+)*)[\s]+</value>
   </constant_variable>
   <constant_variable id="var_audit_rule_{{{ SYSCALL }}}_order_tail" version="1" datatype="string" comment="audit rule auid and key">
     <value>[\s]+(?:-F\s+auid>={{{ auid }}}[\s]+)(?:-F\s+auid!=(?:unset|4294967295)[\s]+)(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</value>


### PR DESCRIPTION
#### Description:

In Fedora 35 pcre2 is not able to handle (?:[\S]+,) change it to be (?:[^,]+,)

#### Rationale:

otherwise prce_exec error -8 "range out of order in character class"

This seems to be pcre2-10.39-1.fc35.x86_64 regression. But this issue is maybe in other regexps too.

Idea of regexp is handle list of syscalls
-S foo,bar,baz
and when targetting bar, pcre gets confused eating foo, with [\S]+, I guess because , is in \S.