### PR TITLE
Update OL8 STIG rules severities

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/rule.yml
@@ -19,7 +19,7 @@ rationale: |-
     client violate expectations, and makes system configuration more
     fragmented.
 
-severity: high
+severity: medium
 
 identifiers:
     cce@rhel8: CCE-85870-4

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/mcafee_endpoint_security_software/package_mcafeetp_installed/rule.yml
@@ -21,7 +21,7 @@ rationale: |-
     Virus scanning software can be used to detect if a system has been compromised by
     computer viruses, as well as to limit their spread to other systems.
 
-severity: high
+severity: medium
 
 identifiers:
     cce@rhel7: CCE-86257-3

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -88,6 +88,7 @@ selections:
 
     # OL08-00-010030
     - encrypt_partitions
+    - encrypt_partitions.severity=medium
 
     # OL08-00-010040
     - sshd_enable_warning_banner
@@ -572,7 +573,7 @@ selections:
 
     # OL08-00-020220
     - accounts_password_pam_pwhistory_remember_system_auth
-    - accounts_password_pam_pwhistory_remember_system_auth.severity=low
+    - accounts_password_pam_pwhistory_remember_system_auth.severity=medium
     - accounts_password_pam_pwhistory_remember_password_auth
     - accounts_password_pam_pwhistory_remember_password_auth.severity=low
 


### PR DESCRIPTION
#### Description:

- Update severities on rules related to OL8 STIG

#### Rationale:

- This is to be compliant with DISA OL8 STIG v1r2
