### PR TITLE
Fix grub_command macro for Ubuntu

### DIFF
--- a/shared/macros/general.jinja
+++ b/shared/macros/general.jinja
@@ -1079,24 +1079,25 @@ Part of the grub2_bootloader_argument(_absent) templates.
 
 #}}
 {{% macro grub_command(action, arg_name_value) -%}}
-{{%- if action == "add" -%}}
-{{%- set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ arg_name_value ] -%}}
-{{%- elif action == "remove" -%}}
-{{%- set grub_helper_args = ["--update-kernel=ALL", "--remove-args=" ~ arg_name_value ] -%}}
-{{%- else -%}}
-{{{ raise("Unknown action" + action) }}}
-{{%- endif -%}}
 {{%- if 'ubuntu' in product -%}}
-	{{%- set grub_helper_executable = "update-grub" -%}}
+    {{%- set grub_helper_executable = "update-grub" -%}}
+    {{%- set grub_helper_args = [] -%}}
 {{%- elif product in ["sle12", "sle15"] -%}}
-{{%- set grub_helper_executable = "grub2-mkconfig" -%}}
-{{%- set grub_helper_args = ["-o " + grub2_boot_path + "/grub2.cfg"] -%}}
+    {{%- set grub_helper_executable = "grub2-mkconfig" -%}}
+    {{%- set grub_helper_args = ["-o " + grub2_boot_path + "/grub2.cfg"] -%}}
 {{%- else -%}}
-	{{%- set grub_helper_executable = "grubby" -%}}
-{{%- endif -%}}
-{{%- if product in ["rhel8", "ol8"] -%}}
-{{# Suppress the None output of append -#}}
-{{{ grub_helper_args.append("--env=/boot/grub2/grubenv") or "" }}}
+    {{%- set grub_helper_executable = "grubby" -%}}
+    {{%- if action == "add" -%}}
+        {{%- set grub_helper_args = ["--update-kernel=ALL", "--args=" ~ arg_name_value ] -%}}
+    {{%- elif action == "remove" -%}}
+        {{%- set grub_helper_args = ["--update-kernel=ALL", "--remove-args=" ~ arg_name_value ] -%}}
+    {{%- else -%}}
+        {{{ raise("Unknown action" + action) }}}
+    {{%- endif -%}}
+    {{%- if product in ["rhel8", "ol8"] -%}}
+        {{# Suppress the None output of append -#}}
+        {{{ grub_helper_args.append("--env=/boot/grub2/grubenv") or "" }}}
+    {{%- endif -%}}
 {{%- endif -%}}
 {{{ grub_helper_executable }}} {{{ " ".join(grub_helper_args) }}}
 {{%- endmacro %}}


### PR DESCRIPTION
On Ubuntu the command update-grub does not have any special arguments
except -o, -h, and -v.

See:
https://github.com/ComplianceAsCode/content/issues/8464

This was fixed by
https://github.com/ComplianceAsCode/content/pull/8578
but then this was broken by
https://github.com/ComplianceAsCode/content/pull/8628
which tried to unify the macros in meanwhile.

cc @dodys 
