### PR TITLE
Update SRG-OS-000376-GPOS-00161 for RHEL 9 STIG

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
@@ -55,3 +55,10 @@ template:
         pkgname@ubuntu1604: opensc-pkcs11
         pkgname@ubuntu1804: opensc-pkcs11
         pkgname@ubuntu2004: opensc-pkcs11
+
+fixtext: |-
+    {{% if 'ubuntu' not in product %}}
+    {{{ describe_package_install(package="opensc") }}}
+    {{% else %}}
+    {{{ describe_package_install(package="opensc-pkcs11") }}}
+    {{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/rule.yml
@@ -49,3 +49,19 @@ ocil: |-
     If properly configured, the output should be <tt>/org/gnome/login-screen/enable-smartcard-authentication</tt>
 
 platform: machine
+
+fixtext: |-
+    The dconf settings can be edited in the /etc/dconf/db/* location.
+
+    First, add or update the [org/gnome/login-screen] section of the "/etc/dconf/db/{{{ dconf_gdm_dir }}}/00-security-settings" database file and add or update the following lines:
+
+    [org/gnome/login-screen]
+    enable-smartcard-authentication=true
+
+    Then, add the following line to "/etc/dconf/db/{{{ dconf_gdm_dir }}}/locks/00-security-settings-lock" to prevent user modification:
+
+    /org/gnome/login-screen/enable-smartcard-authentication
+
+    Finally, update the dconf system databases:
+
+    $ sudo dconf update


### PR DESCRIPTION
#### Description:
* add fixtext to rules package_opensc_installed and dconf_gnome_enable_smartcard_auth

#### Rationale:
RHEL 9 STIG
