### PR TITLE
Update rule sssd_enable_smartcards for OL8 and RHEL8

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -33,3 +33,179 @@
     value: 'true'
     create: yes
     mode: 0600
+
+{{% if product in ["ol8", "rhel8"] %}}
+- name: Check for expected pam_sss.so entry in system-auth
+  ansible.builtin.lineinfile:
+    path: "/etc/pam.d/system-auth"
+    create: no
+    regexp: '^\s*auth.*sufficient.*pam_sss\.so.*try_cert_auth.*$'
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: result_pam_try_cert_auth_present_system_auth
+
+- name: Check for expected pam_sss.so entry in smartcard-auth
+  ansible.builtin.lineinfile:
+    path: "/etc/pam.d/smartcard-auth"
+    create: no
+    regexp: '^\s*auth.*sufficient.*pam_sss\.so.*try_cert_auth.*$'
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: result_pam_try_cert_auth_present_smartcard_auth
+
+- name: Check if system relies on authselect
+  ansible.builtin.stat:
+    path: /usr/bin/authselect
+  register: result_authselect_present
+
+- name: "Remediation where authselect tool is present"
+  block:
+    - name: Check the integrity of the current authselect profile
+      ansible.builtin.command:
+        cmd: authselect check
+      register: result_authselect_check_cmd
+      changed_when: false
+      ignore_errors: true
+
+    - name: Informative message based on the authselect integrity check result
+      ansible.builtin.assert:
+        that:
+          - result_authselect_check_cmd is success
+        fail_msg:
+        - authselect integrity check failed. Remediation aborted!
+        - This remediation could not be applied because the authselect profile is not intact.
+        - It is not recommended to manually edit the PAM files when authselect is available.
+        - In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended.
+        success_msg:
+        - authselect integrity check passed
+
+    - name: Get authselect current profile
+      ansible.builtin.shell:
+        cmd: authselect current -r | awk '{ print $1 }'
+      register: result_authselect_profile
+      changed_when: false
+      when:
+        - result_authselect_check_cmd is success
+
+    - name: Define the current authselect profile as a local fact
+      ansible.builtin.set_fact:
+        authselect_current_profile: "{{ result_authselect_profile.stdout }}"
+        authselect_custom_profile: "{{ result_authselect_profile.stdout }}"
+      when:
+        - result_authselect_profile is not skipped
+        - result_authselect_profile.stdout is match("custom/")
+
+    - name: Define the new authselect custom profile as a local fact
+      ansible.builtin.set_fact:
+        authselect_current_profile: "{{ result_authselect_profile.stdout }}"
+        authselect_custom_profile: "custom/hardening"
+      when:
+        - result_authselect_profile is not skipped
+        - result_authselect_profile.stdout is not match("custom/")
+
+    - name: Get authselect current features to also enable them in the custom profile
+      ansible.builtin.shell:
+        cmd: authselect current | tail -n+3 | awk '{ print $2 }'
+      register: result_authselect_features
+      changed_when: false
+      when:
+        - result_authselect_profile is not skipped
+        - authselect_current_profile is not match("custom/")
+
+    - name: Check if any custom profile with the same name was already created in the past
+      ansible.builtin.stat:
+        path: /etc/authselect/{{ authselect_custom_profile }}
+      register: result_authselect_custom_profile_present
+      changed_when: false
+      when:
+        - authselect_current_profile is not match("custom/")
+
+    - name: Create a custom profile based on the current profile
+      ansible.builtin.command:
+        cmd: authselect create-profile hardening -b sssd
+      when:
+        - result_authselect_check_cmd is success
+        - authselect_current_profile is not match("custom/")
+        - not result_authselect_custom_profile_present.stat.exists
+
+    - name: Ensure the try_cert_auth option is in smartcard-auth
+      ansible.builtin.replace:
+        dest: "/etc/authselect/{{ authselect_custom_profile }}/smartcard-auth"
+        regexp: '^(auth.*sufficient.*pam_sss\.so)((?!try_cert_auth).)*$'
+        replace: '\g<1> try_cert_auth \g<2>'
+      when:
+        - result_authselect_profile is not skipped
+        - result_pam_try_cert_auth_present_smartcard_auth.found == 0
+
+    - name: Ensure the try_cert_auth option is in system-auth
+      ansible.builtin.replace:
+        dest: "/etc/authselect/{{ authselect_custom_profile }}/system-auth"
+        regexp: '^(auth.*sufficient.*pam_sss\.so)((?!try_cert_auth).)*$'
+        replace: '\g<1> try_cert_auth \g<2>'
+      when:
+        - result_authselect_profile is not skipped
+        - result_pam_try_cert_auth_present_system_auth.found == 0
+
+    - name: Ensure a backup of current authselect profile before selecting the custom profile
+      ansible.builtin.command:
+        cmd: authselect apply-changes -b --backup=before-pwhistory-hardening.backup
+      register: result_authselect_backup
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
+        - authselect_current_profile is not match("custom/")
+        - authselect_custom_profile is not match(authselect_current_profile)
+
+    - name: Ensure the custom profile is selected
+      ansible.builtin.command:
+        cmd: authselect select {{ authselect_custom_profile }} --force
+      register: result_pam_authselect_select_profile
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
+        - authselect_current_profile is not match("custom/")
+        - authselect_custom_profile is not match(authselect_current_profile)
+
+    - name: Restore the authselect features in the custom profile
+      ansible.builtin.command:
+        cmd: authselect enable-feature {{ item }}
+      loop: "{{ result_authselect_features.stdout_lines }}"
+      when:
+        - result_authselect_profile is not skipped
+        - result_authselect_features is not skipped
+        - result_pam_authselect_select_profile is not skipped
+
+    - name: Ensure the custom profile changes are applied
+      ansible.builtin.command:
+        cmd: authselect apply-changes -b --backup=after-pwhistory-hardening.backup
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
+  when:
+    - (result_pam_try_cert_auth_present_smartcard_auth.found == 0) or (result_pam_try_cert_auth_present_system_auth.found == 0)
+    - result_authselect_present.stat.exists
+
+# For systems without authselect
+- name: "Remediation where authselect tool is not present and PAM files are directly edited"
+  block:
+    - name: Ensure the try_cert_auth option is in smartcard-auth
+      ansible.builtin.replace:
+        dest: "/etc/pam.d/smartcard-auth"
+        regexp: '^(auth.*sufficient.*pam_sss\.so)((?!try_cert_auth).)*$'
+        replace: '\g<1> try_cert_auth \g<2>'
+      when:
+        - result_pam_try_cert_auth_present_smartcard_auth.found == 0
+
+    - name: Ensure the try_cert_auth option is in system-auth
+      ansible.builtin.replace:
+        dest: "/etc/pam.d/system-auth"
+        regexp: '^(auth.*sufficient.*pam_sss\.so)((?!try_cert_auth).)*$'
+        replace: '\g<1> try_cert_auth \g<2>'
+      when:
+          - result_pam_try_cert_auth_present_system_auth.found == 0
+  when:
+    - (result_pam_try_cert_auth_present_smartcard_auth.found == 0) or (result_pam_try_cert_auth_present_system_auth.found == 0)
+    - not result_authselect_present.stat.exists
+{{% endif %}}

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -5,3 +5,50 @@
 # disruption = medium
 
 {{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "pam", "pam_cert_auth", "true") }}}
