### PR TITLE
Update SRG-OS-000341-GPOS-00132

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/rule.yml
@@ -74,5 +74,11 @@ ocil: |-
     <pre># df -h /var/log/audit/
     /dev/sda2 24G 10.4G 13.6G 43% /var/log/audit</pre>
 
+fixtext: |-
+    Allocate enough storage capacity for at least one week of audit records when audit records are not immediately sent to a central audit record storage facility.
+
+    If audit records are stored on a partition made specifically for audit records, resize the partition with sufficient space to contain one week of audit records.
+
+    If audit records are not stored on a partition made specifically for audit records, a new partition with sufficient space will need be to be created.
 
 platform: machine

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/rule.yml
@@ -41,6 +41,15 @@ ocil_clause: 'audit backlog limit is not configured'
 ocil: |-
     {{{ ocil_grub2_argument("audit_backlog_limit=8192") | indent(4) }}}
 
+fixtext: |-
+    Configure {{{ full_name }}} to allocate sufficient audit_backlog_limit to capture processes that start prior to the audit daemon with the following command:
+
+    $ sudo grubby --update-kernel=ALL --args="audit_backlog_limit=8192"
+
+    Add or modify the following line in "/etc/default/grub" to ensure the configuration survives kernel updates:
+
+    GRUB_CMDLINE_LINUX="audit_backlog_limit=8192"
+
 platform: grub2
 
 template:

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -54,6 +54,9 @@ references:
 
 {{{ complete_ocil_entry_separate_partition(part="/var/log/audit") }}}
 
+fixtext: |-
+    Migrate the system audit data path onto a separate file system.
+
 platform: machine
 
 # (jhrozek): at the moment, the mount probe checks the /proc filesystem


### PR DESCRIPTION
#### Description:

Add fix text to:
- grub2_audit_backlog_limit_argument
- partition_for_var_log_audit
- auditd_audispd_configure_sufficiently_large_partition

#### Rationale:

RHEL9 STIG
