### PR TITLE
Upgrade cosign-installer github action to v2.3.0

### DIFF
--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.2.1
+        uses: sigstore/cosign-installer@v2.3.0
 
       - name: Login to ghcr.io
         uses: docker/login-action@v1.14.1
@@ -102,7 +102,7 @@ jobs:
 
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.2.1
+        uses: sigstore/cosign-installer@v2.3.0
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@v0.11.0
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v2.2.1
+        uses: sigstore/cosign-installer@v2.3.0
 
       - name: Generate provenance
         uses: philips-labs/slsa-provenance-action@v0.7.2


### PR DESCRIPTION
#### Description:

Currently the Kubernetes content image build mostly works... but signing provenance info
is currently failing. This upgrades the cosign installation to attempt to fix that.
