### PR TITLE
Audit test scripts to require audit package

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/default.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_multiple_per_arg.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_arg.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/syscalls_one_per_line.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_creat_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_creat_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_trunc_write_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/o_trunc_write_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/open_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/tests/rules-amis.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_creat_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_creat_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_trunc_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/o_trunc_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/open_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/tests/rules-amis.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/one_rule_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/one_rule_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_arch.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_arch.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_filter.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/ordered_by_filter.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/sorted_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/sorted_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/unordered.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_rule_order/tests/unordered.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_last.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_last.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_creat_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_trunc_write.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/o_trunc_write.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/open_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/tests/rules-amis.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_creat.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_creat.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_trunc.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/o_trunc.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/open_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/open_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/rules-amis.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/tests/rules-amis.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_arch.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_arch.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_filter.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/ordered_filter.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/rule_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/rule_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/sorted_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/sorted_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/unordered.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_rule_order/tests/unordered.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # remediation = none
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line_one_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl, on RHEL7, default is to use augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line_one_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line_one_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/default.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 echo "-w /var/run/faillock -p wa -k logins" >> /etc/audit/rules.d/logins.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/tests/correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/tests/missing_permission.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/tests/missing_permission.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillog/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/missing_permission.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/missing_permission.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/tests/correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/tests/missing_permission.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/tests/missing_permission.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_with_perm_x.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Remediation for this rule cannot remove the duplicates
 # remediation = none
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -4,7 +4,6 @@
 # remediation = none
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /tmp/privileged.rules
 
 cp /tmp/privileged.rules /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -3,6 +3,5 @@
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -3,5 +3,4 @@
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
@@ -3,5 +3,4 @@
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -3,7 +3,6 @@
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin
 # A mixed conbination of -k and -F key= should be accepted

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
@@ -3,7 +3,6 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
 sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/rules.d/privileged.rules
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -3,6 +3,5 @@
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
 echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -3,6 +3,5 @@
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
 echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/tests/augenrules_remove_all_rules.fail.sh
