### PR TITLE
Update configure_bashrc_exec_tmux rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
@@ -30,6 +30,8 @@ references:
     stigid@ol8: OL08-00-020041
     stigid@rhel8: RHEL-08-020041
 
+platform: tmux
+
 ocil_clause: 'exec tmux is not present at the end of bashrc'
 
 ocil: |-
@@ -50,6 +52,3 @@ fixtext: |-
         name=$(ps -o comm= -p $parent)
         case "$name" in sshd|login) exec tmux ;; esac
     fi
-
-
-platform: machine

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -112,12 +112,20 @@ cpes:
       bash_conditional: {{{ bash_pkg_conditional("tftp-server") }}}
       ansible_conditional: {{{ ansible_pkg_conditional("tftp-server") }}}
 
+  - tmux:
+      name: "cpe:/a:tmux"
+      title: "Package tmux is installed"
+      check_id: installed_env_has_tmux_package
+      bash_conditional: {{{ bash_pkg_conditional("tmux") }}}
+      ansible_conditional: {{{ ansible_pkg_conditional("tmux") }}}
+      
   - usbguard:
       name: "cpe:/a:usbguard"
       title: "Package usbguard is installed"
       check_id: installed_env_has_usbguard_package
       bash_conditional: {{{ bash_pkg_conditional("usbguard") }}}
       ansible_conditional: {{{ ansible_pkg_conditional("usbguard") }}}
+
   - yum:
       name: "cpe:/a:yum"
       title: "Package yum is installed"

--- a/shared/checks/oval/installed_env_has_tmux_package.xml
+++ b/shared/checks/oval/installed_env_has_tmux_package.xml
@@ -1,0 +1,37 @@
+<def-group>
+  <definition class="inventory"
+  id="installed_env_has_tmux_package" version="1">
+    <metadata>
+      <title>Package tmux is installed</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>Checks if package tmux is installed.</description>
+      <reference ref_id="cpe:/a:tmux" source="CPE" />
+    </metadata>
+    <criteria>
+      <criterion comment="Package tmux is installed" test_ref="test_env_has_tmux_installed" />
+    </criteria>
+  </definition>
+
+{{% if pkg_system == "rpm" %}}
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
+  id="test_env_has_tmux_installed" version="1"
+  comment="system has package tmux installed">
+    <linux:object object_ref="obj_env_has_tmux_installed" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_object id="obj_env_has_tmux_installed" version="1">
+    <linux:name>tmux</linux:name>
+  </linux:rpminfo_object>
+{{% elif pkg_system == "dpkg" %}}
+  <linux:dpkginfo_test check="all" check_existence="all_exist"
+  id="test_env_has_tmux_installed" version="1"
+  comment="system has package tmux installed">
+    <linux:object object_ref="obj_env_has_tmux_installed" />
+  </linux:dpkginfo_test>
+  <linux:dpkginfo_object id="obj_env_has_tmux_installed" version="1">
+    <linux:name>tmux</linux:name>
+  </linux:dpkginfo_object>
+{{% endif %}}
+
+</def-group>

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -687,6 +687,8 @@ def get_cpe_of_tested_os(test_env, log_file):
 
 INSTALL_COMMANDS = dict(
     fedora=("dnf", "install", "-y"),
+    ol7=("yum", "install", "-y"),
+    ol8=("yum", "install", "-y"),
     rhel7=("yum", "install", "-y"),
     rhel8=("yum", "install", "-y"),
     rhel9=("yum", "install", "-y"),
@@ -724,5 +726,10 @@ def cpes_to_platform(cpes):
                     return "rhel" + major_version
         if "ubuntu" in cpe:
             return "ubuntu"
+        if "oracle:linux" in cpe:
+            match = re.search(r":linux:([^:]+):", cpe)
+            if match:
+                major_version = match.groups()[0]
+                return "ol" + major_version
     msg = "Unable to deduce a platform from these CPEs: {cpes}".format(cpes=cpes)
     raise ValueError(msg)


### PR DESCRIPTION
#### Description:

- Introduce tmux applicability CPE since the remediation is dangerous to run if tmux is not installed
- Add Oracle linux support in python functions related to test_suite

#### Rationale:

- The Oracle linux part is needed to run tests which require packages installation
