### PR TITLE
Use secret token to publish pages to a different repository

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -33,12 +33,18 @@ jobs:
         shell: bash
         env:
           PYTHONPATH: ${{ github.workspace }}
+      - name: Configure git to trust the workspace despite the different owner
+        run:
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Deploy
-        if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@v4.2.3
+        if: ${{ github.event_name == 'push' && github.repository == 'ComplianceAsCode/content' }}
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
           branch: main # The branch the action should deploy to.
           folder: ${{ env.PAGES_DIR }} # The folder the action should deploy.
           clean-exclude: srg_mapping/*
           repository-name: ComplianceAsCode/content-pages
           single-commit: true
+          token: ${{ secrets.CONTENT_PAGES_TOKEN }}
+          git-config-name: openscap-ci
+          git-config-email: openscap-ci@gmail.com

--- a/.github/workflows/srg-mapping-table.yaml
+++ b/.github/workflows/srg-mapping-table.yaml
@@ -52,9 +52,12 @@ jobs:
       - name: Generate HTML pages
         run: utils/generate_html_index_srg_mapping.sh $PAGES_DIR "rhel9" # add more products to this list to generate their index
         shell: bash
+      - name: Configure git to trust the workspace despite the different owner
+        run:
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Deploy
-        if: ${{ github.event_name == 'push' }}
-        uses: JamesIves/github-pages-deploy-action@v4.2.3
+        if: ${{ github.event_name == 'push' && github.repository == 'ComplianceAsCode/content' }}
+        uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
           branch: main # The branch the action should deploy to.
           folder: ${{ env.PAGES_DIR }} # The folder the action should deploy.
@@ -62,3 +65,7 @@ jobs:
           clean: false
           repository-name: ComplianceAsCode/content-pages
           single-commit: true
+          token: ${{ secrets.CONTENT_PAGES_TOKEN }}
+          git-config-name: openscap-ci
+          git-config-email: openscap-ci@gmail.com
+


### PR DESCRIPTION
#### Description:

- Use secret token to publish pages to a different repository.

Don't merge as the removed `if` statement should be brought back in the end. We are going to test if the publishing part is working for a different repository.

