### PR TITLE
 Update var_auditd_disk_<error/full>_action to allow multiple values for OL8 and RHEL8

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: Configure auditd Disk Error Action on Disk Error
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "disk_error_action = {{ var_auditd_disk_error_action }}"
+    line: "disk_error_action = {{ var_auditd_disk_error_action.split('|')[0] }}"
     regexp: '^\s*disk_error_action\s*=\s*.*$'
     state: present
     create: yes

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
@@ -7,10 +7,6 @@
 # to var_auditd_disk_error_action, else
 # add "disk_error_action = $var_auditd_disk_error_action" to /etc/audit/auditd.conf
 #
+var_auditd_disk_full_action="$(echo $var_auditd_disk_full_action | cut -d \| -f 1)"
 
-if grep --silent ^disk_error_action /etc/audit/auditd.conf ; then
-        sed -i 's/^disk_error_action.*/disk_error_action = '"$var_auditd_disk_error_action"'/g' /etc/audit/auditd.conf
-else
-        echo -e "\n# Set disk_error_action to $var_auditd_disk_error_action per security requirements" >> /etc/audit/auditd.conf
-        echo "disk_error_action = $var_auditd_disk_error_action" >> /etc/audit/auditd.conf
-fi
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_full_action', "$var_auditd_disk_full_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/oval/shared.xml
@@ -13,17 +13,25 @@
     <ind:state state_ref="state_auditd_data_disk_error_action" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_auditd_data_disk_error_action" version="2">
+  <ind:textfilecontent54_object id="object_auditd_data_disk_error_action" version="3">
     <ind:filepath>/etc/audit/auditd.conf</ind:filepath>
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*disk_error_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_disk_error_action" version="1">
-    <ind:subexpression operation="case insensitive equals" var_ref="var_auditd_disk_error_action" />
+    <ind:subexpression operation="pattern match" var_ref="var_auditd_disk_error_action_regex" />
   </ind:textfilecontent54_state>
+
+  <local_variable datatype="string" id="var_auditd_disk_error_action_regex" version="1"
+  comment="Build regex to be case insensitive">
+    <concat>
+      <literal_component>(?i)</literal_component>    
+      <variable_component var_ref="var_auditd_disk_error_action"/> 
+    </concat>
+  </local_variable>
 
   <external_variable comment="audit disk_error_action setting" datatype="string" id="var_auditd_disk_error_action" version="1" />
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/common.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+truncate -s 0 /etc/audit/auditd.conf
+mkdir /etc/audit/
+touch /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_and_wrong_value_multiple_possible.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_and_wrong_value_multiple_possible.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_disk_error_action=action1|action2|action3
+
+source common.sh
+
+echo "disk_error_action = action1" >> /etc/audit/auditd.conf
+echo "disk_error_action = action2" >> /etc/audit/auditd.conf
+echo "disk_error_action = action3" >> /etc/audit/auditd.conf
+echo "disk_error_action = non_valid_action" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_and_wrong_value_one_possible.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_and_wrong_value_one_possible.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_disk_error_action=action1
+
+source common.sh
+
+echo "disk_error_action = action1" >> /etc/audit/auditd.conf
+echo "disk_error_action = non_valid_action" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_value_multiple_possible.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_value_multiple_possible.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_disk_error_action=action1|action2|action3
+
+source common.sh
+
+echo "disk_error_action = action1" >> /etc/audit/auditd.conf
+echo "disk_error_action = action2" >> /etc/audit/auditd.conf
+echo "disk_error_action = action3" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_value_one_possible.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/correct_value_one_possible.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_disk_error_action=halt
+
+source common.sh
+
+echo "disk_error_action = halt" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/no_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/no_value.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = audit
+
+source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/wrong_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+
+source common.sh
+
+echo "disk_error_action = non_valid_action" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: Configure auditd Disk Full Action when Disk Space Is Full
   lineinfile:
     dest: /etc/audit/auditd.conf
-    line: "disk_full_action = {{ var_auditd_disk_full_action }}"
+    line: "disk_full_action = {{ var_auditd_disk_full_action.split('|')[0] }}"
     regexp: '^\s*disk_full_action\s*=\s*.*$'
     state: present
     create: yes

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
@@ -2,4 +2,6 @@
 
 {{{ bash_instantiate_variables("var_auditd_disk_full_action") }}}
 
