### PR TITLE
Move README badges for nightly builds to GH Actions

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,4 +1,4 @@
-name: Nightly builds 5.11
+name: Nightly builds with OVAL 5.11
 on:
     schedule:
         # Run daily at 03:00

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,4 +1,4 @@
-name: Nightly builds
+name: Nightly builds 5.11
 on:
     schedule:
         # Run daily at 03:00

--- a/.github/workflows/nightly_build_5_10.yml
+++ b/.github/workflows/nightly_build_5_10.yml
@@ -1,4 +1,4 @@
-name: Nightly builds 5.10
+name: Nightly builds with OVAL 5.10
 on:
     schedule:
         # Run daily at 03:00

--- a/.github/workflows/nightly_build_5_10.yml
+++ b/.github/workflows/nightly_build_5_10.yml
@@ -1,9 +1,8 @@
-name: Nightly builds
+name: Nightly builds 5.10
 on:
     schedule:
         # Run daily at 03:00
         -   cron: "0 3 * * *"
-
 jobs:
     nightly-fedora-5-10:
         name: Nightly build OVAL 5.10 on Fedora Latest (Container)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Docs](https://img.shields.io/readthedocs/complianceascode)](https://complianceascode.readthedocs.io/en/latest/)
 [![Release](https://img.shields.io/github/release/ComplianceAsCode/content.svg)](https://github.com/ComplianceAsCode/content/releases/latest)
-[![Nightly ZIP Status](https://jenkins.open-scap.org/job/scap-security-guide-nightly-zip/badge/icon?subject=Nightly%20OVAL-5.11%20ZIP&status=Download)](https://jenkins.open-scap.org/job/scap-security-guide-nightly-zip/lastSuccessfulBuild/artifact/scap-security-guide-nightly.zip)
-[![Nightly 5.10 ZIP Status](https://jenkins.open-scap.org/job/scap-security-guide-nightly-oval510-zip/badge/icon?subject=Nightly%20OVAL-5.10%20ZIP&status=Download)](https://jenkins.open-scap.org/job/scap-security-guide-nightly-oval510-zip/lastSuccessfulBuild/artifact/scap-security-guide-nightly-oval-510.zip)
+[![Nightly ZIP Status](https://github.com/ComplianceAsCode/content/actions/workflows/nightly_build.yml/badge.svg)](https://nightly.link/ComplianceAsCode/content/workflows/nightly_build/master/Nightly%20Build.zip)
+[![Nightly 5.10 ZIP Status](https://github.com/ComplianceAsCode/content/actions/workflows/nightly_build_5_10.yml/badge.svg)](https://nightly.link/ComplianceAsCode/content/workflows/nightly_build_5_10/master/Nightly%20Build%20OVAL%205.10.zip)
 [![Maintainability](https://api.codeclimate.com/v1/badges/62c1f8d8064b2163db3e/maintainability)](https://codeclimate.com/github/ComplianceAsCode/content/maintainability)
 [![Stats, Guides, Tables](https://github.com/ComplianceAsCode/content/actions/workflows/gh-pages.yaml/badge.svg)](https://complianceascode.github.io/content-pages/)
 [![Join the chat at https://gitter.im/Compliance-As-Code-The/content](https://badges.gitter.im/Compliance-As-Code-The/content.svg)](https://gitter.im/Compliance-As-Code-The/content?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
#### Description:

Update Readme file with links to nightly builds produced by github actions

#### Rationale:

Moving more jobs to GitHub Actions from Jenkins.
