### PR TITLE
extend bash conditionals to allow special block inserted before the remediation

### DIFF
--- a/shared/applicability/aarch64_arch.yml
+++ b/shared/applicability/aarch64_arch.yml
@@ -1,4 +1,5 @@
 name: cpe:/a:aarch64_arch
 title: System architecture is AARCH64
 check_id: proc_sys_kernel_osrelease_arch_aarch64
-bash_conditional: grep -q aarch64 /proc/sys/kernel/osrelease
+bash_conditional:
+    conditional: grep -q aarch64 /proc/sys/kernel/osrelease

--- a/shared/applicability/audit.yml
+++ b/shared/applicability/audit.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:audit"
 title: "Package audit is installed"
 check_id: installed_env_has_audit_package
-bash_conditional: {{{ bash_pkg_conditional("audit") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("audit") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("audit") }}}

--- a/shared/applicability/chrony.yml
+++ b/shared/applicability/chrony.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:chrony"
 title: "Package chrony is installed"
 check_id: installed_env_has_chrony_package
-bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("chrony") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}

--- a/shared/applicability/container.yml
+++ b/shared/applicability/container.yml
@@ -1,4 +1,5 @@
 name: cpe:/a:container
 title: Container
 check_id: installed_env_is_a_container
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+bash_conditional:
+    conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'

--- a/shared/applicability/gdm.yml
+++ b/shared/applicability/gdm.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:gdm"
 title: "Package gdm is installed"
 check_id: installed_env_has_gdm_package
-bash_conditional: {{{ bash_pkg_conditional("gdm") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("gdm") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("gdm") }}}

--- a/shared/applicability/grub2.yml
+++ b/shared/applicability/grub2.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:grub2"
 title: "Package grub2 is installed"
 check_id: installed_env_has_grub2_package
-bash_conditional: {{{ bash_pkg_conditional("grub2") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("grub2") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("grub2") }}}

--- a/shared/applicability/libuser.yml
+++ b/shared/applicability/libuser.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:libuser"
 title: "Package libuser is installed"
 check_id: installed_env_has_libuser_package
-bash_conditional: {{{ bash_pkg_conditional("libuser") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("libuser") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("libuser") }}}

--- a/shared/applicability/login_defs.yml
+++ b/shared/applicability/login_defs.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:login_defs"
 title: "Package providing /etc/login.defs is installed"
 check_id: installed_env_has_login_defs
-bash_conditional: {{{ bash_pkg_conditional("login_defs") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("login_defs") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("login_defs") }}}

--- a/shared/applicability/machine.yml
+++ b/shared/applicability/machine.yml
@@ -1,6 +1,7 @@
 name: cpe:/a:machine
 title: Bare-metal or Virtual Machine
 check_id: installed_env_is_a_machine
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+bash_conditional:
+    conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
 ansible_conditional: ansible_virtualization_type not in ["docker", "lxc", "openvz",
   "podman", "container"]

--- a/shared/applicability/net-snmp.yml
+++ b/shared/applicability/net-snmp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:net-snmp"
 title: "Package net-snmp is installed"
 check_id: installed_env_has_net-snmp_package
-bash_conditional: {{{ bash_pkg_conditional("net-snmp") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("net-snmp") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("net-snmp") }}}

--- a/shared/applicability/not_aarch64_arch.yml
+++ b/shared/applicability/not_aarch64_arch.yml
@@ -1,4 +1,5 @@
 name: cpe:/a:not_aarch64_arch
 title: System architecture is not AARCH64
 check_id: proc_sys_kernel_osrelease_arch_not_aarch64
-bash_conditional: '! grep -q aarch64 /proc/sys/kernel/osrelease'
+bash_conditional:
+    conditional: '! grep -q aarch64 /proc/sys/kernel/osrelease'

--- a/shared/applicability/not_s390x_arch.yml
+++ b/shared/applicability/not_s390x_arch.yml
@@ -1,4 +1,5 @@
 name: cpe:/a:not_s390x_arch
 title: System architecture is not S390X
 check_id: proc_sys_kernel_osrelease_arch_not_s390x
-bash_conditional: '! grep -q s390x /proc/sys/kernel/osrelease'
+bash_conditional:
+    conditional: '! grep -q s390x /proc/sys/kernel/osrelease'

--- a/shared/applicability/nss-pam-ldapd.yml
+++ b/shared/applicability/nss-pam-ldapd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:nss-pam-ldapd"
 title: "Package nss-pam-ldapd is installed"
 check_id: installed_env_has_nss-pam-ldapd_package
-bash_conditional: {{{ bash_pkg_conditional("nss-pam-ldapd") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("nss-pam-ldapd") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("nss-pam-ldapd") }}}

--- a/shared/applicability/ntp.yml
+++ b/shared/applicability/ntp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:ntp"
 title: "Package ntp is installed"
 check_id: installed_env_has_ntp_package
-bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("ntp") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("ntp") }}}

