### PR TITLE
update compliance as code documentation

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -141,19 +141,19 @@ multiple benchmarks in our project:
 </tr>
 <tr class="even">
 <td><p>Java Runtime Environment</p></td>
-<td><p><code>/jre/guide</code></p></td>
+<td><p><code>/products/jre/guide</code></p></td>
 </tr>
 <tr class="odd">
 <td><p>Fuse 6</p></td>
-<td><p><code>/fuse6/guide</code></p></td>
+<td><p><code>/products/fuse6/guide</code></p></td>
 </tr>
 <tr class="even">
 <td><p>Firefox</p></td>
-<td><p><code>/firefox/guide</code></p></td>
+<td><p><code>/products/firefox/guide</code></p></td>
 </tr>
 <tr class="odd">
 <td><p>Chromium</p></td>
-<td><p><code>/chromium/guide</code></p></td>
+<td><p><code>/products/chromium/guide</code></p></td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
#### Description:

- Update `Benchmark Structure/Layout` segment with correct directory path

#### Rationale:

- [Benchmark Structure/Layout ](https://complianceascode.readthedocs.io/en/latest/manual/developer/03_creating_content.html#benchmark-structure-layout) mentions directories that contain benchmark.yml file.
- The directory path mentioned for `linux_os` and `applications` are correct as they are top-level but the path mentioned for `Java Runtime Environment`, `Fuse 6`, `Firefox` and `Chromium` is confusing as they are not on top-level but under `products/`
