### PR TITLE
Update directory_permissions_var_log_audit behavior for OL8 and RHEL8

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
@@ -6,6 +6,7 @@ else
   DIR="/var/log/audit"
 fi
 
+{{% if product != "ol8" %}}
 if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then
@@ -16,3 +17,6 @@ if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
 else
   chmod 0700 $DIR
 fi
+{{% else %}}
+chmod 0700 $DIR
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/bash/shared.sh
@@ -6,7 +6,7 @@ else
   DIR="/var/log/audit"
 fi
 
-{{% if product != "ol8" %}}
+{{% if product not in ["ol8", "rhel8"] %}}
 if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="directory_permissions_var_log_audit" version="1">
     {{{ oval_metadata("Checks for correct permissions for audit logs.") }}}
     <criteria operator="OR">
-      {{% if product != "ol8" %}}
+      {{% if product not in ["ol8", "rhel8"] %}}
       <criteria operator="AND" comment="log_file set">
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criteria operator="AND" comment="log_group in auditd.conf is not root">
@@ -23,8 +23,8 @@
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criterion test_ref="test_dir_permissions_audit_log" negate="true" />
       </criteria>
-      <criteria operator="AND" comment="log_file set">
-        <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" />
+      <criteria operator="AND" comment="log_file not set">
+        <extend_definition comment="log_file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" />
         <criterion test_ref="test_dir_permissions_var_log_audit" negate="true" />
       </criteria>
       {{% endif %}}
@@ -42,7 +42,7 @@
     <unix:state state_ref="state_not_mode_0700" />
   </unix:file_test>
   <unix:file_object comment="audit log files" id="object_audit_log_directory" version="1">
-    {{% if product != "ol8" %}}
+    {{% if product not in ["ol8", "rhel8"] %}}
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
     {{% endif %}}
     <unix:path operation="equals" var_ref="audit_log_dir" />
@@ -55,7 +55,7 @@
     <unix:state state_ref="state_not_mode_0700" />
   </unix:file_test>
   <unix:file_object comment="/var/log/audit files" id="object_var_log_audit_directory" version="1">
-    {{% if product != "ol8" %}}
+    {{% if product not in ["ol8", "rhel8"] %}}
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
     {{% endif %}}
     <unix:path operation="equals">/var/log/audit</unix:path>
@@ -63,7 +63,7 @@
     <filter action="include">state_not_mode_0700</filter>
   </unix:file_object>
 
-  {{% if product != "ol8" %}}
+  {{% if product not in ["ol8", "rhel8"] %}}
   <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit files mode 0750" id="test_dir_permissions_var_log_audit-non_root" version="1">
     <unix:object object_ref="object_var_log_audit_directory-non_root" />
     <unix:state state_ref="state_not_mode_0750" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/oval/shared.xml
@@ -2,6 +2,7 @@
   <definition class="compliance" id="directory_permissions_var_log_audit" version="1">
     {{{ oval_metadata("Checks for correct permissions for audit logs.") }}}
     <criteria operator="OR">
+      {{% if product != "ol8" %}}
       <criteria operator="AND" comment="log_file set">
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criteria operator="AND" comment="log_group in auditd.conf is not root">
@@ -17,6 +18,16 @@
         definition_ref="auditd_conf_log_group_not_root" />
         <criterion test_ref="test_dir_permissions_var_log_audit-non_root" negate="true" /> 
       </criteria>
+      {{% else %}}
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
+        <criterion test_ref="test_dir_permissions_audit_log" negate="true" />
+      </criteria>
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" />
+        <criterion test_ref="test_dir_permissions_var_log_audit" negate="true" />
+      </criteria>
+      {{% endif %}}
     </criteria>
   </definition>
 
@@ -26,6 +37,33 @@
     </regex_capture>
   </local_variable>
 
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit mode 0700" id="test_dir_permissions_audit_log" version="1">
+    <unix:object object_ref="object_audit_log_directory" />
+    <unix:state state_ref="state_not_mode_0700" />
+  </unix:file_test>
+  <unix:file_object comment="audit log files" id="object_audit_log_directory" version="1">
+    {{% if product != "ol8" %}}
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    {{% endif %}}
+    <unix:path operation="equals" var_ref="audit_log_dir" />
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_not_mode_0700</filter>
+  </unix:file_object>
+
+  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit mode 0700" id="test_dir_permissions_var_log_audit" version="1">
+    <unix:object object_ref="object_var_log_audit_directory" />
+    <unix:state state_ref="state_not_mode_0700" />
+  </unix:file_test>
+  <unix:file_object comment="/var/log/audit files" id="object_var_log_audit_directory" version="1">
+    {{% if product != "ol8" %}}
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
+    {{% endif %}}
+    <unix:path operation="equals">/var/log/audit</unix:path>
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_not_mode_0700</filter>
+  </unix:file_object>
+
+  {{% if product != "ol8" %}}
   <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit files mode 0750" id="test_dir_permissions_var_log_audit-non_root" version="1">
     <unix:object object_ref="object_var_log_audit_directory-non_root" />
     <unix:state state_ref="state_not_mode_0750" />
