### PR TITLE
Set check_root_user to true on multiple "audit_rules_dac_modification" rules ol8

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -11,13 +11,13 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -25,13 +25,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -99,6 +99,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: fremovexattr
+        check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         syscall_grouping:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -94,6 +94,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: fsetxattr
+        check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         syscall_grouping:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -11,13 +11,13 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -25,13 +25,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -99,6 +99,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: lremovexattr
+        check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         syscall_grouping:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -94,6 +94,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: lsetxattr
+        check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         syscall_grouping:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -10,13 +10,13 @@ description: |-
     program to read audit rules during daemon startup (the default), add the
     following line to a file with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
@@ -24,13 +24,13 @@ description: |-
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     <br /><br />
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S removexattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -98,6 +98,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: removexattr
+        check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         syscall_grouping:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -9,24 +9,24 @@ description: |-
     startup (the default), add the following line to a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to
     <tt>/etc/audit/audit.rules</tt> file:
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b32 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
     If the system is 64 bit then also add the following line:
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid&gt;={{{ auid }}} -F auid!=unset -F key=perm_mod</pre>
-{{%- if product in ["rhel8", "rhel9"] %}}
+{{%- if product in ["ol8", "rhel8", "rhel9"] %}}
     <pre>-a always,exit -F arch=b64 -S setxattr -F auid=0 -F key=perm_mod</pre>
 {{%- endif %}}
 
@@ -94,6 +94,7 @@ template:
     name: audit_rules_dac_modification
     vars:
         attr: setxattr
+        check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
         syscall_grouping:


### PR DESCRIPTION
#### Description:

- Update audit_rules_dac_modification rules to check root user in OL8

#### Rationale:

- This aligns OL8 to DISA requirements
