### PR TITLE
Add ANSSI minimal profile to SLE12

### DIFF
--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -222,8 +222,6 @@ controls:
     - ensure_gpgcheck_never_disabled
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_local_packages
-    - ensure_redhat_gpgkey_installed
-    - ensure_oracle_gpgkey_installed
 
   - id: R16
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -222,6 +222,7 @@ controls:
     - ensure_gpgcheck_never_disabled
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_local_packages
+    - ensure_suse_gpgkey_installed
 
   - id: R16
     levels:

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel7: CCE-80331-2
     cce@rhel8: CCE-83385-5
     cce@rhel9: CCE-84240-1
+    cce@sle12: CCE-91453-1
     cce@sle15: CCE-85759-9
     
 references:

--- a/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
+++ b/linux_os/guide/services/mail/package_sendmail_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Uninstall Sendmail Package'
 
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-80288-4
     cce@rhel8: CCE-81039-0
     cce@rhel9: CCE-90830-1
+    cce@sle12: CCE-91463-0
     cce@sle15: CCE-85761-5
 
 references:

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-27354-0
     cce@rhel8: CCE-80850-1
     cce@rhel9: CCE-84155-1
+    cce@sle12: CCE-91480-4
     cce@sle15: CCE-91436-6
 
 references:

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel7: CCE-27396-1
     cce@rhel8: CCE-82181-9
     cce@rhel9: CCE-84151-0
+    cce@sle12: CCE-91458-0
     cce@sle15: CCE-91159-4
 
 references:

--- a/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-27399-5
     cce@rhel8: CCE-82432-6
     cce@rhel9: CCE-84152-8
+    cce@sle12: CCE-91459-8
     cce@sle15: CCE-91160-2
 
 references:

--- a/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004,wrlinux1019
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Uninstall rsh-server Package'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-27342-5
     cce@rhel8: CCE-82184-3
     cce@rhel9: CCE-84143-7
+    cce@sle12: CCE-91462-2
     cce@sle15: CCE-91425-9
 
 references:

--- a/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
@@ -30,6 +30,7 @@ identifiers:
     cce@rhel7: CCE-27274-0
     cce@rhel8: CCE-82183-5
     cce@rhel9: CCE-84142-9
+    cce@sle12: CCE-91454-9
     cce@sle15: CCE-85760-7
 
 references:

--- a/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Uninstall talk-server Package'
 
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-27210-4
     cce@rhel8: CCE-82180-1
     cce@rhel9: CCE-84158-5
+    cce@sle12: CCE-91464-8
     cce@sle15: CCE-91433-3
 
 references:

--- a/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel7: CCE-27432-4
     cce@rhel8: CCE-80848-5
     cce@rhel9: CCE-84157-7
+    cce@sle12: CCE-91456-4
     cce@sle15: CCE-91432-5
 
 references:

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-27305-2
     cce@rhel8: CCE-80849-3
     cce@rhel9: CCE-84146-0
+    cce@sle12: CCE-91457-2
     cce@sle15: CCE-91434-1
 
 references:

--- a/linux_os/guide/services/obsolete/tftp/package_tftp_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15
+prodtype: rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Remove tftp Daemon'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-80443-5
     cce@rhel8: CCE-83590-0
     cce@rhel9: CCE-84153-6
+    cce@sle12: CCE-91465-5
     cce@sle15: CCE-91158-6
 
 references:

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Enable Smartcards in SSSD'
 
@@ -41,6 +41,7 @@ identifiers:
     cce@rhel7: CCE-80570-5
     cce@rhel8: CCE-80909-5
     cce@rhel9: CCE-89155-6
+    cce@sle12: CCE-91467-1
     cce@sle15: CCE-85826-6
     
 references:

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Limit Password Reuse'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Configure the root Account for Failed Password Attempts'
 
@@ -24,6 +24,7 @@ identifiers:
     cce@rhel7: CCE-80353-6
     cce@rhel8: CCE-80668-7
     cce@rhel9: CCE-83589-2
+    cce@sle12: CCE-91468-9
     cce@sle15: CCE-91171-9
 
 references:

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Set Interval For Counting Failed Password Attempts'
 
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel7: CCE-27297-1
     cce@rhel8: CCE-80669-5
     cce@rhel9: CCE-83583-5
