### PR TITLE
Exclude package_crypto-policies_installed removal tests

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/tests/test_config.yml
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/tests/test_config.yml
@@ -1,0 +1,3 @@
+deny_templated_scenarios:
+  - package-removed.fail.sh
+  - package-installed-removed.fail.sh


### PR DESCRIPTION
#### Description:
Exclude `package_crypto-policies_installed` test scenarios that remove the crypto policies package.

#### Rationale:
The tests can't be tested with `oscap`:
```
Warning: Permanently added '192.168.122.201' (ED25519) to the list of known hosts.
I: oscap: Identified document type: data-stream-collection [oscap(9072):oscap(7f7d6d0aa900):doc_type.c:96:oscap_determine_document_type_reader]
I: oscap: Created a new XCCDF session from a SCAP Source Datastream '/tmp/tmp.1wK1pNwqdN/input.xml'. [oscap(9072):oscap(7f7d6d0aa900):xccdf_session.c:179:xccdf_session_new_from_source]
D: oscap: Validating SCAP Source Datastream (1.3) document from /tmp/tmp.1wK1pNwqdN/input.xml. [oscap(9072):oscap(7f7d6d0aa900):oscap_source.c:350:oscap_source_validate]
I: oscap: Validating XML signature. [oscap(9072):oscap(7f7d6d0aa900):signature.c:122:_oscap_signature_validate_doc]
func=xmlSecOpenSSLAppInit:file=app.c:line=91:obj=unknown:subj=OPENSSL_init_crypto:error=4:crypto library function failed:openssl error: 2147483650: system library: NULL NULL
OpenSCAP Error: Crypto initialization failed. [/builddir/build/BUILD/openscap-1.3.6/src/source/signature.c:148]
Invalid signature in SCAP Source Datastream (1.3) content in /tmp/tmp.1wK1pNwqdN/input.xml [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:845]
File "/tmp/tmp.1wK1pNwqdN/results-arf.xml" not found.
Failed to download '/tmp/tmp.1wK1pNwqdN/results-arf.xml'
Failed to copy the ARF file back to local machine!
```