### PR TITLE
Update SRG-OS-000355-GPOS-00143

### DIFF
--- a/controls/srg_gpos/SRG-OS-000355-GPOS-00143.yml
+++ b/controls/srg_gpos/SRG-OS-000355-GPOS-00143.yml
@@ -5,7 +5,8 @@ controls:
         title: {{{ full_name }}} must, for networked systems, compare internal information
             system clocks at least every 24 hours with a server which is synchronized to one
             of the redundant United States Naval Observatory (USNO) time servers, or a time
-            server designat
+            server designated for the appropriate DoD network (NIPRNet/SIPRNet), 
+            and/or the Global Positioning System (GPS).
         rules:
             - chronyd_or_ntpd_set_maxpoll
             - package_chrony_installed


### PR DESCRIPTION
#### Description:

- Fix the title in SRG-OS-000355-GPOS-00143

#### Rationale:
RHEL9 STIG
 
`chronyd_or_ntpd_set_maxpoll` is updated in #8614