### PR TITLE
change: use pkg_manager_config_file to allow fedora to work

### DIFF
--- a/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/ansible/shared.yml
@@ -3,9 +3,9 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: "Ensure YUM Removes Previous Package Versions"
+- name: "Ensure {{{ pkg_manager | upper }}} Removes Previous Package Versions"
   lineinfile:
-      dest: /etc/yum.conf
+      dest: {{{ pkg_manager_config_file }}}
       regexp: ^#?clean_requirements_on_remove
       line: clean_requirements_on_remove=1
       insertafter: '\[main\]'

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
@@ -1,8 +1,8 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
 
-if grep --silent ^clean_requirements_on_remove /etc/yum.conf ; then
-        sed -i "s/^clean_requirements_on_remove.*/clean_requirements_on_remove=1/g" /etc/yum.conf
+if grep --silent ^clean_requirements_on_remove {{{ pkg_manager_config_file }}} ; then
+        sed -i "s/^clean_requirements_on_remove.*/clean_requirements_on_remove=1/g" {{{ pkg_manager_config_file }}}
 else
-        echo -e "\n# Set clean_requirements_on_remove to 1 per security requirements" >> /etc/yum.conf
-        echo "clean_requirements_on_remove=1" >> /etc/yum.conf
+        echo -e "\n# Set clean_requirements_on_remove to 1 per security requirements" >> {{{ pkg_manager_config_file }}}
+        echo "clean_requirements_on_remove=1" >> {{{ pkg_manager_config_file }}}
 fi

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
 
 if grep --silent ^clean_requirements_on_remove /etc/yum.conf ; then
         sed -i "s/^clean_requirements_on_remove.*/clean_requirements_on_remove=1/g" /etc/yum.conf

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/oval/shared.xml
@@ -3,14 +3,14 @@
     {{{ oval_metadata("The clean_requirements_on_remove option should be used to ensure that old 
       versions of software components are removed after updating.") }}}
     <criteria>
-      <criterion comment="check value of clean_requirements_on_remove in /etc/yum.conf" test_ref="test_yum_clean_components_post_updating" />
+      <criterion comment="check value of clean_requirements_on_remove in {{{ pkg_manager_config_file }}}" test_ref="test_yum_clean_components_post_updating" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of clean_requirements_on_remove in /etc/yum.conf" id="test_yum_clean_components_post_updating" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of clean_requirements_on_remove in {{{ pkg_manager_config_file }}}" id="test_yum_clean_components_post_updating" version="1">
     <ind:object object_ref="object_yum_clean_components_post_updating" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_yum_clean_components_post_updating" comment="clean_requirements_on_remove set in /etc/yum.conf" version="1">
-    <ind:filepath>/etc/yum.conf</ind:filepath>
+  <ind:textfilecontent54_object id="object_yum_clean_components_post_updating" comment="clean_requirements_on_remove set in {{{ pkg_manager_config_file }}}" version="1">
+    <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*clean_requirements_on_remove\s*=\s*(1|True|yes)\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Ensure {{{ pkg_manager }}} Removes Previous Package Versions'
 
@@ -85,7 +85,7 @@ ocil: |-
     <pre>clean_requirements_on_remove=1</pre>
     {{% endif %}}
 
-{{% if 'rhel' in product %}}
+{{% if product in ['fedora'] or 'rhel' in product %}}
 fixtext: |-
     Configure {{{ full_name }}} to remove all software components after updated versions have been installed.
     

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure {{{ pkg_manager }}} Removes Previous Package Versions'
 description: |-
     <tt>{{{ pkg_manager }}}</tt> should be configured to remove previous software components after
     new versions have been installed. To configure <tt>{{{ pkg_manager }}}</tt> to remove the
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if 'sle' in product %}}
     previous software components after updating, set the <tt>solver.upgradeRemoveDroppedPackages</tt>
     {{% elif 'ubuntu' in product %}}
     previous software components after updating, set the <tt>::Remove-Unused-Dependencies</tt> and
@@ -54,7 +54,7 @@ references:
     vmmsrg: SRG-OS-000437-VMM-001760
 
 ocil_clause: |-
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if 'sle' in product %}}
     'solver.upgradeRemoveDroppedPackages is not enabled or configured correctly'
     {{% elif 'ubuntu' in product %}}
     '::Remove-Unused-Dependencies and ::Remove-Unused-Kernel-Packages is not
