### PR TITLE
Do not remove directory in `audit_rules_sudoers` `empty.fail.sh` test

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/tests/empty.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = audit
-rm -rf /etc/audit/rules.d/
+rm -rf /etc/audit/rules.d/*
 touch /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/tests/empty.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = audit
-rm -rf /etc/audit/rules.d/
+rm -rf /etc/audit/rules.d/*
 touch /etc/audit/audit.rules


### PR DESCRIPTION
#### Description:
Remove only files in `/etc/audit/rules.d/` directory.

#### Rationale:
The directory is not created in remediation as it's there by the package (RHEL9 VM):
```
INFO - Script empty.fail.sh using profile (all) OK
ERROR - Bash remediation for rule xccdf_org.ssgproject.content_rule_audit_rules_sudoers has exited with these errors:
Warning: Permanently added '192.168.122.234' (ED25519) to the list of known hosts.
+ echo 'Remediating rule 1/1: '\''xccdf_org.ssgproject.content_rule_audit_rules_sudoers'\'''
Remediating rule 1/1: 'xccdf_org.ssgproject.content_rule_audit_rules_sudoers'
+ rpm --quiet -q audit
+ files_to_inspect=()
+ files_to_inspect+=('/etc/audit/audit.rules')
+ for audit_rules_file in "${files_to_inspect[@]}"
+ grep -q -P -- '^[\s]*-w[\s]+/etc/sudoers' /etc/audit/audit.rules
+ echo '-w /etc/sudoers -p wa -k actions'
+ files_to_inspect=()
+ readarray -t matches
++ grep -HP '[\s]*-w[\s]+/etc/sudoers' '/etc/audit/rules.d/*.rules'
grep: /etc/audit/rules.d/*.rules: No such file or directory
+ '[' 0 -eq 0 ']'
+ key_rule_file=/etc/audit/rules.d/actions.rules
+ '[' '!' -e /etc/audit/rules.d/actions.rules ']'
+ touch /etc/audit/rules.d/actions.rules
touch: cannot touch '/etc/audit/rules.d/actions.rules': No such file or directory
+ chmod 0640 /etc/audit/rules.d/actions.rules
chmod: cannot access '/etc/audit/rules.d/actions.rules': No such file or directory
+ files_to_inspect+=("$key_rule_file")
+ for audit_rules_file in "${files_to_inspect[@]}"
+ grep -q -P -- '^[\s]*-w[\s]+/etc/sudoers' /etc/audit/rules.d/actions.rules
grep: /etc/audit/rules.d/actions.rules: No such file or directory
+ echo '-w /etc/sudoers -p wa -k actions'
/xccdf_org.ssgproject.content_rule_audit_rules_sudoers.sh: line 160: /etc/audit/rules.d/actions.rules: No such file or directory

ERROR - The remediation failed for rule 'xccdf_org.ssgproject.content_rule_audit_rules_sudoers'.
```

Previously, the directory was created after `rm -rf` but it was removed by mistake in #8655 
