### PR TITLE
Update SRG-OS-000021-GPOS-00005 for RHEL9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000021-GPOS-00005.yml
+++ b/controls/srg_gpos/SRG-OS-000021-GPOS-00005.yml
@@ -5,6 +5,9 @@ controls:
         title: {{{ full_name }}} must enforce the limit of three consecutive invalid
             logon attempts by a user during a 15-minute time period.
         rules:
+            - var_accounts_passwords_pam_faillock_deny=3
+            - var_accounts_passwords_pam_faillock_fail_interval=900
+            - var_accounts_passwords_pam_faillock_unlock_time=never
             - accounts_passwords_pam_faillock_deny
             - accounts_passwords_pam_faillock_deny_root
             - accounts_passwords_pam_faillock_interval

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -65,36 +65,27 @@ ocil: |-
 fixtext: |-
     To configure the system to lock out accounts after a number of incorrect login attempts
     using <tt>pam_faillock.so</tt>, first enable the feature using the following command:
-    <br /><br />
     {{% if product in ["rhel7"] %}}
-    <ul>
-    <li><pre>authconfig --enablefaillock --update</pre></li>
-    </ul>
-    <br />
+    $ sudo authconfig --enablefaillock --update
+
     Then modify the content of both <tt>/etc/pam.d/system-auth</tt> and
     <tt>/etc/pam.d/password-auth</tt> as follows:
-    <br /><br />
-    <ul>
-    <li> edit the deny parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
+    edit the deny parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so preauth silent <tt>deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}</tt> unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
-    <li> edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
+    <pre>auth required pam_faillock.so preauth silent <tt>deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}</tt> unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre>
+
+    edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so authfail <tt>deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}</tt> unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
-    </ul>
+    <pre>auth required pam_faillock.so authfail <tt>deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}</tt> unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre>
     {{% else %}}
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
+    $ sudo authselect enable-feature with-faillock
+
     Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add, uncomment or edit the following line:
-    <pre>deny = {{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
+    add, uncomment or edit the following line:
+    <pre>deny = {{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}}</pre>
+
+    add or uncomment the following line:
+    <pre>silent</pre>
     {{% endif %}}
 
 platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -63,7 +63,7 @@ ocil: |-
     {{% endif %}}
 
 fixtext: |-
-    To configure the system to lock out accounts after a number of incorrect login attempts
+    To configure {{{ full_name }}} to lock out accounts after a number of incorrect login attempts
     using <tt>pam_faillock.so</tt>, first enable the feature using the following command:
     {{% if product in ["rhel7"] %}}
     $ sudo authconfig --enablefaillock --update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/rule.yml
@@ -9,8 +9,8 @@ description: |-
     using <tt>pam_faillock.so</tt>.
 
     pam_faillock.so module requires multiple entries in pam files. These entries must be carefully
-    defined to work as expected. In order to avoid any errors when manually editing these files,
-    it is recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
+    defined to work as expected. In order to avoid errors when manually editing these files, it is
+    recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
     depending on the OS version.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -60,36 +60,27 @@ ocil: |-
 fixtext: |-
     To configure the system to lock out the <tt>root</tt> account after a number of incorrect login
     attempts using <tt>pam_faillock.so</tt>, first enable the feature using the following command:
-    <br /><br />
     {{% if product in ["rhel7"] %}}
-    <ul>
-    <li><pre>authconfig --enablefaillock --update</pre></li>
-    </ul>
-    <br />
+    $ sudo authconfig --enablefaillock --update
+
     Then modify the content of both <tt>/etc/pam.d/system-auth</tt> and
     <tt>/etc/pam.d/password-auth</tt> as follows:
-    <br /><br />
-    <ul>
-    <li> include the even_deny_root parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
+    include the even_deny_root parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}} <tt>even_deny_root</tt></pre></li>
-    <li> include the even_deny_root parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
+    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}} <tt>even_deny_root</tt></pre>
+
+    include the even_deny_root parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}} <tt>even_deny_root</tt></pre></li>
-    </ul>
+    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}} <tt>even_deny_root</tt></pre>
     {{% else %}}
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
+    $ sudo authselect enable-feature with-faillock
+
     Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add or uncomment the following line:
-    <pre>even_deny_root</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
+    add or uncomment the following line:
+    <pre>even_deny_root</pre>
+
+    add or uncomment the following line:
+    <pre>silent</pre>
     {{% endif %}}
 
 platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -9,8 +9,8 @@ description: |-
     incorrect login attempts using <tt>pam_faillock.so</tt>.
 
     pam_faillock.so module requires multiple entries in pam files. These entries must be carefully
