### PR TITLE
Presence of management function Configure host-based firewall is in FMT_SMF_EXT.1.1, not in FMT_MOF_EXT.1.

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -33,6 +33,7 @@ references:
     disa: CCI-002314
     nist: CM-6(a)
     nist@sle15: CM-7,CM-7.1(iii),CM-7(b),AC-17(1)
+    ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000298-GPOS-00116,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00232
     stigid@ol8: OL08-00-040100
     stigid@rhel8: RHEL-08-040100

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
@@ -36,7 +36,7 @@ references:
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: PR.IP-1
     nist@sle15: CM-7,CM-7.1(iii),CM-7(b),AC-17(1)
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00231,SRG-OS-000480-GPOS-00232
     stigid@ol7: OL07-00-040520
     stigid@ol8: OL08-00-040101


### PR DESCRIPTION

Also adding the reference to the rule installing the package.

#### Description:

- Update the OSPP reference.

#### Rationale:

- Presence of management function Configure host-based firewall is in FMT_SMF_EXT.1.1, not in FMT_MOF_EXT.1.
- Also adding the reference to the rule installing the package.

Internal reference RC-406.