### PR TITLE
Workaround for git unsafe repository CVE-2022-24765

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -18,6 +18,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Set git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Find forking point
         env:
           BASE_BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -16,6 +16,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+      # https://github.com/actions/checkout/issues/766
+      - name: Set git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Find forking point
         env:
           BASE_BRANCH: ${{ github.base_ref }}

--- a/.github/workflows/k8s-content.yaml
+++ b/.github/workflows/k8s-content.yaml
@@ -25,6 +25,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      # https://github.com/actions/checkout/issues/766
+      - name: Set git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Login to ghcr.io
         uses: docker/login-action@v1.14.1
         with:

--- a/.github/workflows/ssgts.yaml
+++ b/.github/workflows/ssgts.yaml
@@ -22,6 +22,9 @@ jobs:
         with:
           repository: mildas/content-test-filtering
           path: ctf
+      # https://github.com/actions/checkout/issues/766
+      - name: Set git safe directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Find forking point
         env:
           BASE_BRANCH: ${{ github.base_ref }}


### PR DESCRIPTION
#### Description:
Workaround for working with directory owned by different user.

#### Rationale:
https://github.com/actions/checkout/issues/766

When Github Action is running inside a container, directory there is owned by runner user, not the container user and it's causing the issue.