-    defined to work as expected. In order to avoid any errors when manually editing these files,
-    it is recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
+    defined to work as expected. In order to avoid errors when manually editing these files, it is
+    recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
     depending on the OS version.
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/rule.yml
@@ -7,22 +7,7 @@ title: 'Enforce pam_faillock for Local Accounts Only'
 description: |-
     The pam_faillock module's <tt>local_users_only</tt> parameter controls requirements for
     enforcing failed lockout attempts only for local user accounts and ignoring centralized user
-    account management failed attempt configurations. To enable the <tt>local_users_only</tt>
-    setting in <tt>/etc/security/faillock.conf</tt>, first enable pam_faillock.so using the
-    following command:
-    <br /><br />
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
-    Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add or uncomment the following line:
-    <pre>local_users_only</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
+    account management failed attempt configurations.
 
 rationale: |-
     The operating system must provide automated mechanisms for supporting account management
@@ -46,6 +31,23 @@ ocil: |-
     To check if only local user are impacted by pam_faillock, run the following command:
     <pre>$ grep local_users_only /etc/security/faillock.conf</pre>
     The output should return <tt>local_users_only</tt> not commented.
+
+fixtext: |-
+    To enable the <tt>local_users_only</tt> setting in <tt>/etc/security/faillock.conf</tt>,
+    first enable pam_faillock.so using the following command:
+    <br /><br />
+    <ul>
+    <li><pre>authselect enable-feature with-faillock</pre></li>
+    </ul>
+    <br />
+    Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
+    <br /><br />
+    <ul>
+    <li> add or uncomment the following line:
+    <pre>local_users_only</pre></li>
+    <li> add or uncomment the following line:
+    <pre>silent</pre></li>
+    </ul>
 
 platform: pam
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_enforce_local/rule.yml
@@ -35,19 +35,14 @@ ocil: |-
 fixtext: |-
     To enable the <tt>local_users_only</tt> setting in <tt>/etc/security/faillock.conf</tt>,
     first enable pam_faillock.so using the following command:
-    <br /><br />
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
+    $ sudo authselect enable-feature with-faillock
+
     Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add or uncomment the following line:
-    <pre>local_users_only</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
+    add or uncomment the following line:
+    <pre>local_users_only</pre>
+
+    add or uncomment the following line:
+    <pre>silent</pre>
 
 platform: pam
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -7,38 +7,7 @@ title: 'Set Interval For Counting Failed Password Attempts'
 description: |-
     Utilizing <tt>pam_faillock.so</tt>, the <tt>fail_interval</tt> directive configures the system
     to lock out an account after a number of incorrect login attempts within a specified time
