### PR TITLE
Add template mode to SSGTS

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -285,6 +285,7 @@ Mode of operation, specify one of the following commands;
 - `rule`: Evaluate a rule, remediate, and evaluate again in context of test scenarios.
 - `profile`: Evaluate, remediate and evaluate again using selected profile
 - `combined`: Evaluate, remediate, and evaluate again the rules from a profile in context of test scenarios.
+- `template`: Evaluate, remediate, and evaluate again the rules using a given templat in context of test scenarios.
 
 Specify backend and image to use:
 - To use VM backend, use the following option on the command line:
@@ -514,6 +515,23 @@ If you would like to test all profile's rules against their test scenarios:
 ./test_suite.py combined --libvirt qemu:///system ssg-test-suite-rhel8 --datastream ../build/ssg-rhel8-ds.xml ospp
 ```
 
+## Template-based testing
+
+```
+./test_suite.py template ... <template_name other_template>
+
+```
+
+In this mode you can test all rules that use a template.
+This is very useful when one fixes a bug or makes improvements to the template.
+Each rule may use the template in a specfic way and this provides a way to easily
+run the test scenarios for all rules based on their template.
+
+The test scenarios executed are based on the template and the rule that uses it.
+If the specified template doesn't have tests, only the rule's test scenarios are executed,
+and if a rule doesn't have test scenarios it won't be tested.
+If the specified template does have tests they are combined with the rule's tests, this is
+the sambe behavior we see in the rule mode.
 
 # Analysis of results
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -285,7 +285,7 @@ Mode of operation, specify one of the following commands;
 - `rule`: Evaluate a rule, remediate, and evaluate again in context of test scenarios.
 - `profile`: Evaluate, remediate and evaluate again using selected profile
 - `combined`: Evaluate, remediate, and evaluate again the rules from a profile in context of test scenarios.
-- `template`: Evaluate, remediate, and evaluate again the rules using a given templat in context of test scenarios.
+- `template`: Evaluate, remediate, and evaluate again the rules using a given template in context of test scenarios.
 
 Specify backend and image to use:
 - To use VM backend, use the following option on the command line:
@@ -518,7 +518,7 @@ If you would like to test all profile's rules against their test scenarios:
 ## Template-based testing
 
 ```
