### PR TITLE
Do not try to macro expand swap files of test scenarios

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -360,6 +360,10 @@ def write_rule_dir_tests(local_env_yaml, dest_path, dirpath):
             os.mkdir(tmp_dir_path)
 
         for filename in filenames:
+            # Skip vim swap files, they are not relevant and cause Jinja expansion tracebacks
+            if filename.endswith(".swp"):
+                continue
+
             # We want to recreate the correct path under the temporary
             # directory. Resolve it to a relative path from the tests/
             # directory. Assumption: directories should be created
@@ -625,6 +629,10 @@ def iterate_over_rules(product=None):
             if os.path.exists(tests_dir):
                 tests_dir_files = os.listdir(tests_dir)
                 for test_case in tests_dir_files:
+                    # Skip vim swap files,
+                    # they are not relevant and cause Jinja expansion tracebacks
+                    if test_case.endswith(".swp"):
+                        continue
                     test_path = os.path.join(tests_dir, test_case)
                     if os.path.isdir(test_path):
                         continue


### PR DESCRIPTION
#### Description:

- This adds conditionals so that  `*.swp` files are not macro expanded.

#### Rationale:

- Trying to `process_file_with_macros()` on a vim swp file tracebacks the test suite.
```
$ python3 tests/test_suite.py rule  --libvirt qemu:///session rhel86 --datastream build/ssg-rhel8-ds.xml sysctl_net_ipv4_conf_default_rp_filter
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/wsato/git/content/logs/rule-custom-2022-05-12-1412/test_suite.log
ERROR - Terminating due to error: Error reading file /home/wsato/git/content/linux_os/guide/system/software/sudo/sudo_add_noexec/tests/.noexec_enabled.pass.sh.swp: 'utf-8' codec can't decode byte 0x86 in position 16: invalid start byte.
WARNING - Nothing has been tested!
```