-    period. First make sure the feature is enabled using the following command:
-    <br /><br />
-    {{% if product in ["rhel7"] %}}
-    <ul>
-    <li><pre>authconfig --enablefaillock --update</pre></li>
-    </ul>
-    <br />
-    Then modify the content of both <tt>/etc/pam.d/system-auth</tt> and
-    <tt>/etc/pam.d/password-auth</tt> as follows:
-    <br /><br />
-    <ul>
-    <li> edit the fail_interval parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
-    statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre></li>
-    <li> edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
-    statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre></li>
-    </ul>
-    {{% else %}}
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
-    Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add, uncomment or edit the following line:
-    <pre>fail_interval = {{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
-    {{% endif %}}
+    period.
 
 rationale: |-
     By limiting the number of failed logon attempts the risk of unauthorized system
@@ -82,6 +51,41 @@ ocil: |-
     {{% else %}}
     <pre>$ grep fail_interval /etc/security/faillock.conf</pre>
     The output should show <tt>fail_interval = &lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is <tt>{{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt> or greater.
+    {{% endif %}}
+
+fixtext: |-
+    To configure the fail_interval directive, first make sure the feature is enabled using the
+    following command:
+    <br /><br />
+    {{% if product in ["rhel7"] %}}
+    <ul>
+    <li><pre>authconfig --enablefaillock --update</pre></li>
+    </ul>
+    <br />
+    Then modify the content of both <tt>/etc/pam.d/system-auth</tt> and
+    <tt>/etc/pam.d/password-auth</tt> as follows:
+    <br /><br />
+    <ul>
+    <li> edit the fail_interval parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
+    statement in the <tt>auth</tt> section, like this:
+    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre></li>
+    <li> edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
+    statement in the <tt>auth</tt> section, like this:
+    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre></li>
+    </ul>
+    {{% else %}}
+    <ul>
+    <li><pre>authselect enable-feature with-faillock</pre></li>
+    </ul>
+    <br />
+    Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
+    <br /><br />
+    <ul>
+    <li> add, uncomment or edit the following line:
+    <pre>fail_interval = {{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
+    <li> add or uncomment the following line:
+    <pre>silent</pre></li>
+    </ul>
     {{% endif %}}
 
 srg_requirement: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -56,36 +56,27 @@ ocil: |-
 fixtext: |-
     To configure the fail_interval directive, first make sure the feature is enabled using the
     following command:
-    <br /><br />
     {{% if product in ["rhel7"] %}}
-    <ul>
-    <li><pre>authconfig --enablefaillock --update</pre></li>
-    </ul>
-    <br />
+    $ sudo authconfig --enablefaillock --update
+
     Then modify the content of both <tt>/etc/pam.d/system-auth</tt> and
     <tt>/etc/pam.d/password-auth</tt> as follows:
-    <br /><br />
-    <ul>
-    <li> edit the fail_interval parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
+    edit the fail_interval parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre></li>
-    <li> edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
+    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre>
+
+    edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre></li>
-    </ul>
+    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}} <tt>fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</tt></pre>
     {{% else %}}
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
+    $ sudo authselect enable-feature with-faillock
+
     Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add, uncomment or edit the following line:
-    <pre>fail_interval = {{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
+    add, uncomment or edit the following line:
+    <pre>fail_interval = {{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre>
+
+    add or uncomment the following line:
+    <pre>silent</pre>
     {{% endif %}}
 
 srg_requirement: |-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -67,36 +67,27 @@ fixtext: |-
     To configure the system to lock out accounts during a specified time period after a number of
     incorrect login attempts using <tt>pam_faillock.so</tt>, first make sure the feature is enabled
     using the following command:
-    <br /><br />
     {{% if product in ["rhel7"] %}}
-    <ul>
-    <li><pre>authconfig --enablefaillock --update</pre></li>
-    </ul>
-    <br />
+    $ sudo authconfig --enablefaillock --update
+
     Then modify the content of both <tt>/etc/pam.d/system-auth</tt> and
     <tt>/etc/pam.d/password-auth</tt> as follows:
-    <br /><br />
-    <ul>
-    <li> edit the unlock_time parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
+    edit the unlock_time parameter in the following line <tt>before</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} <tt>unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
-    <li> edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
+    <pre>auth required pam_faillock.so preauth silent deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} <tt>unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre>
+
+    edit the deny parameter in the following line <tt>after</tt> the <tt>pam_unix.so</tt>
     statement in the <tt>auth</tt> section, like this:
-    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} <tt>unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre></li>
-    </ul>
+    <pre>auth required pam_faillock.so authfail deny={{{ xccdf_value("var_accounts_passwords_pam_faillock_deny") }}} <tt>unlock_time={{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> fail_interval={{{ xccdf_value("var_accounts_passwords_pam_faillock_fail_interval") }}}</pre>
     {{% else %}}
-    <ul>
-    <li><pre>authselect enable-feature with-faillock</pre></li>
-    </ul>
-    <br />
+    $ sudo authselect enable-feature with-faillock
+
     Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
-    <br /><br />
-    <ul>
-    <li> add, uncomment or edit the following line:
-    <pre>unlock_time = {{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</pre></li>
-    <li> add or uncomment the following line:
-    <pre>silent</pre></li>
-    </ul>
+    add, uncomment or edit the following line:
+    <pre>unlock_time = {{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</pre>
+
+    add or uncomment the following line:
+    <pre>silent</pre>
     {{% endif %}}
     If <tt>unlock_time</tt> is set to <tt>0</tt>, manual intervention by an administrator is required
     to unlock a user. This should be done using the <tt>faillock</tt> tool.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -115,7 +115,6 @@ warnings:
        The parameters <tt>deny</tt> and <tt>fail_interval</tt>, if used, also have to be migrated
        by their respective remediation.
 
-warnings:
     - general: |-
         If the system relies on <tt>authselect</tt> tool to manage PAM settings, the remediation
         will also use <tt>authselect</tt> tool. However, if any manual modification was made in


### PR DESCRIPTION
#### Description:

Included `fixtext` field where it was not already present for `pam_faillock` related rules.

#### Rationale:

RHEL9 STIG
