### PR TITLE
Document `fixtext` and `check` attributes on controls and rules

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -1411,7 +1411,7 @@ The **bolded** items are under direct control of content authors.
   * The last part is "If {OCIL clause}, then it is a finding"
 * SRG Fix -> DISA OS SRG XML
   * As of V2R1 that field is blank
-* **Fix** -> Rule's fix
+* **Fixtext** -> Rule's fix
 * **Severity** -> DISA OS SRG XML or Control
   * By default, it comes from the DISA OS SRG
   * Can be overridden by the control

--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -100,7 +100,7 @@ Rules sections must be in the following order, if they are present.
 * `platforms`
 * `ocil_clause`
 * `ocil` (HTML Like)
-* `fix` (HTML Like)
+* `fixtext` (HTML Like)
 * `warnings`
     * All subsections are HTML-Like
     * If defined must have at least one of the following sub-sections:

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -193,6 +193,13 @@ A rule itself contains these attributes:
     this contains a `partitions do not have a type of crypto_LUKS` value
     for `ocil_clause`. This clause is prefixed with the phrase `Is it
     the case that <ocil_clause> ?`.
+    If you are using the SRG Export the clause will be used in the sentence `If <ocil_clause>, then this is a finding.`
+
+- `check`: Describes how to manually check the rule.
+   This should be based on the OVAL.
+
+- `fixtext`: This describes how to fix the rule if the system is not compliant.
+    For most Linux systems this should be based on the bash fix.
 
 A rule may contain those reference-type attributes:
 


### PR DESCRIPTION
#### Description:

Update the docs for `fixtext` and `check` attributes on controls and rules.

#### Rationale:

Help others use the project.
