### PR TITLE
Update rule to allow special bits in library dirs

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/rule.yml
@@ -66,7 +66,7 @@ template:
             - /usr/lib64/
         recursive: 'true'
         file_regex: ^.*$
-        filemode: '0755'
+        filemode: '7755'
 
 fixtext: |-
     Configure the library files to be protected from unauthorized access. Run the following command, replacing "[FILE]" with any library file with a mode more permissive than 755.


### PR DESCRIPTION


#### Description:

- Update `file_permissions_library_dirs` to allow special bits in the library dirs.
  - This will generate remediations that remove the write bit from `group` and `others`:
    e.g.: `find -H /lib/  -perm /g+w,o+w -type f -regex '^.*$' -exec chmod g-w,o-w {} \;`

#### Rationale:

- Rule file_permissions_library_dirs is about preventing group-writable or
world-writable files in the library dirs. The Suid bits and the stick
bit don't need to be stripped.
  The default mode of file_permissions is to allow stricter permissions,
so this change will make the template ignore the special bits and remove
only the 'w' bits from `group` and `others`.
- Fixes #8500