+    cce@sle12: CCE-91469-7
     cce@sle15: CCE-91169-3
 
 references:

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -29,6 +29,7 @@ identifiers:
     cce@rhel7: CCE-27345-8
     cce@rhel8: CCE-80655-4
     cce@rhel9: CCE-83570-2
+    cce@sle12: CCE-91477-0
     cce@sle15: CCE-85840-7
 
 references:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
@@ -29,6 +29,7 @@ identifiers:
     cce@rhel7: CCE-82049-8
     cce@rhel8: CCE-80652-1
     cce@rhel9: CCE-83608-0
+    cce@sle12: CCE-83257-6
     cce@sle15: CCE-91168-5
 
 references:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Set number of Password Hashing Rounds - password-auth'
 
@@ -33,6 +33,7 @@ identifiers:
     cce@rhel7: CCE-83402-8
     cce@rhel8: CCE-83403-6
     cce@rhel9: CCE-83615-5
+    cce@sle12: CCE-91470-5
     cce@sle15: CCE-91173-5
 
 references:

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Set number of Password Hashing Rounds - system-auth'
 
@@ -27,6 +27,7 @@ identifiers:
     cce@rhel7: CCE-83384-8
     cce@rhel8: CCE-83386-3
     cce@rhel9: CCE-83621-3
+    cce@sle12: CCE-91471-3
     cce@sle15: CCE-91172-7
 
 references:

--- a/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
@@ -14,6 +14,7 @@ identifiers:
     cce@rhel7: CCE-80187-8
     cce@rhel8: CCE-80847-7
     cce@rhel9: CCE-84063-7
+    cce@sle12: CCE-91455-6
     cce@sle15: CCE-91161-0
 
 references:

--- a/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
@@ -16,6 +16,7 @@ identifiers:
     cce@rhel7: CCE-80188-6
     cce@rhel8: CCE-80886-5
     cce@rhel9: CCE-83989-4
+    cce@sle12: CCE-91460-6
     cce@sle15: CCE-91162-8
 
 references:

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Install firewalld Package'
 
@@ -24,6 +24,7 @@ identifiers:
     cce@rhel7: CCE-82999-4
     cce@rhel8: CCE-82998-6
     cce@rhel9: CCE-84021-5
+    cce@sle12: CCE-91461-4
     cce@sle15: CCE-85698-9
 
 references:

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Verify firewalld Enabled'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-80998-8
     cce@rhel8: CCE-80877-4
     cce@rhel9: CCE-90833-5
+    cce@sle12: CCE-91466-3
     cce@sle15: CCE-85751-6
 
 references:

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_sgid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Ensure All SGID Executables Are Authorized'
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle15,wrlinux1019,wrlinux8
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,wrlinux1019,wrlinux8
 
 description: |-
     The SGID (set group id) bit should be set only on files that were
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel7: CCE-80132-4
     cce@rhel8: CCE-80816-2
     cce@rhel9: CCE-83901-9
+    cce@sle12: CCE-91472-1
     cce@sle15: CCE-91175-0
 
 references:

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_suid/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 title: 'Ensure All SUID Executables Are Authorized'
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle15,wrlinux1019,wrlinux8
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,wrlinux1019,wrlinux8
 
 description: |-
     The SUID (set user id) bit should be set only on files that were
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel7: CCE-80133-2
     cce@rhel8: CCE-80817-0
     cce@rhel9: CCE-83897-9
+    cce@sle12: CCE-91473-9
     cce@sle15: CCE-91174-3
 
 references:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-82022-5
     cce@rhel8: CCE-80804-8
     cce@rhel9: CCE-83926-6
+    cce@sle12: CCE-83259-2
     cce@sle15: CCE-85807-6
 
 references:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -15,6 +15,7 @@ identifiers:
     cce@rhel7: CCE-82032-4
     cce@rhel8: CCE-80810-5
     cce@rhel9: CCE-83934-0
+    cce@sle12: CCE-91451-5
     cce@sle15: CCE-85803-5
 
 references:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-82029-0
     cce@rhel8: CCE-80812-1
     cce@rhel9: CCE-83931-6
+    cce@sle12: CCE-91452-3
     cce@sle15: CCE-85805-0
 
 references:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -26,6 +26,7 @@ identifiers:
     cce@rhel7: CCE-82042-3
     cce@rhel8: CCE-80813-9
     cce@rhel9: CCE-83941-5
+    cce@sle12: CCE-91479-6
     cce@sle15: CCE-85804-3
 
 references:

