### PR TITLE
Ubuntu 20.04 STIG UFW rules

### DIFF
--- a/linux_os/guide/system/network/network-ufw/group.yml
+++ b/linux_os/guide/system/network/network-ufw/group.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+title: Uncomplicated Firewall (ufw)
+
+description: |-
+    The Linux kernel in Ubuntu provides a packet filtering system called
+    netfilter, and the traditional interface for manipulating netfilter are
+    the iptables suite of commands. iptables provide a complete firewall
+    solution that is both highly configurable and highly flexible.
+
+    Becoming proficient in iptables takes time, and getting started with
+    netfilter firewalling using only iptables can be a daunting task. As a
+    result, many frontends for iptables have been created over the years,
+    each trying to achieve a different result and targeting a different
+    audience.
+
+    The Uncomplicated Firewall (ufw) is a frontend for iptables and is
+    particularly well-suited for host-based firewalls. ufw provides a
+    framework for managing netfilter, as well as a command-line interface
+    for manipulating the firewall. ufw aims to provide an easy to use
+    interface for people unfamiliar with firewall concepts, while at the
+    same time simplifies complicated iptables commands to help an
+    administrator who knows what he or she is doing. ufw is an upstream
+    for other distributions and graphical frontends.
+
+platform: machine

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Install ufw Package'
+
+description: |-
+    {{{ describe_package_install(package="ufw") }}}
+
+rationale: |-
+    <tt>ufw</tt> controls the Linux kernel network packet filtering
+    code. <tt>ufw</tt> allows system operators to set up firewalls and IP
+    masquerading, etc.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.1
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="ufw") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: ufw

--- a/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/package_ufw_installed/rule.yml
@@ -16,6 +16,9 @@ severity: medium
 
 references:
     cis@ubuntu2004: 3.5.1.1
+    disa: CCI-002314
+    srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2004: UBTU-20-010433
 
 ocil_clause: 'the package is not installed'
 

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+title: 'Verify ufw Enabled'
+
+description: |-
+    {{{ describe_service_enable(service="ufw") }}}
+
+rationale: |-
+    The ufw service must be enabled and running in order for ufw to protect the system
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.3
+
+ocil: |-
+    {{{ ocil_service_enabled(service="ufw") }}}
+
+template:
+    name: service_enabled
+    vars:
+        servicename: ufw
+
+platform: machine

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -12,6 +12,9 @@ severity: medium
 
 references:
     cis@ubuntu2004: 3.5.1.3
+    disa: CCI-002314
+    srg: SRG-OS-000297-GPOS-00115
+    stigid@ubuntu2004: UBTU-20-010434
 
 ocil: |-
     {{{ ocil_service_enabled(service="ufw") }}}

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -16,6 +16,8 @@ references:
     srg: SRG-OS-000297-GPOS-00115
     stigid@ubuntu2004: UBTU-20-010434
 
+ocil_clause: 'the service is not enabled'
+
 ocil: |-
     {{{ ocil_service_enabled(service="ufw") }}}
 

