### PR TITLE
Rsyslog files permissions fix wildcard path

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -54,7 +54,7 @@ do
 	then
 		NORMALIZED_CONFIG_FILE_LINES=$(sed -e "/^[#|$]/d" "${LOG_FILE}")
 		LINES_WITH_PATHS=$(grep '[^/]*\s\+\S*/\S\+$' <<< "${NORMALIZED_CONFIG_FILE_LINES}")
-		FILTERED_PATHS=$(sed -e 's/[^\/]*[[:space:]]*\([^:;[:space:]]*\)/\1/g' <<< "${LINES_WITH_PATHS}")
+		FILTERED_PATHS=$(awk '{if(NF>=2&&($2~/^\//||$2~/^-\//)){sub(/^-\//,"/",$2);print $2}}' <<< "${LINES_WITH_PATHS}")
 		CLEANED_PATHS=$(sed -e "s/[\"')]//g; /\\/etc.*\.conf/d; /\\/dev\\//d" <<< "${FILTERED_PATHS}")
 		MATCHED_ITEMS=$(sed -e "/^$/d" <<< "${CLEANED_PATHS}")
 		# Since above sed command might return more than one item (delimited by newline), split the particular

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -5,8 +5,8 @@
 RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
-readarray -t RSYSLOG_INCLUDE_CONFIG < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
-readarray -t RSYSLOG_INCLUDE < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+readarray -t RSYSLOG_INCLUDE_CONFIG < <(printf '%s\n' $(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2))
+readarray -t RSYSLOG_INCLUDE < <(printf '%s\n' $(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf))
 
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -21,10 +21,11 @@ RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYS
 declare -a RSYSLOG_CONFIG_FILES
 for ENTRY in "${RSYSLOG_CONFIGS[@]}"
 do
-	# If directory, need to include files recursively
+	# If directory, rsyslog will search for config files in recursively.
+	# However, files in hidden sub-directories or hidden files will be ignored.
 	if [ -d "${ENTRY}" ]
 	then
-		readarray -t FINDOUT < <(find "${ENTRY}" -type f)
+		readarray -t FINDOUT < <(find "${ENTRY}" -not -path '*/.*' -type f)
 		RSYSLOG_CONFIG_FILES+=("${FINDOUT[@]}")
 	elif [ -f "${ENTRY}" ]
 	then

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -24,7 +24,7 @@ do
 	# If directory, need to include files recursively
 	if [ -d "${ENTRY}" ]
 	then
