### PR TITLE
OCP:Fix rule kubelet_enable_streaming_connections

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -50,6 +50,5 @@ template:
         filepath: {{{ kubeletconf_path }}}
         yamlpath: ".streamingConnectionIdleTimeout"
         check_existence: "any_exist"
-        values:
-         - value: "0"
-           operation: "not equal"
+        xccdf_variable: var_streaming_connection_timeouts
+        regex_data: true

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/match.pass.sh
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/match.pass.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# remediation = none
+
+yum install -y jq
+
+mkdir -p "/etc/kubernetes"
+
+cat << EOF > /etc/kubernetes/kubelet.conf
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "staticPodPath": "/etc/kubernetes/manifests",
+  "syncFrequency": "0s",
+  "fileCheckFrequency": "0s",
+  "httpCheckFrequency": "0s",
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+  ],
+  "tlsMinVersion": "VersionTLS12",
+  "rotateCertificates": true,
+  "serverTLSBootstrap": true,
+  "authentication": {
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/kubelet-ca.crt"
+    },
+    "webhook": {
+      "cacheTTL": "0s"
+    },
+    "anonymous": {
+      "enabled": false
+    }
+  },
+  "authorization": {
+    "webhook": {
+      "cacheAuthorizedTTL": "0s",
+      "cacheUnauthorizedTTL": "0s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "clusterDNS": [
+    "172.30.0.10"
+  ],
+  "streamingConnectionIdleTimeout": "5m",
+  "nodeStatusUpdateFrequency": "0s",
+  "nodeStatusReportFrequency": "0s",
+  "imageMinimumGCAge": "0s",
+  "volumeStatsAggPeriod": "0s",
+  "systemCgroups": "/system.slice",
+  "cgroupRoot": "/",
+  "cgroupDriver": "systemd",
+  "cpuManagerReconcilePeriod": "0s",
+  "runtimeRequestTimeout": "0s",
+  "maxPods": 250,
+  "kubeAPIQPS": 50,
+  "kubeAPIBurst": 100,
+  "serializeImagePulls": false,
+  "evictionPressureTransitionPeriod": "0s",
+  "featureGates": {
+    "APIPriorityAndFairness": true,
+    "CSIMigrationAWS": false,
+    "CSIMigrationAzureDisk": false,
+    "CSIMigrationAzureFile": false,
+    "CSIMigrationGCE": false,
+    "CSIMigrationOpenStack": false,
+    "CSIMigrationvSphere": false,
+    "DownwardAPIHugePages": true,
+    "LegacyNodeRoleBehavior": false,
+    "NodeDisruptionExclusion": true,
+    "PodSecurity": true,
+    "RotateKubeletServerCertificate": true,
+    "ServiceNodeExclusion": true,
+    "SupportPodPidsLimit": true
+  },
+  "memorySwap": {},
+  "containerLogMaxSize": "50Mi",
+  "systemReserved": {
+    "ephemeral-storage": "1Gi"
+  },
+  "logging": {
+    "flushFrequency": 0,
+    "verbosity": 0,
+    "options": {
+      "json": {
+        "infoBufferSize": "0"
+      }
+    }
+  },
+  "shutdownGracePeriod": "5m",
+  "shutdownGracePeriodCriticalPods": "0s"
+}
+EOF
+

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/notmatch.fail.sh
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/notmatch.fail.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# remediation = none
+
+yum install -y jq
+
+mkdir -p "/etc/kubernetes"
+
+cat << EOF > /etc/kubernetes/kubelet.conf
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "staticPodPath": "/etc/kubernetes/manifests",
+  "syncFrequency": "0s",
+  "fileCheckFrequency": "0s",
+  "httpCheckFrequency": "0s",
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+  ],
+  "tlsMinVersion": "VersionTLS12",
+  "rotateCertificates": true,
+  "serverTLSBootstrap": true,
+  "authentication": {
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/kubelet-ca.crt"
+    },
+    "webhook": {
+      "cacheTTL": "0s"
+    },
+    "anonymous": {
+      "enabled": false
+    }
+  },
+  "authorization": {
+    "webhook": {
+      "cacheAuthorizedTTL": "0s",
+      "cacheUnauthorizedTTL": "0s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "clusterDNS": [
+    "172.30.0.10"
+  ],
+  "streamingConnectionIdleTimeout": "0s",
+  "nodeStatusUpdateFrequency": "0s",
+  "nodeStatusReportFrequency": "0s",
+  "imageMinimumGCAge": "0s",
+  "volumeStatsAggPeriod": "0s",
+  "systemCgroups": "/system.slice",
+  "cgroupRoot": "/",
+  "cgroupDriver": "systemd",
+  "cpuManagerReconcilePeriod": "0s",
+  "runtimeRequestTimeout": "0s",
+  "maxPods": 250,
+  "kubeAPIQPS": 50,
+  "kubeAPIBurst": 100,
+  "serializeImagePulls": false,
+  "evictionPressureTransitionPeriod": "0s",
+  "featureGates": {
+    "APIPriorityAndFairness": true,
+    "CSIMigrationAWS": false,
+    "CSIMigrationAzureDisk": false,
+    "CSIMigrationAzureFile": false,
+    "CSIMigrationGCE": false,
+    "CSIMigrationOpenStack": false,
+    "CSIMigrationvSphere": false,
+    "DownwardAPIHugePages": true,
+    "LegacyNodeRoleBehavior": false,
+    "NodeDisruptionExclusion": true,
+    "PodSecurity": true,
+    "RotateKubeletServerCertificate": true,
+    "ServiceNodeExclusion": true,
+    "SupportPodPidsLimit": true
+  },
+  "memorySwap": {},
+  "containerLogMaxSize": "50Mi",
+  "systemReserved": {
+    "ephemeral-storage": "1Gi"
+  },
+  "logging": {
+    "flushFrequency": 0,
+    "verbosity": 0,
+    "options": {
+      "json": {
+        "infoBufferSize": "0"
+      }
+    }
+  },
+  "shutdownGracePeriod": "0s",
+  "shutdownGracePeriodCriticalPods": "0s"
+}
+EOF
+

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
 default_result: PASS
+

--- a/applications/openshift/kubelet/var_streaming_connection_timeouts.var
+++ b/applications/openshift/kubelet/var_streaming_connection_timeouts.var
@@ -13,10 +13,10 @@ operator: equals
 interactive: true
 
 options:
-    default: 5m
-    5min: 5m
-    10min: 10m
-    30min: 30m
+    default: 5m0s
+    5min: 5m0s
+    10min: 10m0s
+    30min: 30m0s
     1hour: 1h
     2hours: 2h
     4hours: 4h


### PR DESCRIPTION
This PR fix the rule kubelet_enable_streaming_connections, so that it will check the configuration based on variable dynamically.
