### PR TITLE
Change platform loading and handling of conditionals

### DIFF
--- a/shared/applicability/s390x_arch.yml
+++ b/shared/applicability/s390x_arch.yml
@@ -1,4 +1,5 @@
 name: cpe:/a:s390x_arch
 title: System architecture is S390X
 check_id: proc_sys_kernel_osrelease_arch_s390x
-bash_conditional: grep -q s390x /proc/sys/kernel/osrelease
+bash_conditional:
+    conditional: grep -q s390x /proc/sys/kernel/osrelease

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -36,11 +36,6 @@ class ProductCPEs(object):
         #self.load_product_cpes(product_yaml)
         #self.load_content_cpes()
 
-    def _load_cpes_list(self, map_, cpes_list):
-        for cpe in cpes_list:
-            for cpe_id in cpe.keys():
-                map_[cpe_id] = CPEItem.get_instance_from_full_dict(cpe[cpe_id])
-
     def load_product_cpes(self, env_yaml):
         try:
             product_cpes_list = env_yaml["cpes"]
@@ -78,9 +73,6 @@ class ProductCPEs(object):
                 )
                 continue
 
-            # Get past "cpes" key, which was added for readability of the content
-            #cpes_list = open_and_macro_expand(dir_item_path, self.product_yaml)["cpes"]
-            #self._load_cpes_list(self.cpes_by_id, cpes_list)
             cpe = CPEItem.from_yaml(dir_item_path, env_yaml)
             self.cpes_by_id[cpe.id_] = cpe
             if cpe.is_product_cpe == "true":

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -413,10 +413,10 @@ class AnsibleRemediation(Remediation):
                     if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            cpe_platforms[p].to_ansible_conditional()
+            cpe_platforms[p].get_ansible_conditional()
             for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            cpe_platforms[p].to_ansible_conditional()
+            cpe_platforms[p].get_ansible_conditional()
             for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1882,13 +1882,11 @@ class Platform(XCCDFEntity):
         id = test.as_id()
         platform = cls(id)
         platform.test = test
-        platform.test.enrich_with_cpe_info(product_cpes)
+        # in case some cpe_items were parametrized, we might need to create new CPE items
+        platform.test.add_enriched_cpe_items(product_cpes)
         platform.name = id
         platform.original_expression = expression
         platform.xml_content = platform.get_xml()
-        platform.bash_conditional_line = platform.test.get_bash_conditional_line()
-        platform.bash_inserted_before_remediation = platform.test.get_bash_inserted_before_remediation()
-        platform.ansible_conditional = platform.test.to_ansible_conditional()
         return platform
 
     def get_xml(self):
@@ -1916,18 +1914,21 @@ class Platform(XCCDFEntity):
     def get_bash_inserted_before_remediation(self):
         return self.bash_inserted_before_remediation
 
-    def to_ansible_conditional(self):
+    def get_ansible_conditional(self):
         return self.ansible_conditional
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None):
         platform = super(Platform, cls).from_yaml(yaml_file, env_yaml)
-        platform.xml_content = ET.fromstring(platform.xml_content)
         # if we did receive a product_cpes, we can restore also the original test object
         # it can be later used e.g. for comparison
         if product_cpes:
             platform.test = product_cpes.algebra.parse(
                 platform.original_expression, simplify=True)
+            platform.bash_conditional_line = platform.test.get_bash_conditional_line(product_cpes)
+            platform.bash_inserted_before_remediation = platform.test.get_bash_inserted_before_remediation(product_cpes)
+            platform.ansible_conditional = platform.test.get_ansible_conditional(product_cpes)
+
         return platform
 
     def __eq__(self, other):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1908,7 +1908,7 @@ class Platform(XCCDFEntity):
         return xmlstr
 
     def to_xml_element(self):
-        return self.xml_content
+        return ET.fromstring(self.xml_content)
 
     def get_bash_conditional_line(self):
         return self.bash_conditional_line

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1809,11 +1809,13 @@ class LinearLoader(object):
         filenames = glob.glob(os.path.join(self.resolved_values_dir, "*.yml"))
         self.load_entities_by_id(filenames, self.values, Value)
 
