### PR TITLE
Stop SSGTS when a wrong domain name is informed

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -241,6 +241,9 @@ class VMTestEnv(TestEnv):
         self.domain = virt.connect_domain(
             self.hypervisor, self.domain_name)
 
+        if self.domain is None:
+            sys.exit(1)
+
         if not self.keep_snapshots:
             self.snapshots_cleanup()
 


### PR DESCRIPTION
#### Description:

When calling the SSGTS to use libvirt it is necessary to inform the
domain name. If it is not possible to connect in the domain because
the informed domain name is incorrect, the connection function returns
None. However, other following functions depends on a connected domain
and exceptions are raised. After informing the user, there is no sense
in continue when a domain does not exist. It was included a check for this.

#### Rationale:

Avoid unnecessary code execution and better report the issue for the user.
