### PR TITLE
Update var_password_pam_remember_control_flag to allow multiple values in OL8

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/ansible/shared.yml
@@ -4,5 +4,14 @@
 # complexity = low
 # disruption = medium
 
-{{{ ansible_instantiate_variables("var_password_pam_remember", "var_password_pam_remember_control_flag") }}}
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', '{{ var_password_pam_remember_control_flag }}', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_remember }}', '^password.*requisite.*pam_pwquality.so') }}}
+{{{ ansible_instantiate_variables("var_password_pam_remember",
+                                  "var_password_pam_remember_control_flag") }}}
+{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth',
+                                            'password',
+                                            '{{ 
+                                              var_password_pam_remember_control_flag.split(",")[0]
+                                            }}',
+                                            'pam_pwhistory.so',
+                                            'remember',
+                                            '{{ var_password_pam_remember }}',
+                                            '^password.*requisite.*pam_pwquality.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/bash/shared.sh
@@ -2,4 +2,6 @@
 
 {{{ bash_instantiate_variables("var_password_pam_remember", "var_password_pam_remember_control_flag") }}}
 
+var_password_pam_remember_control_flag="$(echo $var_password_pam_remember_control_flag | cut -d \, -f 1)"
+
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', "$var_password_pam_remember_control_flag", 'pam_pwhistory.so', 'remember', "$var_password_pam_remember", '^password.*requisite.*pam_pwquality.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/oval/shared.xml
@@ -13,7 +13,8 @@
 
   <ind:textfilecontent54_object id="obj_accounts_password_pam_pwhistory_remember_password_auth" version="1">
     <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
-    <ind:pattern var_ref="pwhistory_line_regex_password_auth" operation="pattern match"></ind:pattern>
+    <ind:pattern var_ref="pwhistory_line_regex_password_auth" var_check="at least one"
+    operation="pattern match" />
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -24,9 +25,15 @@
   <local_variable id="pwhistory_line_regex_password_auth" datatype="string" comment="The regex of the directive" version="1">
     <concat>
       <literal_component>^\s*password\s+(?:</literal_component>
-      <variable_component var_ref="var_password_pam_remember_control_flag"/>
+      <variable_component var_ref="var_possible_control_flags_password_auth"/>
       <literal_component>)\s+pam_pwhistory\.so.*remember=([0-9]*).*$</literal_component>
     </concat>
+  </local_variable>
+
+  <local_variable id="var_possible_control_flags_password_auth" datatype="string" comment="All accepted control flags" version="1">
+  <split delimiter=",">
+      <variable_component var_ref="var_password_pam_remember_control_flag"/>
+  </split> 
   </local_variable>
 
   <external_variable comment="number of passwords that should be remembered" datatype="int" id="var_password_pam_remember" version="1" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -7,6 +7,15 @@ title: 'Limit Password Reuse: password-auth'
 description: |-
     Do not allow users to reuse recent passwords. This can be accomplished by using the
     <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module.
