### PR TITLE
Fix bash in umask related rules to manage correctly commented lines

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/bash/shared.sh
@@ -8,8 +8,8 @@
 {{% set etc_bash_rc = "/etc/bashrc" %}}
 {{% endif %}}
 
-grep -q umask {{{ etc_bash_rc }}} && \
-  sed -i "s/umask.*/umask $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
+grep -q "^\s*umask" {{{ etc_bash_rc }}} && \
+  sed -i -E -e "s/^(\s*umask).*/\1 $var_accounts_user_umask/g" {{{ etc_bash_rc }}}
 if ! [ $? -eq 0 ]; then
     echo "umask $var_accounts_user_umask" >> {{{ etc_bash_rc }}}
 fi

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/bash/shared.sh
@@ -2,8 +2,8 @@
 
 {{{ bash_instantiate_variables("var_accounts_user_umask") }}}
 
-grep -q umask /etc/csh.cshrc && \
-  sed -i "s/umask.*/umask $var_accounts_user_umask/g" /etc/csh.cshrc
+grep -q "^\s*umask" /etc/csh.cshrc && \
+  sed -i -E -e "s/^(\s*umask).*/\1 $var_accounts_user_umask/g" /etc/csh.cshrc
 if ! [ $? -eq 0 ]; then
     echo "umask $var_accounts_user_umask" >> /etc/csh.cshrc
 fi


### PR DESCRIPTION
#### Description:

- Update bash in rules `accounts_umask_etc_bashrc` & `accounts_umask_etc_csh_cshrc` to handle commented occurrences as it should. Previously "fixed" commented lines(leaving them commented), but if there wasn't any non commented line didn't add anything, now it does.

#### Rationale:

-  Bash in these rules wasn't fixing the scenario in which there were only commented lines with umask info
