### PR TITLE
OCP4: Don't use a list in platforms

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_flowschema_catch_all/rule.yml
@@ -27,9 +27,7 @@ identifiers:
   cce@ocp4: CCE-83522-3
 
 platforms:
-  - ocp4.8
-  - ocp4.9
-  - ocp4.10
+  - ocp4.8 or ocp4.9 or ocp4.10
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1alpha1_flowschema_catch_all/rule.yml
@@ -28,8 +28,7 @@ identifiers:
 
 
 platforms:
-  - ocp4.6
-  - ocp4.7
+  - ocp4.6 or ocp4.7
 
 severity: medium
 


### PR DESCRIPTION


#### Description:

The list notation doesn't work anymore, let's use a boolean "sentence"
instead.

#### Rationale:

Related: #8833