+    <br /><br />
+    In the file <tt>/etc/pam.d/password-auth</tt>, make sure the parameter
+    <tt>remember</tt> is present and it has a value equal to or greater than
+    {{{ xccdf_value("var_password_pam_remember") }}}. For example:
+    <pre>password <i>control_flag</i> pam_pwhistory.so <i>...existing_options...</i> remember={{{
+    xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
+    <i>control_flag</i> should be one of the next values: <tt>{{{
+    xccdf_value("var_password_pam_remember_control_flag") }}}</tt><br />
+    The DoD STIG requirement is 5 passwords.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -48,16 +57,17 @@ ocil: |-
     Check that the operating system prohibits the reuse of a password for
     a minimum of <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
     <pre># grep pam_pwhistory.so /etc/pam.d/password-auth
-    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, or the returned line is commented
-    out, has a second column value different from <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
+    password <i>control_flag</i> pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
+    If the command does not return a result, or the returned line is commented out,
+    <i>control_flag</i> value isn't one of the next: <tt>{{{
+    xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
     "remember" value, or the value is less than
     <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>, this is a finding.
 
 fixtext: |-
     To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
-    file <tt>/etc/pam.d/password-auth</tt>, make sure the parameter <tt>remember</tt> is present,
-    and that the value for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater.
+    file <tt>/etc/pam.d/password-auth</tt>, make sure the parameter <tt>remember</tt> is present
+    and it has a value equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
     For example:
     <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -15,7 +15,6 @@ description: |-
     xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
     <i>control_flag</i> should be one of the next values: <tt>{{{
     xccdf_value("var_password_pam_remember_control_flag") }}}</tt><br />
-    The DoD STIG requirement is 5 passwords.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -58,15 +57,15 @@ ocil: |-
     a minimum of <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
     <pre># grep pam_pwhistory.so /etc/pam.d/password-auth
     password <i>control_flag</i> pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, or the returned line is commented out,
-    <i>control_flag</i> value isn't one of the next: <tt>{{{
-    xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
-    "remember" value, or the value is less than
-    <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>, this is a finding.
+    If the command does not return a result, the returned line is commented out,
+    the line does not contain "remember" value, the value is less than <tt>{{{
+    xccdf_value("var_password_pam_remember") }}}</tt>, the <i>control_flag</i> value isn't one of
+    the next: <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt> this is a
+    finding.
 
 fixtext: |-
     To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
-    file <tt>/etc/pam.d/password-auth</tt>, make sure the parameter <tt>remember</tt> is present
+    file <tt>/etc/pam.d/password-auth</tt>, make sure the <tt>remember</tt> parameter is present
     and it has a value equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
     For example:
     <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/argument_missing.fail.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7, Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
-
-{{{ bash_package_remove("authselect") }}}
 
 config_file=/etc/pam.d/password-auth
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/argument_missing.fail.sh
@@ -2,6 +2,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # packages = pam
 
+{{{ bash_package_remove("authselect") }}}
+
 config_file=/etc/pam.d/password-auth
 
 if grep -q "pam_pwhistory\.so.*remember=" "$config_file" ; then

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value.pass.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
-
-{{{ bash_package_remove("authselect") }}}
 
 remember_cnt=5
 control_flag='requisite'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value.pass.sh
@@ -3,6 +3,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 
+{{{ bash_package_remove("authselect") }}}
+
 remember_cnt=5
 control_flag='requisite'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_required.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_required.pass.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # packages = pam
-# platforms = Oracle Linux 8
+# platform = Oracle Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-{{{ bash_package_remove("authselect") }}}
-
-config_file="/etc/pam.d/password-auth"
-
-sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
-
-echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
+sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_required.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_required.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = pam
+# platforms = Oracle Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+{{{ bash_package_remove("authselect") }}}
+
+config_file="/etc/pam.d/password-auth"
+
+sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
+
+echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_requisite.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_requisite.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = pam
+# platforms = Oracle Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+{{{ bash_package_remove("authselect") }}}
+
+config_file="/etc/pam.d/password-auth"
+
+sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
+
+echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_requisite.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_requisite.pass.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # packages = pam
-# platforms = Oracle Linux 8
+# platform = Oracle Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-{{{ bash_package_remove("authselect") }}}
-
-config_file="/etc/pam.d/password-auth"
-
-sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
-
-echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
+sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_control.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
-
-{{{ bash_package_remove("authselect") }}}
 
 remember_cnt=5
 control_flag='required'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_control.fail.sh
@@ -3,6 +3,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 
+{{{ bash_package_remove("authselect") }}}
+
 remember_cnt=5
 control_flag='required'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
-
-{{{ bash_package_remove("authselect") }}}
 
 remember_cnt=3
 control_flag='requisite'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value.fail.sh
@@ -3,6 +3,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 
+{{{ bash_package_remove("authselect") }}}
+
 remember_cnt=3
 control_flag='requisite'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value_multiple_control_sufficient.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value_multiple_control_sufficient.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = pam
+# platform = Oracle Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
+sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+echo "password sufficient pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/ansible/shared.yml
@@ -4,5 +4,14 @@
 # complexity = low
 # disruption = medium
 
-{{{ ansible_instantiate_variables("var_password_pam_remember", "var_password_pam_remember_control_flag") }}}
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', '{{ var_password_pam_remember_control_flag }}', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_remember }}', '^password.*requisite.*pam_pwquality.so') }}}
+{{{ ansible_instantiate_variables("var_password_pam_remember",
+                                  "var_password_pam_remember_control_flag") }}}
+{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth',
+                                            'password',
+                                            '{{
+                                              var_password_pam_remember_control_flag.split(",")[0]
+                                            }}',
+                                            'pam_pwhistory.so',
+                                            'remember',
+                                            '{{ var_password_pam_remember }}',
+                                            '^password.*requisite.*pam_pwquality.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/bash/shared.sh
@@ -2,4 +2,6 @@
 
 {{{ bash_instantiate_variables("var_password_pam_remember", "var_password_pam_remember_control_flag") }}}
 
