### PR TITLE
Refactor rule's test scenarios selection

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -40,9 +40,7 @@ class CombinedChecker(rule.RuleChecker):
         self.run_aborted = False
 
     def _rule_should_be_tested(self, rule_short_id, rules_to_be_tested):
-        if rule_short_id not in rules_to_be_tested:
-            return False
-        return True
+        return (rule_short_id in rules_to_be_tested)
 
     def _modify_parameters(self, script, params):
         # If there is no profiles metadata in a script we will use

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -39,8 +39,8 @@ class CombinedChecker(rule.RuleChecker):
         self._current_result = None
         self.run_aborted = False
 
-    def _rule_should_be_tested(self, rule, rules_to_be_tested):
-        if rule.short_id not in rules_to_be_tested:
+    def _rule_should_be_tested(self, rule_short_id, rules_to_be_tested):
+        if rule_short_id not in rules_to_be_tested:
             return False
         return True
 

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -39,8 +39,8 @@ class CombinedChecker(rule.RuleChecker):
         self._current_result = None
         self.run_aborted = False
 
-    def _rule_should_be_tested(self, rule_short_id, rules_to_be_tested):
-        return (rule_short_id in rules_to_be_tested)
+    def _rule_matches_rule_spec(self, rule_short_id):
+        return (rule_short_id in self.rule_spec)
 
     def _modify_parameters(self, script, params):
         # If there is no profiles metadata in a script we will use
@@ -117,6 +117,8 @@ def perform_combined_check(options):
         checker.profile = profile
         target_rules = checker._generate_target_rules(profile)
 
+        checker.rule_spec = target_rules
+        checker.template_spec = None
         checker.test_target(target_rules)
         if checker.run_aborted:
             return

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -39,10 +39,10 @@ class CombinedChecker(rule.RuleChecker):
         self._current_result = None
         self.run_aborted = False
 
-    def _rule_should_be_tested(self, rule, rules_to_be_tested, tested_templates):
+    def _rule_should_be_tested(self, rule, rules_to_be_tested):
         if rule.short_id not in rules_to_be_tested:
             return False
-        return not self._rule_template_been_tested(rule, tested_templates)
+        return True
 
     def _modify_parameters(self, script, params):
         # If there is no profiles metadata in a script we will use

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -76,11 +76,11 @@ class CombinedChecker(rule.RuleChecker):
                       "rules: {1}".format(profile, target_rules))
         return target_rules
 
-    def _test_target(self, target):
-        self.rules_not_tested_yet = set(target)
+    def _test_target(self):
+        self.rules_not_tested_yet = set(self.rule_spec)
 
         try:
-            super(CombinedChecker, self)._test_target(target)
+            super(CombinedChecker, self)._test_target()
         except KeyboardInterrupt as exec_interrupt:
             self.run_aborted = True
             raise exec_interrupt
@@ -119,6 +119,6 @@ def perform_combined_check(options):
 
         checker.rule_spec = target_rules
         checker.template_spec = None
-        checker.test_target(target_rules)
+        checker.test_target()
         if checker.run_aborted:
             return

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -575,6 +575,19 @@ def fetch_templated_test_scenarios(
     return all_tests
 
 
+def fetch_local_test_scenarios(tests_dir, local_env_yaml):
+    all_tests = dict()
+    if os.path.exists(tests_dir):
+        tests_dir_files = os.listdir(tests_dir)
+        for test_case in tests_dir_files:
+            test_path = os.path.join(tests_dir, test_case)
+            if os.path.isdir(test_path):
+                continue
+            all_tests[test_case] = process_file_with_macros(
+                test_path, local_env_yaml)
+    return all_tests
+
+
 def iterate_over_rules(product=None):
     """Iterate over rule directories which have test scenarios".
 
@@ -640,18 +653,9 @@ def iterate_over_rules(product=None):
             # Add additional tests from the local rule directory. Note that,
             # like the behavior in template_tests, this will overwrite any
             # templated tests with the same file name.
-            if os.path.exists(tests_dir):
-                tests_dir_files = os.listdir(tests_dir)
-                for test_case in tests_dir_files:
-                    # Skip vim swap files,
-                    # they are not relevant and cause Jinja expansion tracebacks
-                    if test_case.endswith(".swp"):
-                        continue
-                    test_path = os.path.join(tests_dir, test_case)
-                    if os.path.isdir(test_path):
-                        continue
-
-                    all_tests[test_case] = process_file_with_macros(test_path, local_env_yaml)
+            local_test_scenarios = fetch_local_test_scenarios(
+                tests_dir, local_env_yaml)
+            all_tests.update(local_test_scenarios)
 
             # Filter out everything except the shell test scenarios.
             # Other files in rule directories are editor swap files

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -31,8 +31,6 @@ Scenario_run = namedtuple(
 Scenario_conditions = namedtuple(
     "Scenario_conditions",
     ("backend", "scanning_mode", "remediated_by", "datastream"))
-Rule = namedtuple(
-    "Rule", ["directory", "id", "short_id", "template", "local_env_yaml", "rule"])
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -588,7 +588,7 @@ def fetch_local_test_scenarios(tests_dir, local_env_yaml):
     return all_tests
 
 
-def iterate_over_rules(product=None):
+def iterate_over_rules(template_builder, product=None):
     """Iterate over rule directories which have test scenarios".
 
     Returns:
@@ -609,11 +609,6 @@ def iterate_over_rules(product=None):
     #
     # Begin by loading context about our execution environment, if any.
     product_yaml = get_product_context(product)
-
-    # Initialize a mock template_builder.
-    empty = "/{}/empty/placeholder".format(TEST_SUITE_NAME)
-    template_builder = ssg.templates.Builder(product_yaml, empty,
-                                             _SHARED_TEMPLATES, empty, empty)
 
     for dirpath, dirnames, filenames in walk_through_benchmark_dirs(product):
         if is_rule_dir(dirpath):

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -562,6 +562,19 @@ def select_templated_tests(test_dir_config, available_scenarios_basenames):
     return available_scenarios_basenames
 
 
+def fetch_templated_test_scenarios(
+        rule, template_builder, test_config, local_env_yaml):
+    if not rule.template or not rule.template['vars']:
+        return dict()
+    templated_tests = template_builder.get_all_tests(
+        rule.id_, rule.template, local_env_yaml)
+
+    allowed_templated_tests = select_templated_tests(
+        test_config, templated_tests.keys())
+    all_tests = {name: templated_tests[name] for name in allowed_templated_tests}
+    return all_tests
+
+
 def iterate_over_rules(product=None):
     """Iterate over rule directories which have test scenarios".
 
@@ -620,13 +633,9 @@ def iterate_over_rules(product=None):
 
             # Start by checking for templating tests and provision them if
             # present.
-            if rule.template and rule.template['vars']:
-                templated_tests = template_builder.get_all_tests(
-                    rule.id_, rule.template, local_env_yaml)
-
-                allowed_templated_tests = select_templated_tests(
-                    test_config, templated_tests.keys())
-                all_tests.update({name: templated_tests[name] for name in allowed_templated_tests})
+            templated_test_scenarios = fetch_templated_test_scenarios(
+                rule, template_builder, test_config, local_env_yaml)
+            all_tests.update(templated_test_scenarios)
 
             # Add additional tests from the local rule directory. Note that,
             # like the behavior in template_tests, this will overwrite any

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -589,38 +589,6 @@ def fetch_local_test_scenarios(tests_dir, local_env_yaml):
     return all_tests
 
 
-def fetch_test_scenarios(
-        tests_dir, rule, template_builder, product_yaml, local_env_yaml):
-    # All tests is a mapping from path (in the tarball) to contents
-    # of the test case. This is necessary because later code (which
-    # attempts to parse headers from the test case) don't have easy
-    # access to templated content. By reading it and returning it
-    # here, we can save later code from having to understand the
-    # templating system.
-    all_tests = dict()
-
-    # Start by checking for templating tests and provision them if
-    # present.
-    templated_test_scenarios = fetch_templated_test_scenarios(
-        rule, template_builder, tests_dir, product_yaml, local_env_yaml)
-    all_tests.update(templated_test_scenarios)
-
-    # Add additional tests from the local rule directory. Note that,
-    # like the behavior in template_tests, this will overwrite any
-    # templated tests with the same file name.
-    local_test_scenarios = fetch_local_test_scenarios(
-        tests_dir, local_env_yaml)
-    all_tests.update(local_test_scenarios)
-
-    # Filter out everything except the shell test scenarios.
-    # Other files in rule directories are editor swap files
-    # or other content than a test case.
-    allowed_scripts = filter(lambda x: x.endswith(".sh"), all_tests)
-    content_mapping = {x: all_tests[x] for x in allowed_scripts}
-
-    return content_mapping
-
-
 def iterate_over_rules(product=None):
     """Iterate over rule directories which have test scenarios".
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -32,7 +32,7 @@ Scenario_conditions = namedtuple(
     "Scenario_conditions",
     ("backend", "scanning_mode", "remediated_by", "datastream"))
 Rule = namedtuple(
-    "Rule", ["directory", "id", "short_id", "scenarios", "template"])
+    "Rule", ["directory", "id", "short_id", "scenarios", "template", "local_env_yaml"])
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -675,7 +675,8 @@ def iterate_over_rules(product=None):
                 template_name = rule.template['name']
             result = Rule(
                 directory=tests_dir, id=full_rule_id, short_id=short_rule_id,
-                scenarios=content_mapping, template=template_name)
+                scenarios=content_mapping, template=template_name,
+                local_env_yaml=local_env_yaml)
             yield result
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -599,8 +599,9 @@ def iterate_over_rules(product=None):
             id -- full rule id as it is present in datastream
             short_id -- short rule ID, the same as basename of the directory
                         containing the test scenarios in Bash