--- a/shared/applicability/os_release.yml
+++ b/shared/applicability/os_release.yml
@@ -1,7 +1,8 @@
 name: "cpe:/o:{arg}"
 title: "Operating System is {arg} {ver}"
 check_id: "installed_os_is_{arg}_{ver}"
-bash_conditional: 'true'
+bash_conditional:
+    conditional: 'true'
 ansible_conditional: 'true'
 template:
     name: os_release

--- a/shared/applicability/package_installed.yml
+++ b/shared/applicability/package_installed.yml
@@ -1,7 +1,8 @@
 name: 'cpe:/a:{arg}'
 title: 'Package {arg} is installed'
 check_id: 'installed_env_has_{arg}_package_conditional'
-bash_conditional: {{{ bash_pkg_conditional(PKGNAME) }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional(PKGNAME) }}}
 ansible_conditional: {{{ ansible_pkg_conditional(PKGNAME) }}}
 template:
     name: package_installed

--- a/shared/applicability/pam.yml
+++ b/shared/applicability/pam.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:pam"
 title: "Package pam is installed"
 check_id: installed_env_has_pam_package
-bash_conditional: {{{ bash_pkg_conditional("pam") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("pam") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("pam") }}}

--- a/shared/applicability/postfix.yml
+++ b/shared/applicability/postfix.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:postfix"
 title: "Package postfix is installed"
 check_id: installed_env_has_postfix_package
-bash_conditional: {{{ bash_pkg_conditional("postfix") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("postfix") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("postfix") }}}

--- a/shared/applicability/sssd.yml
+++ b/shared/applicability/sssd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:sssd"
 title: "Package sssd-common is installed"
 check_id: installed_env_has_sssd-common_package
-bash_conditional: {{{ bash_pkg_conditional("sssd") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("sssd") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("sssd") }}}

--- a/shared/applicability/sudo.yml
+++ b/shared/applicability/sudo.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:sudo"
 title: "Package sudo is installed"
 check_id: installed_env_has_sudo_package
-bash_conditional: {{{ bash_pkg_conditional("sudo") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("sudo") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("sudo") }}}

--- a/shared/applicability/systemd.yml
+++ b/shared/applicability/systemd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:systemd"
 title: "Package systemd is installed"
 check_id: installed_env_has_systemd_package
-bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("systemd") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}

--- a/shared/applicability/yum.yml
+++ b/shared/applicability/yum.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:yum"
 title: "Package yum is installed"
 check_id: installed_env_has_yum_package
-bash_conditional: {{{ bash_pkg_conditional("yum") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("yum") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}

--- a/shared/applicability/zypper.yml
+++ b/shared/applicability/zypper.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:zypper"
 title: "Package zypper is installed"
 check_id: installed_env_has_zypper_package
-bash_conditional: {{{ bash_pkg_conditional("zypper") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("zypper") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("zypper") }}}

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -242,19 +242,28 @@ class BashRemediation(Remediation):
                     if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            cpe_platforms[p].to_bash_conditional()
+            cpe_platforms[p].get_bash_conditional_line()
             for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            cpe_platforms[p].to_bash_conditional()
+            cpe_platforms[p].get_bash_conditional_line()
             for p in rule_specific_cpe_platform_names]
+        lines_before_remediation = set()
+        all_lines_before_remediation = [
+            cpe_platforms[p].get_bash_inserted_before_remediation() for p in inherited_cpe_platform_names.union(rule_specific_cpe_platform_names)
+        ]
+        lines_before_remediation.update(all_lines_before_remediation)
+
         # remove potential "None" from lists
         inherited_conditionals = sorted([
             p for p in inherited_conditionals if p != ''])
         rule_specific_conditionals = sorted([
             p for p in rule_specific_conditionals if p != ''])
+        lines_before_remediation = sorted([
+            l for l in lines_before_remediation if l != ''])
 
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
+            wrapped_fix_text.append("\n".join(lines_before_remediation))
 
             all_conditions = ""
             if inherited_conditionals:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1856,7 +1856,8 @@ class Platform(XCCDFEntity):
         name=lambda: "",
         original_expression=lambda: "",
         xml_content=lambda: "",
-        bash_conditional=lambda: "",
+        bash_conditional_line=lambda: "",
+        bash_inserted_before_remediation=lambda: "",
         ansible_conditional=lambda: "",
         ** XCCDFEntity.KEYS
     )
@@ -1865,7 +1866,7 @@ class Platform(XCCDFEntity):
         "name",
         "xml_content",
         "original_expression",
-        "bash_conditional",
+        "bash_conditional_line",
         "ansible_conditional"
     ]
 
@@ -1885,7 +1886,8 @@ class Platform(XCCDFEntity):
         platform.name = id
         platform.original_expression = expression
         platform.xml_content = platform.get_xml()
-        platform.bash_conditional = platform.test.to_bash_conditional()
+        platform.bash_conditional_line = platform.test.get_bash_conditional_line()
+        platform.bash_inserted_before_remediation = platform.test.get_bash_inserted_before_remediation()
         platform.ansible_conditional = platform.test.to_ansible_conditional()
         return platform
 
