### PR TITLE
Sysctl separate object from state

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/tests/wrong_value_d_directory.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/tests/wrong_value_d_directory.fail.sh
@@ -5,19 +5,19 @@
 setting_name="kernel.randomize_va_space"
 setting_value="2"
 # sysctl -w "$setting_name=$setting_value"
-if grep -q "^$setting_name" /usr/lib/sysctl.d/50-sysctl.conf; then
-    sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /usr/lib/sysctl.d/50-sysctl.conf
+if grep -q "^$setting_name" /etc/sysctl.conf; then
+    sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /etc/sysctl.conf
 else
-    echo "$setting_name = $setting_value" >> /usr/lib/sysctl.d/50-sysctl.conf
+    echo "$setting_name = $setting_value" >> /etc/sysctl.conf
 fi
 
 setting_name="kernel.randomize_va_space"
 setting_value="0"
 # sysctl -w "$setting_name=$setting_value"
-if grep -q "^$setting_name" /etc/sysctl.d/99-sysctl.conf; then
-    sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /etc/sysctl.d/99-sysctl.conf
+if grep -q "^$setting_name" /etc/sysctl.d/98-sysctl.conf; then
+    sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /etc/sysctl.d/98-sysctl.conf
 else
-    echo "$setting_name = $setting_value" >> /etc/sysctl.d/99-sysctl.conf
+    echo "$setting_name = $setting_value" >> /etc/sysctl.d/98-sysctl.conf
 fi
 
 sysctl --system

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -6,21 +6,15 @@
 
 {{% macro state_static_sysctld(prefix) -%}}
     <ind:object object_ref="object_static_{{{ prefix }}}_{{{ SYSCTLID }}}"/>
-{{%- if SYSCTLVAL == "" %}}
     <ind:state state_ref="state_static_sysctld_{{{ SYSCTLID }}}"/>
-{{%- endif -%}}
 {{%- endmacro -%}}
 {{%- macro sysctl_match() -%}}
 {{%- if SYSCTLVAL == "" -%}}
     <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(\d+)[\s]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
 {{%- else -%}}
-{{% if OPERATION == "pattern match" %}}
-    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*{{{ SYSCTLVAL_REGEX }}}[\s]*$</ind:pattern>
-{{% else %}}
-    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*{{{ SYSCTLVAL }}}[\s]*$</ind:pattern>
-{{% endif %}}
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(.*)[\s]*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
 {{%- endif -%}}
 {{%- endmacro -%}}
 {{%- if "P" in FLAGS -%}}
@@ -279,6 +273,14 @@
 
   <external_variable id="sysctl_{{{ SYSCTLID }}}_value" version="1"
                      comment="External variable for {{{ SYSCTLVAR }}}" datatype="{{{ DATATYPE }}}"/>
+{{% else %}}
+  <ind:textfilecontent54_state id="state_static_sysctld_{{{ SYSCTLID }}}" version="1">
+{{% if OPERATION == "pattern match" %}}
+    <ind:subexpression operation="{{{ OPERATION }}}" datatype="{{{ DATATYPE }}}">{{{ SYSCTLVAL_REGEX }}}</ind:subexpression>
+{{% else %}}
+    <ind:subexpression operation="{{{ OPERATION }}}" datatype="{{{ DATATYPE }}}">{{{ SYSCTLVAL }}}</ind:subexpression>
+{{% endif %}}
+  </ind:textfilecontent54_state>
 {{% endif %}}
 </def-group>
 {{%- endif -%}}


### PR DESCRIPTION
#### Description:

- Modify the sysctl template not to consider the compliant value part of the OVAL object we are looking for.
  - We need to collect all sysctl option definitions and then check their values.
- This also fixes a test that was adding sysctl options to a directory the remediation doesn't traverse.
  - Current understanding is that config files in `/usr/lib/sysctl.d` and `/run/sysctl.d` are not to be changed. (They are not config files in the RPM package)

#### Rationale:

- Follow up to #8656