@@ -2,6 +2,5 @@
 # platform = multi_platform_ubuntu
 # packages = auditd
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/tests/correct_rules.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /sbin/insmod -p x -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditclt_modprobe_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditclt_modprobe_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditclt_modprobe_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditclt_modprobe_wrong_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /sbin/something -p x -k modules" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/auditctl_modprobe_remove_all_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d
 echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_correct.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d
 echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_remove_all_rules.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_remove_all_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_wrong_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d
 echo "-w /sbin/something -p x -k modules" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/augenrules_modprobe_wrong_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d
 echo "-w /sbin/something -p x -k modules" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/correct_rules.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /sbin/modprobe -p x -k modules" >> /etc/audit/rules.d/delete.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/modprobe.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/modprobe.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 res=`cat /etc/audit/rules.d/audit.rules | grep -w "\-w /sbin/modprobe -p x -k modules" | wc -l`
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/tests/correct_rules.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /sbin/rmmod -p x -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
@@ -3,5 +3,4 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
@@ -3,6 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_remove_all_rules.fail.sh
@@ -3,6 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_remove_all_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
@@ -3,5 +3,4 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
@@ -3,5 +3,4 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
@@ -3,5 +3,4 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-mkdir -p /etc/audit/rules.d
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/no_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/no_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F path=/sbin/unix2_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F path=/sbin/unix2_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/no_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/no_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/auditctl_wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/augen_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/augen_correct.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 echo "-e 2" > /etc/audit/rules.d/immutable.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/augen_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/augen_missing.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/augen_wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/tests/augen_wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/*
 echo "-e 1" > /etc/audit/rules.d/immutable.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/auditctl_wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_correct.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /etc/selinux/ -p wa -k MAC-policy" > /etc/audit/rules.d/MAC-policy.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_missing.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/tests/augen_wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/*
 echo "-w /etc/group -p w -k MAC-policy" > /etc/audit/rules.d/MAC-policy.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
 echo "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/auditctl_correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # use auditctl

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/augen_correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/networkconfig.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/partial_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F arch=b32 -S sethostname,setdomainname -F key=audit_rules_networkconfig_modification" >> /etc/audit/rules.d/some.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_rules_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/auditctl_rules_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # use auditctl
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/augen_partial_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/augen_partial_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/*
 rm -f /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/augen_rules_missing.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/tests/augen_rules_missing.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/auditctl_correct_btmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/auditctl_correct_btmp.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /var/log/btmp -p wa -k logins" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/auditctl_remove_all_rules_btmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/auditctl_remove_all_rules_btmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/auditctl_wrong_rule_btmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/auditctl_wrong_rule_btmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /var/log/something -p wa -k logins" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_correct_btmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_correct_btmp.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_correct_btmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_correct_btmp.pass.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /var/log/btmp -p wa -k logins" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_remove_all_rules_btmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_remove_all_rules_btmp.fail.sh
@@ -2,6 +2,5 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_remove_all_rules_btmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_remove_all_rules_btmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_wrong_rule_btmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_wrong_rule_btmp.fail.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /var/log/something -p wa -k logins" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_wrong_rule_btmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_btmp/tests/augenrules_wrong_rule_btmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/auditctl_correct_utmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/auditctl_correct_utmp.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /run/utmp -p wa -k session" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/auditctl_remove_all_rules_utmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/auditctl_remove_all_rules_utmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/auditctl_wrong_rule_utmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/auditctl_wrong_rule_utmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /run/something -p wa -k session" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_correct_utmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_correct_utmp.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_correct_utmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_correct_utmp.pass.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /run/utmp -p wa -k session" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_remove_all_rules_utmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_remove_all_rules_utmp.fail.sh
@@ -2,6 +2,5 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_remove_all_rules_utmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_remove_all_rules_utmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_wrong_rule_utmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_wrong_rule_utmp.fail.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /run/something -p wa -k session" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_wrong_rule_utmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_utmp/tests/augenrules_wrong_rule_utmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/auditctl_correct_wtmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/auditctl_correct_wtmp.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /var/log/wtmp -p wa -k logins" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/auditctl_remove_all_rules_wtmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/auditctl_remove_all_rules_wtmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/auditctl_wrong_rule_wtmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/auditctl_wrong_rule_wtmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /var/log/something -p wa -k logins" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_correct_wtmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_correct_wtmp.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_correct_wtmp.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_correct_wtmp.pass.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /var/log/wtmp -p wa -k logins" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_remove_all_rules_wtmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_remove_all_rules_wtmp.fail.sh
@@ -2,6 +2,5 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_remove_all_rules_wtmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_remove_all_rules_wtmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_wrong_rule_wtmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_wrong_rule_wtmp.fail.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /var/log/something -p wa -k logins" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_wrong_rule_wtmp.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events_wtmp/tests/augenrules_wrong_rule_wtmp.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/correct.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 # packages = audit
-mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/correct.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/empty.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 rm -rf /etc/audit/rules.d/
-mkdir -p /etc/audit/rules.d/
 touch /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 rm -rf /etc/audit/rules.d/
 mkdir -p /etc/audit/rules.d/
 touch /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudo -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/wrong_value.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudo -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/correct.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudoers.d/ -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/correct.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 # packages = audit
-mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudoers.d/ -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/empty.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 rm -rf /etc/audit/rules.d/
-mkdir -p /etc/audit/rules.d/
 touch /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 rm -rf /etc/audit/rules.d/
 mkdir -p /etc/audit/rules.d/
 touch /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/missing_slash.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/missing_slash.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudoers.d -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/missing_slash.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/missing_slash.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 echo "-w /etc/sudoers.d -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
 echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_value.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 rm -rf /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/correct.pass.sh
@@ -1,3 +1,4 @@
 
+# packages = audit
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d/ -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/empty.fail.sh
@@ -1,3 +1,4 @@
 
+# packages = audit
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/tests/missing_slash.fail.sh
@@ -1,3 +1,4 @@
 
+# packages = audit
 echo "-w /etc/sudoers -p wa -k actions" >> /etc/audit/rules.d/actions.rules
 echo "-w /etc/sudoers.d -p wa -k actions" >> /etc/audit/rules.d/actions.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-e 2" > /etc/audit/rules.d/immutable.rules
 echo "-f 2" >> /etc/audit/rules.d/immutable.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_e_2_immutable.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/tests/augen_e_2_immutable.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 
 echo "-e 2" > /etc/audit/rules.d/immutable.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/auditctl_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/auditctl_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /etc/passwd -p wa -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/auditctl_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/auditctl_remove_all_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 rm -f /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/auditctl_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/auditctl_wrong_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 echo "-w /etc/passwd -p w -k audit_rules_usergroup_modification" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_correct.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_correct.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_correct.pass.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /etc/passwd -p wa -k audit_rules_usergroup_modification" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_remove_all_rules.fail.sh
@@ -2,6 +2,5 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_remove_all_rules.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_remove_all_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_wrong_rule.fail.sh
@@ -2,5 +2,4 @@
 # packages = audit
 
 
-mkdir -p /etc/audit/rules.d
 echo "-w /etc/passwd -p w -k audit_rules_usergroup_modification" >> /etc/audit/rules.d/login.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_wrong_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/tests/augenrules_wrong_rule.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 mkdir -p /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
@@ -3,6 +3,5 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
-mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S adjtimex -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/correct_syscall.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -rf /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/syscall_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/tests/syscall_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -rf /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
@@ -3,6 +3,5 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
-mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S clock_settime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S clock_settime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/correct_syscall.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -rf /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -rf /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_arg_field.fail.sh
@@ -3,6 +3,5 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
-mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S clock_settime -F a0=0x1 -k time-change" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S clock_settime -F a0=0x1 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
@@ -3,6 +3,5 @@
 
 
 rm -rf /etc/audit/rules.d/*.rules
-mkdir -p /etc/audit/rules.d/
 echo "-a always,exit -F arch=b32 -S stime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules
 echo "-a always,exit -F arch=b64 -S stime -F a0=0x0 -k time-change" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/tests/incorrect_syscall.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 rm -rf /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
 	echo "-a always,exit -F arch=b32 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules
 	echo "-a always,exit -F arch=b64 -S settimeofday -k audit_time_rules" >> /etc/audit/rules.d/time.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/tests/line_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+settimeofday[\s]+|([\s]+|[,])settimeofday([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then
 	echo "-a always,exit -F arch=b32 -S stime -k audit_time_rules" >> /etc/audit/rules.d/time.rules
 fi

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 mkdir -p /etc/audit/rules.d/
 if grep -qv "^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" /etc/audit/rules.d/*.rules; then

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/tests/line_not_there.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-mkdir -p /etc/audit/rules.d/
 sed -i "/^[\s]*-a[\s]+always,exit[\s]+-F[\s]+arch=b32.*(-S[\s]+stime[\s]+|([\s]+|[,])stime([\s]+|[,])).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$/d" /etc/audit/rules.d/*.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/tests/correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/tests/missing_permission.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/tests/missing_permission.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/tests/rules_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 rm -f /etc/audit/rules.d/*

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 # Use auditctl in RHEL7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 
 echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 sed -i "/\s*log_group.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 groupadd group_test
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 sed -i "/\s*log_group.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/correct_groupowner.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 export AUDITFILE=/etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/correct_groupowner.pass.sh
@@ -3,7 +3,6 @@
 
 export TESTFILE=/etc/audit/rules.d/test_rule.rules
 export AUDITFILE=/etc/audit/auditd.conf
-mkdir -p /etc/audit/rules.d/
 touch $TESTFILE
 touch $AUDITFILE
 chgrp root $TESTFILE

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/incorrect_groupowner.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/incorrect_groupowner.fail.sh
@@ -4,7 +4,6 @@
 groupadd group_test
 export TESTFILLE=/etc/audit/rules.d/test_rule.rules
 export AUDITFILE=/etc/audit/auditd.conf
-mkdir -p /etc/audit/rules.d/
 touch $TESTFILLE
 touch $AUDITFILE
 chgrp group_test $TESTFILLE

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/incorrect_groupowner.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/tests/incorrect_groupowner.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 groupadd group_test
 export TESTFILLE=/etc/audit/rules.d/test_rule.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit_stig/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audit_remote_server_hostname.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audit_remote_server_hostname.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audit_remote_server_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/tests/audit_remote_server_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_bogus_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_bogus_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/tests/transport_wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,multi_platform_fedora
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_alias.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_alias.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_email.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_email.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_root.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/tests/action_mail_acct_root.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_email.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_email.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_exec.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_exec.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt_cis.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_halt_cis.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # profiles = xccdf_org.ssgproject.content_profile_cis
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_ignore.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_rotate.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_rotate.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_single.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_single.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_suspend.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_suspend.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_syslog.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/tests/admin_space_left_action_syslog.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_data.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_data.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_incremental.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_incremental.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_incremental_async.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_incremental_async.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_none.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_none.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_sync.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_flush/tests/flush_sync.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 # remediation = bash

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_greater_than_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_greater_than_minimum_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_minimum_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_enough.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_enough.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/tests/max_log_file_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_cis.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_cis.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_ignore.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9, multi_platform_fedora
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig_rhel7.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig_rhel7.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Red Hat Enterprise Linux 7
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_suspend.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_suspend.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_greater_than_minimum.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_greater_than_minimum.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_minimum_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_enough.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_enough.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/tests/num_logs_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_greater_than_minimum.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_greater_than_minimum.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_minimum_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_not_enough.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_not_enough.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/tests/space_left_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_email.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_email.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_exec.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_exec.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_halt.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_halt.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_ignore.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_single.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_single.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_suspend.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_suspend.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_syslog.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/tests/space_left_action_syslog.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 #
 # remediation = bash
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/no_percent_sign.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/no_percent_sign.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # variables = var_auditd_space_left_percentage=25
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_greater_than_minimum.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_greater_than_minimum.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # variables = var_auditd_space_left_percentage=25
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_minimum_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_minimum_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # variables = var_auditd_space_left_percentage=25
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_not_enough.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_not_enough.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # variables = var_auditd_space_left_percentage=25
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/tests/space_left_not_there.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # variables = var_auditd_space_left_percentage=25
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/commented.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/commented.pass.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# packages = audit
 echo "#local_events = yes" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value.pass.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# packages = audit
 echo "local_events = yes" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value_capital.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/correct_value_capital.pass.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# packages = audit
 echo "LOCAL_EVENTS = YES" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/double_assignment.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/double_assignment.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 echo "local_events = yes" >> "/etc/audit/auditd.conf"
 echo "local_events = no" >> "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_file.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_file.pass.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# packages = audit
 rm -f "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/missing_value.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = audit
 touch "/etc/audit/auditd.conf"
 sed -i "/local_events/d" "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value.fail.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# packages = audit
 echo "local_events = no" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value_capital.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/tests/wrong_value_capital.fail.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# packages = audit
 echo "LOCAL_EVENTS = NO" > "/etc/audit/auditd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/commented_out.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/commented_out.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/empty.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 
 bash -x setup.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/file_not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/file_not_present.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 {{%- if product in ["rhel7", "ol7"] %}}
 config_file="/etc/audisp/audispd.conf"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/halt.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/halt.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/ignore.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/not_present.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/single.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/single.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/syslog.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/tests/syslog.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # Ensure test system has proper directories/files for test scenario
 bash -x setup.sh
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-3-access-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-3-access-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/correct_rules.pass.sh
@@ -1,2 +1,3 @@
 
+# packages = audit
 cp $SHARED/audit/10-base-config.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_missing.fail.sh
@@ -1,2 +1,3 @@
 
+# packages = audit
 rm -f /etc/audit/rules.d/10-base-config.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_not_identical.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/file_not_identical.fail.sh
@@ -1,3 +1,4 @@
 
+# packages = audit
 cp $SHARED/audit/10-base-config.rules /etc/audit/rules.d/
 echo "some additional text" >> /etc/audit/rules.d/10-base-config.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/10-base-config.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-1-create-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-1-create-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-4-delete-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-4-delete-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/11-loginuid.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-2-modify-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-2-modify-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/43-module-load.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/correct_rules.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp $SHARED/audit/30-ospp-v42.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/correct_rules.pass.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp $SHARED/audit/30-ospp-v42.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-6-owner-change-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-6-owner-change-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-5-perm-change-failed.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/tests/rules_from_audit_package.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/tests/rules_from_audit_package.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
 cp /usr/share/audit/sample-rules/30-ospp-v42-5-perm-change-success.rules /etc/audit/rules.d/

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/no_rules.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/no_rules.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_changed.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_changed.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_configured.pass.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_configured.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then

--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_incomplete.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/tests/ospp_incomplete.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 
 # These tests are for systems with 30-ospp-v42.rules file installed
 if [ ! -f /usr/share/doc/audit*/rules/30-ospp-v42.rules ]; then


