### PR TITLE
use grub2_uefi_boot_path

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
@@ -5,17 +5,10 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8
 title: 'Verify the UEFI Boot Loader grub.cfg Group Ownership'
 
 description: |-
-{{%- if product == "fedora" %}}
-    The file <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should
+    The file <tt>{{{ grub2_uefi_boot_path }}}/grub.cfg</tt> should
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
-    {{{ describe_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
-{{% else %}}
-    The file <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should
-    be group-owned by the <tt>root</tt> group to prevent
-    destruction or modification of the file.
-    {{{ describe_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
-{{%- endif %}}
+    {{{ describe_file_group_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", group="root") }}}
 
 rationale: |-
     The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
@@ -42,25 +35,15 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
 
-ocil_clause: |-
-{{%- if product == "fedora" %}}
-    {{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
-{{% else %}}
-    {{{ ocil_clause_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
-{{%- endif %}}
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", group="root") }}}'
 
 ocil: |-
-{{%- if product == "fedora" %}}
-    {{{ ocil_file_group_owner(file="/boot/efi/EFI/fedora/grub.cfg", group="root") }}}
-{{% else %}}
-    {{{ ocil_file_group_owner(file="/boot/efi/EFI/redhat/grub.cfg", group="root") }}}
-{{%- endif %}}
+    {{{ ocil_file_group_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", group="root") }}}
 
 platform: machine
 
 template:
     name: file_groupowner
     vars:
-        filepath: /boot/efi/EFI/redhat/grub.cfg
-        filepath@fedora: /boot/efi/EFI/fedora/grub.cfg
+        filepath: {{{ grub2_uefi_boot_path }}}/grub.cfg
         filegid: '0'

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
@@ -5,17 +5,10 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8
 title: 'Verify the UEFI Boot Loader grub.cfg User Ownership'
 
 description: |-
-{{%- if product == "fedora" %}}
-    The file <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should
+    The file <tt>{{{ grub2_uefi_boot_path }}}/grub.cfg</tt> should
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
-    {{{ describe_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
-{{% else %}}
-    The file <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should
-    be owned by the <tt>root</tt> user to prevent destruction
-    or modification of the file.
-    {{{ describe_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
-{{%- endif %}}
+    {{{ describe_file_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", owner="root") }}}
 
 rationale: 'Only root should be able to modify important boot parameters.'
 
@@ -40,25 +33,15 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
 
-ocil_clause: |-
-{{%- if product == "fedora" %}}
-    {{{ ocil_clause_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
-{{% else %}}
-    {{{ ocil_clause_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
-{{%- endif %}}
+ocil_clause: '{{{ ocil_clause_file_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", owner="root") }}}'
 
 ocil: |-
-{{%- if product == "fedora" %}}
-    {{{ ocil_file_owner(file="/boot/efi/EFI/fedora/grub.cfg", owner="root") }}}
-{{% else %}}
-    {{{ ocil_file_owner(file="/boot/efi/EFI/redhat/grub.cfg", owner="root") }}}
-{{%- endif %}}
+    {{{ ocil_file_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", owner="root") }}}
 
 platform: machine
 
 template:
     name: file_owner
     vars:
-        filepath: /boot/efi/EFI/redhat/grub.cfg
-        filepath@fedora: /boot/efi/EFI/fedora/grub.cfg
+        filepath: {{{ grub2_uefi_boot_path }}}/grub.cfg
         fileuid: '0'

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
@@ -2,16 +2,12 @@ documentation_complete: true
 
 prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
+
 title: 'Verify the UEFI Boot Loader grub.cfg Permissions'
 
 description: |-
-{{%- if product == "fedora" %}}
-    File permissions for <tt>/boot/efi/EFI/fedora/grub.cfg</tt> should be set to 700.
-    {{{ describe_file_permissions(file="/boot/efi/EFI/fedora/grub.cfg", perms="700") }}}
-{{% else %}}
-    File permissions for <tt>/boot/efi/EFI/redhat/grub.cfg</tt> should be set to 700.
-    {{{ describe_file_permissions(file="/boot/efi/EFI/redhat/grub.cfg", perms="700") }}}
-{{%- endif %}}
+    File permissions for <tt>{{{ grub2_uefi_boot_path }}}/grub.cfg</tt> should be set to 700.
+    {{{ describe_file_permissions(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", perms="700") }}}
 
 rationale: |-
     Proper permissions ensure that only the root user can modify important boot
@@ -40,13 +36,8 @@ references:
 ocil_clause: 'it does not'
 
 ocil: |-
-{{%- if product == "fedora" %}}
-    To check the permissions of /boot/efi/EFI/fedora/grub.cfg, run the command:
-    <pre>$ sudo ls -lL /boot/efi/EFI/fedora/grub.cfg</pre>
-{{% else %}}
-    To check the permissions of /boot/efi/EFI/redhat/grub.cfg, run the command:
-    <pre>$ sudo ls -lL /boot/efi/EFI/redhat/grub.cfg</pre>
-{{%- endif %}}
+    To check the permissions of {{{ grub2_uefi_boot_path }}}/grub.cfg, run the command:
+    <pre>$ sudo ls -lL {{{ grub2_uefi_boot_path }}}/grub.cfg</pre>
     If properly configured, the output should indicate the following
     permissions: <tt>-rwx------</tt>
 
@@ -55,6 +46,5 @@ platform: machine
 template:
     name: file_permissions
     vars:
-        filepath: /boot/efi/EFI/redhat/grub.cfg
-        filepath@fedora: /boot/efi/EFI/fedora/grub.cfg
+        filepath: {{{ grub2_uefi_boot_path }}}/grub.cfg
         filemode: '0700'

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/shared.xml
@@ -7,7 +7,7 @@
     </criteria>
   </definition>
   
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in /boot/efi/EFI/redhat/user.cfg" id="test_grub2_uefi_password_usercfg" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/user.cfg" id="test_grub2_uefi_password_usercfg" version="1">
     <ind:object object_ref="object_grub2_uefi_password_usercfg" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_grub2_uefi_password_usercfg" version="1">

--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/rule.yml
@@ -31,7 +31,7 @@ ocil_clause: 'it is not'
 ocil: |-
     To verify the system is not configured to use a boot loader on removable media,
     run the following command:
-    <pre>$ sudo grep "set root='hd0" /boot/efi/EFI/redhat/grub.cfg</pre>
+    <pre>$ sudo grep "set root='hd0" {{{ grub2_uefi_boot_path }}}/grub.cfg</pre>
     The output should return something similar to:
     <pre>set root='hd0,msdos1'</pre>
     <tt>usb0</tt>, <tt>cd</tt>, <tt>fd0</tt>, etc. are some examples of removeable

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -18,7 +18,7 @@ description: |-
     <li>On BIOS-based machines, issue the following command as <tt>root</tt>:
     <pre>~]# grub2-mkconfig -o {{{ grub2_boot_path }}}/grub.cfg</pre></li>
     <li>On UEFI-based machines, issue the following command as <tt>root</tt>:
-    <pre>~]# grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg</pre></li>
+    <pre>~]# grub2-mkconfig -o {{{ grub2_uefi_boot_path }}}/grub.cfg</pre></li>
     </ul>
 
 rationale: |-


### PR DESCRIPTION
#### Description:

Maybe use variable grub2_uefi_boot_path instead of implementing respective tests again and again.

#### Rationale:

There are variables, but not used. Bad strings used.

There should be some kind of job which crosschecks if product variable values are used in rules.

If distro implementations are alike so that rules can be implemented using variable, then that probably creates least amount of lines to maintain.