-            scenarios -- dictionary mapping names of executable .sh files in
-                         the uploaded tarball to their content
+            template -- name of the template the rule uses
+            local_env_yaml -- env_yaml specific to rule's own context
+            rule -- rule class, contains information parsed from rule.yml
     """
 
     # Here we need to perform some magic to handle parsing the rule (from a

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -589,6 +589,38 @@ def fetch_local_test_scenarios(tests_dir, local_env_yaml):
     return all_tests
 
 
+def fetch_test_scenarios(
+        tests_dir, rule, template_builder, product_yaml, local_env_yaml):
+    # All tests is a mapping from path (in the tarball) to contents
+    # of the test case. This is necessary because later code (which
+    # attempts to parse headers from the test case) don't have easy
+    # access to templated content. By reading it and returning it
+    # here, we can save later code from having to understand the
+    # templating system.
+    all_tests = dict()
+
+    # Start by checking for templating tests and provision them if
+    # present.
+    templated_test_scenarios = fetch_templated_test_scenarios(
+        rule, template_builder, tests_dir, product_yaml, local_env_yaml)
+    all_tests.update(templated_test_scenarios)
+
+    # Add additional tests from the local rule directory. Note that,
+    # like the behavior in template_tests, this will overwrite any
+    # templated tests with the same file name.
+    local_test_scenarios = fetch_local_test_scenarios(
+        tests_dir, local_env_yaml)
+    all_tests.update(local_test_scenarios)
+
+    # Filter out everything except the shell test scenarios.
+    # Other files in rule directories are editor swap files
+    # or other content than a test case.
+    allowed_scripts = filter(lambda x: x.endswith(".sh"), all_tests)
+    content_mapping = {x: all_tests[x] for x in allowed_scripts}
+
+    return content_mapping
+
+
 def iterate_over_rules(template_builder, product=None):
     """Iterate over rule directories which have test scenarios".
 
@@ -629,35 +661,9 @@ def iterate_over_rules(template_builder, product=None):
                 if "all" not in prodtypes and product not in prodtypes:
                     continue
 
-            # All tests is a mapping from path (in the tarball) to contents
-            # of the test case. This is necessary because later code (which
-            # attempts to parse headers from the test case) don't have easy
-            # access to templated content. By reading it and returning it
-            # here, we can save later code from having to understand the
-            # templating system.
-            all_tests = dict()
-
             tests_dir = os.path.join(dirpath, "tests")
-
-            # Start by checking for templating tests and provision them if
-            # present.
-            templated_test_scenarios = fetch_templated_test_scenarios(
-                rule, template_builder, tests_dir, product_yaml, local_env_yaml)
-            all_tests.update(templated_test_scenarios)
-
-            # Add additional tests from the local rule directory. Note that,
-            # like the behavior in template_tests, this will overwrite any
-            # templated tests with the same file name.
-            local_test_scenarios = fetch_local_test_scenarios(
-                tests_dir, local_env_yaml)
-            all_tests.update(local_test_scenarios)
-
-            # Filter out everything except the shell test scenarios.
-            # Other files in rule directories are editor swap files
-            # or other content than a test case.
-            allowed_scripts = filter(lambda x: x.endswith(".sh"), all_tests)
-            content_mapping = {x: all_tests[x] for x in allowed_scripts}
-
+            content_mapping = fetch_test_scenarios(
+                tests_dir, rule, template_builder, product_yaml, local_env_yaml)
             # Skip any rules that lack any content. This ensures that if we
             # end up with rules with a template lacking tests and without any
             # rule directory tests, we don't include the empty rule here.

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -32,7 +32,7 @@ Scenario_conditions = namedtuple(
     "Scenario_conditions",
     ("backend", "scanning_mode", "remediated_by", "datastream"))
 Rule = namedtuple(
-    "Rule", ["directory", "id", "short_id", "scenarios_basenames", "template"])
+    "Rule", ["directory", "id", "short_id", "scenarios", "template"])
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -572,7 +572,8 @@ def iterate_over_rules(product=None):
             id -- full rule id as it is present in datastream
             short_id -- short rule ID, the same as basename of the directory
                         containing the test scenarios in Bash
