### PR TITLE
Fix audit file contents templated rules

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -50,13 +50,6 @@ ocil: |-
     The output has to be exactly as follows:
     <pre>{{{ file_contents_audit_delete_failed|indent }}}    </pre>
 
-template:
-    name: audit_file_contents
-    vars:
-        filepath: /etc/audit/rules.d/30-ospp-v42-4-delete-failed.rules
-        contents: |+
-            {{{ file_contents_audit_delete_failed|indent(12) }}}
-
 fixtext: |-
     Configure {{{ full_name }}} to audit all unsuccessful attempts to delete a file.
 
@@ -68,3 +61,10 @@ fixtext: |-
 
     $ sudo chmod o-rwx /etc/audit/rules.d/30-ospp-v42-4-delete-failed.rules
     $ sudo augenrules --load
+
+template:
+    name: audit_file_contents
+    vars:
+        filepath: /etc/audit/rules.d/30-ospp-v42-4-delete-failed.rules
+        contents: |+
+            {{{ file_contents_audit_delete_failed|indent(12) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/rule.yml
@@ -50,13 +50,6 @@ ocil: |-
     The output has to be exactly as follows:
     <pre>{{{ file_contents_audit_immutable_login|indent }}}    </pre>
 
-template:
-    name: audit_file_contents
-    vars:
-        filepath: /etc/audit/rules.d/11-loginuid.rules
-        contents: |+
-            {{{ file_contents_audit_immutable_login|indent(12) }}}
-
 fixtext: |-
     Configure {{{ full_name }}} kernel to prevent modification of login UIDs once they are set.
 
@@ -68,5 +61,13 @@ fixtext: |-
 
     $ sudo chmod o-rwx "/etc/audit/rules.d/11-loginuid.rules"
     $ sudo augenrules --load
+
 srg_requirement: |-
     {{{ full_name }}} audit system must protect logon UIDs from unauthorized change.
+
+template:
+    name: audit_file_contents
+    vars:
+        filepath: /etc/audit/rules.d/11-loginuid.rules
+        contents: |+
+            {{{ file_contents_audit_immutable_login|indent(12) }}}


### PR DESCRIPTION
#### Description:

- Fix audit file contents templated rules
  - The template uses file contents and if defined in the middle of the
file, extra blank lines are added to the check causing the checks to
fail with the sample files and even the expected content defined in the
file. Moving the template section to the end of the file makes it
require only one newline as expected.
