### PR TITLE
package_mcafeetp_installed: fix package name

### DIFF
--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
@@ -1,7 +1,7 @@
 {{% if 'ubuntu' in product %}}
 {{% set pkg='mfetp' %}}
 {{% else %}}
-{{% set pkg='mcafeetp' %}}
+{{% set pkg='McAfeeTP' %}}
 {{% endif %}}
 
 documentation_complete: true


### PR DESCRIPTION
#### Description:

- change package name to McAfeeTP

#### Rationale:

- the name was all in lower case before