--- a/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
@@ -1,0 +1,69 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'Only Allow Authorized Network Services in ufw'
+
+description: |-
+    Check the firewall configuration for any unnecessary or prohibited
+    functions, ports, protocols, and/or services by running the following
+    command:
+    <pre>$ sudo ufw show raw
+    Chain OUTPUT (policy ACCEPT)
+    target prot opt sources destination
+    Chain INPUT (policy ACCEPT 1 packets, 40 bytes)
+    pkts bytes target prot opt in out source destination
+    Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
+    pkts bytes target prot opt in out source destination
+    Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+    pkts bytes target prot opt in out source destination</pre>
+
+    Ask the System Administrator for the site or program PPSM CLSA. Verify
+    the services allowed by the firewall match the PPSM CLSA.
+
+rationale: |-
+    To prevent unauthorized connection of devices, unauthorized transfer of
+    information, or unauthorized tunneling (i.e., embedding of data types
+    within data types), organizations must disable or restrict unused or
+    unnecessary physical and logical ports/protocols on information systems.
+    
+    Operating systems are capable of providing a wide variety of functions
+    and services. Some of the functions and services provided by default
+    may not be necessary to support essential organizational operations.
+    Additionally, it is sometimes convenient to provide multiple services
+    from a single component (e.g., VPN and IPS); however, doing so
+    increases risk over limiting the services provided by any one component.
+
+    To support the requirements and principles of least functionality, the
+    operating system must support the organizational requirements, providing
+    only essential capabilities and limiting the use of ports, protocols,
+    and/or services to only those required, authorized, and approved to
+    conduct official business or to address authorized quality of life
+    issues.
+
+severity: medium
+
+references:
+    disa: CCI-000382
+    srg: SRG-OS-000096-GPOS-00050
+    stigid@ubuntu2004: UBTU-20-010407
+
+ocil_clause: 'unauthorized network services can be accessed from the network'
+
+ocil: |-
+    Check the firewall configuration for any unnecessary or prohibited
+    functions, ports, protocols, and/or services by running the following
+    command:
+    <pre>$ sudo ufw show raw</pre>
+
+    Ask the System Administrator for the site or program PPSM CLSA. Verify
+    the services allowed by the firewall match the PPSM CLSA.
+
+    Add all ports, protocols, or services allowed by the PPSM CLSA by using
+    the following command:
+    <pre>$ sudo ufw allow "direction" "port/protocol/service"</pre>
+    where the direction is "in" or "out" and the port is the one
+    corresponding to the protocol or service allowed.
+
+    To deny access to ports, protocols, or services, use:
+    <pre>$ sudo ufw deny "direction" "port/protocol/service"</pre>

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
@@ -1,0 +1,48 @@
+documentation_complete: true
+
+prodtype: ubuntu2004
+
+title: 'ufw Must rate-limit network interfaces'
+
+description: |-
+    The operating system must configure the uncomplicated firewall to
+    rate-limit impacted network interfaces.
+
+rationale: |-
+    This requirement addresses the configuration of the operating system to
+    mitigate the impact of DoS attacks that have occurred or are ongoing on
+    system availability. For each system, known and potential DoS attacks
+    must be identified and solutions for each type implemented. A variety
+    of technologies exist to limit or, in some cases, eliminate the effects
+    of DoS attacks (e.g., limiting processes or establishing memory
+    partitions). Employing increased capacity and bandwidth, combined with
+    service redundancy, may reduce the susceptibility to some DoS attacks.
+
+severity: medium
+
+references:
+    disa: CCI-002385
+    srg: SRG-OS-000420-GPOS-00186
+    stigid@ubuntu2004: UBTU-20-010446
+
+ocil_clause: 'network interface not rate-limit'
+
+ocil: |-
+    Check all the services listening to the ports with the following
+    command:
+    <pre>$ sudo ss -l46ut
+    Netid State Recv-Q Send-Q Local Address:Port Peer Address:Port Process
+    tcp LISTEN 0 128 [::]:ssh [::]:*</pre>
+
+    For each entry, verify that the ufw is configured to rate limit the
+    service ports with the following command:
+    <pre>$ sudo ufw status</pre>
+
+    If any port with a state of "LISTEN" is not marked with the "LIMIT"
+    action, run the following command, replacing "service" with the
+    service that needs to be rate limited:
+    <pre>$ sudo ufw limit "service"</pre>
+
+    Rate-limiting can also be done on an interface. An example of adding
+    a rate-limit on the eth0 interface follows:
+    <pre>$ sudo ufw limit in on eth0</pre>

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -513,6 +513,7 @@ selections:
     - service_rsyslog_enabled
 
     # UBTU-20-010433 The Ubuntu operating system must have an application firewall installed in order to control remote access methods.
+    - package_ufw_installed
 
     # UBTU-20-010434 The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -516,6 +516,7 @@ selections:
     - package_ufw_installed
 
     # UBTU-20-010434 The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).
+    - service_ufw_enabled
 
     # UBTU-20-010435 The Ubuntu operating system must, for networked systems, compare internal information system clocks at least every 24 hours with a server which is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).
     - var_time_service_set_maxpoll=36_hours

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -211,7 +211,7 @@ selections:
     - audit_rules_privileged_commands_chfn
 
     # UBTU-20-010138 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the mount command.
-    - audit_rules_privileged_commands_mount 
+    - audit_rules_privileged_commands_mount
 
     # UBTU-20-010139 The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the umount command.
     - audit_rules_privileged_commands_umount

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -437,6 +437,7 @@ selections:
     - package_rsh-server_removed
 
     # UBTU-20-010407 The Ubuntu operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.
+    - ufw_only_required_services
 
     # UBTU-20-010408 The Ubuntu operating system must prevent direct login into the root account.
     - prevent_direct_root_logins

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -550,6 +550,7 @@ selections:
     # UBTU-20-010445 Ubuntu operating system must implement cryptographic mechanisms to prevent unauthorized disclosure of all information at rest.
 
     # UBTU-20-010446 The Ubuntu operating system must configure the uncomplicated firewall to rate-limit impacted network interfaces.
+    - ufw_rate_limit
 
     # UBTU-20-010447 The Ubuntu operating system must implement non-executable data to protect its memory from unauthorized code execution.
     - bios_enable_execution_restrictions


### PR DESCRIPTION
#### Description:

- Add UFW group
- Add a few ufw rules:
  - package_ufw_installed
  - service_ufw_enabled
  - ufw_rate_limit
  - ufw_only_required_services
 
#### Rationale:

- Ubuntu uses UFW as its default firewall and STIG defines a few requirements for it.