@@ -66,7 +66,7 @@ ocil_clause: |-
 ocil: |-
     Verify {{{ full_name }}} removes all software components after updated versions have been installed.
 
-    {{% if product in ["sle12", "sle15"] %}}
+    {{% if 'sle' in product %}}
     To verify that <tt>solver.upgradeRemoveDroppedPackages</tt> is configured properly, run the
     following command:
     <pre>$ grep -i upgradeRemoveDroppedPackages {{{ pkg_manager_config_file }}}</pre>
@@ -93,8 +93,9 @@ fixtext: |-
 
     <pre>clean_requirements_on_remove=1</pre>
 {{% endif %}}
-{{% if product == 'sle12' %}}
+
+{{% if 'sle' in product %}}
 platform: zypper
-{{% elif product in ['ol7', 'ol8', 'rhel7', 'rhel8', 'rhel9', 'rhv4', 'sle15'] %}}
+{{% elif product in ['ol7', 'ol8', 'rhel7', 'rhel8', 'rhel9', 'rhv4'] %}}
 platform: yum
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/rule.yml
@@ -96,6 +96,7 @@ fixtext: |-
 
 {{% if 'sle' in product %}}
 platform: zypper
-{{% elif product in ['ol7', 'ol8', 'rhel7', 'rhel8', 'rhel9', 'rhv4'] %}}
+{{% elif 'ubuntu' in product %}}
+{{% else %}}
 platform: yum
 {{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -76,7 +76,7 @@ ocil: |-
     <tt>gpgcheck</tt> line or a setting of <tt>0</tt> indicates that it is
     disabled.
 
-{{% if product in ['sle12', 'sle15'] %}}
+{{% if 'sle' in product %}}
 platform: zypper
 {{% else %}}
 platform: yum

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/oval/shared.xml
@@ -3,14 +3,14 @@
     {{{ oval_metadata("The repo_gpgcheck option should be used to ensure that checking
       of repository metadata always occurs.") }}}
     <criteria>
-      <criterion comment="check value of repo_gpgcheck in /etc/yum.conf" test_ref="test_yum_ensure_gpgcheck_repo_metadata" />
+      <criterion comment="check value of repo_gpgcheck in {{{ pkg_manager_config_file }}}" test_ref="test_yum_ensure_gpgcheck_repo_metadata" />
     </criteria>
   </definition>
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of repo_gpgcheck in /etc/yum.conf" id="test_yum_ensure_gpgcheck_repo_metadata" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="check value of repo_gpgcheck in {{{ pkg_manager_config_file }}}" id="test_yum_ensure_gpgcheck_repo_metadata" version="1">
     <ind:object object_ref="object_yum_ensure_gpgcheck_repo_metadata" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_yum_ensure_gpgcheck_repo_metadata" comment="repo_gpgcheck set in /etc/yum.conf" version="1">
-    <ind:filepath>/etc/yum.conf</ind:filepath>
+  <ind:textfilecontent54_object id="object_yum_ensure_gpgcheck_repo_metadata" comment="repo_gpgcheck set in {{{ pkg_manager_config_file }}}" version="1">
+    <ind:filepath>{{{ pkg_manager_config_file }}}</ind:filepath>
     <ind:pattern operation="pattern match">^\s*repo_gpgcheck\s*=\s*(1|True|yes)\s*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_repo_metadata/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Ensure gpgcheck Enabled for Repository Metadata'
 


### PR DESCRIPTION
#### Description:

Use pkg_manager and pkg_manager_config_file instead of YUM and /etc/yum.conf.

#### Rationale:

There are variables, but not used. Bad strings used.

This affects especially Fedora where those are DNF.

There should be some kind of job which crosschecks if product variable values are used in rules.
