### PR TITLE
Add SUSE to remediation for audit_rules_file_deletion_events, audit_rules_unsuccessful_file_modification, audit_rules_usergroup_modification

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,,multi_platform_sle
 
 # Perform the remediation for the syscall rule
 # Retrieve hardware architecture of the underlying system

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 # Perform the remediation of the syscall rule
 # Retrieve hardware architecture of the underlying system

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,,multi_platform_sle
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 {{{ bash_fix_audit_watch_rule("auditctl", "/etc/group", "wa", "audit_rules_usergroup_modification") }}}


### PR DESCRIPTION
Add SUSE to remediation for:
   audit_rules_file_deletion_events
   audit_rules_unsuccessful_file_modification
   audit_rules_usergroup_modification
The rules are referenced in sle standard.profile

#### Description:

- Add SUSE to remediation for:
   audit_rules_file_deletion_events
   audit_rules_unsuccessful_file_modification
   audit_rules_usergroup_modification
The rules are referenced in sle standard.profile
This is bash only since, the rules only have bash
remediation.

#### Rationale:
 
- Fix lapses in the standard.profile remediations for SUSE.
