### PR TITLE
Update sssd_offline_cred_expiration OVAL for OL8 and RHEL8

### DIFF
--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
@@ -26,15 +26,19 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% if product in ["ol8", "rhel8"] %}}
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
   comment="tests the value of cache_credentials setting in the /etc/sssd/sssd.conf file"
   id="test_sssd_cache_credentials" version="1">
     <ind:object object_ref="obj_sssd_cache_credentials" />
+    <ind:state state_ref="state_sssd_cache_credentials" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_cache_credentials" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*cache_credentials\s*=\s*(?i)false\s*(?:#.*)?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:pattern operation="pattern match">^[\s]*cache_credentials\s*=\s*(\w+)\s*(?:#.*)?$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_sssd_cache_credentials" version="1">
+    <ind:subexpression operation="case insensitive equals">false</ind:subexpression>
+  </ind:textfilecontent54_state>
   {{% endif %}}
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
@@ -9,6 +9,10 @@
       </criteria>
       <criterion comment="Check offline_credentials_expiration in /etc/sssd/sssd.conf"
       test_ref="test_sssd_offline_cred_expiration" />
+      {{% if product == "ol8" %}}
+      <criterion comment="Check cache_credentials in /etc/sssd/sssd.conf"
+      test_ref="test_sssd_cache_credentials" />
+      {{% endif %}}
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -18,7 +22,19 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_offline_cred_expiration" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*offline_credentials_expiration[\s]*=[\s]*1$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*offline_credentials_expiration[\s]*=[\s]*1\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% if product == "ol8" %}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the value of cache_credentials setting in the /etc/sssd/sssd.conf file"
+  id="test_sssd_cache_credentials" version="1">
+    <ind:object object_ref="obj_sssd_cache_credentials" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sssd_cache_credentials" version="1">
+    <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*cache_credentials\s*=\s*(?i)false\s*(?:#.*)?$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% endif %}}
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/oval/shared.xml
@@ -9,7 +9,7 @@
       </criteria>
       <criterion comment="Check offline_credentials_expiration in /etc/sssd/sssd.conf"
       test_ref="test_sssd_offline_cred_expiration" />
-      {{% if product == "ol8" %}}
+      {{% if product in ["ol8", "rhel8"] %}}
       <criterion comment="Check cache_credentials in /etc/sssd/sssd.conf"
       test_ref="test_sssd_cache_credentials" />
       {{% endif %}}
@@ -25,7 +25,7 @@
     <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*offline_credentials_expiration[\s]*=[\s]*1\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  {{% if product == "ol8" %}}
+  {{% if product in ["ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the value of cache_credentials setting in the /etc/sssd/sssd.conf file"
   id="test_sssd_cache_credentials" version="1">

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/rule.yml
@@ -6,6 +6,14 @@ title: 'Configure SSSD to Expire Offline Credentials'
 
 description: |-
     SSSD should be configured to expire offline credentials after 1 day.
+    {{% if product in ["ol8", "rhel8"] %}}
+    Check if SSSD allows cached authentications with the following command:
+    <pre>
+    $ sudo grep cache_credentials /etc/sssd/sssd.conf
+    cache_credentials = true
+    </pre>
+    If "cache_credentials" is set to "false" or is missing no further checks are required.<br/>
+    {{% endif %}}
     To configure SSSD to expire offline credentials, set
     <tt>offline_credentials_expiration</tt> to <tt>1</tt> under the <tt>[pam]</tt>
     section in <tt>/etc/sssd/sssd.conf</tt>. For example:
@@ -48,6 +56,14 @@ references:
 ocil_clause: 'it does not exist or is not configured properly'
 
 ocil: |-
+    {{% if product in ["ol8", "rhel8"] %}}
+    Check if SSSD allows cached authentications with the following command:
+    <pre>
+    $ sudo grep cache_credentials /etc/sssd/sssd.conf
+    cache_credentials = true
+    </pre>
+    If "cache_credentials" is set to "false" or is missing no further checks are required.<br/>
+    {{% endif %}}
     To verify that SSSD expires offline credentials, run the following command:
     <pre>$ sudo grep offline_credentials_expiration /etc/sssd/sssd.conf</pre>
     If configured properly, output should be

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/cache_credentials_false.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/cache_credentials_false.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
+source common.sh
+
+echo -e "[pam]\noffline_credentials_expiration = 2" >> $SSSD_CONF
+
+echo -e "[domain/EXAMPLE]\ncache_credentials = false" >> $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/comment.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/comment.fail.sh
@@ -3,3 +3,5 @@
 source common.sh
 
 echo -e "[pam]\n#offline_credentials_expiration = 1" >> $SSSD_CONF
+
+echo -e "[domain/EXAMPLE]\ncache_credentials = true" >> $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/correct_value.pass.sh
@@ -3,3 +3,5 @@
 source common.sh
 
 echo -e "[pam]\noffline_credentials_expiration = 1" >> $SSSD_CONF
+
+echo -e "[domain/EXAMPLE]\ncache_credentials = true" >> $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_section.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_section.fail.sh
@@ -4,3 +4,5 @@ source common.sh
 
 echo -e "[pam]\ntest = 1" >> $SSSD_CONF
 echo -e "[sssd]\noffline_credentials_expiration = 1" >> $SSSD_CONF
+
+echo -e "[domain/EXAMPLE]\ncache_credentials = true" >> $SSSD_CONF

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/tests/wrong_value.fail.sh
@@ -3,3 +3,5 @@
 source common.sh
 
 echo -e "[pam]\noffline_credentials_expiration = 0" >> $SSSD_CONF
+
+echo -e "[domain/EXAMPLE]\ncache_credentials = true" >> $SSSD_CONF


### PR DESCRIPTION
#### Description:

- Update OVAL to check for cache_credentials configuration in sssd.conf

#### Rationale:

- This is needed for OL08-00-020290 STIG IG and RHEL-08-020290
