### PR TITLE
Clean up the text in account_temp_expire_date

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -54,7 +54,7 @@ references:
 ocil_clause: 'any temporary accounts have no expiration date set or do not expire within a documented time frame'
 
 ocil: |-
-    For every temporary, run the following command
+    For every temporary account, run the following command
     to obtain its account aging and expiration information:
     <pre>$ sudo chage -l <i>USER</i></pre>
     Verify each of these accounts has an expiration date set as documented.

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -51,10 +51,10 @@ references:
     stigid@ubuntu2004: UBTU-20-010000
     vmmsrg: SRG-OS-000002-VMM-000020,SRG-OS-000123-VMM-000620
 
-ocil_clause: 'any temporary or emergency accounts have no expiration date set or do not expire within a documented time frame'
+ocil_clause: 'any temporary accounts have no expiration date set or do not expire within a documented time frame'
 
 ocil: |-
-    For every temporary and emergency account, run the following command
+    For every temporary, run the following command
     to obtain its account aging and expiration information:
     <pre>$ sudo chage -l <i>USER</i></pre>
     Verify each of these accounts has an expiration date set as documented.


### PR DESCRIPTION

#### Description:

Only talk about temp accounts.
There is another rule for emergency accounts.


#### Rationale:
RHEL9 STIG