### PR TITLE
Update OVAL, bash and tests for set_password_hashing_min_rounds_logindefs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/bash/shared.sh
@@ -1,0 +1,8 @@
+# platform = multi_platform_ol
+
+{{{ set_config_file(path="/etc/login.defs",
+                    parameter="SHA_CRYPT_MIN_ROUNDS",
+                    value="5000",
+                    separator=" ",
+                    separator_regex="\s*") }}}
+

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/oval/shared.xml
@@ -25,10 +25,11 @@
 
   <ind:textfilecontent54_test id="test_etc_login_defs_sha_crypt_min_rounds_present" check="all" check_existence="all_exist" comment="SHA_CRYPT_MIN_ROUNDS is explicitly configured in /etc/login.defs and its value most be greater or equal to 5000" version="1">
     <ind:object object_ref="object_etc_login_defs_sha_crypt_min_rounds_present" />
+    <ind:state state_ref="state_etc_login_defs_sha_crypt_rounds" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_etc_login_defs_sha_crypt_min_rounds_present" version="1">
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*SHA_CRYPT_MIN_ROUNDS\s+([5-9]\d{3,}|\d{5,})\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*SHA_CRYPT_MIN_ROUNDS\s+(\d+)\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -43,10 +44,17 @@
 
   <ind:textfilecontent54_test id="test_etc_login_defs_sha_crypt_max_rounds_present" check="all" check_existence="all_exist" comment="SHA_CRYPT_MAX_ROUNDS is explicitly configured in /etc/login.defs and its value most be greater or equal to 5000" version="1">
     <ind:object object_ref="object_etc_login_defs_sha_crypt_max_rounds_present" />
+    <ind:state state_ref="state_etc_login_defs_sha_crypt_rounds" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_etc_login_defs_sha_crypt_max_rounds_present" version="1">
     <ind:filepath>/etc/login.defs</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*SHA_CRYPT_MAX_ROUNDS\s+([5-9]\d{3,}|\d{5,})\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*SHA_CRYPT_MAX_ROUNDS\s+(\d+)\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_etc_login_defs_sha_crypt_rounds"
+  comment="Rounds should be set to more than 5000" version="1">
+    <ind:subexpression datatype="int" operation="greater than or equal">5000</ind:subexpression>
+  </ind:textfilecontent54_state>
+
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/argument_missing.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/argument_missing.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+source common.sh

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/common.sh
@@ -1,0 +1,2 @@
+
+truncate -s 0 "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/correct_value.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source common.sh
+
+echo "SHA_CRYPT_MIN_ROUNDS 5000" > "/etc/login.defs"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/tests/wrong_value.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+source common.sh
+
+echo "SHA_CRYPT_MIN_ROUNDS 4999" > "/etc/login.defs"


### PR DESCRIPTION
#### Description:

- Set comparison against 5000 instead of using the regex to catch it
- Add tests
- Add bash remediation for OL8

#### Rationale:

- The regex was limitihg the value to 5 digits, and also it is easier to maintain this way