-		readarray -t FINDOUT < <(find "${ENTRY}" -type f -name '*.conf')
+		readarray -t FINDOUT < <(find "${ENTRY}" -type f)
 		RSYSLOG_CONFIG_FILES+=("${FINDOUT[@]}")
 	elif [ -f "${ENTRY}" ]
 	then

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -5,8 +5,10 @@
 RSYSLOG_ETC_CONFIG="/etc/rsyslog.conf"
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
-readarray -t RSYSLOG_INCLUDE_CONFIG < <(printf '%s\n' $(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2))
-readarray -t RSYSLOG_INCLUDE < <(printf '%s\n' $(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf))
+readarray -t OLD_INC < <(grep -e "\$IncludeConfig[[:space:]]\+[^[:space:];]\+" /etc/rsyslog.conf | cut -d ' ' -f 2)
+readarray -t RSYSLOG_INCLUDE_CONFIG < <(for INCPATH in "${OLD_INC[@]}"; do eval printf '%s\\n' "${INCPATH}"; done)
+readarray -t NEW_INC < <(awk '/)/{f=0} /include\(/{f=1} f{nf=gensub("^(include\\(|\\s*)file=\"(\\S+)\".*","\\2",1); if($0!=nf){print nf}}' /etc/rsyslog.conf)
+readarray -t RSYSLOG_INCLUDE < <(for INCPATH in "${NEW_INC[@]}"; do eval printf '%s\\n' "${INCPATH}"; done)
 
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -13,22 +13,12 @@ readarray -t RSYSLOG_INCLUDE < <(for INCPATH in "${NEW_INC[@]}"; do eval printf 
 # Declare an array to hold the final list of different log file paths
 declare -a LOG_FILE_PATHS
 
-RSYSLOG_CONFIGS=()
-RSYSLOG_CONFIGS=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
+declare -a RSYSLOG_CONFIGS
+RSYSLOG_CONFIGS+=("${RSYSLOG_ETC_CONFIG}" "${RSYSLOG_INCLUDE_CONFIG[@]}" "${RSYSLOG_INCLUDE[@]}")
 
-# Get full list of files to be checked
-# RSYSLOG_CONFIGS may contain globs such as 
-# /etc/rsyslog.d/*.conf /etc/rsyslog.d/*.frule
-# So, loop over the entries in RSYSLOG_CONFIGS and use find to get the list of included files.
-RSYSLOG_FILES=()
-for ENTRY in "${RSYSLOG_CONFIGS[@]}"
-do
-     mapfile -t FINDOUT < <(find "$(dirname "${ENTRY}")" -maxdepth 1 -name "$(basename "${ENTRY}")")
-     RSYSLOG_FILES+=("${FINDOUT[@]}")
-done
-
-# Check file and fix if needed.
-for LOG_FILE in "${RSYSLOG_FILES[@]}"
+# Browse each file selected above as containing paths of log files
+# ('/etc/rsyslog.conf' and '/etc/rsyslog.d/*.conf' in the default configuration)
+for LOG_FILE in "${RSYSLOG_CONFIGS[@]}"
 do
 	# From each of these files extract just particular log file path(s), thus:
 	# * Ignore lines starting with space (' '), comment ('#"), or variable syntax ('$') characters,

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
@@ -9,20 +9,24 @@ source $SHARED/rsyslog_log_utils.sh
 PERMS=0600
 
 # setup test data
-create_rsyslog_test_logs 3
+create_rsyslog_test_logs 4
 
 # setup test log files and permissions
 chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
 chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
 chmod $PERMS ${RSYSLOG_TEST_LOGS[2]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[3]}
 
 # create test configuration file
 conf_subdir=${RSYSLOG_TEST_DIR}/subdir
 mkdir ${conf_subdir}
 test_subdir_conf=${conf_subdir}/test_subdir.conf
 test_conf=${RSYSLOG_TEST_DIR}/test.conf
+test_bak=${RSYSLOG_TEST_DIR}/test.bak
+
 cat << EOF > ${test_subdir_conf}
 # rsyslog configuration file
+# test_subdir_conf
 
 #### RULES ####
 
@@ -31,10 +35,20 @@ EOF
 
 cat << EOF > ${test_conf}
 # rsyslog configuration file
+# test_conf
 
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+cat << EOF > ${test_bak}
+# rsyslog configuration file
+# test_bak
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[3]}
 EOF
 
 # create rsyslog.conf configuration file

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
@@ -9,46 +9,59 @@ source $SHARED/rsyslog_log_utils.sh
 PERMS=0600
 
 # setup test data
-create_rsyslog_test_logs 4
+create_rsyslog_test_logs 5
 
 # setup test log files and permissions
 chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
 chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
 chmod $PERMS ${RSYSLOG_TEST_LOGS[2]}
 chmod $PERMS ${RSYSLOG_TEST_LOGS[3]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[4]}
 
-# create test configuration file
+# create test configuration files
 conf_subdir=${RSYSLOG_TEST_DIR}/subdir
+conf_hiddir=${RSYSLOG_TEST_DIR}/.hiddir
 mkdir ${conf_subdir}
-test_subdir_conf=${conf_subdir}/test_subdir.conf
-test_conf=${RSYSLOG_TEST_DIR}/test.conf
-test_bak=${RSYSLOG_TEST_DIR}/test.bak
+mkdir ${conf_hiddir}
 
-cat << EOF > ${test_subdir_conf}
+test_conf_in_subdir=${conf_subdir}/in_subdir.conf
+test_conf_name_bak=${RSYSLOG_TEST_DIR}/name.bak
+
+test_conf_in_hiddir=${conf_hiddir}/in_hiddir.conf
+test_conf_dot_name=${RSYSLOG_TEST_DIR}/.name.conf
+
+cat << EOF > ${test_conf_in_subdir}
 # rsyslog configuration file
