### PR TITLE
Update SRG-OS-000077-GPOS-00045 for RHEL9 STIG

### DIFF
--- a/controls/srg_gpos.yml
+++ b/controls/srg_gpos.yml
@@ -18,8 +18,6 @@ controls:
         rules:
             - var_sshd_disable_compression=no
             - var_password_hashing_algorithm=SHA512
-            - var_password_pam_remember=5
-            - var_password_pam_remember_control_flag=required
             - var_password_pam_unix_rounds=5000
             - var_password_pam_dictcheck=1
             - var_password_pam_retry=3

--- a/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
+++ b/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
@@ -4,6 +4,9 @@ controls:
             - medium
         title: {{{ full_name }}} must prohibit password reuse for a minimum of five generations.
         rules:
+            - var_password_pam_remember=5
+            - var_password_pam_remember_control_flag=required
+            - var_password_pam_unix_remember=5
             - accounts_password_pam_pwhistory_remember_password_auth
             - accounts_password_pam_pwhistory_remember_system_auth
             - accounts_password_pam_unix_remember

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -5,15 +5,8 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 title: 'Limit Password Reuse: password-auth'
 
 description: |-
-    Do not allow users to reuse recent passwords. This can be
-    accomplished by using the <tt>remember</tt> option for the
-    <tt>pam_pwhistory</tt> PAM modules.
-    <br /><br />
-    In the file <tt>/etc/pam.d/password-auth</tt>, make sure the parameter
-    <tt>remember</tt> is present, and that the value
-    for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater. For example:
-    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    The DoD STIG requirement is 5 passwords.
+    Do not allow users to reuse recent passwords. This can be accomplished by using the
+    <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -58,6 +51,13 @@ ocil: |-
     out, has a second column value different from <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
     "remember" value, or the value is less than
     <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>, this is a finding.
+
+fixtext: |-
+    To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
+    file <tt>/etc/pam.d/password-auth</tt>, make sure the parameter <tt>remember</tt> is present,
+    and that the value for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater.
+    For example:
+    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
 
 platform: pam
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -5,15 +5,8 @@ prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 title: 'Limit Password Reuse: system-auth'
 
 description: |-
-    Do not allow users to reuse recent passwords. This can be
-    accomplished by using the <tt>remember</tt> option for the
-    <tt>pam_pwhistory</tt> PAM modules.
-    <br /><br />
-    In the file <tt>/etc/pam.d/system-auth</tt>, make sure the parameter
-    <tt>remember</tt> is present, and that the value
-    for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater. For example:
-    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    The DoD STIG requirement is 5 passwords.
+    Do not allow users to reuse recent passwords. This can be accomplished by using the
+    <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -50,14 +43,21 @@ ocil_clause: |-
      the value of remember is not set equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
 
 ocil: |-
-    Check that the operating system prohibits the reuse of a password for
-    a minimum of <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
+    Check that the operating system prohibits the reuse of a password for a minimum of
+    <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
     <pre># grep pam_pwhistory.so /etc/pam.d/system-auth
     password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, or the returned line is commented
-    out, has a second column value different from <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
-    "remember" value, or the value is less than
-    <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>, this is a finding.
+    If the command does not return a result, or the returned line is commented out, has a second
+    column value different from <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt>,
+    does not contain "remember" value, or the value is less than <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>,
+    this is a finding.
+
+fixtext: |-
+    To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
+    file <tt>/etc/pam.d/system-auth</tt>, make sure the parameter <tt>remember</tt> is present,
+    and that the value for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater.
+    For example:
+    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
 
 platform: pam
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -11,21 +11,8 @@ title: 'Limit Password Reuse'
 {{% endif %}}
 
 description: |-
-    Do not allow users to reuse recent passwords. This can be
-    accomplished by using the <tt>remember</tt> option for the <tt>pam_unix</tt>
-    or <tt>pam_pwhistory</tt> PAM modules.
-    <br /><br />
-    In the file <tt>{{{ configFile }}}</tt>, append <tt>remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</tt>
-    to the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module, as shown below:
-    <ul>
-    <li>for the <tt>pam_unix.so</tt> case:
-    <pre>password sufficient pam_unix.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</pre>
-    </li>
-    <li>for the <tt>pam_pwhistory.so</tt> case:
-    <pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</pre>
-    </li>
-    </ul>
-    The DoD STIG requirement is 5 passwords.
+    Do not allow users to reuse recent passwords. This can be accomplished by using the
+    <tt>remember</tt> option for the <tt>pam_unix</tt> or <tt>pam_pwhistory</tt> PAM modules.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -59,13 +46,27 @@ references:
     stigid@ubuntu2004: UBTU-20-010070
     vmmsrg: SRG-OS-000077-VMM-000440
 
-ocil_clause: 'the value of remember is not set equal to or greater than the expected setting'
+ocil_clause: 'the value of remember is not equal to or greater than the expected value'
 
 ocil: |-
     To verify the password reuse setting is compliant, run the following command:
     <pre>$ grep remember {{{ configFile }}}</pre>
     The output should show the following at the end of the line:
     <pre>remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</pre>
+
+fixtext: |-
+    To configure the <tt>remember</tt> option for the <tt>pam_unix</tt> or <tt>pam_pwhistory</tt>
+    PAM modules, in the file <tt>{{{ configFile }}}</tt>, append <tt>remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</tt>
+    to the line which refers to the <tt>pam_unix.so</tt> or <tt>pam_pwhistory.so</tt>module,
+    as shown below:
+    <ul>
+    <li>for the <tt>pam_unix.so</tt> case:
+    <pre>password sufficient pam_unix.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</pre>
+    </li>
+    <li>for the <tt>pam_pwhistory.so</tt> case:
+    <pre>password requisite pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_unix_remember") }}}</pre>
+    </li>
+    </ul>
 
 platform: pam
 


### PR DESCRIPTION
#### Description:

Included `fixtext` on rules related to `remember` option from `pam_pwhistory.so` and `pam_unix.so` PAM modules. 

#### Rationale:

RHEL9 STIG
