### PR TITLE
Update SRG-OS-000377-GPOS-00162 for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000375-GPOS-00160.yml
+++ b/controls/srg_gpos/SRG-OS-000375-GPOS-00160.yml
@@ -12,5 +12,4 @@ controls:
             - package_opensc_installed
             - package_pcsc-lite_installed
             - service_pcscd_enabled
-            - dconf_gnome_enable_smartcard_auth
         status: automated

--- a/controls/srg_gpos/SRG-OS-000376-GPOS-00161.yml
+++ b/controls/srg_gpos/SRG-OS-000376-GPOS-00161.yml
@@ -5,5 +5,4 @@ controls:
         title: {{{ full_name }}} must accept Personal Identity Verification (PIV) credentials.
         rules:
             - package_opensc_installed
-            - dconf_gnome_enable_smartcard_auth
         status: automated

--- a/controls/srg_gpos/SRG-OS-000377-GPOS-00162.yml
+++ b/controls/srg_gpos/SRG-OS-000377-GPOS-00162.yml
@@ -6,6 +6,7 @@ controls:
             (PIV) credentials.
         rules:
             - sssd_certificate_verification
+            - var_sssd_certificate_verification_digest_function=sha1
             - install_smartcard_packages
             - dconf_gnome_enable_smartcard_auth
         status: automated

--- a/controls/srg_gpos/SRG-OS-000377-GPOS-00162.yml
+++ b/controls/srg_gpos/SRG-OS-000377-GPOS-00162.yml
@@ -8,5 +8,4 @@ controls:
             - sssd_certificate_verification
             - var_sssd_certificate_verification_digest_function=sha1
             - install_smartcard_packages
-            - dconf_gnome_enable_smartcard_auth
         status: automated

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/rule.yml
@@ -2,16 +2,16 @@ documentation_complete: true
 
 prodtype: fedora,ol8,rhel8,rhel9
 
-title: 'Certificate certificate status checking in SSSD'
+title: 'Certificate status checking in SSSD'
 
 description: |-
     Multifactor solutions that require devices separate from information systems gaining access include,
     for example, hardware tokens providing time-based or challenge-response authenticators and smart cards.
-    By configuring <tt>certificate_verification</tt> to <tt>ocsp_dgst=sha1</tt> sures that certificates for
+    Configuring <tt>certificate_verification</tt> to <tt>ocsp_dgst={{{ xccdf_value("var_sssd_certificate_verification_digest_function") }}}</tt> ensures that certificates for
     multifactor solutions are checked via Online Certificate Status Protocol (OCSP).
 
 rationale: |-
-    Enusring that multifactor solutions certificates are checked via Online Certificate Status Protocol (OCSP)
+    Ensuring that multifactor solutions certificates are checked via Online Certificate Status Protocol (OCSP)
     ensures the security of the system.
 
 severity: medium
@@ -36,7 +36,23 @@ ocil: |-
     <pre>$ sudo grep certificate_verification /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf | grep -v "^#"</pre>
     If configured properly, output should look like
     <pre>
-        certificate_verification = ocsp_dgst=sha1
+        certificate_verification = ocsp_dgst={{{ xccdf_value("var_sssd_certificate_verification_digest_function") }}}
     </pre>
+
+fixtext: |-
+    Configure the operating system to implement certificate status checking for multifactor authentication.
+
+    Review the "/etc/sssd/conf.d/certificate_verification.conf" file to determine if the system is configured to prevent OCSP or certificate verification.
+
+    Add the following line to the "/etc/sssd/conf.d/certificate_verification.conf" file:
+
+    certificate_verification = ocsp_dgst={{{ xccdf_value("var_sssd_certificate_verification_digest_function") }}}
+
+    Set the correct ownership and permissions on the "/etc/sssd/conf.d/certificate_verification.conf" file by running these commands:
+
+    $ sudo chown root:root "/etc/sssd/conf.d/certificate_verification.conf"
+    $ sudo chmod 600 "/etc/sssd/conf.d/certificate_verification.conf"
+
     The "sssd" service must be restarted for the changes to take effect. To restart the "sssd" service, run the following command:
-    <pre>$ sudo systemctl restart sssd.service</pre>
+
+    $ sudo systemctl restart sssd.service


### PR DESCRIPTION
#### Description:
Update rule sssd_certificate_verification
- fix typos
- add fixtext
- this rule is parametrized by a variable so let's use the vairable
- set the variable in the referenced SRG

Rule install_smartcard_packages doesn't need changes and rule dconf_gnome_enable_smartcard_auth will be updated by https://github.com/ComplianceAsCode/content/pull/8624.

#### Rationale:
RHEL 9 STIG