### PR TITLE
Update SRG-OS-000058-GPOS-00028 for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000058-GPOS-00028.yml
+++ b/controls/srg_gpos/SRG-OS-000058-GPOS-00028.yml
@@ -9,7 +9,6 @@ controls:
             - directory_ownership_var_log_audit
             - directory_permissions_var_log_audit
             - file_group_ownership_var_log_audit
-            - file_ownership_var_log_audit
             - file_ownership_var_log_audit_stig
             - file_permissions_var_log_audit
             - audit_immutable_login_uids


### PR DESCRIPTION
#### Description:
Remove rule file_ownership_var_log_audit

Other rules are already updated.

#### Rationale:
RHEL 9 STIG