-            scenarios_basenames -- list of executable .sh files in the uploaded tarball
+            scenarios -- dictionary mapping names of executable .sh files in
+                         the uploaded tarball to their content
     """
 
     # Here we need to perform some magic to handle parsing the rule (from a
@@ -660,7 +661,7 @@ def iterate_over_rules(product=None):
             full_rule_id = OSCAP_RULE + short_rule_id
             result = Rule(
                 directory=tests_dir, id=full_rule_id, short_id=short_rule_id,
-                scenarios_basenames=content_mapping, template=template_name)
+                scenarios=content_mapping, template=template_name)
             yield result
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -560,14 +560,16 @@ def select_templated_tests(test_dir_config, available_scenarios_basenames):
     return available_scenarios_basenames
 
 
-def fetch_templated_test_scenarios(
-        rule, template_builder, tests_dir, product_yaml, local_env_yaml):
-    test_config = get_test_dir_config(tests_dir, product_yaml)
+def fetch_templated_test_scenarios(rule, template_builder, local_env_yaml):
     if not rule.template or not rule.template['vars']:
         return dict()
     templated_tests = template_builder.get_all_tests(
         rule.id_, rule.template, local_env_yaml)
+    return templated_tests
 
+
+def apply_test_config(tests_dir, product_yaml, templated_tests):
+    test_config = get_test_dir_config(tests_dir, product_yaml)
     allowed_templated_tests = select_templated_tests(
         test_config, templated_tests.keys())
     all_tests = {name: templated_tests[name] for name in allowed_templated_tests}

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -32,7 +32,7 @@ Scenario_conditions = namedtuple(
     "Scenario_conditions",
     ("backend", "scanning_mode", "remediated_by", "datastream"))
 Rule = namedtuple(
-    "Rule", ["directory", "id", "short_id", "scenarios", "template", "local_env_yaml"])
+    "Rule", ["directory", "id", "short_id", "scenarios", "template", "local_env_yaml", "rule"])
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -671,7 +671,7 @@ def iterate_over_rules(template_builder, product=None):
             result = Rule(
                 directory=tests_dir, id=full_rule_id, short_id=short_rule_id,
                 scenarios=content_mapping, template=template_name,
-                local_env_yaml=local_env_yaml)
+                local_env_yaml=local_env_yaml, rule=rule)
             yield result
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -595,7 +595,6 @@ def iterate_over_rules(product=None):
 
             # Load the rule itself to check for a template.
             rule, local_env_yaml = load_rule_and_env(dirpath, product_yaml, product)
-            template_name = None
 
             # Before we get too far, we wish to search the rule YAML to see if
             # it is applicable to the current product. If we have a product
@@ -628,7 +627,6 @@ def iterate_over_rules(product=None):
                 allowed_templated_tests = select_templated_tests(
                     test_config, templated_tests.keys())
                 all_tests.update({name: templated_tests[name] for name in allowed_templated_tests})
-                template_name = rule.template['name']
 
             # Add additional tests from the local rule directory. Note that,
             # like the behavior in template_tests, this will overwrite any
@@ -659,6 +657,9 @@ def iterate_over_rules(product=None):
                 continue
 
             full_rule_id = OSCAP_RULE + short_rule_id
+            template_name = None
+            if rule.template and rule.template['vars']:
+                template_name = rule.template['name']
             result = Rule(
                 directory=tests_dir, id=full_rule_id, short_id=short_rule_id,
                 scenarios=content_mapping, template=template_name)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -563,7 +563,8 @@ def select_templated_tests(test_dir_config, available_scenarios_basenames):
 
 
 def fetch_templated_test_scenarios(
-        rule, template_builder, test_config, local_env_yaml):
+        rule, template_builder, tests_dir, product_yaml, local_env_yaml):
+    test_config = get_test_dir_config(tests_dir, product_yaml)
     if not rule.template or not rule.template['vars']:
         return dict()
     templated_tests = template_builder.get_all_tests(
@@ -637,12 +638,11 @@ def iterate_over_rules(template_builder, product=None):
             all_tests = dict()
 
             tests_dir = os.path.join(dirpath, "tests")
-            test_config = get_test_dir_config(tests_dir, product_yaml)
 
             # Start by checking for templating tests and provision them if
             # present.
             templated_test_scenarios = fetch_templated_test_scenarios(
-                rule, template_builder, test_config, local_env_yaml)
+                rule, template_builder, tests_dir, product_yaml, local_env_yaml)
             all_tests.update(templated_test_scenarios)
 
             # Add additional tests from the local rule directory. Note that,

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -32,7 +32,7 @@ Scenario_conditions = namedtuple(
     "Scenario_conditions",
     ("backend", "scanning_mode", "remediated_by", "datastream"))
 Rule = namedtuple(
-    "Rule", ["directory", "id", "short_id", "scenarios", "template", "local_env_yaml", "rule"])
+    "Rule", ["directory", "id", "short_id", "template", "local_env_yaml", "rule"])
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
@@ -621,7 +621,7 @@ def fetch_test_scenarios(
     return content_mapping
 
 
-def iterate_over_rules(template_builder, product=None):
+def iterate_over_rules(product=None):
     """Iterate over rule directories which have test scenarios".
 
     Returns:
@@ -662,13 +662,6 @@ def iterate_over_rules(template_builder, product=None):
                     continue
 
             tests_dir = os.path.join(dirpath, "tests")
-            content_mapping = fetch_test_scenarios(
-                tests_dir, rule, template_builder, product_yaml, local_env_yaml)
-            # Skip any rules that lack any content. This ensures that if we
-            # end up with rules with a template lacking tests and without any
-            # rule directory tests, we don't include the empty rule here.
-            if not content_mapping:
-                continue
 
             full_rule_id = OSCAP_RULE + short_rule_id
             template_name = None
@@ -676,7 +669,7 @@ def iterate_over_rules(template_builder, product=None):
                 template_name = rule.template['name']
             result = Rule(
                 directory=tests_dir, id=full_rule_id, short_id=short_rule_id,
-                scenarios=content_mapping, template=template_name,
+                template=template_name,
                 local_env_yaml=local_env_yaml, rule=rule)
             yield result
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -589,60 +589,6 @@ def fetch_local_test_scenarios(tests_dir, local_env_yaml):
     return all_tests
 
 
