### PR TITLE
Remove rules that do not belong to SRG-OS-000240-GPOS-00090 and SRG-OS-000240-GPOS-00091

### DIFF
--- a/controls/srg_gpos/SRG-OS-000240-GPOS-00090.yml
+++ b/controls/srg_gpos/SRG-OS-000240-GPOS-00090.yml
@@ -6,11 +6,9 @@ controls:
         rules:
             - audit_rules_sudoers
             - audit_rules_sudoers_d
-            - audit_rules_sysadmin_actions
             - audit_rules_usergroup_modification_group
             - audit_rules_usergroup_modification_gshadow
             - audit_rules_usergroup_modification_opasswd
             - audit_rules_usergroup_modification_passwd
             - audit_rules_usergroup_modification_shadow
-            - audit_rules_for_ospp
         status: automated

--- a/controls/srg_gpos/SRG-OS-000241-GPOS-00091.yml
+++ b/controls/srg_gpos/SRG-OS-000241-GPOS-00091.yml
@@ -6,13 +6,9 @@ controls:
         rules:
             - audit_rules_sudoers
             - audit_rules_sudoers_d
-            - audit_rules_sysadmin_actions
-            - audit_rules_usergroup_modification
             - audit_rules_usergroup_modification_group
             - audit_rules_usergroup_modification_gshadow
             - audit_rules_usergroup_modification_opasswd
             - audit_rules_usergroup_modification_passwd
             - audit_rules_usergroup_modification_shadow
-            - audit_ospp_general
-            - audit_rules_for_ospp
         status: automated


### PR DESCRIPTION
#### Description:
- Remove rules that do not belong to SRG-OS-000240-GPOS-00090 and SRG-OS-000240-GPOS-00091
  - These requirements are very similar to [SRG-OS-000239-GPOS-00089](https://github.com/ComplianceAsCode/content/blob/master/controls/srg_gpos/SRG-OS-000239-GPOS-00089.yml) as they
contain the very same set of rules according to previous STIGs.
    - Significant changes were done in https://github.com/ComplianceAsCode/content/pull/8595
