### PR TITLE
Send coverage to Code Climate

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -105,7 +105,7 @@ jobs:
       image: fedora:34
     steps:
       - name: Install Deps
-        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck
+        run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck git
       - name: Install deps python
         run: pip install ruamel.yaml yamlpath
       - name: Checkout
@@ -131,6 +131,12 @@ jobs:
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
+      - name: Upload coverage to Code Climate  # Requires: git package
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+        with:
+          coverageLocations: build/tests/coverage.xml:coverage.py
 
   validate-fedora-rawhide:
     name: Build, Test on Fedora Rawhide (Container)

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -131,6 +131,8 @@ jobs:
       - name: Test
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
+      - name: "Set git safe directory, ref: https://github.com/actions/checkout/issues/760"
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Upload coverage to Code Climate  # Requires: git package
         uses: paambaati/codeclimate-action@v3.0.0
         env:

--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -134,9 +134,10 @@ jobs:
       - name: "Set git safe directory, ref: https://github.com/actions/checkout/issues/760"
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Upload coverage to Code Climate  # Requires: git package
+        if: ${{ github.repository == 'ComplianceAsCode/content' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+          CC_TEST_REPORTER_ID: e67e068471d32b63f8e9561dba8f6a3f84dcc76b05ebfd98e44ced1a91cff854
         with:
           coverageLocations: build/tests/coverage.xml:coverage.py
 


### PR DESCRIPTION
As we already install the pytest-cov and its dependencies on the Fedora, runner, the coverage is probably generated, and the only step remaining is to send it.