### PR TITLE
Sysctl filter out symlinks to files already collected

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/symlink_different_option.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/symlink_different_option.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/net.ipv4.conf.default.accept_source_route/d" /etc/sysctl.conf
+echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.conf
+
+# Configure a different sysctl option
+echo "net.ipv4.conf.all.accept_source_route = 0" >> /etc/sysctl.d/90-test.conf
+
+# Add a symlink
+ln -s /etc/sysctl.d/90-test.conf /etc/sysctl.d/99-sysctl.conf
+
+sysctl -w net.ipv4.conf.default.accept_source_route=0

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/symlink_repeated_sysctl_conf.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/symlink_repeated_sysctl_conf.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/net.ipv4.conf.default.accept_source_route/d" /etc/sysctl.conf
+echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.conf
+
+ln -s /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf
+
+sysctl -w net.ipv4.conf.default.accept_source_route=0

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/symlink_same_option.fail.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/tests/symlink_same_option.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/net.ipv4.conf.default.accept_source_route/d" /etc/sysctl.conf
+echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.conf
+
+# Configure the same sysctl option
+echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.d/90-test.conf
+
+# and add a symlink
+ln -s /etc/sysctl.d/90-test.conf /etc/sysctl.d/99-sysctl.conf
+
+sysctl -w net.ipv4.conf.default.accept_source_route=0

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -168,9 +168,36 @@
     </count>
   </local_variable>
 
+  <ind:textfilecontent54_object id="object_static_set_sysctls_{{{ SYSCTLID }}}" version="1">
+    <set>
+      <object_reference>object_static_set_unfiltered_sysctls_{{{ SYSCTLID }}}</object_reference>
+      <filter action="exclude">state_{{{ SYSCTLID }}}_filepath_is_symlink</filter>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ SYSCTLID }}}_filepath_is_symlink" version="1">
+    <ind:filepath operation="equals" var_check="at least one" var_ref="local_var_symlinks_{{{ SYSCTLID }}}" datatype="string" />
+  </ind:textfilecontent54_state>
+
+  <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_symlinks_{{{ SYSCTLID }}}" version="1">
+    <unique>
+      <object_component object_ref="object_{{{ SYSCTLID }}}_symlinks" item_field="filepath" />
+    </unique>
+  </local_variable>
+
+  <!-- "pattern match" doesn't seem to work with symlink_object, not sure if a bug or not.
+       Workaround by querying for all conf files found -->
+  <unix:symlink_object comment="syctl symlinks" id="object_{{{ SYSCTLID }}}_symlinks" version="1">
+    <unix:filepath operation="equals" var_ref="local_var_conf_files_{{{ SYSCTLID }}}" />
+  </unix:symlink_object>
+
+  <local_variable comment="List of conf files" datatype="string" id="local_var_conf_files_{{{ SYSCTLID }}}" version="1">
+    <object_component object_ref="object_static_set_unfiltered_sysctls_{{{ SYSCTLID }}}" item_field="filepath" />
+  </local_variable>
+
   <!-- Avoid directly referencing a possibly empty collection, one empty collection will cause the
        variable to have no value even when there are valid objects. -->
-  <ind:textfilecontent54_object id="object_static_set_sysctls_{{{ SYSCTLID }}}" version="1">
+  <ind:textfilecontent54_object id="object_static_set_unfiltered_sysctls_{{{ SYSCTLID }}}" version="1">
     <set>
       <object_reference>object_static_etc_sysctls_{{{ SYSCTLID }}}</object_reference>
       <object_reference>object_static_run_usr_sysctls_{{{ SYSCTLID }}}</object_reference>

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -176,8 +176,38 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_{{{ SYSCTLID }}}_filepath_is_symlink" version="1">
-    <ind:filepath operation="equals" var_check="at least one" var_ref="local_var_symlinks_{{{ SYSCTLID }}}" datatype="string" />
+    <ind:filepath operation="equals" var_check="at least one" var_ref="local_var_safe_symlinks_{{{ SYSCTLID }}}" datatype="string" />
   </ind:textfilecontent54_state>
+
+  <!-- <no simlink handling> -->
+  <!-- We craft a variable with blank string to combine with the symlink paths found.
+       This ultimately avoids referencing a variable with "no values",
+       we reference a variable with a blank string -->
+  <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_safe_symlinks_{{{ SYSCTLID }}}" version="1">
+    <unique>
+      <object_component object_ref="var_object_symlink_{{{ SYSCTLID }}}" item_field="value" />
+    </unique>
+  </local_variable>
+
+  <ind:variable_object id="var_object_symlink_{{{ SYSCTLID }}}" comment="combine the blank string with symlink paths found" version="1">
+    <set>
+      <object_reference>var_obj_symlink_{{{ SYSCTLID }}}</object_reference>
+      <object_reference>var_obj_blank_{{{ SYSCTLID }}}</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <ind:variable_object id="var_obj_blank_{{{ SYSCTLID }}}" comment="variable object of the blank string" version="1">
+    <ind:var_ref>local_var_blank_path_{{{ SYSCTLID }}}</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable comment="Blank string" datatype="string" id="local_var_blank_path_{{{ SYSCTLID }}}" version="1">
+    <literal_component datatype="string"></literal_component>
+  </local_variable>
+
+  <ind:variable_object id="var_obj_symlink_{{{ SYSCTLID }}}" comment="variable object of the symlinks found" version="1">
+    <ind:var_ref>local_var_symlinks_{{{ SYSCTLID }}}</ind:var_ref>
+  </ind:variable_object>
+  <!-- </no simlink handling> -->
 
   <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_symlinks_{{{ SYSCTLID }}}" version="1">
     <unique>


### PR DESCRIPTION
#### Description:

- Identify symlinks among the `*.conf` files collected and filter them out before calculating number of unique files with the sysctl option.

#### Rationale:

- Follow up from #8656
- Fixes #8686
