### PR TITLE
Update ocp4_content fedora version to latest

### DIFF
--- a/Dockerfiles/ocp4_content
+++ b/Dockerfiles/ocp4_content
@@ -1,9 +1,6 @@
 # This dockerfile builds the content in the current repo for OCP4
-#
-# We're using Fedora 34 here because we're hitting issues with Fedora 35 (e.g.,
-# https://bugzilla.redhat.com/show_bug.cgi?id=2009047). Update this when Fedora
-# 35 is fixed.
-FROM registry.fedoraproject.org/fedora-minimal:34 as builder
+
+FROM registry.fedoraproject.org/fedora-minimal:latest as builder
 
 WORKDIR /content
 


### PR DESCRIPTION
Fedora 35 recently updated podman to 3.4.7 from 3.4.4. This included a
fix so that dnf works [0].

This commit removes the f34 image and uses latest instead. If you hit
issues building newer versions of ocp4_content locally, please make sure
podman is updated to version 3.4.7.

[0] https://github.com/containers/buildah/issues/3776 (related-content)
