### PR TITLE
`xwindows_runlevel_target` machine platform

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/rule.yml
@@ -48,3 +48,5 @@ ocil: |-
     <pre>$ systemctl get-default</pre>
     The output should show the following:
     <pre>multi-user.target</pre>
+
+platform: machine


### PR DESCRIPTION
#### Description:
Add `platform: machine` for `xwindows_runlevel_target` rule.

I've disabled only the single rule. Other rules in the group makes sense in containers as they check installed xwindows packages.

#### Rationale:
The rule doesn't make sense in container as it checks running X windows.