### PR TITLE
Update SRG-OS-000057-GPOS-00027 for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000057-GPOS-00027.yml
+++ b/controls/srg_gpos/SRG-OS-000057-GPOS-00027.yml
@@ -10,7 +10,6 @@ controls:
             - directory_ownership_var_log_audit
             - directory_permissions_var_log_audit
             - file_group_ownership_var_log_audit
-            - file_ownership_var_log_audit
             - file_ownership_var_log_audit_stig
             - file_permissions_var_log_audit
             - audit_immutable_login_uids

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
@@ -20,7 +20,7 @@ rationale: |-
     Making the audit configuration immutable prevents accidental as
     well as malicious modification of the audit rules, although it may be
     problematic if legitimate changes are needed during system
-    operation
+    operation.
 
 severity: medium
 
@@ -52,3 +52,19 @@ references:
     srg: SRG-OS-000057-GPOS-00027,SRG-OS-000058-GPOS-00028,SRG-OS-000059-GPOS-00029
     stigid@ol8: OL08-00-030121
     stigid@rhel8: RHEL-08-030121
+
+ocil: |-
+    Verify the audit system prevents unauthorized changes with the following command:
+
+    $ sudo grep "^\s*[^#]" /etc/audit/audit.rules | tail -1
+
+    -e 2
+
+ocil_clause: the audit system is not set to be immutable by adding the "-e 2" option to the "/etc/audit/audit.rules"
+
+fixtext: |-
+    Configure the audit system to set the audit rules to be immutable by adding the following line to "/etc/audit/rules.d/audit.rules"
+
+    -e 2
+
+    Note: Once set, the system must be rebooted for auditing to be changed.  It is recommended to add this option as the last step in securing the system.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/rule.yml
@@ -34,9 +34,42 @@ references:
     stigid@rhel8: RHEL-08-030120
     stigid@ubuntu2004: UBTU-20-010128
 
-ocil_clause: 'any are more permissive'
+ocil_clause: 'audit logs has more permissive mode'
 
 ocil: |-
+    Verify the audit log directories have a correct mode or less permissive mode.
+
+    Find the location of the audit logs:
+
+    $ sudo grep "^log_file" /etc/audit/auditd.conf
+
+    Find the group that owns audit logs:
+
+    $ sudo grep "^log_group" /etc/audit/auditd.conf
+
     Run the following command to check the mode of the system audit logs:
-    <pre>$ sudo ls -ld /var/log/audit</pre>
-    Audit log directories must be mode 0700 or less permissive.
+
+    $ sudo stat -c "%a %n" [audit_log_directory]
+
+    Replace "[audit_log_directory]" to the correct audit log directory path, by default this location is "/var/log/audit".
+
+    If the log_group is "root" or is not set, the correct permissions are 0700, otherwise they are 0750.
+
+fixtext: |-
+    Configure the audit log directory to be protected from unauthorized read access by setting the correct permissive mode.
+
+    Find the location of the audit logs:
+
+    $ sudo grep "^log_file" /etc/audit/auditd.conf
+
+    Find the group that owns audit logs:
+
+    $ sudo grep "^log_group" /etc/audit/auditd.conf
+
+    If the log_group is "root" or is not set, the correct permissions are 0700, otherwise they are 0750.
+
+    Set the correct permissions mode by the following command:
+
+    $ sudo chmod [correct_permissions] [audit_log_directory]
+
+    Replace "[audit_log_directory]" to the correct audit log directory path, by default this location is "/var/log/audit".

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -56,3 +56,15 @@ template:
         filepath: /etc/audit/rules.d/11-loginuid.rules
         contents: |+
             {{{ file_contents_audit_immutable_login|indent(12) }}}
+
+fixtext: |-
+    Configure {{{ full_name }}} kernel to prevent modification of login UIDs once they are set.
+
+    Create file "/etc/audit/rules.d/11-loginuid.rules" with the exactly following content:
+
+    {{{ file_contents_audit_immutable_login|indent(4) }}}
+
+    Then, run the following commands:
+
+    $ sudo chmod o-rwx "/etc/audit/rules.d/11-loginuid.rules"
+    $ sudo augenrules --load


### PR DESCRIPTION
#### Description:

* Remove rule file_ownership_var_log_audit from the SRG
* Add OCIL and fixtext where missing

#### Rationale:

RHEL 9 STIG