-./test_suite.py template ... <template_name other_template>
+./test_suite.py template ... <template_name1>[ <template_name2> <template_name3> ...]
 
 ```
 
@@ -531,7 +531,7 @@ The test scenarios executed are based on the template and the rule that uses it.
 If the specified template doesn't have tests, only the rule's test scenarios are executed,
 and if a rule doesn't have test scenarios it won't be tested.
 If the specified template does have tests they are combined with the rule's tests, this is
-the sambe behavior we see in the rule mode.
+the same behavior we see in the rule mode.
 
 # Analysis of results
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -124,6 +124,7 @@ class RuleChecker(oscap.Checker):
         self.results = list()
         self._current_result = None
         self.remote_dir = ""
+        self.target_type = "rule ID"
 
     def _run_test(self, profile, test_data):
         scenario = test_data["scenario"]
@@ -306,7 +307,9 @@ class RuleChecker(oscap.Checker):
     def _test_target(self, target):
         rules_to_test = self._get_rules_to_test(target)
         if not rules_to_test:
-            logging.error("No tests found matching the rule ID(s) '{0}'".format(", ".join(target)))
+            logging.error("No tests found matching the {0}(s) '{1}'".format(
+                self.target_type,
+                ", ".join(target)))
             return
 
         scenarios_by_rule_id = dict()

--- a/tests/ssg_test_suite/template.py
+++ b/tests/ssg_test_suite/template.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python3
 from __future__ import print_function
 
-import logging
-import re
-
 from ssg_test_suite import rule
 
 
@@ -14,7 +11,7 @@ class TemplateChecker(rule.RuleChecker):
 
     If the target template doesn't have tests, only the tests
     from the rules are executed.
-    If there are templated test scenarios they are exeuted together
+    If there are templated test scenarios they are executed together
     with any extra tests available for the rule.
     """
 
@@ -36,7 +33,7 @@ def perform_template_check(options):
     checker.remediate_using = options.remediate_using
     checker.dont_clean = options.dont_clean
     checker.no_reports = options.no_reports
-    # No debug option is provided for combined mode
+    # No debug option is provided for template mode
     checker.manual_debug = False
     checker.benchmark_cpes = options.benchmark_cpes
     checker.scenarios_regex = options.scenarios_regex

--- a/tests/ssg_test_suite/template.py
+++ b/tests/ssg_test_suite/template.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+from __future__ import print_function
+
+import logging
+import re
+
+from ssg_test_suite import rule
+
+
+class TemplateChecker(rule.RuleChecker):
+    """
+    The template mode tests every rule that uses the specified
+    target template.
+
+    If the target template doesn't have tests, only the tests
+    from the rules are executed.
+    If there are templated test scenarios they are exeuted together
+    with any extra tests available for the rule.
+    """
+
+    def _rule_should_be_tested(self, rule, target_templates, tested_templates):
+        if rule.template in target_templates:
+            return True
+        return False
+
+
+def perform_template_check(options):
+    checker = TemplateChecker(options.test_env)
+
+    checker.datastream = options.datastream
+    checker.benchmark_id = options.benchmark_id
+    checker.remediate_using = options.remediate_using
+    checker.dont_clean = options.dont_clean
+    checker.no_reports = options.no_reports
+    # No debug option is provided for combined mode
+    checker.manual_debug = False
+    checker.benchmark_cpes = options.benchmark_cpes
+    checker.scenarios_regex = options.scenarios_regex
+    checker.slice_current = options.slice_current
+    checker.slice_total = options.slice_total
+    checker.scenarios_profile = options.scenarios_profile
+
+    checker.test_target(options.target)
+    return

--- a/tests/ssg_test_suite/template.py
+++ b/tests/ssg_test_suite/template.py
@@ -18,6 +18,10 @@ class TemplateChecker(rule.RuleChecker):
     with any extra tests available for the rule.
     """
 
+    def __init__(self, test_env):
+        super(TemplateChecker, self).__init__(test_env)
+        self.target_type = "template"
+
     def _rule_should_be_tested(self, rule, target_templates, tested_templates):
         if rule.template in target_templates:
             return True

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -22,6 +22,7 @@ import ssg_test_suite.test_env
 import ssg_test_suite.profile
 import ssg_test_suite.rule
 import ssg_test_suite.combined
+import ssg_test_suite.template
 from ssg_test_suite import xml_operations
 
 
@@ -249,8 +250,48 @@ def parse_args():
                                        "in a profile will be evaluated against all its test "
                                        "scenarios."))
 
+    parser_template = subparsers.add_parser("template",
+                                            help=("Tests all rules in a template evaluating them "
+                                                  "against their test scenarios."),
+                                            parents=[common_parser])
+    parser_template.set_defaults(func=ssg_test_suite.template.perform_template_check)
+    parser_template.add_argument("--dontclean",
+                                 dest="dont_clean",
+                                 action="store_true",
+                                 help="Do not remove html reports of successful runs")
+    parser_template.add_argument("--no-reports",
+                                 dest="no_reports",
+                                 action="store_true",
+                                 help="Do not run oscap with --report and --results options")
+    parser_template.add_argument("--scenarios",
+                                 dest="scenarios_regex",
+                                 default=None,
+                                 help="Regular expression matching test scenarios to run")
+    parser_template.add_argument("--profile",
+                                 dest="scenarios_profile",
+                                 default=None,
+                                 help="Override the profile used for test scenarios."
+                                      " Variable selections will be done according "
+                                      "to this profile.")
+    parser_template.add_argument("--slice",
+                                 dest='_slices',
+                                 # real dest is postprocessed later:
+                                 # 'slice_current' and 'slice_total'
+                                 metavar=('X', 'Y'),
+                                 default=[1, 1],
+                                 nargs=2,
+                                 type=int,
+                                 help=("Allows to run only Xth slice of Y in total, to enable "
+                                       "stable parallelization of the bigger test sets."))
+    parser_template.add_argument("target",
+                                 nargs="+",
+                                 metavar="TARGET",
+                                 help=("Template whose rules are to be tested. Each rule using"
+                                       "a template will be evaluated against all its test "
+                                       "scenarios."))
+
     options = parser.parse_args()
-    if options.subparser_name in ["rule", "combined"]:
+    if options.subparser_name in ["rule", "combined", "template"]:
         options.slice_current, options.slice_total = options._slices
         if options.slice_current < 1:
             raise argparse.ArgumentTypeError('Current slice needs to be positive integer')


### PR DESCRIPTION

#### Description:

- This makes it possible to test rules based on their templates.

#### Rationale:

- We often make fixes or improvements to a template in the context of a rule. A rule may trigger a bug in the template or need more features from it. After it has been fixed or improved, it is important to know if the other rules are still working as expected. 
