### PR TITLE
strip trailing blank lines for some templated audit rules

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
@@ -50,5 +50,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-3-access-failed.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_access_failed|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
@@ -55,5 +55,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-3-access-success.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_access_success|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_basic_configuration/rule.yml
@@ -16,8 +16,7 @@ title: 'Configure basic parameters of Audit system'
 --backlog_wait_time 60000
 
 ## Set failure mode to syslog
--f 1
-" %}}
+-f 1" %}}
 
 description: |-
     Perform basic configuration of Audit system.
@@ -74,3 +73,4 @@ template:
         filepath: /etc/audit/rules.d/10-base-config.rules
         contents: |+
             {{{ file_contents_audit_base_config|indent(12) }}}
+#do not remove this comment, it stops Jinja from including more blank lines to the variable

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
@@ -62,5 +62,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-1-create-failed.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_create_failed|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
@@ -55,5 +55,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-1-create-success.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_create_success|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -54,7 +54,7 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-4-delete-failed.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_delete_failed|indent(12) }}}
 
 fixtext: |-

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
@@ -53,7 +53,7 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-4-delete-success.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_delete_success|indent(12) }}}
 
 fixtext: |-

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -62,5 +62,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-2-modify-failed.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_modify_failed|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
@@ -57,5 +57,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-2-modify-success.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_modify_success|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_module_load/rule.yml
@@ -54,5 +54,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/43-module-load.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_module_load|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -88,8 +88,7 @@ title: 'Perform general configuration of Audit for OSPP'
 ## Application invocation. The requirements list an optional requirement
 ## FPT_SRP_EXT.1 Software Restriction Policies. This event is intended to
 ## state results from that policy. This would be handled entirely by
-## that daemon.
-" %}}
+## that daemon." %}}
 
 
 description: |-
@@ -142,3 +141,5 @@ template:
         filepath: /etc/audit/rules.d/30-ospp-v42.rules
         contents: |+
             {{{ file_contents_audit_ospp_general|indent(12) }}}
+#do not remove this comment, it stops Jinja from including more blank lines to the variable
+

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -55,5 +55,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-6-owner-change-failed.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_owner_change_failed|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -56,5 +56,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-6-owner-change-success.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_owner_change_success|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -54,5 +54,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-5-perm-change-failed.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_perm_change_failed|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -53,5 +53,5 @@ template:
     name: audit_file_contents
     vars:
         filepath: /etc/audit/rules.d/30-ospp-v42-5-perm-change-success.rules
-        contents: |+
+        contents: |-
             {{{ file_contents_audit_perm_change_success|indent(12) }}}


### PR DESCRIPTION
#### Description:

- strip trailing blank lines in some cases of usage of audit_file_contents template
- and in other cases, ensure that no additional blank lines except for those specified within the content variable are processed
- see commit messages for more information

#### Rationale:

- in some cases of audit_file_contents templated rules, we need to preserve one trailing blank line to be aligned with files provided by Audit package.
- And there are also cases where there must not be any trailing blank lines
- This PR fixes both cases