### PR TITLE
OCP4 build: Don't use fedora-33 anymore

### DIFF
--- a/ocp-resources/ds-build-remote.yaml
+++ b/ocp-resources/ds-build-remote.yaml
@@ -17,7 +17,7 @@ spec:
       type: "ImageChange"
   source: 
     dockerfile: |
-      FROM registry.fedoraproject.org/fedora-minimal:33 as builder
+      FROM registry.fedoraproject.org/fedora-minimal:35 as builder
 
       WORKDIR /content
 


### PR DESCRIPTION
#### Description:

- Switches a manifest we use to build OCP4 content images with the
  `./utils/build_ds_container.py` script to use Fedora 35.

#### Rationale:

- Fedora 33 is EOL and its repos were removed, making the builds fail
