### PR TITLE
Fix sssd_enable_certmap OVAL

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -440,6 +440,9 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
 
 -   Parameters:
 
+    -   **escape_text** - if set to true the given text is escaped to treat it as regex,
+        when set to false the text is taken directly as it is.
+
     -   **path** - path to the file to check.
 
     -   **text** - the line that should be present in the file.

--- a/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_certmap/rule.yml
@@ -42,7 +42,7 @@ ocil_clause: 'Certmap is not configured in SSSD'
 
 ocil: |-
     To verify Certmap is enabled in SSSD, run the following command:
-    <pre>$ cat sudo cat /etc/sssd/sssd.conf</pre>
+    <pre>$ sudo cat /etc/sssd/sssd.conf</pre>
     If configured properly, output should contain section like the following
     <pre>
     [certmap/testing.test/rule_name]
@@ -70,7 +70,8 @@ template:
     name: lineinfile
     vars:
       path: '/etc/sssd/sssd.conf'
-      text: '^\[certmap\/.+\/.+\]$'
+      text: '\[certmap\/.+\/.+\]'
+      escape_text: "false"
     backends:
         ansible: "off"
         bash: "off"

--- a/shared/templates/lineinfile/oval.template
+++ b/shared/templates/lineinfile/oval.template
@@ -1,4 +1,8 @@
-{{%- set regex = "^[\s]*" ~ (TEXT | escape_regex) ~ "[\s]*$" -%}}
+{{% if ESCAPE_TEXT %}}
+  {{%- set regex = "^[\s]*" ~ (TEXT | escape_regex) ~ "[\s]*$" -%}}
+{{% else %}}
+  {{%- set regex = "^[\s]*" ~ TEXT ~ "[\s]*$" -%}}
+{{% endif %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Check presence of " + TEXT + " in " + PATH) }}}

--- a/shared/templates/lineinfile/template.py
+++ b/shared/templates/lineinfile/template.py
@@ -1,4 +1,8 @@
+from ssg.utils import parse_template_boolean_value
 
 def preprocess(data, lang):
     data["oval_extend_definitions"] = data.get("oval_extend_definitions", [])
+    data["escape_text"] = parse_template_boolean_value(data,
+                                                     parameter="escape_text",
+                                                     default_value=True)
     return data


### PR DESCRIPTION
#### Description:

- Introduce the variable `escape_regex` to the template `lineinfile` so the given regex in `sssd_enable_certmap` works properly
- Fix typo in rule.yml file

#### Rationale:

- The text given in `sssd_enable_certmap` to `lineinfile` template was being escaped so it wasn't interpreted as the expected regex, which resulted in an undesired behavior
