### PR TITLE
The debug-shell.target does not exist, the rule is about service.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/service_debug-shell_disabled/rule.yml
@@ -49,8 +49,8 @@ ocil: |-
 fixtext: |-
     Configure the system to mask the debug-shell systemd service with the following command:
 
-    $ sudo systemctl disable --now debug-shell.target
-    $ sudo systemctl mask --now debug-shell.target
+    $ sudo systemctl disable --now debug-shell.service
+    $ sudo systemctl mask --now debug-shell.service
 
 platform: machine
 


### PR DESCRIPTION
#### Description:

- Fix the fixtext.

#### Rationale:

- The debug-shell.target does not exist, the rule is about service.