### PR TITLE
Include snapshot cleanup functions for SSGTS

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -45,10 +45,11 @@ _SHARED_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../shared
 
 _SHARED_TEMPLATES = os.path.abspath(os.path.join(SSG_ROOT, 'shared/templates'))
 
+TEST_SUITE_NAME="ssgts"
+TEST_SUITE_PREFIX = "__{}".format(TEST_SUITE_NAME)
 REMOTE_USER = "root"
 REMOTE_USER_HOME_DIRECTORY = "/root"
-REMOTE_TEST_SCENARIOS_DIRECTORY = os.path.join(REMOTE_USER_HOME_DIRECTORY, "ssgts")
-SNAPSHOT_PREFIX = "ssgts_"
+REMOTE_TEST_SCENARIOS_DIRECTORY = os.path.join(REMOTE_USER_HOME_DIRECTORY, TEST_SUITE_NAME)
 
 try:
     SSH_ADDITIONAL_OPTS = tuple(os.environ.get('SSH_ADDITIONAL_OPTIONS').split())
@@ -435,7 +436,7 @@ def template_tests(product=None):
         product_yaml = get_product_context(product)
 
         # Initialize a mock template_builder.
-        empty = "/ssgts/empty/placeholder"
+        empty = "/{}/empty/placeholder".format(TEST_SUITE_NAME)
         template_builder = ssg.templates.Builder(product_yaml, empty,
                                                  _SHARED_TEMPLATES, empty,
                                                  empty)
@@ -520,6 +521,10 @@ def send_scripts(test_env):
     return remote_dir
 
 
+def get_prefixed_name(state_name):
+    return "{}_{}".format(TEST_SUITE_PREFIX, state_name)
+
+
 def get_test_dir_config(test_dir, product_yaml):
     test_config = dict()
     test_config_filename = os.path.join(test_dir, TESTS_CONFIG_NAME)
@@ -575,7 +580,7 @@ def iterate_over_rules(product=None):
     product_yaml = get_product_context(product)
 
     # Initialize a mock template_builder.
-    empty = "/ssgts/empty/placeholder"
+    empty = "/{}/empty/placeholder".format(TEST_SUITE_NAME)
     template_builder = ssg.templates.Builder(product_yaml, empty,
                                              _SHARED_TEMPLATES, empty, empty)
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -48,6 +48,7 @@ _SHARED_TEMPLATES = os.path.abspath(os.path.join(SSG_ROOT, 'shared/templates'))
 REMOTE_USER = "root"
 REMOTE_USER_HOME_DIRECTORY = "/root"
 REMOTE_TEST_SCENARIOS_DIRECTORY = os.path.join(REMOTE_USER_HOME_DIRECTORY, "ssgts")
+SNAPSHOT_PREFIX = "ssgts_"
 
 try:
     SSH_ADDITIONAL_OPTS = tuple(os.environ.get('SSH_ADDITIONAL_OPTIONS').split())

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -320,7 +320,8 @@ class RuleChecker(oscap.Checker):
                                                       self.slice_total)
         self._prepare_environment(sliced_scenarios_by_rule_id)
 
-        with test_env.SavedState.create_from_environment(self.test_env, "tests_uploaded") as state:
+        with test_env.SavedState.create_from_environment(self.test_env,
+                                    common.SNAPSHOT_PREFIX+"tests_uploaded") as state:
             for rule in rules_to_test:
                 try:
                     self.test_rule(state, rule, sliced_scenarios_by_rule_id[rule.id])

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -321,7 +321,7 @@ class RuleChecker(oscap.Checker):
         self._prepare_environment(sliced_scenarios_by_rule_id)
 
         with test_env.SavedState.create_from_environment(self.test_env,
-                                    common.SNAPSHOT_PREFIX+"tests_uploaded") as state:
+            common.SNAPSHOT_PREFIX+"tests_uploaded") as state:
             for rule in rules_to_test:
                 try:
                     self.test_rule(state, rule, sliced_scenarios_by_rule_id[rule.id])

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -320,8 +320,7 @@ class RuleChecker(oscap.Checker):
                                                       self.slice_total)
         self._prepare_environment(sliced_scenarios_by_rule_id)
 
-        with test_env.SavedState.create_from_environment(self.test_env,
-            common.SNAPSHOT_PREFIX+"tests_uploaded") as state:
+        with test_env.SavedState.create_from_environment(self.test_env, "tests_uploaded") as state:
             for rule in rules_to_test:
                 try:
                     self.test_rule(state, rule, sliced_scenarios_by_rule_id[rule.id])
@@ -495,6 +494,7 @@ def perform_rule_check(options):
     checker.scenarios_regex = options.scenarios_regex
     checker.slice_current = options.slice_current
     checker.slice_total = options.slice_total