-def iterate_over_rules(product=None):
-    """Iterate over rule directories which have test scenarios".
-
-    Returns:
-        Named tuple Rule having these fields:
-            directory -- absolute path to the rule "tests" subdirectory
-                         containing the test scenarios in Bash
-            id -- full rule id as it is present in datastream
-            short_id -- short rule ID, the same as basename of the directory
-                        containing the test scenarios in Bash
-            template -- name of the template the rule uses
-            local_env_yaml -- env_yaml specific to rule's own context
-            rule -- rule class, contains information parsed from rule.yml
-    """
-
-    # Here we need to perform some magic to handle parsing the rule (from a
-    # product perspective) and loading any templated tests. In particular,
-    # identifying which tests to potentially run involves invoking the
-    # templating engine.
-    #
-    # Begin by loading context about our execution environment, if any.
-    product_yaml = get_product_context(product)
-
-    for dirpath, dirnames, filenames in walk_through_benchmark_dirs(product):
-        if is_rule_dir(dirpath):
-            short_rule_id = os.path.basename(dirpath)
-
-            # Load the rule itself to check for a template.
-            rule, local_env_yaml = load_rule_and_env(dirpath, product_yaml, product)
-
-            # Before we get too far, we wish to search the rule YAML to see if
-            # it is applicable to the current product. If we have a product
-            # and the rule isn't applicable for the product, there's no point
-            # in continuing with the rest of the loading. This should speed up
-            # the loading of the templated tests. Note that we've already
-            # parsed the prodtype into local_env_yaml
-            if product and local_env_yaml['products']:
-                prodtypes = local_env_yaml['products']
-                if "all" not in prodtypes and product not in prodtypes:
-                    continue
-
-            tests_dir = os.path.join(dirpath, "tests")
-
-            full_rule_id = OSCAP_RULE + short_rule_id
-            template_name = None
-            if rule.template and rule.template['vars']:
-                template_name = rule.template['name']
-            result = Rule(
-                directory=tests_dir, id=full_rule_id, short_id=short_rule_id,
-                template=template_name,
-                local_env_yaml=local_env_yaml, rule=rule)
-            yield result
-
-
 def get_cpe_of_tested_os(test_env, log_file):
     os_release_file = "/etc/os-release"
     cpe_line = test_env.execute_ssh_command(

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -693,10 +693,10 @@ class Checker(object):
         now = datetime.datetime.now()
         self.test_timestamp_str = now.strftime("%Y-%m-%d %H:%M")
 
-    def test_target(self, target):
+    def test_target(self):
         self.start()
         try:
-            self._test_target(target)
+            self._test_target()
         except KeyboardInterrupt:
             logging.info("Terminating the test run due to keyboard interrupt.")
         except RuntimeError as exc:
@@ -714,7 +714,7 @@ class Checker(object):
         elif profiles:
             self._run_test(profiles[0], test_data)
 
-    def _test_target(self, target):
+    def _test_target(self):
         raise NotImplementedError()
 
     def _run_test(self, profile, test_data):

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -16,9 +16,9 @@ class ProfileChecker(ssg_test_suite.oscap.Checker):
     using every profile according to input. Also perform remediation run.
     Return value not defined, textual output and generated reports is the result.
     """
-    def _test_target(self, target):
+    def _test_target(self):
         profiles = get_viable_profiles(
-            target, self.datastream, self.benchmark_id)
+            self.profile_spec, self.datastream, self.benchmark_id)
         self.run_test_for_all_profiles(profiles)
 
     def _run_test(self, profile, test_data):
@@ -44,5 +44,6 @@ def perform_profile_check(options):
     checker.datastream = options.datastream
     checker.benchmark_id = options.benchmark_id
     checker.remediate_using = options.remediate_using
+    checker.profile_spec = options.target
 
-    checker.test_target(options.target)
+    checker.test_target()

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -381,21 +381,26 @@ class RuleChecker(oscap.Checker):
 
         return params
 
+    def _scenario_matches_regex(self, scenario):
+        if self.scenarios_regex is not None:
+            scenarios_pattern = re.compile(self.scenarios_regex)
+            if scenarios_pattern.match(scenario.script) is None:
+                logging.debug(
+                    "Skipping script %s - it did not match "
+                    "--scenarios regex" % scenario.script
+                )
+                return False
+        return True
+
     def _filter_scenarios(self, scenarios):
         """ Returns only valid scenario files, rest is ignored (is not meant
         to be executed directly.
         """
 
-        if self.scenarios_regex is not None:
-            scenarios_pattern = re.compile(self.scenarios_regex)
-
         filtered_scenarios = []
         for scenario in scenarios:
-            if self.scenarios_regex is not None:
-                if scenarios_pattern.match(scenario.script) is None:
-                    logging.debug("Skipping script %s - it did not match "
-                                  "--scenarios regex" % scenario.script)
-                    continue
+            if not self._scenario_matches_regex(scenario):
+                continue
             if scenario.context is not None:
                 if common.matches_platform(scenario.script_params["platform"], self.benchmark_cpes):
                     filtered_scenarios.append(scenario)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -392,21 +392,27 @@ class RuleChecker(oscap.Checker):
                 return False
         return True
 
+    def _scenario_matches_platform(self, scenario):
+        if scenario.context is None:
+            return False
+        if common.matches_platform(
+                scenario.script_params["platform"], self.benchmark_cpes):
+            return True
+        else:
+            logging.warning(
+                "Script %s is not applicable on given platform" %
+                scenario.script)
+            return False
+
     def _filter_scenarios(self, scenarios):
         """ Returns only valid scenario files, rest is ignored (is not meant
         to be executed directly.
         """
-
         filtered_scenarios = []
         for scenario in scenarios:
-            if not self._scenario_matches_regex(scenario):
-                continue
-            if scenario.context is not None:
-                if common.matches_platform(scenario.script_params["platform"], self.benchmark_cpes):
-                    filtered_scenarios.append(scenario)
-                else:
-                    logging.warning("Script %s is not applicable on given platform" % script)
-
+            if (self._scenario_matches_regex(scenario) and
+                    self._scenario_matches_platform(scenario)):
+                filtered_scenarios.append(scenario)
         return filtered_scenarios
 
     def _check_rule(self, rule, scenarios, remote_dir, state, remediation_available):

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -258,13 +258,7 @@ class RuleChecker(oscap.Checker):
     def _get_rules_to_test(self, target):
         rules_to_test = []
         tested_templates = set()
-        product_yaml = common.get_product_context(self.test_env.product)
-        # Initialize a mock template_builder.
-        empty = "/ssgts/empty/placeholder"
-        template_builder = ssg.templates.Builder(
-            product_yaml, empty, common._SHARED_TEMPLATES, empty, empty)
-        for rule in common.iterate_over_rules(
-                template_builder, self.test_env.product):
+        for rule in common.iterate_over_rules(self.test_env.product):
             if not self._rule_should_be_tested(rule, target, tested_templates):
                 continue
             if not xml_operations.find_rule_in_benchmark(
@@ -305,7 +299,15 @@ class RuleChecker(oscap.Checker):
 
     def _get_rule_scenarios(self, rule):
         scenarios = []
-        for script, script_contents in rule.scenarios.items():
+        product_yaml = common.get_product_context(self.test_env.product)
+        # Initialize a mock template_builder.
+        empty = "/ssgts/empty/placeholder"
+        template_builder = ssg.templates.Builder(
+            product_yaml, empty, common._SHARED_TEMPLATES, empty, empty)
+        rule_scenarios = common.fetch_test_scenarios(
+            rule.directory, rule.rule, template_builder, product_yaml,
+            rule.local_env_yaml)
+        for script, script_contents in rule_scenarios.items():
             scenario = Scenario(script, script_contents)
             scenario.override_profile(self.scenarios_profile)
             if (scenario.matches_regex(self.scenarios_regex) and

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -374,9 +374,10 @@ class RuleChecker(oscap.Checker):
 
         # Start by checking for templating tests and provision them if
         # present.
-        templated_test_scenarios = common.fetch_templated_test_scenarios(
-            rule.rule, template_builder, rule.directory, product_yaml,
-            rule.local_env_yaml)
+        all_templated_test_scenarios = common.fetch_templated_test_scenarios(
+            rule.rule, template_builder, rule.local_env_yaml)
+        templated_test_scenarios = common.apply_test_config(
+            rule.directory, product_yaml, all_templated_test_scenarios)
 
         # Add additional tests from the local rule directory. Note that,
         # like the behavior in template_tests, this will overwrite any

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -284,7 +284,14 @@ class RuleChecker(oscap.Checker):
             if not common.is_rule_dir(dirpath):
                 continue
             short_rule_id = os.path.basename(dirpath)
+            full_rule_id = OSCAP_RULE + short_rule_id
             if not self._rule_should_be_tested(short_rule_id, target):
+                continue
+            if not xml_operations.find_rule_in_benchmark(
+                    self.datastream, self.benchmark_id, full_rule_id):
+                logging.error(
+                    "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
+                    .format(full_rule_id, self.benchmark_id, self.datastream))
                 continue
 
             # Load the rule itself to check for a template.
@@ -303,8 +310,6 @@ class RuleChecker(oscap.Checker):
                     continue
 
             tests_dir = os.path.join(dirpath, "tests")
-
-            full_rule_id = OSCAP_RULE + short_rule_id
             template_name = None
             if rule.template and rule.template['vars']:
                 template_name = rule.template['name']
@@ -319,12 +324,6 @@ class RuleChecker(oscap.Checker):
         tested_templates = set()
         for rule in self._iterate_over_rules(target, self.test_env.product):
             if self._rule_template_been_tested(rule, tested_templates):
-                continue
-            if not xml_operations.find_rule_in_benchmark(
-                    self.datastream, self.benchmark_id, rule.id):
-                logging.error(
-                    "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
-                    .format(rule.id, self.benchmark_id, self.datastream))
                 continue
             rules_to_test.append(rule)
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -311,9 +311,7 @@ class RuleChecker(oscap.Checker):
     def _get_scenarios_by_rule_id(self, rules_to_test):
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
-            rule_scenarios = self._filter_scenarios(
-                rule.scenarios_basenames, self.scenarios_regex,
-                self.benchmark_cpes)
+            rule_scenarios = self._filter_scenarios(rule.scenarios_basenames)
             scenarios_by_rule_id[rule.id] = rule_scenarios
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
                                                       self.slice_current,
@@ -371,18 +369,18 @@ class RuleChecker(oscap.Checker):
 
         return params
 
-    def _filter_scenarios(self, scripts, scenarios_regex, benchmark_cpes):
+    def _filter_scenarios(self, scripts):
         """ Returns only valid scenario files, rest is ignored (is not meant
         to be executed directly.
         """
 
-        if scenarios_regex is not None:
-            scenarios_pattern = re.compile(scenarios_regex)
+        if self.scenarios_regex is not None:
+            scenarios_pattern = re.compile(self.scenarios_regex)
 
         scenarios = []
         for script in scripts:
             script_contents = scripts[script]
-            if scenarios_regex is not None:
+            if self.scenarios_regex is not None:
                 if scenarios_pattern.match(script) is None:
                     logging.debug("Skipping script %s - it did not match "
                                   "--scenarios regex" % script)
@@ -391,7 +389,7 @@ class RuleChecker(oscap.Checker):
             if script_context is not None:
                 script_params = self._parse_parameters(script_contents)
                 script_params = self._modify_parameters(script, script_params)
-                if common.matches_platform(script_params["platform"], benchmark_cpes):
+                if common.matches_platform(script_params["platform"], self.benchmark_cpes):
                     scenarios += [Scenario(script, script_context, script_params, script_contents)]
                 else:
                     logging.warning("Script %s is not applicable on given platform" % script)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -221,10 +221,6 @@ class RuleChecker(oscap.Checker):
     def _rule_should_be_tested(self, rule_short_id, rules_to_be_tested):
         rule_id = OSCAP_RULE + rule_short_id
         if 'ALL' in rules_to_be_tested:
-            # don't select rules that are not present in benchmark
-            if not xml_operations.find_rule_in_benchmark(
-                    self.datastream, self.benchmark_id, rule_id):
-                return False
             return True
         else:
             for rule_to_be_tested in rules_to_be_tested:

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -218,13 +218,13 @@ class RuleChecker(oscap.Checker):
         tested_templates.add(rule.template)
         return False
 
-    def _rule_should_be_tested(self, rule, rules_to_be_tested, tested_templates):
+    def _rule_should_be_tested(self, rule, rules_to_be_tested):
         if 'ALL' in rules_to_be_tested:
             # don't select rules that are not present in benchmark
             if not xml_operations.find_rule_in_benchmark(
                     self.datastream, self.benchmark_id, rule.id):
                 return False
-            return not self._rule_template_been_tested(rule, tested_templates)
+            return True
         else:
             for rule_to_be_tested in rules_to_be_tested:
                 # we check for a substring
@@ -233,7 +233,7 @@ class RuleChecker(oscap.Checker):
                 else:
                     pattern = OSCAP_RULE + rule_to_be_tested
                 if fnmatch.fnmatch(rule.id, pattern):
-                    return not self._rule_template_been_tested(rule, tested_templates)
+                    return True
             return False
 
     def _ensure_package_present_for_all_scenarios(self, scenarios_by_rule):
@@ -259,7 +259,9 @@ class RuleChecker(oscap.Checker):
         rules_to_test = []
         tested_templates = set()
         for rule in common.iterate_over_rules(self.test_env.product):
-            if not self._rule_should_be_tested(rule, target, tested_templates):
+            if not self._rule_should_be_tested(rule, target):
+                continue
+            if self._rule_template_been_tested(rule, tested_templates):
                 continue
             if not xml_operations.find_rule_in_benchmark(
                     self.datastream, self.benchmark_id, rule.id):

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -319,7 +319,7 @@ class RuleChecker(oscap.Checker):
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
             rule_scenarios = self._get_scenarios(
-                rule.directory, rule.scenarios_basenames, self.scenarios_regex,
+                rule.scenarios_basenames, self.scenarios_regex,
                 self.benchmark_cpes)
             scenarios_by_rule_id[rule.id] = rule_scenarios
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
@@ -366,7 +366,7 @@ class RuleChecker(oscap.Checker):
 
         return params
 
-    def _get_scenarios(self, rule_dir, scripts, scenarios_regex, benchmark_cpes):
+    def _get_scenarios(self, scripts, scenarios_regex, benchmark_cpes):
         """ Returns only valid scenario files, rest is ignored (is not meant
         to be executed directly.
         """

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -263,11 +263,10 @@ class RuleChecker(oscap.Checker):
 
         self._ensure_package_present_for_all_scenarios(scenarios_by_rule)
 
-    def _iterate_over_rules(self, product=None):
-        """Iterate over rule directories which have test scenarios".
-
+    def _get_rules_to_test(self):
+        """
         Returns:
-            Named tuple Rule having these fields:
+            List of named tuples Rule having these fields:
                 directory -- absolute path to the rule "tests" subdirectory
                             containing the test scenarios in Bash
                 id -- full rule id as it is present in datastream
@@ -284,7 +283,9 @@ class RuleChecker(oscap.Checker):
         # templating engine.
         #
         # Begin by loading context about our execution environment, if any.
+        product = self.test_env.product
         product_yaml = common.get_product_context(product)
+        rules = []
 
         for dirpath, dirnames, filenames in common.walk_through_benchmark_dirs(
                 product):
@@ -326,10 +327,8 @@ class RuleChecker(oscap.Checker):
                 directory=tests_dir, id=full_rule_id,
                 short_id=short_rule_id, template=template_name,
                 local_env_yaml=local_env_yaml, rule=rule)
-            yield result
-
-    def _get_rules_to_test(self):
-        return list(self._iterate_over_rules(self.test_env.product))
+            rules.append(result)
+        return rules
 
     def test_rule(self, state, rule, scenarios):
         remediation_available = self._is_remediation_available(rule)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -218,11 +218,12 @@ class RuleChecker(oscap.Checker):
         tested_templates.add(rule.template)
         return False
 
-    def _rule_should_be_tested(self, rule, rules_to_be_tested):
+    def _rule_should_be_tested(self, rule_short_id, rules_to_be_tested):
+        rule_id = OSCAP_RULE + rule_short_id
         if 'ALL' in rules_to_be_tested:
             # don't select rules that are not present in benchmark
             if not xml_operations.find_rule_in_benchmark(
-                    self.datastream, self.benchmark_id, rule.id):
+                    self.datastream, self.benchmark_id, rule_id):
                 return False
             return True
         else:
@@ -232,7 +233,7 @@ class RuleChecker(oscap.Checker):
                     pattern = rule_to_be_tested
                 else:
                     pattern = OSCAP_RULE + rule_to_be_tested
-                if fnmatch.fnmatch(rule.id, pattern):
+                if fnmatch.fnmatch(rule_id, pattern):
                     return True
             return False
 
@@ -314,7 +315,7 @@ class RuleChecker(oscap.Checker):
         rules_to_test = []
         tested_templates = set()
         for rule in self._iterate_over_rules(self.test_env.product):
-            if not self._rule_should_be_tested(rule, target):
+            if not self._rule_should_be_tested(rule.short_id, target):
                 continue
             if self._rule_template_been_tested(rule, tested_templates):
                 continue

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -256,7 +256,7 @@ class RuleChecker(oscap.Checker):
 
         self._ensure_package_present_for_all_scenarios(scenarios_by_rule)
 
-    def _iterate_over_rules(self, product=None):
+    def _iterate_over_rules(self, target, product=None):
         """Iterate over rule directories which have test scenarios".
 
         Returns:
@@ -283,6 +283,8 @@ class RuleChecker(oscap.Checker):
                 product):
             if common.is_rule_dir(dirpath):
                 short_rule_id = os.path.basename(dirpath)
+                if not self._rule_should_be_tested(short_rule_id, target):
+                    continue
 
                 # Load the rule itself to check for a template.
                 rule, local_env_yaml = common.load_rule_and_env(
@@ -314,9 +316,7 @@ class RuleChecker(oscap.Checker):
     def _get_rules_to_test(self, target):
         rules_to_test = []
         tested_templates = set()
-        for rule in self._iterate_over_rules(self.test_env.product):
-            if not self._rule_should_be_tested(rule.short_id, target):
-                continue
+        for rule in self._iterate_over_rules(target, self.test_env.product):
             if self._rule_template_been_tested(rule, tested_templates):
                 continue
             if not xml_operations.find_rule_in_benchmark(

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -301,15 +301,15 @@ class RuleChecker(oscap.Checker):
         for script, script_contents in rule.scenarios.items():
             scenario = Scenario(
                 script, script_contents, self.scenarios_profile)
-            scenarios.append(scenario)
+            if (scenario.matches_regex(self.scenarios_regex) and
+                    scenario.matches_platform(self.benchmark_cpes)):
+                scenarios.append(scenario)
         return scenarios
 
     def _get_scenarios_by_rule_id(self, rules_to_test):
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
-            rule_scenarios = self._get_rule_scenarios(rule)
-            filtered_rule_scenarios = self._filter_scenarios(rule_scenarios)
-            scenarios_by_rule_id[rule.id] = filtered_rule_scenarios
+            scenarios_by_rule_id[rule.id] = self._get_rule_scenarios(rule)
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
                                                       self.slice_current,
                                                       self.slice_total)
@@ -334,17 +334,6 @@ class RuleChecker(oscap.Checker):
                 except KeyError:
                     # rule is not processed in given slice
                     pass
-
-    def _filter_scenarios(self, scenarios):
-        """ Returns only valid scenario files, rest is ignored (is not meant
-        to be executed directly.
-        """
-        filtered_scenarios = []
-        for scenario in scenarios:
-            if (scenario.matches_regex(self.scenarios_regex) and
-                    scenario.matches_platform(self.benchmark_cpes)):
-                filtered_scenarios.append(scenario)
-        return filtered_scenarios
 
     def _check_rule(self, rule, scenarios, remote_dir, state, remediation_available):
         remote_rule_dir = os.path.join(remote_dir, rule.short_id)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -374,7 +374,7 @@ class RuleChecker(oscap.Checker):
         # Start by checking for templating tests and provision them if
         # present.
         templated_test_scenarios = common.fetch_templated_test_scenarios(
-            rule, template_builder, rule.directory, product_yaml,
+            rule.rule, template_builder, rule.directory, product_yaml,
             rule.local_env_yaml)
         all_tests.update(templated_test_scenarios)
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -281,37 +281,38 @@ class RuleChecker(oscap.Checker):
 
         for dirpath, dirnames, filenames in common.walk_through_benchmark_dirs(
                 product):
-            if common.is_rule_dir(dirpath):
-                short_rule_id = os.path.basename(dirpath)
-                if not self._rule_should_be_tested(short_rule_id, target):
+            if not common.is_rule_dir(dirpath):
+                continue
+            short_rule_id = os.path.basename(dirpath)
+            if not self._rule_should_be_tested(short_rule_id, target):
+                continue
+
+            # Load the rule itself to check for a template.
+            rule, local_env_yaml = common.load_rule_and_env(
+                dirpath, product_yaml, product)
+
+            # Before we get too far, we wish to search the rule YAML to see if
+            # it is applicable to the current product. If we have a product
+            # and the rule isn't applicable for the product, there's no point
+            # in continuing with the rest of the loading. This should speed up
+            # the loading of the templated tests. Note that we've already
+            # parsed the prodtype into local_env_yaml
+            if product and local_env_yaml['products']:
+                prodtypes = local_env_yaml['products']
+                if "all" not in prodtypes and product not in prodtypes:
                     continue
 
-                # Load the rule itself to check for a template.
-                rule, local_env_yaml = common.load_rule_and_env(
-                    dirpath, product_yaml, product)
+            tests_dir = os.path.join(dirpath, "tests")
 
-                # Before we get too far, we wish to search the rule YAML to see
-                # if it is applicable to the current product. If we have a
-                # product and the rule isn't applicable for the product, there's
-                # no point in continuing with the rest of the loading. This
-                # should speed up the loading of the templated tests. Note that
-                # we've already parsed the prodtype into local_env_yaml
-                if product and local_env_yaml['products']:
-                    prodtypes = local_env_yaml['products']
-                    if "all" not in prodtypes and product not in prodtypes:
-                        continue
-
-                tests_dir = os.path.join(dirpath, "tests")
-
-                full_rule_id = OSCAP_RULE + short_rule_id
-                template_name = None
-                if rule.template and rule.template['vars']:
-                    template_name = rule.template['name']
-                result = common.Rule(
-                    directory=tests_dir, id=full_rule_id,
-                    short_id=short_rule_id, template=template_name,
-                    local_env_yaml=local_env_yaml, rule=rule)
-                yield result
+            full_rule_id = OSCAP_RULE + short_rule_id
+            template_name = None
+            if rule.template and rule.template['vars']:
+                template_name = rule.template['name']
+            result = common.Rule(
+                directory=tests_dir, id=full_rule_id,
+                short_id=short_rule_id, template=template_name,
+                local_env_yaml=local_env_yaml, rule=rule)
+            yield result
 
     def _get_rules_to_test(self, target):
         rules_to_test = []

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -434,21 +434,19 @@ class RuleChecker(oscap.Checker):
 class Scenario():
     def __init__(self, script, script_contents, scenarios_profile):
         self.script = script
-        self.context = self._get_script_context(script)
-        script_params = self._parse_parameters(script_contents)
-        script_params = self._modify_parameters(
-            script, script_params, scenarios_profile)
-        self.script_params = script_params
+        self.context = self._get_script_context()
         self.contents = script_contents
+        self.script_params = self._parse_parameters()
+        self._modify_parameters(scenarios_profile)
 
-    def _get_script_context(self, script):
+    def _get_script_context(self):
         """Return context of the script."""
-        result = re.search(r'.*\.([^.]*)\.[^.]*$', script)
+        result = re.search(r'.*\.([^.]*)\.[^.]*$', self.script)
         if result is None:
             return None
         return result.group(1)
 
-    def _parse_parameters(self, script_content):
+    def _parse_parameters(self):
         """Parse parameters from script header"""
         params = {
             'profiles': [],
@@ -462,7 +460,7 @@ class Scenario():
         for parameter in params:
             found = re.search(
                 r'^# {0} = (.*)$'.format(parameter),
-                script_content, re.MULTILINE)
+                self.contents, re.MULTILINE)
             if found is None:
                 continue
             splitted = found.group(1).split(',')
@@ -470,17 +468,16 @@ class Scenario():
 
         return params
 
-    def _modify_parameters(self, script, params, scenarios_profile):
+    def _modify_parameters(self, scenarios_profile):
         if scenarios_profile:
-            params['profiles'] = [scenarios_profile]
+            self.script_params['profiles'] = [scenarios_profile]
 
-        if not params["profiles"]:
-            params["profiles"].append(OSCAP_PROFILE_ALL_ID)
+        if not self.script_params["profiles"]:
+            self.script_params["profiles"].append(OSCAP_PROFILE_ALL_ID)
             logging.debug(
                 "Added the {0} profile to the list of available profiles "
                 "for {1}"
-                .format(OSCAP_PROFILE_ALL_ID, script))
-        return params
+                .format(OSCAP_PROFILE_ALL_ID, self.script))
 
     def matches_regex(self, scenarios_regex):
         if scenarios_regex is not None:

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -318,7 +318,7 @@ class RuleChecker(oscap.Checker):
 
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
-            rule_scenarios = self._get_scenarios(
+            rule_scenarios = self._filter_scenarios(
                 rule.scenarios_basenames, self.scenarios_regex,
                 self.benchmark_cpes)
             scenarios_by_rule_id[rule.id] = rule_scenarios
@@ -366,7 +366,7 @@ class RuleChecker(oscap.Checker):
 
         return params
 
-    def _get_scenarios(self, scripts, scenarios_regex, benchmark_cpes):
+    def _filter_scenarios(self, scripts, scenarios_regex, benchmark_cpes):
         """ Returns only valid scenario files, rest is ignored (is not meant
         to be executed directly.
         """

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -297,8 +297,8 @@ class RuleChecker(oscap.Checker):
                 new_sbr[rule_id] = [scenario]
         return new_sbr
 
-    def _get_rule_scenarios(self, rule):
-        scenarios = []
+    def _get_all_rule_scenarios(self, rule):
+        rule_scenarios = []
         product_yaml = common.get_product_context(self.test_env.product)
         # Initialize a mock template_builder.
         empty = "/ssgts/empty/placeholder"
@@ -307,6 +307,10 @@ class RuleChecker(oscap.Checker):
         rule_scenarios = fetch_test_scenarios(
             rule.directory, rule.rule, template_builder, product_yaml,
             rule.local_env_yaml)
+        return rule_scenarios
+
+    def _filter_rule_scenarios(self, rule_scenarios):
+        scenarios = []
         for scenario in rule_scenarios:
             scenario.override_profile(self.scenarios_profile)
             if (scenario.matches_regex(self.scenarios_regex) and
@@ -317,7 +321,10 @@ class RuleChecker(oscap.Checker):
     def _get_scenarios_by_rule_id(self, rules_to_test):
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
-            scenarios_by_rule_id[rule.id] = self._get_rule_scenarios(rule)
+            all_rule_scenarios = self._get_all_rule_scenarios(rule)
+            filtered_rule_scenarios = self._filter_rule_scenarios(
+                all_rule_scenarios)
+            scenarios_by_rule_id[rule.id] = filtered_rule_scenarios
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
                                                       self.slice_current,
                                                       self.slice_total)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -357,7 +357,7 @@ class RuleChecker(oscap.Checker):
                 new_sbr[rule_id] = [scenario]
         return new_sbr
 
-    def _get_all_rule_scenarios(self, rule):
+    def _get_rule_scenarios(self, rule):
         product_yaml = common.get_product_context(self.test_env.product)
         # Initialize a mock template_builder.
         empty = "/ssgts/empty/placeholder"
@@ -412,8 +412,7 @@ class RuleChecker(oscap.Checker):
     def _get_scenarios_by_rule_id(self, rules_to_test):
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
-            all_rule_scenarios = self._get_all_rule_scenarios(rule)
-            scenarios_by_rule_id[rule.id] = all_rule_scenarios
+            scenarios_by_rule_id[rule.id] = self._get_rule_scenarios(rule)
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
                                                       self.slice_current,
                                                       self.slice_total)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -307,8 +307,7 @@ class RuleChecker(oscap.Checker):
         rule_scenarios = fetch_test_scenarios(
             rule.directory, rule.rule, template_builder, product_yaml,
             rule.local_env_yaml)
-        for script, script_contents in rule_scenarios.items():
-            scenario = Scenario(script, script_contents)
+        for scenario in rule_scenarios:
             scenario.override_profile(self.scenarios_profile)
             if (scenario.matches_regex(self.scenarios_regex) and
                     scenario.matches_platform(self.benchmark_cpes)):
@@ -565,4 +564,8 @@ def fetch_test_scenarios(
     allowed_scripts = filter(lambda x: x.endswith(".sh"), all_tests)
     content_mapping = {x: all_tests[x] for x in allowed_scripts}
 
-    return content_mapping
+    scenarios = []
+    for script, script_contents in content_mapping.items():
+        scenario = Scenario(script, script_contents)
+        scenarios.append(scenario)
+    return scenarios

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -417,12 +417,12 @@ class RuleChecker(oscap.Checker):
                                                       self.slice_total)
         return sliced_scenarios_by_rule_id
 
-    def _test_target(self, target):
+    def _test_target(self):
         rules_to_test = self._get_rules_to_test()
         if not rules_to_test:
             logging.error("No tests found matching the {0}(s) '{1}'".format(
                 self.target_type,
-                ", ".join(target)))
+                ", ".join(self.rule_spec)))
             return
 
         scenarios_by_rule_id = self._get_scenarios_by_rule_id(rules_to_test)
@@ -618,14 +618,12 @@ def perform_rule_check(options):
     checker.slice_current = options.slice_current
     checker.slice_total = options.slice_total
     checker.keep_snapshots = options.keep_snapshots
-
+    checker.rule_spec = options.target
+    checker.template_spec = None
     checker.scenarios_profile = options.scenarios_profile
     # check if target is a complete profile ID, if not prepend profile prefix
     if (checker.scenarios_profile is not None and
             not checker.scenarios_profile.startswith(OSCAP_PROFILE) and
             not oscap.is_virtual_oscap_profile(checker.scenarios_profile)):
         checker.scenarios_profile = OSCAP_PROFILE+options.scenarios_profile
-
-    checker.rule_spec = options.target
-    checker.template_spec = None
-    checker.test_target(options.target)
+    checker.test_target()

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -304,7 +304,7 @@ class RuleChecker(oscap.Checker):
         empty = "/ssgts/empty/placeholder"
         template_builder = ssg.templates.Builder(
             product_yaml, empty, common._SHARED_TEMPLATES, empty, empty)
-        rule_scenarios = common.fetch_test_scenarios(
+        rule_scenarios = fetch_test_scenarios(
             rule.directory, rule.rule, template_builder, product_yaml,
             rule.local_env_yaml)
         for script, script_contents in rule_scenarios.items():
@@ -534,3 +534,35 @@ def perform_rule_check(options):
         checker.scenarios_profile = OSCAP_PROFILE+options.scenarios_profile
 
     checker.test_target(options.target)
+
+
+def fetch_test_scenarios(
+        tests_dir, rule, template_builder, product_yaml, local_env_yaml):
+    # All tests is a mapping from path (in the tarball) to contents
+    # of the test case. This is necessary because later code (which
+    # attempts to parse headers from the test case) don't have easy
+    # access to templated content. By reading it and returning it
+    # here, we can save later code from having to understand the
+    # templating system.
+    all_tests = dict()
+
+    # Start by checking for templating tests and provision them if
+    # present.
+    templated_test_scenarios = common.fetch_templated_test_scenarios(
+        rule, template_builder, tests_dir, product_yaml, local_env_yaml)
+    all_tests.update(templated_test_scenarios)
+
+    # Add additional tests from the local rule directory. Note that,
+    # like the behavior in template_tests, this will overwrite any
+    # templated tests with the same file name.
+    local_test_scenarios = common.fetch_local_test_scenarios(
+        tests_dir, local_env_yaml)
+    all_tests.update(local_test_scenarios)
+
+    # Filter out everything except the shell test scenarios.
+    # Other files in rule directories are editor swap files
+    # or other content than a test case.
+    allowed_scripts = filter(lambda x: x.endswith(".sh"), all_tests)
+    content_mapping = {x: all_tests[x] for x in allowed_scripts}
+
+    return content_mapping

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -311,7 +311,7 @@ class RuleChecker(oscap.Checker):
     def _get_scenarios_by_rule_id(self, rules_to_test):
         scenarios_by_rule_id = dict()
         for rule in rules_to_test:
-            rule_scenarios = self._filter_scenarios(rule.scenarios_basenames)
+            rule_scenarios = self._filter_scenarios(rule.scenarios)
             scenarios_by_rule_id[rule.id] = rule_scenarios
         sliced_scenarios_by_rule_id = self._slice_sbr(scenarios_by_rule_id,
                                                       self.slice_current,

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -21,6 +21,7 @@ from ssg_test_suite import test_env
 from ssg_test_suite import common
 from ssg_test_suite.log import LogHelper
 
+import ssg.templates
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
@@ -257,7 +258,13 @@ class RuleChecker(oscap.Checker):
     def _get_rules_to_test(self, target):
         rules_to_test = []
         tested_templates = set()
-        for rule in common.iterate_over_rules(self.test_env.product):
+        product_yaml = common.get_product_context(self.test_env.product)
+        # Initialize a mock template_builder.
+        empty = "/ssgts/empty/placeholder"
+        template_builder = ssg.templates.Builder(
+            product_yaml, empty, common._SHARED_TEMPLATES, empty, empty)
+        for rule in common.iterate_over_rules(
+                template_builder, self.test_env.product):
             if not self._rule_should_be_tested(rule, target, tested_templates):
                 continue
             if not xml_operations.find_rule_in_benchmark(

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -23,6 +23,11 @@ from ssg_test_suite.log import LogHelper
 
 import ssg.templates
 
+Rule = collections.namedtuple(
+    "Rule",
+    ["directory", "id", "short_id", "template", "local_env_yaml", "rule"])
+
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
@@ -309,7 +314,7 @@ class RuleChecker(oscap.Checker):
             template_name = None
             if rule.template and rule.template['vars']:
                 template_name = rule.template['name']
-            result = common.Rule(
+            result = Rule(
                 directory=tests_dir, id=full_rule_id,
                 short_id=short_rule_id, template=template_name,
                 local_env_yaml=local_env_yaml, rule=rule)

--- a/tests/ssg_test_suite/template.py
+++ b/tests/ssg_test_suite/template.py
@@ -44,5 +44,5 @@ def perform_template_check(options):
 
     checker.rule_spec = None
     checker.template_spec = options.target
-    checker.test_target(options.target)
+    checker.test_target()
     return

--- a/tests/ssg_test_suite/template.py
+++ b/tests/ssg_test_suite/template.py
@@ -19,10 +19,11 @@ class TemplateChecker(rule.RuleChecker):
         super(TemplateChecker, self).__init__(test_env)
         self.target_type = "template"
 
-    def _rule_should_be_tested(self, rule, target_templates, tested_templates):
-        if rule.template in target_templates:
-            return True
-        return False
+    def _rule_matches_rule_spec(self, rule_short_id):
+        return True
+
+    def _rule_matches_template_spec(self, template):
+        return (template in self.template_spec)
 
 
 def perform_template_check(options):
@@ -41,5 +42,7 @@ def perform_template_check(options):
     checker.slice_total = options.slice_total
     checker.scenarios_profile = options.scenarios_profile
 
+    checker.rule_spec = None
+    checker.template_spec = options.target
     checker.test_target(options.target)
     return

--- a/tests/unit/ssg_test_suite/data/correct.pass.sh
+++ b/tests/unit/ssg_test_suite/data/correct.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = sudo,authselect
+# platform = multi_platform_rhel,Fedora
+# profiles = xccdf_org.ssgproject.content_profile_cis
+# remediation = none
+# variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
+
+echo "RekeyLimit 1000" >> "/etc/ssh/sshd_config"

--- a/tests/unit/ssg_test_suite/data/correct_defaults.pass.sh
+++ b/tests/unit/ssg_test_suite/data/correct_defaults.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "RekeyLimit 1000" >> "/etc/ssh/sshd_config"

--- a/tests/unit/ssg_test_suite/test_rule.py
+++ b/tests/unit/ssg_test_suite/test_rule.py
@@ -1,0 +1,59 @@
+import os
+import pytest
+
+from ssg_test_suite import rule
+from tests.ssg_test_suite.rule import Scenario
+from ssg.constants import OSCAP_PROFILE_ALL_ID
+
+DATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
+
+
+def test_scenario():
+    file_name = "correct.pass.sh"
+    file_contents = open(os.path.join(DATADIR, file_name)).read()
+    s = Scenario(file_name, file_contents, None)
+    assert s.script == file_name
+    assert s.contents == file_contents
+    assert s.context == "pass"
+    assert len(s.script_params["packages"]) == 2
+    assert "sudo" in s.script_params["packages"]
+    assert "authselect" in s.script_params["packages"]
+    assert len(s.script_params["platform"]) == 2
+    assert "multi_platform_rhel" in s.script_params["platform"]
+    assert "Fedora" in s.script_params["platform"]
+    assert len(s.script_params["profiles"]) == 1
+    assert "xccdf_org.ssgproject.content_profile_cis" in \
+        s.script_params["profiles"]
+    assert OSCAP_PROFILE_ALL_ID not in s.script_params["profiles"]
+    assert len(s.script_params["remediation"]) == 1
+    assert "none" in s.script_params["remediation"]
+    assert len(s.script_params["variables"]) == 2
+    assert "var_password_pam_remember=5" in s.script_params["variables"]
+    assert "var_password_pam_remember_control_flag=requisite" in \
+        s.script_params["variables"]
+    assert len(s.script_params["templates"]) == 0
+    assert s.matches_regex(r".*pass\.sh")
+    assert s.matches_regex(r"^correct.*")
+    assert not s.matches_regex(r".*fail\.sh")
+    assert not s.matches_regex(r"^wrong")
+    assert s.matches_platform({"cpe:/o:redhat:enterprise_linux:7"})
+    assert not s.matches_platform({"cpe:/o:debian:debian:8"})
+
+def test_scenario_defaults():
+    file_name = "correct_defaults.pass.sh"
+    file_contents = open(os.path.join(DATADIR, file_name)).read()
+    s = Scenario(file_name, file_contents, None)
+    assert s.script == file_name
+    assert s.contents == file_contents
+    assert s.context == "pass"
+    assert len(s.script_params["profiles"]) == 1
+    assert OSCAP_PROFILE_ALL_ID in s.script_params["profiles"]
+    assert len(s.script_params["templates"]) == 0
+    assert len(s.script_params["packages"]) == 0
+    assert len(s.script_params["platform"]) == 1
+    assert "multi_platform_all" in s.script_params["platform"]
+    assert len(s.script_params["remediation"]) == 1
+    assert "all" in s.script_params["remediation"]
+    assert len(s.script_params["variables"]) == 0
+    assert s.matches_platform({"cpe:/o:redhat:enterprise_linux:7"})
+    assert s.matches_platform({"cpe:/o:debian:debian:8"})

--- a/tests/unit/ssg_test_suite/test_rule.py
+++ b/tests/unit/ssg_test_suite/test_rule.py
@@ -11,7 +11,7 @@ DATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 def test_scenario():
     file_name = "correct.pass.sh"
     file_contents = open(os.path.join(DATADIR, file_name)).read()
-    s = Scenario(file_name, file_contents, None)
+    s = Scenario(file_name, file_contents)
     assert s.script == file_name
     assert s.contents == file_contents
     assert s.context == "pass"
@@ -42,7 +42,7 @@ def test_scenario():
 def test_scenario_defaults():
     file_name = "correct_defaults.pass.sh"
     file_contents = open(os.path.join(DATADIR, file_name)).read()
-    s = Scenario(file_name, file_contents, None)
+    s = Scenario(file_name, file_contents)
     assert s.script == file_name
     assert s.contents == file_contents
     assert s.context == "pass"
@@ -57,3 +57,6 @@ def test_scenario_defaults():
     assert len(s.script_params["variables"]) == 0
     assert s.matches_platform({"cpe:/o:redhat:enterprise_linux:7"})
     assert s.matches_platform({"cpe:/o:debian:debian:8"})
+    s.override_profile("xccdf_org.ssgproject.content_profile_cis")
+    assert "xccdf_org.ssgproject.content_profile_cis" in \
+        s.script_params["profiles"]


### PR DESCRIPTION
#### Description:

The aim of the PR is to separate code processing rules from code processing test scenarios.

First, we will collect rules to be tested using the `RuleChecker._get_rules_to_test()` method. Then, we will collect a list of test scenarios to be executed using the `RuleChecker._get_scenarios_by_rule_id()` which finds test scenarios for each rule.

#### Rationale:
Rule's test scenarios selection was extended with several features in past year (SSGTS `–scenario` option, templated test scenarios that can be overwritten with rule specific test scenarios) causing the code to be difficult to understand and maintain.
