### PR TITLE
configure_openssl_crypto_policy: OpenSSL v3.0 has = in include

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="object_configure_openssl_crypto_policy"
   version="1">
     <ind:filepath>/etc/pki/tls/openssl.cnf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*\[\s*crypto_policy\s*\]\s*\n*\s*\.include\s*/etc/crypto-policies/back-ends/opensslcnf.config\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*\[\s*crypto_policy\s*\]\s*\n*\s*\.include\s*(?:=\s*)?/etc/crypto-policies/back-ends/opensslcnf.config\s*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/include_with_equal_sign.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/tests/include_with_equal_sign.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+. common.sh
+
+create_config_file_with "[ crypto_policy ]
+
+.include = /etc/crypto-policies/back-ends/opensslcnf.config
+"


### PR DESCRIPTION
#### Description:

Default crypto-policies uses '.include =' in Fedora 35.

#### Rationale:

.include is in OpenSSL v1.1.1
https://www.openssl.org/docs/man1.1.1/man5/config.html

.include [=] pathname is in OpenSSL v3.0
https://www.openssl.org/docs/man3.0/man5/config.html