@@ -48,27 +86,17 @@
     <filter action="include">state_not_mode_0750</filter>
   </unix:file_object>
 
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit mode 0700" id="test_dir_permissions_var_log_audit" version="1">
-    <unix:object object_ref="object_var_log_audit_directory" />
-    <unix:state state_ref="state_not_mode_0700" />
-  </unix:file_test>
-  <unix:file_object comment="/var/log/audit files" id="object_var_log_audit_directory" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <unix:path operation="equals">/var/log/audit</unix:path>
-    <unix:filename xsi:nil="true" />
-    <filter action="include">state_not_mode_0700</filter>
-  </unix:file_object>
-
-  <unix:file_test check="all" check_existence="at_least_one_exists" comment="/var/log/audit mode 0700" id="test_dir_permissions_audit_log" version="1">
-    <unix:object object_ref="object_audit_log_directory" />
-    <unix:state state_ref="state_not_mode_0700" />
-  </unix:file_test>
-  <unix:file_object comment="audit log files" id="object_audit_log_directory" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="local" />
-    <unix:path operation="equals" var_ref="audit_log_dir" />
-    <unix:filename xsi:nil="true" />
-    <filter action="include">state_not_mode_0700</filter>
-  </unix:file_object>
+  <unix:file_state id="state_not_mode_0750" version="1" operator="OR">
+    <!-- if any one of these is true then mode is NOT 0750 (hence the OR operator) -->
+    <unix:suid datatype="boolean">true</unix:suid>
+    <unix:sgid datatype="boolean">true</unix:sgid>
+    <unix:sticky datatype="boolean">true</unix:sticky>
+    <unix:gwrite datatype="boolean">true</unix:gwrite>
+    <unix:oread datatype="boolean">true</unix:oread>
+    <unix:owrite datatype="boolean">true</unix:owrite>
+    <unix:oexec datatype="boolean">true</unix:oexec>
+  </unix:file_state>
+  {{% endif %}}
 
   <unix:file_state id="state_not_mode_0700" version="1" operator="OR">
     <!-- if any one of these is true then mode is NOT 0700 (hence the OR operator) -->
@@ -78,17 +106,6 @@
     <unix:gread datatype="boolean">true</unix:gread>
     <unix:gwrite datatype="boolean">true</unix:gwrite>
     <unix:gexec datatype="boolean">true</unix:gexec>
-    <unix:oread datatype="boolean">true</unix:oread>
-    <unix:owrite datatype="boolean">true</unix:owrite>
-    <unix:oexec datatype="boolean">true</unix:oexec>
-  </unix:file_state>
-
-  <unix:file_state id="state_not_mode_0750" version="1" operator="OR">
-    <!-- if any one of these is true then mode is NOT 0750 (hence the OR operator) -->
-    <unix:suid datatype="boolean">true</unix:suid>
-    <unix:sgid datatype="boolean">true</unix:sgid>
-    <unix:sticky datatype="boolean">true</unix:sticky>
-    <unix:gwrite datatype="boolean">true</unix:gwrite>
     <unix:oread datatype="boolean">true</unix:oread>
     <unix:owrite datatype="boolean">true</unix:owrite>
     <unix:oexec datatype="boolean">true</unix:oexec>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/rule.yml
@@ -3,12 +3,24 @@ documentation_complete: true
 title: 'System Audit Logs Must Have Mode 0750 or Less Permissive'
 
 description: |-
+    {{% if product in ["ol8", "rhel8"] %}}
+    Verify the audit log directories have a mode of "0700" or less permissive by first determining
+    where the audit logs are stored with the following command:
+    <pre>$ sudo grep -iw log_file /etc/audit/auditd.conf
+
+    log_file = /var/log/audit/audit.log</pre>
+    Configure the audit log directory to be protected from unauthorized read access by setting the
+    correct permissive mode with the following command:
+    <pre>$ sudo chmod 0700 <i>audit_log_directory</i></pre>
+    By default, <tt><i>audit_log_directory</i></tt> is "/var/log/audit".
+    {{% else %}}
     If <tt>log_group</tt> in <tt>/etc/audit/auditd.conf</tt> is set to a group other than the <tt>root</tt>
     group account, change the mode of the audit log files with the following command:
     <pre>$ sudo chmod 0750 /var/log/audit</pre>
     <br />
     Otherwise, change the mode of the audit log files with the following command:
     <pre>$ sudo chmod 0700 /var/log/audit</pre>
+    {{% endif %}}
 
 rationale: 'If users can write to audit logs, audit trails can be modified or destroyed.'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/common_0700.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/common_0700.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ol,multi_platform_rhel
+#!/bin/bash
+
+sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
+
+DIR1=/var/log/audit/
+DIR2=/var/log/audit2/
+
+mkdir ${DIR2}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/correct_value_0700.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/correct_value_0700.pass.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ol,multi_platform_rhel
+#!/bin/bash
+
+source common_0700.sh
+
+echo "log_file = ${DIR2}/audit.log" >> /etc/audit/auditd.conf
+
+chmod 0700 ${DIR2}
+chmod 0750 ${DIR1}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/correct_value_default_0700.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/correct_value_default_0700.pass.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ol,multi_platform_rhel
+#!/bin/bash
+
+source common_0700.sh
+
+chmod 0700 ${DIR1}
+chmod 0750 ${DIR2}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/incorrect_value_0700.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/incorrect_value_0700.fail.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_ol,multi_platform_rhel
+#!/bin/bash
+
+source common_0700.sh
+
+echo "log_file = ${DIR2}/audit.log" >> /etc/audit/auditd.conf
+
+chmod 0750 ${DIR2}
+chmod 0700 ${DIR1}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/incorrect_value_default_file_0700.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/incorrect_value_default_file_0700.fail.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ol,multi_platform_rhel
+#!/bin/bash
+
+source common_0700.sh
+
+chmod 0700 ${DIR2}
+chmod 0750 ${DIR1}


### PR DESCRIPTION
#### Description:

- Changed criteria so now OVAL passes only if (`log_file` is set and its directory has permissions 0700 or less permissive) or (`log_file` is not set and default has permissions 0700 or less permissive)

#### Rationale:

- This is to comply with DISA's STIG IDs `OL08-00-030120` & `RHEL-08-030120`