+
+{{% if product in ["ol8", "rhel8"] %}}
+if [ -f /usr/bin/authselect ]; then
+    if authselect check; then
+        CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
+        # Standard profiles delivered with authselect should not be modified.
+        # If not already in use, a custom profile is created preserving the enabled features.
+        if [[ ! $CURRENT_PROFILE == custom/* ]]; then
+            ENABLED_FEATURES=$(authselect current | tail -n+3 | awk '{ print $2 }')
+            authselect create-profile hardening -b $CURRENT_PROFILE
+            CURRENT_PROFILE="custom/hardening"
+            # Ensure a backup before changing the profile
+            authselect apply-changes -b --backup=before-pwhistory-hardening.backup
+            authselect select $CURRENT_PROFILE
+            for feature in $ENABLED_FEATURES; do
+                authselect enable-feature $feature;
+            done
+        fi
+        # Include the desired configuration in the custom profile
+        CUSTOM_PROFILE_DIR="/etc/authselect/$CURRENT_PROFILE"
+        # The line should be included on the top of postlogin file
+        
+        {{{ bash_ensure_pam_module_options("$CUSTOM_PROFILE_DIR/smartcard-auth",
+                                           'auth',
+                                           'sufficient',
+                                           'pam_sss.so',
+                                           'try_cert_auth', '', '') }}}
+        {{{ bash_ensure_pam_module_options("$CUSTOM_PROFILE_DIR/system-auth",
+                                           'auth',
+                                           'sufficient', 
+                                           'pam_sss.so',
+                                           'try_cert_auth', '', '') }}}
+        authselect apply-changes -b --backup=after-pwhistory-hardening.backup
+    else
+        echo "
+authselect integrity check failed. Remediation aborted!
+This remediation could not be applied because the authselect profile is not intact.
+It is not recommended to manually edit the PAM files when authselect is available.
+In cases where the default authselect profile does not cover a specific demand, a custom authselect profile is recommended."
+        false
+    fi
+else
+    {{{ bash_ensure_pam_module_options('/etc/pam.d/smartcard-auth', 'auth', 'sufficient', 'pam_sss.so', 'try_cert_auth', '', '') }}}
+    {{{ bash_ensure_pam_module_options('/etc/pam.d/system-auth', 'auth', 'sufficient', 'pam_sss.so', 'try_cert_auth', '', '') }}}
+fi
+{{% endif %}}
+

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
@@ -8,8 +8,16 @@
         <extend_definition comment="Check if /etc/sssd/sssd.conf is configured for usage"
         definition_ref="sssd_conf_exists" negate="true"/>
       </criteria>
-      <criterion comment="Check pam_cert_auth in /etc/sssd/sssd.conf"
-      test_ref="test_sssd_enable_smartcards" />
+      <criteria operator="AND">
+        <criterion comment="Check pam_cert_auth in /etc/sssd/sssd.conf"
+        test_ref="test_sssd_enable_smartcards" />
+        {{% if product in ["ol8", "rhel8"] %}}
+        <criterion comment="Check try_cert_auth or require_cert_auth in /etc/pam.d/smartcard-auth"
+        test_ref="test_sssd_enable_smartcards_cert_auth_smartcard_auth" />
+        <criterion comment="Check try_cert_auth or require_cert_auth in /etc/pam.d/system-auth"
+        test_ref="test_sssd_enable_smartcards_cert_auth_system_auth" />
+        {{% endif %}}
+      </criteria>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -19,7 +27,39 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_sssd_enable_smartcards" version="1">
     <ind:filepath>/etc/sssd/sssd.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*pam_cert_auth[\s]*=[\s]*true$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*\[pam](?:[^\n\[]*\n+)+?[\s]*pam_cert_auth[\s]*=[\s]*(?i)true\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  {{% if product in ["ol8", "rhel8"] %}}
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the presence of try_cert_auth or require_cert_auth in /etc/pam.d/smartcard-auth"
+  id="test_sssd_enable_smartcards_cert_auth_smartcard_auth" version="1">
+    <ind:object object_ref="obj_sssd_enable_smartcards_cert_auth_smartcard_auth" />
+    <ind:state state_ref="test_sssd_enable_smartcards_cert_auth" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sssd_enable_smartcards_cert_auth_smartcard_auth" version="1">
+    <ind:filepath>/etc/pam.d/smartcard-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*auth.*?pam_sss\.so(.*)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+  comment="tests the presence of try_cert_auth or require_cert_auth in /etc/pam.d/smartcard-auth"
+  id="test_sssd_enable_smartcards_cert_auth_system_auth" version="1">
+    <ind:object object_ref="obj_sssd_enable_smartcards_cert_auth_system_auth" />
+    <ind:state state_ref="test_sssd_enable_smartcards_cert_auth" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_sssd_enable_smartcards_cert_auth_system_auth" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*auth.*?pam_sss\.so(.*)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="test_sssd_enable_smartcards_cert_auth" version="1">
+    <ind:subexpression 
+    operation="pattern match">^.*(try_cert_auth|require_cert_auth).*$</ind:subexpression>
+  </ind:textfilecontent54_state>
+  {{% endif %}}
+
 </def-group>

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -12,6 +12,14 @@ description: |-
     <pre>[pam]
     pam_cert_auth = true
     </pre>
+    {{% if product in ["ol8", "rhel8"] %}}
+    Add or update "pam_sss.so" with "try_cert_auth" or "require_cert_auth" in the
+    "/etc/pam.d/system-auth" and "/etc/pam.d/smartcard-auth" files based on the following
+    examples:
+    <pre>/etc/pam.d/smartcard-auth:auth sufficient pam_sss.so try_cert_auth
+    /etc/pam.d/system-auth:auth [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_sss.so try_cert_auth
+    </pre>
+    {{% endif %}}
 
 rationale: |-
     Using an authentication device, such as a CAC or token that is separate from
@@ -51,7 +59,21 @@ ocil: |-
     If configured properly, output should be
     <pre>pam_cert_auth = true</pre>
 
+    {{% if product in ["ol8", "rhel8"] %}}
+    <pre>$ sudo grep cert_auth /etc/sssd/sssd.conf /etc/pam.d/*</pre>
+    {{% endif %}}
+
+
 fixtext: |-
     Edit the file "/etc/sssd/sssd.conf" and add or edit the following line:
 
     pam_cert_auth = true
+
+    {{% if product in ["ol8", "rhel8"] %}}
+    Add or update "pam_sss.so" with "try_cert_auth" or "require_cert_auth" in the
+    "/etc/pam.d/system-auth" and "/etc/pam.d/smartcard-auth" files based on the following
+    examples:
+    <pre>/etc/pam.d/smartcard-auth:auth sufficient pam_sss.so try_cert_auth
+    /etc/pam.d/system-auth:auth [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_sss.so try_cert_auth
+    </pre>
+    {{% endif %}}

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/common.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/common.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+{{{ bash_package_remove("authselect") }}}
+
+SSSD_FILE="/etc/sssd/sssd.conf"
+
+truncate -s 0 $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/correct_value.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = sssd
+
+source common.sh
+
+echo "[pam]" > $SSSD_FILE
+echo "pam_cert_auth = True" >> $SSSD_FILE
+
+{{% if product in ["ol8", "rhel8"] %}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/smartcard-auth', 'auth', 'sufficient', 'pam_sss.so', 'try_cert_auth', '', '') }}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/system-auth', 'auth', 'sufficient', 'pam_sss.so', 'try_cert_auth', '', '') }}}
+{{% endif %}}

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/pamd_argument_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/pamd_argument_missing.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = sssd
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
+
+source common.sh
+
+echo "[pam]" > $SSSD_FILE
+echo "pam_cert_auth = True" >> $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/pamd_argument_missing_authselect.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/pamd_argument_missing_authselect.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = sssd
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
+
+source common.sh
+
+{{{ bash_package_install("authselect") }}}
+
+authselect create-profile testingProfile --base-on minimal
+authselect select --force custom/testingProfile
+
+echo "[pam]" > $SSSD_FILE
+echo "pam_cert_auth = True" >> $SSSD_FILE

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/value_missing.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/value_missing.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = sssd
+
+source common.sh

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/wrong_value.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = sssd
+
+source common.sh
+
+echo "[pam]" > $SSSD_FILE
+echo "pam_cert_auth = False" >> $SSSD_FILE
+
+{{% if product in ["ol8", "rhel8"] %}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/smartcard-auth', 'auth', 'sufficient', 'pam_sss.so', 'try_cert_auth', '', '') }}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/system-auth', 'auth', 'sufficient', 'pam_sss.so', 'try_cert_auth', '', '') }}}
+{{% endif %}}

--- a/shared/macros/bash.jinja
+++ b/shared/macros/bash.jinja
@@ -1862,7 +1862,7 @@ for f in $(echo -n "{{{ files }}}"); do
 
     # find section and add key = value to it
     elif grep -qs "[[:space:]]*\[{{{ section }}}\]" "$f"; then
-            sed -i "/[[:space:]]*{{{ section }}}/a {{{ key }}} = {{{ value }}}" "$f"
+            sed -i "/[[:space:]]*\[{{{ section }}}\]/a {{{ key }}} = {{{ value }}}" "$f"
             found=true
     fi
 done


### PR DESCRIPTION
#### Description:

- Update OVAL in rule `sssd_enable_smartcards` to check also `/etc/pam.d/system-auth` & `smartcard-auth`
- Update bash and ansible to remediate also `/etc/pam.d/system-auth` & `smartcard-auth` using `authselect` if available
- Add tests to verify this behavior

#### Rationale:

- This complies with `OL08-00-020250` and `RHEL-08-020250`
