### PR TITLE
 fix ansible remediation of enable_dracut_fips_module

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/ansible/shared.yml
@@ -8,6 +8,7 @@
   command: /usr/bin/fips-mode-setup --check
   register: is_fips_enabled
   changed_when: false
+  failed_when: "is_fips_enabled.rc not in [0,1]"
 
 - name: Enable FIPS mode
   command: /usr/bin/fips-mode-setup --enable

--- a/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_dracut_fips_module/ansible/shared.yml
@@ -8,7 +8,7 @@
   command: /usr/bin/fips-mode-setup --check
   register: is_fips_enabled
   changed_when: false
-  failed_when: "is_fips_enabled.rc not in [0,1]"
+  failed_when:  False
 
 - name: Enable FIPS mode
   command: /usr/bin/fips-mode-setup --enable


### PR DESCRIPTION
#### Description:

- do not fail fatally when encountering non-zero  from fips-mode-setup

#### Rationale:

- in RHEL9, if the FIPS mode is not completely configured, the command returns 1. This made our Ansible remediations fail fatally.