### PR TITLE
Move to CI to Fedora 35

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -99,10 +99,10 @@ jobs:
         working-directory: ./build
 
   validate-fedora:
-    name: Build, Test on Fedora 34 (Container)
+    name: Build, Test on Fedora Latest (Container)
     runs-on: ubuntu-latest
     container:
-      image: fedora:34
+      image: fedora:latest
     steps:
       - name: Install Deps
         run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Release on Fedora Latest (Container)
     runs-on: ubuntu-latest
     container:
-      image: fedora:34
+      image: fedora:latest
     steps:
       - name: Install Deps
         run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible-lint expat libxslt


### PR DESCRIPTION
#### Description:

Move CI and release jobs to F35.

#### Rationale:
Since Fedora 36 is coming out on May 10th, we should
move to Fedora 35. Fedora 34 will EOL soon.
