### PR TITLE
Update SRG-OS-000426-GPOS-00190 for RHEL 9 STIG

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/rule.yml
@@ -40,5 +40,13 @@ ocil_clause: |-
 ocil: |-
     To verify that BIND uses the system crypto policy, check out that the BIND config file
     <pre>/etc/named.conf</pre> contains the <pre>include "/etc/crypto-policies/back-ends/bind.config";</pre>
-    directive: <pre>grep 'include "/etc/crypto-policies/back-ends/bind.config";' /etc/named.conf</pre>,
-    and verify that the directive is at the bottom of the <pre>options</pre> section of the config file.
+    directive:
+    <pre>$ sudo grep 'include "/etc/crypto-policies/back-ends/bind.config";' /etc/named.conf</pre>
+    Verify that the directive is at the bottom of the <pre>options</pre> section of the config file.
+
+fixtext: |-
+    Configure BIND to use the system crypto policy.
+
+    Add the following line to the "options" section in "/etc/named.conf":
+
+    include "/etc/crypto-policies/back-ends/bind.config";


### PR DESCRIPTION
#### Description:
Add a fixtext and improve OCIL in configure_bind_crypto policy

The rule package_openssh-server_installed  will be changed in https://github.com/ComplianceAsCode/content/pull/8626


#### Rationale:
RHEL 9 STIG
