### PR TITLE
Update pam password hash algo ol8 stig

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/bash/shared.sh
@@ -1,5 +1,3 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 
-if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" "/etc/pam.d/password-auth"; then
-	sed -i --follow-symlinks "/^password.*sufficient.*pam_unix.so/ s/$/ sha512/" "/etc/pam.d/password-auth"
-fi
+{{{ bash_ensure_pam_module_options('/etc/pam.d/password-auth', 'password', 'sufficient', 'pam_unix.so', 'sha512', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 
 if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" "/etc/pam.d/password-auth"; then
 	sed -i --follow-symlinks "/^password.*sufficient.*pam_unix.so/ s/$/ sha512/" "/etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,rhv4
+prodtype: fedora,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: "Set PAM's Password Hashing Algorithm - password-auth"
 
@@ -57,6 +57,7 @@ references:
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     pcidss: Req-8.2.1
     srg: SRG-OS-000073-GPOS-00041
+    stigid@ol8: OL08-00-010160
     stigid@rhel7: RHEL-07-010200
     stigid@rhel8: RHEL-08-010160
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -68,7 +68,7 @@ references:
     pcidss: Req-8.2.1
     srg: SRG-OS-000073-GPOS-00041
     stigid@ol7: OL07-00-010200
-    stigid@ol8: OL08-00-010160
+    stigid@ol8: OL08-00-010159
     stigid@rhel7: RHEL-07-010200
     stigid@rhel8: RHEL-08-010159
     stigid@sle12: SLES-12-010230

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -139,8 +139,11 @@ selections:
     # OL08-00-010152
     - require_emergency_target_auth
 
-    # OL08-00-010160
+    # OL08-00-010159
     - set_password_hashing_algorithm_systemauth
+
+    # OL08-00-010160
+    - set_password_hashing_algorithm_passwordauth
 
     # OL08-00-010161
     - kerberos_disable_no_keytab


### PR DESCRIPTION
#### Description:

- Add the OL8 STIG ID to `set_password_hashing_algorithm_passwordauth` rule and this rule to the OL8 stig profile
- Update bash remediation for `set_password_hashing_algorithm_passwordauth` to use the `bash_ensure_pam_module_options` macro
- Update the OL8 STIG ID in `set_password_hashing_algorithm_systemauth`

#### Rationale:

- OL8 STIG profile efforts