### PR TITLE
Update rule directory_group_ownership_var_log_audit 

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/bash/shared.sh
@@ -5,4 +5,13 @@ if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
 else
   GROUP=root
 fi
-find /var/log/audit -type d -exec chgrp ${GROUP} {} \;
+if LC_ALL=C grep -iw ^log_file /etc/audit/auditd.conf; then
+  DIR=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ' | rev | cut -d"/" -f2- | rev)
+else
+  DIR="/var/log/audit"
+fi
+
+{{% if product == "ol8" %}}
+GROUP="root"
+{{% endif %}}
+find ${DIR} -type d -exec chgrp ${GROUP} {} \;

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/oval/shared.xml
@@ -2,39 +2,83 @@
   <definition class="compliance" id="directory_group_ownership_var_log_audit" version="1">
     {{{ oval_metadata("Checks that all /var/log/audit directories are group owned by the root user.") }}}
     <criteria operator="OR">
-      <criterion test_ref="test_group_ownership_var_log_audit_directories" />
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log_file set in auditd.conf"
+        definition_ref="auditd_conf_log_file_not_set" negate="true" />
+        <criterion comment="log directory is owned by root"
+        test_ref="test_group_ownership_var_log_audit_directories" />
+      </criteria>
+      <criteria operator="AND" comment="log_file not set">
+        <extend_definition comment="log_file set in auditd.conf"
+        definition_ref="auditd_conf_log_file_not_set" />
+        <criterion comment="default log directory is owned by root"
+        test_ref="test_group_ownership_default_var_log_audit_directories" />
+      </criteria>
+      {{% if product != "ol8" %}}
       <criteria operator="AND" comment="log_group in auditd.conf is not root">
         <extend_definition comment="log_group in auditd.conf is not root"
         definition_ref="auditd_conf_log_group_not_root" />
         <criterion test_ref="test_group_ownership_var_log_audit_directories-non_root" />
       </criteria>
+      {{% endif %}}
     </criteria>
   </definition>
-  
-  <unix:file_test check="all" check_existence="none_exist" comment="/var/log/audit directories uid root gid root" id="test_group_ownership_var_log_audit_directories" version="1">
-    <unix:object object_ref="object_group_ownership_var_log_audit_directories" />
+
+  <local_variable id="audit_log_dir_group_ownership" datatype="string" version="1"
+  comment="path to audit log directory">
+    <regex_capture pattern="^(.*)\/([^\/]+$)">
+      <variable_component var_ref="audit_log_file_path" />
+    </regex_capture>
+  </local_variable>
+
+  <unix:file_test check="all" check_existence="none_exist"
+  comment="/var/log/audit directories uid root gid root"
+  id="test_group_ownership_default_var_log_audit_directories" version="1">
+    <unix:object object_ref="object_group_ownership_default_var_log_audit_directories" />
   </unix:file_test>
 
-  <unix:file_object comment="/var/log/audit directories" id="object_group_ownership_var_log_audit_directories" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
+  <unix:file_object comment="/var/log/audit directories"
+  id="object_group_ownership_default_var_log_audit_directories" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+    recurse_file_system="all" />
     <unix:path operation="equals">/var/log/audit</unix:path>
     <unix:filename xsi:nil="true" />
     <filter action="include">state_group_owner_not_root_var_log_audit_directories</filter>
   </unix:file_object>
 
-  <unix:file_state id="state_group_owner_not_root_var_log_audit_directories" version="1" operator="OR">
+  <unix:file_state id="state_group_owner_not_root_var_log_audit_directories" version="1"
+  operator="OR">
     <unix:group_id datatype="int" operation="not equal">0</unix:group_id>
   </unix:file_state>
 
+  {{% if product != "ol8" %}}
   <unix:file_test check="all" check_existence="all_exist" comment="/var/log/audit directories uid root gid root" id="test_group_ownership_var_log_audit_directories-non_root" version="1">
     <unix:object object_ref="object_group_ownership_var_log_audit_directories-non_root" />
   </unix:file_test>
+  {{% endif %}}
 
+  <unix:file_test check="all" check_existence="none_exist"
+  comment="/var/log/audit directories uid root gid root"
+  id="test_group_ownership_var_log_audit_directories" version="1">
+    <unix:object object_ref="object_group_ownership_var_log_audit_directories" />
+  </unix:file_test>
+
+  {{% if product != "ol8" %}}
   <unix:file_object comment="/var/log/audit directories" id="object_group_ownership_var_log_audit_directories-non_root" version="1">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
     <unix:path operation="equals">/var/log/audit</unix:path>
     <unix:filename xsi:nil="true" />
     <filter action="include">state_group_owner_not_root_var_log_audit_directories-non_root</filter>