+var_auditd_disk_full_action="$(echo $var_auditd_disk_full_action | cut -d \| -f 1)"
+
 {{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_full_action', "$var_auditd_disk_full_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/oval/shared.xml
@@ -13,18 +13,27 @@
     <ind:state state_ref="state_auditd_data_disk_full_action" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="object_auditd_data_disk_full_action" version="2">
+  <ind:textfilecontent54_object id="object_auditd_data_disk_full_action" version="3">
     <ind:filepath>/etc/audit/auditd.conf</ind:filepath>
     <!-- Allow only space (exactly) as delimiter: https://fedorahosted.org/audit/browser/trunk/src/auditd-config.c#L426 -->
     <!-- Require at least one space before and after the equal sign -->
     <ind:pattern operation="pattern match">^[ ]*disk_full_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_auditd_data_disk_full_action" version="1">
-    <ind:subexpression operation="case insensitive equals" var_ref="var_auditd_disk_full_action" />
+    <ind:subexpression operation="pattern match" var_ref="var_auditd_disk_full_action_regex" />
   </ind:textfilecontent54_state>
 
-  <external_variable comment="audit disk_full_action setting" datatype="string" id="var_auditd_disk_full_action" version="1" />
+  <local_variable datatype="string" id="var_auditd_disk_full_action_regex" version="1"
+  comment="Build regex to be case insensitive">
+    <concat>
+      <literal_component>(?i)</literal_component>    
+      <variable_component var_ref="var_auditd_disk_full_action"/> 
+    </concat>
+  </local_variable>
+
+  <external_variable comment="audit disk_full_action setting" datatype="string"
+  id="var_auditd_disk_full_action" version="1" />
 
 </def-group>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/common.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+truncate -s 0 /etc/audit/auditd.conf
+mkdir /etc/audit/
+touch /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_multiple_possible.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_multiple_possible.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+# variables = var_auditd_disk_full_action=action1|action2|action3
+
+source common.sh
+
+echo "disk_full_action = action1" >> /etc/audit/auditd.conf
+echo "disk_full_action = action2" >> /etc/audit/auditd.conf
+echo "disk_full_action = action3" >> /etc/audit/auditd.conf
+echo "disk_full_action = non_valid_action" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_one_possible.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_one_possible.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+# variables = var_auditd_disk_full_action=action1
+
+source common.sh
+
+echo "disk_full_action = action1" >> /etc/audit/auditd.conf
+echo "disk_full_action = non_valid_action" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_multiple_possible.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_multiple_possible.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+# variables = var_auditd_disk_full_action=action1|action2|action3
+
+source common.sh
+
+echo "disk_full_action = action1" >> /etc/audit/auditd.conf
+echo "disk_full_action = action2" >> /etc/audit/auditd.conf
+echo "disk_full_action = action3" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_one_possible.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_one_possible.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+# variables = var_auditd_disk_full_action=halt
+
+source common.sh
+
+echo "disk_full_action = halt" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/no_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/no_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+
+source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/wrong_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+{{% if "ubuntu" in product%}}
+# packages = auditd
+{{% else %}}
+# packages = audit
+{{% endif %}}
+
+source common.sh
+
+echo "disk_full_action = non_valid_action" >> /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_error_action.var
@@ -2,7 +2,10 @@ documentation_complete: true
 
 title: 'Action for auditd to take when disk errors'
 
-description: 'The setting for disk_error_action in /etc/audit/auditd.conf'
+description: |-
+    'The setting for disk_error_action in /etc/audit/auditd.conf, if multiple
+    values are allowed write them separated by pipes as in "syslog|single|halt",
+    for remediations the first value will be taken'
 
 type: string
 
@@ -16,3 +19,5 @@ options:
     suspend: suspend
     syslog: syslog
     ignore: ignore
+    ol8: syslog|single|halt
+    rhel8: syslog|single|halt

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_disk_full_action.var
@@ -2,7 +2,10 @@ documentation_complete: true
 
 title: 'Action for auditd to take when disk is full'
 
-description: 'The setting for disk_full_action in /etc/audit/auditd.conf'
+description: |-
+    'The setting for disk_full_action in /etc/audit/auditd.conf, if multiple
+    values are allowed write them separated by pipes as in "syslog|single|halt",
+    for remediations the first value will be taken'
 
 type: string
 
@@ -17,3 +20,5 @@ options:
     syslog: syslog
     ignore: ignore
     rotate: rotate
+    ol8: syslog|single|halt
+    rhel8: syslog|single|halt

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -55,9 +55,9 @@ selections:
     - var_accounts_maximum_age_login_defs=60
     - var_auditd_space_left_percentage=25pc
     - var_auditd_space_left_action=email
-    - var_auditd_disk_error_action=halt
+    - var_auditd_disk_error_action=ol8
     - var_auditd_max_log_file_action=syslog
-    - var_auditd_disk_full_action=halt
+    - var_auditd_disk_full_action=ol8
     - var_sssd_certificate_verification_digest_function=sha1
     - login_banner_text=dod_banners
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -68,9 +68,9 @@ selections:
     - var_accounts_maximum_age_login_defs=60
     - var_auditd_space_left_percentage=25pc
     - var_auditd_space_left_action=email
-    - var_auditd_disk_error_action=halt
+    - var_auditd_disk_error_action=rhel8
     - var_auditd_max_log_file_action=syslog
-    - var_auditd_disk_full_action=halt
+    - var_auditd_disk_full_action=rhel8
     - var_sssd_certificate_verification_digest_function=sha1
     - login_banner_text=dod_banners
 

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -447,9 +447,9 @@ selections:
 - var_accounts_maximum_age_login_defs=60
 - var_auditd_space_left_percentage=25pc
 - var_auditd_space_left_action=email
-- var_auditd_disk_error_action=halt
+- var_auditd_disk_error_action=rhel8
 - var_auditd_max_log_file_action=syslog
-- var_auditd_disk_full_action=halt
+- var_auditd_disk_full_action=rhel8
 - var_sssd_certificate_verification_digest_function=sha1
 - login_banner_text=dod_banners
 - var_system_crypto_policy=fips

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -455,9 +455,9 @@ selections:
 - var_accounts_maximum_age_login_defs=60
 - var_auditd_space_left_percentage=25pc
 - var_auditd_space_left_action=email
-- var_auditd_disk_error_action=halt
+- var_auditd_disk_error_action=rhel8
 - var_auditd_max_log_file_action=syslog
-- var_auditd_disk_full_action=halt
+- var_auditd_disk_full_action=rhel8
 - var_sssd_certificate_verification_digest_function=sha1
 - login_banner_text=dod_banners
 - var_system_crypto_policy=fips


### PR DESCRIPTION
#### Description:

- Update `var_auditd_disk_error_action` & `var_auditd_disk_full_action` to allow multiple values
- Update rules `auditd_data_disk_error_action` & `auditd_data_disk_full_action` to function with the multiple values in vars
- Update RHEL8 and OL8 profiles to use those multiple values
- Add tests

#### Rationale:

- This is to allow all values permitted by DISA in `OL08-00-030040`, `OL08-00-030060`, `RHEL-08-030040`, `RHEL-08-030060`
