### PR TITLE
Kubernetes container image: Use lowercase for image repository

### DIFF
--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -7,7 +7,7 @@ on:
 
 env:
   COSIGN_EXPERIMENTAL: 1
-  IMAGE_NAME: ghcr.io/ComplianceAsCode/k8scontent
+  IMAGE_NAME: ghcr.io/complianceascode/k8scontent
 
 jobs:
   container:


### PR DESCRIPTION
docker doesn't allow building with mixed-case repositories, this
switches to using lowercase.