+  </unix:file_object>
+  {{% endif %}}
+
+  <unix:file_object comment="log directories"
+  id="object_group_ownership_var_log_audit_directories" version="1">
+    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
+    recurse_file_system="all" />
+    <unix:path operation="equals" var_ref="audit_log_dir_group_ownership"/>
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_group_owner_not_root_var_log_audit_directories</filter>
   </unix:file_object>
 
   <unix:file_state id="state_group_owner_not_root_var_log_audit_directories-non_root" version="1" operator="OR">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/rule.yml
@@ -7,8 +7,10 @@ title: 'System Audit Directories Must Be Group Owned By Root'
 description: |-
     All audit directories must be group owned by root user. By default, the path for audit log is <pre>/var/log/audit/</pre>.
     {{{ describe_file_group_owner(file="/var/log/audit", group="root") }}}
+    {{% if product != "ol8" %}}
     If <tt>log_group</tt> in <tt>/etc/audit/auditd.conf</tt> is set to a group other than the <tt>root</tt>
     group account, change the group ownership of the audit directories to this specific group.
+    {{% endif %}}
 
 rationale: |-
     Unauthorized disclosure of audit records can reveal system and configuration data to
@@ -37,6 +39,23 @@ references:
     stigid@rhel8: RHEL-08-030110
 
 ocil: |-
+    {{% if product =="ol8" %}}
+    Determine where the audit logs are stored with the following command:
+
+    $ sudo grep -iw log_file /etc/audit/auditd.conf
+
+    log_file = /var/log/audit/audit.log
+
+    Determine the group owner of the audit log directory by using the output of the above command
+    (default: "/var/log/audit/"). Run the following command with the correct audit log directory
+    path:
+
+    $ sudo ls -ld /var/log/audit
+
+    drwx------ 2 root root 23 Jun 11 11:56 /var/log/audit
+
+    The audit log directory must be group-owned by "root".
+    {{% else %}}
     Determine the audit log group by running the following command:
 
     $ sudo grep -P '^[ ]*log_group[ ]+=.*$' /etc/audit/auditd.conf
@@ -47,11 +66,20 @@ ocil: |-
     $ sudo find /var/log/audit -type d -printf "%p %g\n"
 
     All listed directories must be owned by the log_group or by root if the log_group is not specified.
-
+    {{% endif %}}
 ocil_clause:
     "there is a directory owned by different group"
 
 fixtext: |-
+    {{% if product == "ol8" %}}
+    Configure the audit log to be protected from unauthorized read access by setting the correct
+    group-owner as "root" with the following command:
+
+    $ sudo chgrp root [audit_log_directory]
+
+    Replace "[audit_log_directory]" with the correct audit log directory path. By default, this
+    location is usually "/var/log/audit".
+    {{% else %}}
     Change the group of the directory of "/var/log/audit" to be owned by a correct group.
 
     Identify the group that is configured to own audit log:
@@ -60,6 +88,6 @@ fixtext: |-
 
     Change the ownership to that group:
     $ sudo chgrp ${GROUP} /var/log/audit
-
+    {{% endif %}}
 srg_requirement: |-
     {{{ full_name }}} audit logs must be group-owned by root or by a restricted logging group to prevent unauthorized read access.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_log_file.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_log_file.pass.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 # packages = audit
 
+
 sed -i "/\s*log_group.*/d" /etc/audit/auditd.conf
 sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf
-chgrp root /var/log/audit
+echo "log_file = /var/log/audit2/audit.log" >> /etc/audit/auditd.conf
+
+mkdir /var/log/audit2
+groupadd group_test
+
+chgrp root /var/log/audit2
+chgrp group_test /var/log/audit

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = audit
+# platform = multi_platform_rhel
 
 groupadd group_test
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value.fail.sh
@@ -2,6 +2,7 @@
 # packages = audit
 
 sed -i "/\s*log_group.*/d" /etc/audit/auditd.conf
+sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf
 groupadd group_test
 chgrp group_test /var/log/audit

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value_log_file.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value_log_file.fail.sh
@@ -4,4 +4,10 @@
 sed -i "/\s*log_group.*/d" /etc/audit/auditd.conf
 sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf
+echo "log_file = /var/log/audit2/audit.log" >> /etc/audit/auditd.conf
+
+mkdir /var/log/audit2
+groupadd group_test
+
 chgrp root /var/log/audit
+chgrp group_test /var/log/audit2


### PR DESCRIPTION
#### Description:

- Update OVAL, bash and rule description to take into consideration `log_file` from `/etc/audit/auditd.conf`

#### Rationale:

- This complies with OL08-00-030110