@@ -1908,8 +1910,11 @@ class Platform(XCCDFEntity):
     def to_xml_element(self):
         return self.xml_content
 
-    def to_bash_conditional(self):
-        return self.bash_conditional
+    def get_bash_conditional_line(self):
+        return self.bash_conditional_line
+
+    def get_bash_inserted_before_remediation(self):
+        return self.bash_inserted_before_remediation
 
     def to_ansible_conditional(self):
         return self.ansible_conditional

--- a/tests/unit/ssg-module/data/applicability/chrony.yml
+++ b/tests/unit/ssg-module/data/applicability/chrony.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:chrony"
 title: "Package chrony is installed"
 check_id: installed_env_has_chrony_package
-bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("chrony") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}

--- a/tests/unit/ssg-module/data/applicability/machine.yml
+++ b/tests/unit/ssg-module/data/applicability/machine.yml
@@ -1,6 +1,7 @@
 name: cpe:/a:machine
 title: Bare-metal or Virtual Machine
 check_id: installed_env_is_a_machine
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+bash_conditional:
+    conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
 ansible_conditional: ansible_virtualization_type not in ["docker", "lxc", "openvz",
   "podman", "container"]

--- a/tests/unit/ssg-module/data/applicability/ntp.yml
+++ b/tests/unit/ssg-module/data/applicability/ntp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:ntp"
 title: "Package ntp is installed"
 check_id: installed_env_has_ntp_package
-bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("ntp") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("ntp") }}}

--- a/tests/unit/ssg-module/data/applicability/systemd.yml
+++ b/tests/unit/ssg-module/data/applicability/systemd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:systemd"
 title: "Package systemd is installed"
 check_id: installed_env_has_systemd_package
-bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("systemd") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}

--- a/tests/unit/ssg-module/data/applicability/yum.yml
+++ b/tests/unit/ssg-module/data/applicability/yum.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:yum"
 title: "Package yum is installed"
 check_id: installed_env_has_yum_package
-bash_conditional: {{{ bash_pkg_conditional("yum") }}}
+bash_conditional:
+    conditional: {{{ bash_pkg_conditional("yum") }}}
 ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}

--- a/tests/unit/ssg-module/data/machine.yml
+++ b/tests/unit/ssg-module/data/machine.yml
@@ -7,6 +7,7 @@ xml_content: !!binary |
     ZiBuYW1lPSJjcGU6L2E6bWFjaGluZSIgLz48L25zMDpsb2dpY2FsLXRlc3Q+PC9uczA6cGxhdGZv
     cm0+
 bash_conditional_line: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+bash_inserted_before_remediation: "some_helper_function"
 ansible_conditional: ansible_virtualization_type not in ["docker", "lxc", "openvz",
     "podman", "container"]
 definition_location: ''

--- a/tests/unit/ssg-module/data/machine.yml
+++ b/tests/unit/ssg-module/data/machine.yml
@@ -6,7 +6,7 @@ xml_content: !!binary |
     MDpsb2dpY2FsLXRlc3Qgb3BlcmF0b3I9IkFORCIgbmVnYXRlPSJmYWxzZSI+PG5zMDpmYWN0LXJl
     ZiBuYW1lPSJjcGU6L2E6bWFjaGluZSIgLz48L25zMDpsb2dpY2FsLXRlc3Q+PC9uczA6cGxhdGZv
     cm0+
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+bash_conditional_line: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
 ansible_conditional: ansible_virtualization_type not in ["docker", "lxc", "openvz",
     "podman", "container"]
 definition_location: ''

--- a/tests/unit/ssg-module/test_build_cpe.py
+++ b/tests/unit/ssg-module/test_build_cpe.py
@@ -137,13 +137,13 @@ def test_product_cpes():
     assert(rhel7_cpe_2.ansible_conditional == rhel7_cpe.ansible_conditional)
 
     # get a content CPE by name and verify it's loaded
-    # this CPE is defined in `DATADIR/applicability/virtualization.yml`
+    # this CPE is defined in `DATADIR/applicability/machine.yml`
     cpe1 = product_cpes.get_cpe("machine")
     assert(cpe1.name == "cpe:/a:machine")
     assert(cpe1.title == "Bare-metal or Virtual Machine")
     assert(cpe1.check_id == "installed_env_is_a_machine")
     assert(cpe1.ansible_conditional == "ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"]")
-    assert(cpe1.bash_conditional == "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]")
+    assert(cpe1.bash_conditional["conditional"] == "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]")
 
     # get CPE by ID and verify it's loaded, the get_cpe method should return
     # the same object as when CPE name was used above


### PR DESCRIPTION
#### Description:

- the bash_conditional attribute for platform unit files is now a dictionary
  - bash_conditional_line contains the line which is inserted into the actual conditional
  - bash_inserted_before_remediation contains text which gets inserted at the begining of the remediation - good for declaring functions which can be used later
- updated platform unit files and tests

#### Rationale:

To implement comparison of package versions in a platform agnostic way we need a special function to be defined before the conditional gets executed. This PR enables us to do that.