-# test_subdir_conf
-
-#### RULES ####
-
-*.*     ${RSYSLOG_TEST_LOGS[2]}
-EOF
-
-cat << EOF > ${test_conf}
-# rsyslog configuration file
-# test_conf
 
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[1]}
 EOF
 
-cat << EOF > ${test_bak}
+cat << EOF > ${test_conf_name_bak}
 # rsyslog configuration file
-# test_bak
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+cat << EOF > ${test_conf_in_hiddir}
+# rsyslog configuration file
+# not used
 
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[3]}
+EOF
+
+cat << EOF > ${test_conf_dot_name}
+# rsyslog configuration file
+# not used
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[4]}
 EOF
 
 # create rsyslog.conf configuration file

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
@@ -49,8 +49,10 @@ cat << EOF > $RSYSLOG_CONF
 
 include(file="${RSYSLOG_TEST_DIR}/*/*.conf" mode="optional")
 include(file="${RSYSLOG_TEST_DIR}/*.conf" mode="optional")
+include(file="${RSYSLOG_TEST_DIR}" mode="optional")
 
 \$IncludeConfig ${RSYSLOG_TEST_DIR}/*/*.conf
 \$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
+\$IncludeConfig ${RSYSLOG_TEST_DIR}
 
 EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0600.pass.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0600 from $IncludeConfig passes.
+
+source $SHARED/rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[1]}
+chmod $PERMS ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+conf_subdir=${RSYSLOG_TEST_DIR}/subdir
+mkdir ${conf_subdir}
+test_subdir_conf=${conf_subdir}/test_subdir.conf
+test_conf=${RSYSLOG_TEST_DIR}/test.conf
+cat << EOF > ${test_subdir_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${RSYSLOG_TEST_DIR}/*/*.conf" mode="optional")
+include(file="${RSYSLOG_TEST_DIR}/*.conf" mode="optional")
+
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*/*.conf
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
+
+EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
@@ -10,46 +10,59 @@ PERMS_PASS=0600
 PERMS_FAIL=0601
 
 # setup test data
-create_rsyslog_test_logs 4
+create_rsyslog_test_logs 5
 
 # setup test log files and permissions
 chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
 chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[1]}
 chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[2]}
 chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[3]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[4]}
 
-# create test configuration file
+# create test configuration files
 conf_subdir=${RSYSLOG_TEST_DIR}/subdir
+conf_hiddir=${RSYSLOG_TEST_DIR}/.hiddir
 mkdir ${conf_subdir}
-test_subdir_conf=${conf_subdir}/test_subdir.conf
-test_conf=${RSYSLOG_TEST_DIR}/test.conf
-test_bak=${RSYSLOG_TEST_DIR}/test.bak
+mkdir ${conf_hiddir}
 
-cat << EOF > ${test_subdir_conf}
+test_conf_in_subdir=${conf_subdir}/in_subdir.conf
+test_conf_name_bak=${RSYSLOG_TEST_DIR}/name.bak
+
+test_conf_in_hiddir=${conf_hiddir}/in_hiddir.conf
+test_conf_dot_name=${RSYSLOG_TEST_DIR}/.name.conf
+
+cat << EOF > ${test_conf_in_subdir}
 # rsyslog configuration file
-# test_subdir_conf
-
-#### RULES ####
-
-*.*     ${RSYSLOG_TEST_LOGS[2]}
-EOF
-
-cat << EOF > ${test_conf}
-# rsyslog configuration file
-# test_conf
 
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[1]}
 EOF
 
-cat << EOF > ${test_bak}
+cat << EOF > ${test_conf_name_bak}
 # rsyslog configuration file
-# test_bak
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+cat << EOF > ${test_conf_in_hiddir}
+# rsyslog configuration file
+# not used
 
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[3]}
+EOF
+
+cat << EOF > ${test_conf_dot_name}
+# rsyslog configuration file
+# not used
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[4]}
 EOF
 
 # create rsyslog.conf configuration file

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
@@ -50,8 +50,10 @@ cat << EOF > $RSYSLOG_CONF
 
 include(file="${RSYSLOG_TEST_DIR}/*/*.conf" mode="optional")
 include(file="${RSYSLOG_TEST_DIR}/*.conf" mode="optional")
