### PR TITLE
Update bash of rsyslog_encrypt_offload_actionsendstreamdriverauthmode

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/bash/shared.sh
@@ -4,8 +4,8 @@
 # complexity = low
 # disruption = low
 
-if ! grep -s "\$ActionSendStreamDriverAuthMode\s*x509/name" /etc/rsyslog.conf /etc/rsyslog.d/*.conf; then
-	mkdir -p /etc/rsyslog.d
-    sed -i '/^.*\$ActionSendStreamDriverAuthMode.*/d' /etc/rsyslog.conf /etc/rsyslog.d/*.conf
-    echo "\$ActionSendStreamDriverAuthMode x509/name" > /etc/rsyslog.d/stream_driver_auth.conf
-fi
+sed -i '/^.*\$ActionSendStreamDriverAuthMode.*/d' /etc/rsyslog.conf /etc/rsyslog.d/*.conf 2> /dev/null
+
+{{{ set_config_file(path="/etc/rsyslog.d/stream_driver_auth.conf",
+             parameter="\$ActionSendStreamDriverAuthMode", value="x509/name", create=true, separator=" ", separator_regex=" ")
+}}}


### PR DESCRIPTION
#### Description:

- Update bash of `rsyslog_encrypt_offload_actionsendstreamdriverauthmode` to use the macro `set_config_file`.

#### Rationale:

- In the rule `rsyslog_encrypt_offload_actionsendstreamdriverauthmode`, the previous bash failed when the configuration was correct but commented out, in that case the previous bash wouldn't fix that scenario. Now it does