### PR DESCRIPTION
#### Description:

Any distro where there is no audit package installed by default fails to run any tests.

#### Rationale:

Default testing container is missing audit package.
```
cd tests
./build_test_container.sh 
podman run --rm -ti --name foo localhost/ssg_test_suite /bin/bash
[root@da1d6603cd3d /]# rpm -qa|grep audit
audit-libs-3.0.7-2.fc35.x86_64
[root@da1d6603cd3d /]# ls -l /etc/audit*
ls: cannot access '/etc/audit*': No such file or directory
```
Use magic package comment to install audit package.

Also many rules require audit package to be installed and because of that it is not enough just to create the dir and it actually strictly not needed as installing package should create those directories:
```
mkdir -p /etc/audit/rules.d
```

It seems this is quite pervasive problem where tests do not run in minimal container. Also it seems most tests do not run (notapplicable) with local default podman container without --remove-machine-only. And with it test runs just end where there is no package installed and it seems hard to fix as packages might different names to provide service. So this makes it really hard to test locally any of this kind of changes.

```
ERROR - Terminating due to error: Return code of 'cd /root/ssgts/grub2_audit_backlog_limit_argument; SHARED=/root/ssgts/shared bash -x wrong_value_etcdefaultgrub.fail.sh' on root@localhost is 2: Warning: Permanently added '[localhost]:44365' (ECDSA) to the list of known hosts.
+ grep -q '^GRUB_CMDLINE_LINUX=.*audit_backlog_limit=.*"' /etc/default/grub
grep: /etc/default/grub: No such file or directory
+ sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)"/\1 audit_backlog_limit=123"/' /etc/default/grub
sed: can't read /etc/default/grub: No such file or directory
```

Any rule should check that actual packages are installed when things are checked or used to remediate is installed and this package values could be automatically used in tests too. Obviously you do not want packages when test case targets package not being installed. But otherwise I think you need them. It just seems to me it is wrong when test scripts to setup test where there is no actual package installed.

And then there is multiple ways packages can end up in test containers. Some use # packages, some just install them via script. Package names can come via variables too. Sometimes there is jinja2 if about platform to have variant of package, but then again there is also platform_package_overrides to do it. And it seems there is variations what names are used in platform_package_overrides. And not all platforms implement platform_package_overrides where there I would expect.