+include(file="${RSYSLOG_TEST_DIR}" mode="optional")
 
 \$IncludeConfig ${RSYSLOG_TEST_DIR}/*/*.conf
 \$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
+\$IncludeConfig ${RSYSLOG_TEST_DIR}
 
 EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+
+# Check rsyslog.conf with log file permissions 0600 from rules and
+# log file permissions 0601 from $IncludeConfig fails.
+
+source $SHARED/rsyslog_log_utils.sh
+
+PERMS_PASS=0600
+PERMS_FAIL=0601
+
+# setup test data
+create_rsyslog_test_logs 3
+
+# setup test log files and permissions
+chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[1]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[2]}
+
+# create test configuration file
+conf_subdir=${RSYSLOG_TEST_DIR}/subdir
+mkdir ${conf_subdir}
+test_subdir_conf=${conf_subdir}/test_subdir.conf
+test_conf=${RSYSLOG_TEST_DIR}/test.conf
+cat << EOF > ${test_subdir_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[2]}
+EOF
+
+cat << EOF > ${test_conf}
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+
+#### MODULES ####
+
+include(file="${RSYSLOG_TEST_DIR}/*/*.conf" mode="optional")
+include(file="${RSYSLOG_TEST_DIR}/*.conf" mode="optional")
+
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*/*.conf
+\$IncludeConfig ${RSYSLOG_TEST_DIR}/*.conf
+
+EOF

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 # Check rsyslog.conf with log file permissions 0600 from rules and
 # log file permissions 0601 from $IncludeConfig fails.

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_config_syntax_perms_0601.fail.sh
@@ -10,20 +10,24 @@ PERMS_PASS=0600
 PERMS_FAIL=0601
 
 # setup test data
-create_rsyslog_test_logs 3
+create_rsyslog_test_logs 4
 
 # setup test log files and permissions
 chmod $PERMS_PASS ${RSYSLOG_TEST_LOGS[0]}
 chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[1]}
 chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[2]}
+chmod $PERMS_FAIL ${RSYSLOG_TEST_LOGS[3]}
 
 # create test configuration file
 conf_subdir=${RSYSLOG_TEST_DIR}/subdir
 mkdir ${conf_subdir}
 test_subdir_conf=${conf_subdir}/test_subdir.conf
 test_conf=${RSYSLOG_TEST_DIR}/test.conf
+test_bak=${RSYSLOG_TEST_DIR}/test.bak
+
 cat << EOF > ${test_subdir_conf}
 # rsyslog configuration file
+# test_subdir_conf
 
 #### RULES ####
 
@@ -32,10 +36,20 @@ EOF
 
 cat << EOF > ${test_conf}
 # rsyslog configuration file
+# test_conf
 
 #### RULES ####
 
 *.*     ${RSYSLOG_TEST_LOGS[1]}
+EOF
+
+cat << EOF > ${test_bak}
+# rsyslog configuration file
+# test_bak
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[3]}
 EOF
 
 # create rsyslog.conf configuration file


### PR DESCRIPTION
* A simple test case as follows:

/etc/rsyslog.conf
```
include(file="/etc/rsyslog.d/*/*.conf" mode="optional")
include(file="/etc/rsyslog.d/*.conf" mode="optional")
```

/etc/rsyslog.d/subdir/custom1.conf
```
local1.* /tmp/local1.out
```

/etc/rsyslog.d/custom2.conf
```
local2.* /tmp/local2.out
```

* Rationale:

With current code, the RSYSLOG_INCLUDE or RSYSLOG_INCLUDE_CONFIG will be read as a string '/etc/rsyslog.d/*.conf' in the for loop.
This patch ensures the wildcard path is expanded to suitable files and then added to the array.