+var_password_pam_remember_control_flag="$(echo $var_password_pam_remember_control_flag | cut -d \, -f 1)"
+
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', "$var_password_pam_remember_control_flag", 'pam_pwhistory.so', 'remember', "$var_password_pam_remember", '^password.*requisite.*pam_pwquality.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/oval/shared.xml
@@ -13,7 +13,8 @@
 
   <ind:textfilecontent54_object id="obj_accounts_password_pam_pwhistory_remember_system_auth" version="1">
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
-    <ind:pattern var_ref="pwhistory_line_regex_system_auth" operation="pattern match"></ind:pattern>
+    <ind:pattern var_ref="pwhistory_line_regex_system_auth" var_check="at least one"
+    operation="pattern match" />
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -24,9 +25,15 @@
   <local_variable id="pwhistory_line_regex_system_auth" datatype="string" comment="The regex of the directive" version="1">
     <concat>
       <literal_component>^\s*password\s+(?:</literal_component>
-      <variable_component var_ref="var_password_pam_remember_control_flag"/>
+      <variable_component var_ref="var_possible_control_flags_system_auth"/>
       <literal_component>)\s+pam_pwhistory\.so.*remember=([0-9]*).*$</literal_component>
     </concat>
+  </local_variable>
+
+ <local_variable id="var_possible_control_flags_system_auth" datatype="string" comment="All accepted control flags" version="1">
+  <split delimiter=",">
+      <variable_component var_ref="var_password_pam_remember_control_flag"/>
+  </split> 
   </local_variable>
 
   <external_variable comment="number of passwords that should be remembered" datatype="int" id="var_password_pam_remember" version="1" />

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -16,7 +16,6 @@ description: |-
     xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
     <i>control_flag</i> should be one of the next values: <tt>{{{
     xccdf_value("var_password_pam_remember_control_flag") }}}</tt><br />
-    The DoD STIG requirement is 5 passwords.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -59,15 +58,15 @@ ocil: |-
     <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
     <pre># grep pam_pwhistory.so /etc/pam.d/system-auth
     password <i>control_flag</i> pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, or the returned line is commented out,
-    <i>control_flag</i> value isn't one of the next: <tt>{{{
-    xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
-    "remember" value, or the value is less than
-    <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>, this is a finding.
+    If the command does not return a result, the returned line is commented out,
+    the line does not contain "remember" value, the value is less than <tt>{{{
+    xccdf_value("var_password_pam_remember") }}}</tt>, the <i>control_flag</i> value isn't one of
+    the next: <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt> this is a
+    finding.
 
 fixtext: |-
     To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
-    file <tt>/etc/pam.d/system-auth</tt>, make sure the parameter <tt>remember</tt> is present
+    file <tt>/etc/pam.d/system-auth</tt>, make sure the <tt>remember</tt> parameter is present
     and it has a value equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
     For example:
     <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -7,6 +7,16 @@ title: 'Limit Password Reuse: system-auth'
 description: |-
     Do not allow users to reuse recent passwords. This can be accomplished by using the
     <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module.
+    <br /><br />
+    In the file <tt>/etc/pam.d/system-auth</tt>, make sure the parameter
+    <tt>remember</tt> is present and it has a value equal to or greater than
+    {{{ xccdf_value("var_password_pam_remember") }}}
+    For example:
+    <pre>password <i>control_flag</i> pam_pwhistory.so <i>...existing_options...</i> remember={{{
+    xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
+    <i>control_flag</i> should be one of the next values: <tt>{{{
+    xccdf_value("var_password_pam_remember_control_flag") }}}</tt><br />
+    The DoD STIG requirement is 5 passwords.
 
 rationale: 'Preventing re-use of previous passwords helps ensure that a compromised password is not re-used by a user.'
 
@@ -48,16 +58,17 @@ ocil: |-
     Check that the operating system prohibits the reuse of a password for a minimum of
     <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
     <pre># grep pam_pwhistory.so /etc/pam.d/system-auth
-    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, or the returned line is commented out, has a second
-    column value different from <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt>,
-    does not contain "remember" value, or the value is less than <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>,
-    this is a finding.
+    password <i>control_flag</i> pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
+    If the command does not return a result, or the returned line is commented out,
+    <i>control_flag</i> value isn't one of the next: <tt>{{{
+    xccdf_value("var_password_pam_remember_control_flag") }}}</tt>, does not contain
+    "remember" value, or the value is less than
+    <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt>, this is a finding.
 
 fixtext: |-
     To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
