### PR TITLE
Add variables to SRG GPOS control according to RHEL9 STIG profile

### DIFF
--- a/controls/srg_gpos.yml
+++ b/controls/srg_gpos.yml
@@ -8,3 +8,36 @@ levels:
 - id: high
 - id: medium
 - id: low
+controls:
+    -   id: Variables
+        levels:
+            - high
+            - medium
+            - low
+        title: Variables
+        rules:
+            - var_password_pam_difok=8
+            - var_password_pam_maxrepeat=3
+            - var_sshd_disable_compression=no
+            - var_password_hashing_algorithm=SHA512
+            - var_password_pam_maxclassrepeat=4
+            - var_password_pam_minclass=4
+            - var_password_pam_remember=5
+            - var_password_pam_remember_control_flag=required
+            - var_password_pam_unix_rounds=5000
+            - var_password_pam_dictcheck=1
+            - var_password_pam_ucredit=1
+            - var_password_pam_retry=3
+            - sshd_approved_macs=stig
+            - sshd_approved_ciphers=stig
+            - sshd_idle_timeout_value=10_minutes
+            - var_accounts_authorized_local_users_regex=rhel8
+            - var_account_disable_post_pw_expiration=35
+            - var_auditd_action_mail_acct=root
+            - var_auditd_space_left_percentage=25pc
+            - var_auditd_space_left_action=email
+            - var_auditd_disk_error_action=halt
+            - var_auditd_max_log_file_action=syslog
+            - var_auditd_disk_full_action=halt
+            - login_banner_text=dod_banners
+            - var_system_crypto_policy=fips


### PR DESCRIPTION
#### Description:

- Add variables to SRG GPOS control according to RHEL9 STIG profile

#### Rationale:

No missing variables for the profile. These variables should be relocated to their correct SRG accordingly at some point.

Relates to: #8580