+    checker.keep_snapshots = options.keep_snapshots
 
     checker.scenarios_profile = options.scenarios_profile
     # check if target is a complete profile ID, if not prepend profile prefix

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -412,9 +412,10 @@ class RuleChecker(oscap.Checker):
 
     @contextlib.contextmanager
     def copy_of_datastream(self, new_filename=None):
+        prefixed_name = common.get_prefixed_name("ds_modified")
         old_filename = self.datastream
         if not new_filename:
-            descriptor, new_filename = tempfile.mkstemp(prefix="ssgts_ds_modified", dir="/tmp")
+            descriptor, new_filename = tempfile.mkstemp(prefix=prefixed_name, dir="/tmp")
         os.close(descriptor)
         shutil.copy(old_filename, new_filename)
         self.datastream = new_filename

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -220,11 +220,7 @@ class VMTestEnv(TestEnv):
         self._origin = None
 
     def snapshot_lookup(self, snapshot_name):
-        try:
-            snapshot = self.domain.snapshotLookupByName(snapshot_name)
-        except Exception as exc:
-            raise RuntimeError(exc)
-        return snapshot
+        return self.domain.snapshotLookupByName(snapshot_name)
 
     def snapshot_cleanup(self):
         snapshot_list = self.domain.snapshotListNames()

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -15,7 +15,7 @@ from ssg_test_suite import common
 
 class SavedState(object):
     def __init__(self, environment, name):
-        self.name = TestEnv.get_prefixed_name(self, name)
+        self.name = common.get_prefixed_name(name)
         self.environment = environment
         self.initial_running_state = True
 
@@ -166,11 +166,8 @@ class TestEnv(object):
     def reset_state_to(self, state_name, new_running_state_name):
         raise NotImplementedError()
 
-    def get_prefixed_name(self, state_name):
-        return common.SNAPSHOT_PREFIX+state_name
-
     def save_state(self, state_name):
-        self.running_state_base = self.get_prefixed_name(state_name)
+        self.running_state_base = common.get_prefixed_name(state_name)
         running_state = self.running_state
         return self._save_state(state_name)
 
@@ -223,8 +220,8 @@ class VMTestEnv(TestEnv):
 
         self._origin = None
 
-    def has_ssgts_prefix(self, snapshot_name):
-        if str(snapshot_name).startswith(common.SNAPSHOT_PREFIX):
+    def has_test_suite_prefix(self, snapshot_name):
+        if str(snapshot_name).startswith(common.TEST_SUITE_PREFIX):
             return True
         return False
 
@@ -234,7 +231,7 @@ class VMTestEnv(TestEnv):
     def snapshots_cleanup(self):
         snapshot_list = self.domain.snapshotListNames()
         for snapshot_name in snapshot_list:
-            if self.has_ssgts_prefix(snapshot_name):
+            if self.has_test_suite_prefix(snapshot_name):
                 snapshot = self.snapshot_lookup(snapshot_name)
                 snapshot.delete()
 
@@ -283,7 +280,7 @@ class VMTestEnv(TestEnv):
         return state
 
     def _save_state(self, state_name):
-        prefixed_state_name = self.get_prefixed_name(state_name)
+        prefixed_state_name = common.get_prefixed_name(state_name)
         state = self.snapshot_stack.create(prefixed_state_name)
         return state
 
@@ -341,7 +338,7 @@ class ContainerTestEnv(TestEnv):
         return new_image_name
 
     def _save_state(self, state_name):
-        prefixed_state_name = self.get_prefixed_name(state_name)
+        prefixed_state_name = common.get_prefixed_name(state_name)
         state = self._create_new_image(self.current_container, prefixed_state_name)
         return state
 

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -133,8 +133,13 @@ def parse_args():
         default=False,
         action="store_true",
         help="Execute all tests even for tests using shared templates; "
-        "otherwise, executes one test per template type"
-    )
+        "otherwise, executes one test per template type")
+
+    common_parser.add_argument(
+        "--keep-snapshots",
+        dest="keep_snapshots",
+        action="store_true",
+        help="Do not remove existing snapshots created during previous tests.")
 
     subparsers = parser.add_subparsers(dest="subparser_name",
                                        help="Subcommands: profile, rule, combined")
@@ -397,7 +402,7 @@ def normalize_passed_arguments(options):
         if not re.match(r"[\w\+]+:///", hypervisor):
             hypervisor = "qemu:///" + hypervisor
         options.test_env = ssg_test_suite.test_env.VMTestEnv(
-            options.scanning_mode, hypervisor, domain_name)
+            options.scanning_mode, hypervisor, domain_name, options.keep_snapshots)
         logging.info(
             "The base image option has not been specified, "
             "choosing libvirt-based test environment.")


### PR DESCRIPTION
#### Description:

Sometimes the SSGTS is interrupted and the created snapshots are not
removed and manual intervention is needed. It was included a feature
to cleanup old snapshots before a new SSGTS round is started.

#### Rationale:

Any automation is welcome during the tests.