-    file <tt>/etc/pam.d/system-auth</tt>, make sure the parameter <tt>remember</tt> is present,
-    and that the value for the <tt>remember</tt> parameter is {{{ xccdf_value("var_password_pam_remember") }}} or greater.
+    file <tt>/etc/pam.d/system-auth</tt>, make sure the parameter <tt>remember</tt> is present
+    and it has a value equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
     For example:
     <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/argument_missing.fail.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
-
-{{{ bash_package_remove("authselect") }}}
 
 config_file=/etc/pam.d/system-auth
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/argument_missing.fail.sh
@@ -2,6 +2,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # packages = pam
 
+{{{ bash_package_remove("authselect") }}}
+
 config_file=/etc/pam.d/system-auth
 
 if grep -q "pam_pwhistory\.so.*remember=" "$config_file" ; then

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value.pass.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
-
-{{{ bash_package_remove("authselect") }}}
 
 remember_cnt=5
 control_flag='requisite'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value.pass.sh
@@ -3,6 +3,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 
+{{{ bash_package_remove("authselect") }}}
+
 remember_cnt=5
 control_flag='requisite'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_required.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_required.pass.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # packages = pam
-# platforms = Oracle Linux 8
+# platform = Oracle Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-{{{ bash_package_remove("authselect") }}}
-
-config_file="/etc/pam.d/system-auth"
-
-sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
-
-echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
+sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_required.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_required.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = pam
+# platforms = Oracle Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+{{{ bash_package_remove("authselect") }}}
+
+config_file="/etc/pam.d/system-auth"
+
+sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
+
+echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_requisite.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_requisite.pass.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # packages = pam
-# platforms = Oracle Linux 8
+# platform = Oracle Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-{{{ bash_package_remove("authselect") }}}
-
-config_file="/etc/pam.d/system-auth"
-
-sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
-
-echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
+sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_requisite.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_requisite.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = pam
+# platforms = Oracle Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+{{{ bash_package_remove("authselect") }}}
+
+config_file="/etc/pam.d/system-auth"
+
+sed -i --follow-symlinks "/pam_pwhistory\.so/d" $config_file
+
+echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $config_file

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_control.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
-
-{{{ bash_package_remove("authselect") }}}
 
 remember_cnt=5
 control_flag='required'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_control.fail.sh
@@ -3,6 +3,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 
+{{{ bash_package_remove("authselect") }}}
+
 remember_cnt=5
 control_flag='required'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value.fail.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
-
-{{{ bash_package_remove("authselect") }}}
 
 remember_cnt=3
 control_flag='requisite'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value.fail.sh
@@ -3,6 +3,8 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 # variables = var_password_pam_remember=5,var_password_pam_remember_control_flag=requisite
 
+{{{ bash_package_remove("authselect") }}}
+
 remember_cnt=3
 control_flag='requisite'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value_multiple_control_requisite.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value_multiple_control_requisite.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = pam
+# platform = Oracle Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+authselect create-profile hardening -b sssd
+CUSTOM_PROFILE="custom/hardening"
+authselect select $CUSTOM_PROFILE --force
+CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
+sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+echo "password sufficient pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
+authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember_control_flag.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember_control_flag.var
@@ -2,7 +2,10 @@ documentation_complete: true
 
 title: 'PAM pwhistory remember - control flag'
 
-description: 'Specify the control flag required for password remember requirement.'
+description: |-
+    'Specify the control flag required for password remember requirement. If multiple
+    values are allowed write them separated by commas as in "required,requisite",
+    for remediations the first value will be taken'
 
 type: string
 
@@ -16,4 +19,5 @@ options:
     "requisite": "requisite"
     "sufficient": "sufficient"
     "binding": "binding"
+    "ol8": "required,requisite"
     default: "requisite"

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -25,7 +25,7 @@ selections:
     - var_accounts_minimum_age_login_defs=1
     - var_accounts_max_concurrent_login_sessions=10
     - var_password_pam_remember=5
-    - var_password_pam_remember_control_flag=required
+    - var_password_pam_remember_control_flag=ol8
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted
     - var_accounts_password_minlen_login_defs=15


### PR DESCRIPTION
#### Description:

- Update `var_password_pam_remember_control_flag`  to allow multiple values
- Update ansible, bash and OVAL to work with this new `var_password_pam_remember_control_flag`
- Update bash to use the `bash_ensure_pam_module_options` to cover all possible scenarios
- Update ansible regex to fix any control flag
- Update tests

#### Rationale:

- This makes the rule to accept multiple compliant scenarios
- The updates in fixes increase the scenarios which they can handle
