### PR TITLE
Update configure_openssl_tls_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/oval/shared.xml
@@ -1,6 +1,81 @@
-{{{ oval_check_config_file(
-    path="/etc/crypto-policies/back-ends/opensslcnf.config",
-    prefix_regex="^(?:.*\\n)*\s*(?:TLS\.)?",
-    parameter="MinProtocol",
-    value="TLSv1.2",
-    separator_regex="\s*=\s*", ) }}}
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Configure OpenSSL library to use TLS Encryption") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_{{{ rule_id }}}"
+      comment="OpenSSL library is configured to use only TLS v1.2 or newer encryption" />
+      <criteria operator="OR">
+        <criterion test_ref="test_installed_version_of_crypto_policies"
+        comment="Installed version of  crypto-policies is older than 20210617-1" />
+        <criterion test_ref="test_configure_openssl_dtls_crypto_policy"
+        comment="OpenSSL library is configured to use only DTLS v1.2 or newer encryption" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}" check="only one"
+  comment="Check that the SSH configuration mandates usage of system-wide crypto policies."
+  check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="obj_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+    <ind:state state_ref="state_{{{ rule_id }}}_last_instance" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
+    <ind:filepath>/etc/crypto-policies/back-ends/opensslcnf.config</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*(?:TLS\.)?(?i)MinProtocol\s*=\s*TLSv(\S*)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_configure_openssl_dtls_crypto_policy" check="only one"
+  comment="Check that the SSH configuration mandates usage of system-wide crypto policies."
+  check_existence="at_least_one_exists" version="1">
+    <ind:object object_ref="obj_configure_openssl_dtls_crypto_policy" />
+    <ind:state state_ref="state_{{{ rule_id }}}" />
+    <ind:state state_ref="state_configure_openssl_dtls_crypto_policy_last_instance" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_configure_openssl_dtls_crypto_policy" version="1">
+    <ind:filepath>/etc/crypto-policies/back-ends/opensslcnf.config</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*(?:DTLS\.)?(?i)MinProtocol\s*=\s*DTLSv(\S*)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}" version="1">
+    <ind:subexpression datatype="version" operation="greater than or equal">1.2</ind:subexpression>
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_state id="state_{{{ rule_id }}}_last_instance" version="1">
+    <ind:instance datatype="int" operation="equals" var_ref="var_count_{{{ rule_id }}}" />
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_state id="state_configure_openssl_dtls_crypto_policy_last_instance" version="1">
+    <ind:instance datatype="int" operation="equals" var_ref="var_count_configure_openssl_dtls_crypto_policy" />
+  </ind:textfilecontent54_state>
+
+  <linux:rpminfo_test check="all" check_existence="any_exist"
+  comment="Installed version of  crypto-policies is older than 20210617-1"
+  id="test_installed_version_of_crypto_policies" version="1">
+    <linux:object object_ref="obj_installed_version_of_crypto_policies" />
+    <linux:state state_ref="state_installed_version_of_crypto_policies" />
+  </linux:rpminfo_test>
+
+  <local_variable id="var_count_{{{ rule_id }}}" datatype="int" version="1"
+  comment="Number of matches of TLS versions">
+    <count>
+      <object_component item_field="instance" object_ref="obj_{{{ rule_id }}}" />
+    </count>
+  </local_variable>
+
+  <local_variable id="var_count_configure_openssl_dtls_crypto_policy" datatype="int" version="1"
+  comment="Number of matches of DTLS versions">
+    <count>
+      <object_component item_field="instance" object_ref="obj_configure_openssl_dtls_crypto_policy" />
+    </count>
+  </local_variable>
+
+  <linux:rpminfo_state id="state_installed_version_of_crypto_policies" version="1">
+    <linux:evr operation="less than" datatype="evr_string">0:20210617-1</linux:evr> 
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_installed_version_of_crypto_policies" version="1">
+    <linux:name>crypto-policies</linux:name>
+  </linux:rpminfo_object>
+</def-group>

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct.pass.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 
 echo "MinProtocol = TLSv1.2" > "$configfile"
+echo "MinProtocol = DTLSv1.2" >> "$configfile"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_commented.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 
 echo "#MinProtocol = TLSv1.2" > "$configfile"
+echo "#MinProtocol = DTLSv1.2" >> "$configfile"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_followed_by_incorrect.fail.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 
 echo "MinProtocol = TLSv1.2" > "$configfile"
+echo "MinProtocol = DTLSv1.2" >> "$configfile"
 echo "MinProtocol = TLSv1.0" >> "$configfile"
+echo "MinProtocol = DTLSv1.0" >> "$configfile"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_value_old.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/correct_value_old.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# platform = Oracle Linux 8
+
+{{{ bash_package_install("yum-utils") }}}
+
+yum-config-manager --enable ol8_u4_baseos_base
+
+yum downgrade -y crypto-policies-20210209-1.gitbfb6bed.el8_3
+
+configfile=/etc/crypto-policies/back-ends/opensslcnf.config
+
+echo "MinProtocol = TLSv1.2" > "$configfile"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/incorrect_followed_by_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/incorrect_followed_by_correct.pass.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 
 echo "MinProtocol = TLSv1.1" > "$configfile"
+echo "MinProtocol = DTLSv1.0" >> "$configfile"
 echo "MinProtocol = TLSv1.2" >> "$configfile"
+echo "MinProtocol = DTLSv1.2" >> "$configfile"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/incorrect_policy.fail.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 
 echo "MinProtocol = TLSv1.0" > "$configfile"
+echo "MinProtocol = DTLSv1.0" >> "$configfile"

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,Oracle Linux 8,Red Hat Enterprise Linux 8
 
 configfile=/etc/crypto-policies/back-ends/opensslcnf.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/wrong_value_new.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/tests/wrong_value_new.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Oracle Linux 8
+
+configfile=/etc/crypto-policies/back-ends/opensslcnf.config
+
+echo "MinProtocol = TLSv1.2" > "$configfile"


### PR DESCRIPTION
#### Description:

- Update OVAL in configure_openssl_tls_crypto_policy to check for DTLS Minprotocol when it is applicable(`crypto-policies` package is newer or equal to `20210617-1.gitc776d3e`)

#### Rationale:

- This is to cover DISA's STIG IDs `OL08-00-010294` & `RHEL-08-010294`
