### PR TITLE
platform magic comment cleanup

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/kubernetes/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/kubernetes/shared.yml
@@ -1,5 +1,5 @@
 ---
-# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos 
+# platform = multi_platform_wrlinux,multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_rhcos
 {{% macro usbguard_hid_and_hub_config_source() %}}
 allow with-interface match-all { 03:*:* 09:00:* }
 {{%- endmacro -%}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/missing_pam_tally2.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/missing_pam_tally2.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform=Ubuntu 20.04
+# platform = Ubuntu 20.04
 
 cp -f common-account_pam_config_missing /etc/pam.d/common-account
 cp -f common-auth_pam_config_missing /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_big_deny.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_big_deny.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform=Ubuntu 20.04
+# platform = Ubuntu 20.04
 
 cp -f common-account_pam_config_configured /etc/pam.d/common-account
 cp -f common-auth_pam_config_big_deny /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform=Ubuntu 20.04
+# platform = Ubuntu 20.04
 
 cp -f common-account_pam_config_commented /etc/pam.d/common-account
 cp -f common-auth_pam_config_commented /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_configured.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform=Ubuntu 20.04
+# platform = Ubuntu 20.04
 
 cp -f common-account_pam_config_configured /etc/pam.d/common-account
 cp -f common-auth_pam_config_configured /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_empty_deny.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_empty_deny.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform=Ubuntu 20.04
+# platform = Ubuntu 20.04
 
 cp -f common-account_pam_config_configured /etc/pam.d/common-account
 cp -f common-auth_pam_config_empty_deny /etc/pam.d/common-auth

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_zero_deny.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_zero_deny.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform=Ubuntu 20.04
+# platform = Ubuntu 20.04
 
 cp -f common-account_pam_config_configured /etc/pam.d/common-account
 cp -f common-auth_pam_config_zero_deny /etc/pam.d/common-auth

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_wrlinux,multi_platform_all
+# platform = multi_platform_all
 
 {{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
 AUDISP_REMOTE_CONFIG="/etc/audit/audisp-remote.conf"

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform=multi_platform_rhel,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_rhv
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform=multi_platform_sle
+# platform = multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = medium

--- a/products/jre/guide/java/java_jre_configure_crypto_policy/bash/shared.sh
+++ b/products/jre/guide/java/java_jre_configure_crypto_policy/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  Java Runtime Environment
+# platform = Java Runtime Environment
 
 
 JRE_CONFIG_FILE="/usr/lib/jvm/jre/lib/security/java.security"

--- a/products/vsel/guide/vsel/general_settings/virus_notification/bash/shared.sh
+++ b/products/vsel/guide/vsel/general_settings/virus_notification/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/general_settings/web_client_disabled/bash/shared.sh
+++ b/products/vsel/guide/vsel/general_settings/web_client_disabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_app_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_app_primary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_app_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_app_secondary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_default_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_default_primary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_default_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_default_secondary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_error/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_error/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_action_timeout/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_action_timeout/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_allFiles/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_allFiles/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_decompArchive/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_decompArchive/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_enabled/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_enabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_heuristicAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_heuristicAnalysis/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_macroAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_macroAnalysis/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_program/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_program/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanMaxTmo/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanMaxTmo/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanNWFiles/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanNWFiles/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanOnRead/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanOnRead/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_access_settings/oas_scanOnWrite/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_access_settings/oas_scanOnWrite/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/nailsd.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_app_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_app_primary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_app_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_app_secondary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_default_primary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_default_primary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_action_default_secondary/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_action_default_secondary/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_allFiles/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_allFiles/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_decompArchive/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_decompArchive/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_extensions/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_extensions/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_heuristicAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_heuristicAnalysis/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_macroAnalysis/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_macroAnalysis/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_mime/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_mime/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_program/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_program/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"

--- a/products/vsel/guide/vsel/on_demand_settings/ods_scanNWFiles_local/bash/shared.sh
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_scanNWFiles_local/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform =  McAfee VirusScan Enterprise for Linux
+# platform = McAfee VirusScan Enterprise for Linux
 
 
 NAILS_CONFIG_FILE="/var/opt/NAI/LinuxShield/etc/ods.cfg"


### PR DESCRIPTION
#### Description:

If multi_platform_all drop other.
Ensure platform is in format:
```
# platform = values
```
without additional spaces before or after and only one space.

#### Rationale:

Just cleanups.
I guess there is scripts to modify these entries and it does not hurt when their format is always the same.