### PR TITLE
Fix a traceback in combined mode

### DIFF
--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -110,6 +110,7 @@ def perform_combined_check(options):
     checker.manual_debug = False
     checker.benchmark_cpes = options.benchmark_cpes
     checker.scenarios_regex = options.scenarios_regex
+    checker.scenarios_profile = None
     checker.slice_current = options.slice_current
     checker.slice_total = options.slice_total
     for profile in options.target:

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -126,6 +126,7 @@ class RuleChecker(oscap.Checker):
         self.used_templated_test_scenarios = collections.defaultdict(set)
         self.rule_spec = None
         self.template_spec = None
+        self.scenarios_profile = None
 
     def _run_test(self, profile, test_data):
         scenario = test_data["scenario"]


### PR DESCRIPTION
We need to always define the member scenarios_profile, the CombinedChecker
inherits from RuleChecker, so it needs to be set in the parent class.

Addressing:
```
[jcerny@thinkpad scap-security-guide{master}]$ python3 tests/test_suite.py combined --slice 1 3 --libvirt qemu:///system ssgts_rhel9 --datastream /usr/share/xml/scap/ssg/content/ssg-rhel9-ds.xml --mode online --remediate-using ansible --duplicate-templates --no-reports xccdf_org.ssgproject.content_profile_ospp
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/jcerny/work/git/scap-security-guide/logs/combined-custom-2022-06-01-1034/test_suite.log
INFO - Performing combined test using profile: xccdf_org.ssgproject.content_profile_ospp
WARNING - Nothing has been tested!
Traceback (most recent call last):
  File "/home/jcerny/work/git/scap-security-guide/tests/test_suite.py", line 508, in <module>
    main()
  File "/home/jcerny/work/git/scap-security-guide/tests/test_suite.py", line 504, in main
    options.func(options)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/combined.py", line 122, in perform_combined_check
    checker.test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/oscap.py", line 699, in test_target
    self._test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/combined.py", line 83, in _test_target
    super(CombinedChecker, self)._test_target()
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 428, in _test_target
    scenarios_by_rule_id = self._get_scenarios_by_rule_id(rules_to_test)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 414, in _get_scenarios_by_rule_id
    scenarios_by_rule_id[rule.id] = self._get_rule_scenarios(rule)
  File "/home/jcerny/work/git/scap-security-guide/tests/ssg_test_suite/rule.py", line 405, in _get_rule_scenarios
    scenario.override_profile(self.scenarios_profile)
AttributeError: 'CombinedChecker' object has no attribute 'scenarios_profile'
```

Fixes: #8858

#### Description:

- _Description here. Replace this text. Don't use the italics format!_

#### Rationale:

- _Rationale here. Replace this text. Don't use the italics format!_

- Fixes # _Issue number here (e.g. #26) or remove this line if no issue exists._
