### PR TITLE
Code Climate Config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -14,3 +14,8 @@ plugins:
     enabled: true
   sonar-python:
     enabled: true
+
+exclude_patterns:
+  - linux_os/
+  - applications/
+  - products/

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,3 +4,13 @@ checks:
   file-lines:
     config:
       threshold: 400
+
+plugins:
+  markdownlint:
+    enabled: true
+  pep8:
+    enabled: true
+  radon:
+    enabled: true
+  sonar-python:
+    enabled: true

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,6 @@
+---
+version: "2"
+checks:
+  file-lines:
+    config:
+      threshold: 400

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+max-line-length = 99


### PR DESCRIPTION
#### Description:

* Set pycodestyle max line length to 99, per the style guide
* Set Code Climate line limit to 400.

#### Rationale:

Get code climate with less noise and make it follow our guidelines.