+        self.product_cpes.load_cpes_from_directory_tree(self.resolved_cpe_items_dir, self.env_yaml)
+
         filenames = glob.glob(os.path.join(self.resolved_platforms_dir, "*.yml"))
         self.load_entities_by_id(filenames, self.platforms, Platform)
         self.product_cpes.platforms = self.platforms
 
-        self.product_cpes.load_cpes_from_directory_tree(self.resolved_cpe_items_dir, self.env_yaml)
+    
 
         for g in self.groups.values():
             g.load_entities(self.rules, self.values, self.groups)

--- a/tests/unit/ssg-module/test_build_cpe.py
+++ b/tests/unit/ssg-module/test_build_cpe.py
@@ -124,7 +124,7 @@ def test_product_cpes():
     assert(rhel7_cpe.name == "cpe:/o:redhat:enterprise_linux:7")
     assert(rhel7_cpe.title == "Red Hat Enterprise Linux 7")
     assert(rhel7_cpe.check_id == "installed_OS_is_rhel7")
-    assert(rhel7_cpe.bash_conditional == "")
+    assert(rhel7_cpe.bash_conditional == {})
     assert(rhel7_cpe.ansible_conditional == "")
 
     # get CPE by ID and verify it's loaded, the get_cpe method should return

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -152,11 +152,7 @@ def test_platform_from_text_unknown_platform(product_cpes):
 
 def test_platform_from_text_simple(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("machine", product_cpes)
-    assert platform.to_ansible_conditional() == \
-        "ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"]"
-    assert platform.get_bash_conditional_line() == \
-        "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]"
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "machine"
     logical_tests = platform_el.findall(
@@ -172,9 +168,7 @@ def test_platform_from_text_simple(product_cpes):
 
 def test_platform_from_text_simple_product_cpe(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("rhel7-workstation", product_cpes)
-    assert platform.get_bash_conditional_line() == ""
-    assert platform.to_ansible_conditional() == ""
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "rhel7-workstation"
     logical_tests = platform_el.findall(
@@ -191,10 +185,7 @@ def test_platform_from_text_simple_product_cpe(product_cpes):
 
 def test_platform_from_text_or(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("ntp or chrony", product_cpes)
-    assert platform.get_bash_conditional_line() == "( rpm --quiet -q chrony || rpm --quiet -q ntp )"
-    assert platform.to_ansible_conditional() == \
-        "( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages )"
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "chrony_or_ntp"
     logical_tests = platform_el.findall(
@@ -212,9 +203,7 @@ def test_platform_from_text_or(product_cpes):
 def test_platform_from_text_complex_expression(product_cpes):
     platform = ssg.build_yaml.Platform.from_text(
         "systemd and !yum and (ntp or chrony)", product_cpes)
-    assert platform.get_bash_conditional_line() == "( rpm --quiet -q systemd && ( rpm --quiet -q chrony || rpm --quiet -q ntp ) && ! ( rpm --quiet -q yum ) )"
-    assert platform.to_ansible_conditional() == "( \"systemd\" in ansible_facts.packages and ( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages ) and not ( \"yum\" in ansible_facts.packages ) )"
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "systemd_and_chrony_or_ntp_and_not_yum"
     logical_tests = platform_el.findall(
@@ -260,6 +249,4 @@ def test_platform_as_dict(product_cpes):
     assert d["name"] == "chrony_and_rhel7"
     # the "rhel7" platform doesn't have any conditionals
     # therefore the final conditional doesn't use it
-    assert d["ansible_conditional"] == "( \"chrony\" in ansible_facts.packages )"
-    assert d["bash_conditional_line"] == "( rpm --quiet -q chrony )"
     assert "xml_content" in d


### PR DESCRIPTION
#### Description:

- platforms are now loaded differently
-   - when loaded from the textual expression, any additional CPE items are automatically created (templated items, version comparison items etc)
- the conditionals are no longer stored along platforms but rather they are  evaluated when needed using currently loaded CPE items so that they are present only in one place
- some minor cleanups