--- a/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_apply_updates/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhel9,sle15
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15
 
 title: 'Configure dnf-automatic to Install Available Updates Automatically'
 
@@ -21,6 +21,7 @@ severity: medium
 identifiers:
     cce@rhel8: CCE-82494-6
     cce@rhel9: CCE-83456-4
+    cce@sle12: CCE-91474-7
     cce@sle15: CCE-91165-1
 
 references:

--- a/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
+++ b/linux_os/guide/system/software/updating/dnf-automatic_security_updates_only/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhel9,sle15
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15
 
 title: 'Configure dnf-automatic to Install Only Security Updates'
 
@@ -19,6 +19,7 @@ severity: low
 identifiers:
     cce@rhel8: CCE-82267-6
     cce@rhel9: CCE-83461-4
+    cce@sle12: CCE-91478-8
     cce@sle15: CCE-91166-9
 
 references:

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure gpgcheck Enabled for Local Packages'
 
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel7: CCE-80347-8
     cce@rhel8: CCE-80791-7
     cce@rhel9: CCE-83463-0
+    cce@sle12: CCE-91475-4
     cce@sle15: CCE-91167-7
 
 references:

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -6,7 +6,11 @@
 - name: Grep for {{{ pkg_manager }}} repo section names
   shell: |
     set -o pipefail
+{{% if product in ["sle12", "sle15"] %}}
+    grep -HEr '^\[.+\]' -r /etc/zypp/repos.d/
+{{% else %}}
     grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
+{{% endif %}}
   register: repo_grep_results
   ignore_errors: True
   changed_when: False

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/bash/shared.sh
@@ -1,2 +1,6 @@
-# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
+{{% if product in ["sle12", "sle15"] %}}
+sed -i 's/gpgcheck\s*=.*/gpgcheck=1/g' /etc/zypp/repos.d/*
+{{% else %}}
 sed -i 's/gpgcheck\s*=.*/gpgcheck=1/g' /etc/yum.repos.d/*
+{{% endif %}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel7: CCE-26876-3
     cce@rhel8: CCE-80792-5
     cce@rhel9: CCE-83464-8
+    cce@sle12: CCE-83258-4
     cce@sle15: CCE-85797-9
 
 references:

--- a/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_suse_gpgkey_installed/rule.yml
@@ -35,6 +35,7 @@ rationale: |-
 severity: high
 
 identifiers:
+    cce@sle12: CCE-91482-0
     cce@sle15: CCE-85796-1
 
 references:

--- a/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/package_dnf-automatic_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhel9,sle15
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15
 
 title: 'Install dnf-automatic Package'
 
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-82986-1
     cce@rhel8: CCE-82985-3
     cce@rhel9: CCE-83454-9
+    cce@sle12: CCE-91476-2
     cce@sle15: CCE-91163-6
     
 

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,rhel8,rhel9,sle15
+prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15
 
 title: 'Enable dnf-automatic Timer'
 

--- a/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
+++ b/linux_os/guide/system/software/updating/timer_dnf-automatic_enabled/rule.yml
@@ -16,6 +16,7 @@ severity: medium
 identifiers:
     cce@rhel8: CCE-82360-9
     cce@rhel9: CCE-83459-8
+    cce@sle12: CCE-91481-2
     cce@sle15: CCE-91164-4
 
 references:

--- a/products/sle12/profiles/anssi_bp28_minmal.profile
+++ b/products/sle12/profiles/anssi_bp28_minmal.profile
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+metadata:
+    SMEs:
+        - abergmann
+
+title: 'ANSSI-BP-028 (minimal)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the minimal hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    Only the components strictly necessary to the service provided by the system should be installed.
+    Those whose presence can not be justified should be disabled, removed or deleted.
+    Performing a minimal install is a good starting point, but doesn't provide any assurance
+    over any package installed later.
+    Manual review is required to assess if the installed services are minimal.
+
+selections:
+  - anssi:all:minimal
+


### PR DESCRIPTION
#### Description:

- Add ANSSI minimal profile definition for SLE12 and relevant changes regarding CCE ids and platform compatability

#### Rationale:
- Add ANSSI minimal profile definition for SLE12
- Add sle12 CCEs for ANSSI profile rules
- Add missing cce test for SLE platforms
- Add SLE support for ensure_gpgcheck_never_disabled remediations
