### PR TITLE
Update audit_immutable_login_uids template

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -11,13 +11,16 @@ title: 'Configure immutable Audit login UIDs'
 
 description: |-
     Configure kernel to prevent modification of login UIDs once they are set.
-    Changing login UIDs while this configuration is enforced requires special capabilities which are not available to unprivileged users.
+    Changing login UIDs while this configuration is enforced requires special capabilities which
+    are not available to unprivileged users.
 
     The following rules configure audit as described above:
     <pre>{{{ file_contents_audit_immutable_login|indent }}}    </pre>
 
-    The <tt>Audit</tt> provides pre-configured  rules in <tt>/usr/share/audit/sample-rules</tt>. The above content can be found in <tt>/usr/share/audit/sample-rules/11-loginuid.rules</tt>.
-    To deploy this configuration, it is recommended to copy it over to the <tt>/etc/audit/rules.d/</tt> directory:
+    The <tt>Audit</tt> provides pre-configured  rules in <tt>/usr/share/audit/sample-rules</tt>.
+    The above content can be found in <tt>/usr/share/audit/sample-rules/11-loginuid.rules</tt>.
+    To deploy this configuration, it is recommended to copy it over to the
+    <tt>/etc/audit/rules.d/</tt> directory:
     <pre>
     cp /usr/share/audit/sample-rules/11-loginuid.rules /etc/audit/rules.d/
     </pre>
@@ -26,7 +29,8 @@ description: |-
     <pre>augenrules --load</pre>
 
 rationale: |-
-    If modification of login UIDs is not prevented, they can be changed by unprivileged users and make auditing complicated or impossible. 
+    If modification of login UIDs is not prevented, they can be changed by unprivileged users and
+    make auditing complicated or impossible. 
 
 severity: medium
 
@@ -45,17 +49,17 @@ references:
 ocil_clause: 'the file does not exist or the content differs'
 
 ocil: |-
-    To verify that the <tt>Audit</tt> is correctly configured according to recommended rules, check the content of the file with the following command:
-    <pre>cat /etc/audit/rules.d/11-loginuid.rules</pre>
-    The output has to be exactly as follows:
-    <pre>{{{ file_contents_audit_immutable_login|indent }}}    </pre>
+    To verify that the <tt>Audit</tt> is correctly configured according to recommended rules,
+    check the content of the file with the following command:
+    <pre>sudo grep -i loginuid-immutable /etc/audit/audit.rules</pre>
+    The output has to contain a non commented line as follows:
+    <pre>--loginuid-immutable</pre>
 
 template:
-    name: audit_file_contents
+    name: lineinfile
     vars:
-        filepath: /etc/audit/rules.d/11-loginuid.rules
-        contents: |+
-            {{{ file_contents_audit_immutable_login|indent(12) }}}
+        path: /etc/audit/rules.d/11-loginuid.rules
+        text: "--loginuid-immutable"
 
 fixtext: |-
     Configure {{{ full_name }}} kernel to prevent modification of login UIDs once they are set.

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -4,18 +4,13 @@ prodtype: ol8,rhcos4,rhel8,rhel9
 
 title: 'Configure immutable Audit login UIDs'
 
-{{% set file_contents_audit_immutable_login =
-"## Make the loginuid immutable. This prevents tampering with the auid.
---loginuid-immutable
-" %}}
-
 description: |-
     Configure kernel to prevent modification of login UIDs once they are set.
     Changing login UIDs while this configuration is enforced requires special capabilities which
     are not available to unprivileged users.
 
     The following rules configure audit as described above:
-    <pre>{{{ file_contents_audit_immutable_login|indent }}}    </pre>
+    <pre>--loginuid-immutable</pre>
 
     The <tt>Audit</tt> provides pre-configured  rules in <tt>/usr/share/audit/sample-rules</tt>.
     The above content can be found in <tt>/usr/share/audit/sample-rules/11-loginuid.rules</tt>.
@@ -24,13 +19,13 @@ description: |-
     <pre>
     cp /usr/share/audit/sample-rules/11-loginuid.rules /etc/audit/rules.d/
     </pre>
-    
+
     Load new Audit rules into kernel by running:
     <pre>augenrules --load</pre>
 
 rationale: |-
     If modification of login UIDs is not prevented, they can be changed by unprivileged users and
-    make auditing complicated or impossible. 
+    make auditing complicated or impossible.
 
 severity: medium
 
@@ -64,13 +59,21 @@ template:
 fixtext: |-
     Configure {{{ full_name }}} kernel to prevent modification of login UIDs once they are set.
 
-    Create file "/etc/audit/rules.d/11-loginuid.rules" with the exactly following content:
+    Make sure the file "/etc/audit/rules.d/11-loginuid.rules" contains the following content:
 
-    {{{ file_contents_audit_immutable_login|indent(4) }}}
+    <pre>--loginuid-immutable</pre>
+
+    If the file doesn't exist, it can be copied from <tt>/usr/share/audit/sample-rules</tt>
+    using the next command
+
+    <pre>
+    cp /usr/share/audit/sample-rules/11-loginuid.rules /etc/audit/rules.d/
+    </pre>
 
     Then, run the following commands:
 
     $ sudo chmod o-rwx "/etc/audit/rules.d/11-loginuid.rules"
     $ sudo augenrules --load
+
 srg_requirement: |-
     {{{ full_name }}} audit system must protect logon UIDs from unauthorized change.


### PR DESCRIPTION
#### Description:

- Update rule `audit_immutable_login_uids` to use `lineinfile` template

#### Rationale:

- this is a more flexible template so it won't fail if the user make any non-related change to the `11-loginuid.rules` file
