### PR TITLE
Sysctl template: Restrict the check for option definition in single file to OVAL 5.11

### DIFF
--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -114,7 +114,9 @@
         <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /usr/lib/sysctl.d/*.conf"
                    test_ref="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}"/>
       </criteria>
+{{% if target_oval_version >= [5, 11] %}}
       <criterion comment="Check that {{{ SYSCTLID }}} is defined in only one file" test_ref="test_sysctl_{{{ SYSCTLID }}}_defined_in_one_file" />
+{{% endif %}}
     </criteria>
   </definition>
 
@@ -140,6 +142,7 @@
     {{{ state_static_sysctld("usr_lib_sysctld") }}}
   </ind:textfilecontent54_test>
 
+{{% if target_oval_version >= [5, 11] %}}
   <ind:variable_test check="all" check_existence="all_exist" comment="Check that only one file contains {{{ SYSCTLID }}}"
   id="test_sysctl_{{{ SYSCTLID }}}_defined_in_one_file" version="1">
     <ind:object object_ref="oject_sysctl_{{{ SYSCTLID }}}_defined_in_one_file" />
@@ -214,6 +217,7 @@
   <unix:symlink_object comment="syctl symlinks" id="object_{{{ SYSCTLID }}}_symlinks" version="1">
     <unix:filepath operation="equals" var_ref="local_var_conf_files_{{{ SYSCTLID }}}" />
   </unix:symlink_object>
+{{% endif %}}
 
   <local_variable comment="List of conf files" datatype="string" id="local_var_conf_files_{{{ SYSCTLID }}}" version="1">
     <object_component object_ref="object_static_set_unfiltered_sysctls_{{{ SYSCTLID }}}" item_field="filepath" />


### PR DESCRIPTION


#### Description:

- Remove `symlink_test` from the template when building OVAL 5.10 content.
  - The consequence is the 5.10 version of the template will will not check for options defined in multiple files.

#### Rationale:
- The symlink_test was added in OVAL 5.11 and is not availble in 5.10.
- Fixes OVAL 5.10 SCAP validation
