### PR TITLE
fix: fedora: define login_defs in platform_package_overrides

### DIFF
--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -72,3 +72,7 @@ previous_version: 34
 previous_release_fingerprint: "8C5BA6990BDB26E19F2A1A801161AE6945719A39"
 previous_pkg_version: "45719a39"
 previous_pkg_release: "5f2c0192"
+
+# Mapping of CPE platform to package
+platform_package_overrides:
+  login_defs: "shadow-utils"


### PR DESCRIPTION
#### Description:

Mirror rhel8 / rhel9 platform_package_overrides.login_defs into fedora.

#### Rationale:

Fix package responsible of login_defs under fedora.