### PR TITLE
Update rules for SRG-OS-000373-GPOS-00156

### DIFF
--- a/controls/srg_gpos/SRG-OS-000373-GPOS-00156.yml
+++ b/controls/srg_gpos/SRG-OS-000373-GPOS-00156.yml
@@ -9,4 +9,5 @@ controls:
             - sudo_remove_no_authenticate
             - sudo_remove_nopasswd
             - sudo_require_reauthentication
+            - var_sudo_timestamp_timeout=always_prompt
         status: automated

--- a/controls/srg_gpos/SRG-OS-000373-GPOS-00156.yml
+++ b/controls/srg_gpos/SRG-OS-000373-GPOS-00156.yml
@@ -8,6 +8,5 @@ controls:
             - use_pam_wheel_for_su
             - sudo_remove_no_authenticate
             - sudo_remove_nopasswd
-            - sudo_require_authentication
             - sudo_require_reauthentication
         status: automated

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -36,3 +36,12 @@ ocil: |-
     <pre>grep pam_wheel /etc/pam.d/su</pre>
     The output should contain the following line:
     <pre>auth             required        pam_wheel.so use_uid</pre>
+
+fixtext: |-
+    Configure {{{ full_name }}} to require users to be in the "wheel" group to run "su" command.
+
+    In file "/etc/pam.d/su", uncomment the following line:
+
+    "#auth    required    pam_wheel.so use_id"
+
+    $ sed '/^[[:space:]]*#[[:space:]]*auth[[:space:]]\+required[[:space:]]\+pam_wheel\.so[[:space:]]\+use_uid$/s/^[[:space:]]*#//' -i /etc/pam.d/su

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -51,3 +51,10 @@ ocil: |-
     The output should be:
     <pre>/etc/sudoers:Defaults timestamp_timeout=0</pre> or "timestamp_timeout" is set to a positive number.
     If results are returned from more than one file location, this is a finding.
+
+fixtext: |-
+    Configure {{{ full_name }}} to re-authenticate "sudo" commands after the specified timeout:
+
+    Add the following line to "/etc/sudoers":
+
+    Defaults timestamp_timeout={{{ xccdf_value("var_sudo_timestamp_timeout") }}}


### PR DESCRIPTION
#### Description:

- Remove `sudo_require_authentication`, which is a combination of `sudo_remove_no_authenticate` and `sudo_remove_nopasswd`
- Add fixtext for `use_pam_wheel_for_su` and `sudo_require_reauthentication`
- Explicitly selected value for timestamp_timeout vallue
