### PR TITLE
Remove duplicated ocp4 test result

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/tests/e2e.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_rule_order/tests/e2e.yml
@@ -1,3 +1,0 @@
----
-default_result: FAIL
-result_after_remediation: PASS


### PR DESCRIPTION


#### Description:

- The e2e.yml file in `tests/` is identical to the one in `tests/ocp4/`

#### Rationale:

- Remove duplicated code
