### PR TITLE
Update directory_ownership_var_log_audit

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/bash/shared.sh
@@ -1,3 +1,13 @@
 # platform = multi_platform_all
 
+{{% if product == "ol8" %}}
+if LC_ALL=C grep -iw ^log_file /etc/audit/auditd.conf; then
+    FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
+    LOGPATH="$(dirname "$FILE")"
+    chown root $LOGPATH
+else
+    chown root /var/log/audit
+fi
+{{% else %}}
 chown root /var/log/audit
+{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/bash/shared.sh
@@ -1,6 +1,5 @@
 # platform = multi_platform_all
 
-{{% if product == "ol8" %}}
 if LC_ALL=C grep -iw ^log_file /etc/audit/auditd.conf; then
     FILE=$(awk -F "=" '/^log_file/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
     LOGPATH="$(dirname "$FILE")"
@@ -8,6 +7,3 @@ if LC_ALL=C grep -iw ^log_file /etc/audit/auditd.conf; then
 else
     chown root /var/log/audit
 fi
-{{% else %}}
-chown root /var/log/audit
-{{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/oval/shared.xml
@@ -2,7 +2,6 @@
   <definition class="compliance" id="directory_ownership_var_log_audit" version="1">
     {{{ oval_metadata("Checks that all /var/log/audit directories are owned by the root user.") }}}
     <criteria comment="directories are root owned" operator="OR">
-      {{% if product == "ol8" %}}
       <criteria operator="AND" comment="log_file set">
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criterion test_ref="test_user_ownership_var_log_audit_path" />
@@ -11,13 +10,9 @@
         <extend_definition comment="log_file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" />
         <criterion test_ref="test_user_ownership_var_log_audit_directories" />
       </criteria>
-      {{% else %}}
-      <criterion test_ref="test_user_ownership_var_log_audit_directories" />
-      {{% endif %}}
     </criteria>
   </definition>
 
-  {{% if product == "ol8" %}}
   <unix:file_object comment="audit log files" id="object_directory_ownership_var_log_audit_file" version="1">
     <unix:filepath operation="pattern match" var_ref="audit_log_file_path" />
   </unix:file_object>
@@ -39,15 +34,12 @@
     <unix:filename xsi:nil="true" />
     <filter action="include">state_owner_not_root_var_log_audit_directories</filter>
   </unix:file_object>
-  {{% endif %}}
+
   <unix:file_test check="all" check_existence="none_exist" comment="/var/log/audit directories uid root gid root" id="test_user_ownership_var_log_audit_directories" version="1">
     <unix:object object_ref="object_user_ownership_var_log_audit_directories" />
   </unix:file_test>
 
   <unix:file_object comment="/var/log/audit directories" id="object_user_ownership_var_log_audit_directories" version="1">
-    {{% if product != "ol8" %}}
-    <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
-    {{% endif %}}
     <unix:path operation="equals">/var/log/audit</unix:path>
     <unix:filename xsi:nil="true" />
     <filter action="include">state_owner_not_root_var_log_audit_directories</filter>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/oval/shared.xml
@@ -1,17 +1,53 @@
 <def-group>
   <definition class="compliance" id="directory_ownership_var_log_audit" version="1">
     {{{ oval_metadata("Checks that all /var/log/audit directories are owned by the root user.") }}}
-    <criteria comment="directories are root owned">
+    <criteria comment="directories are root owned" operator="OR">
+      {{% if product == "ol8" %}}
+      <criteria operator="AND" comment="log_file set">
+        <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
+        <criterion test_ref="test_user_ownership_var_log_audit_path" />
+      </criteria>
+      <criteria operator="AND" comment="log_file not set">
+        <extend_definition comment="log_file not set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" />
+        <criterion test_ref="test_user_ownership_var_log_audit_directories" />
+      </criteria>
+      {{% else %}}
       <criterion test_ref="test_user_ownership_var_log_audit_directories" />
+      {{% endif %}}
     </criteria>
   </definition>
-  
+
+  {{% if product == "ol8" %}}
+  <unix:file_object comment="audit log files" id="object_directory_ownership_var_log_audit_file" version="1">
+    <unix:filepath operation="pattern match" var_ref="audit_log_file_path" />
+  </unix:file_object>
+
+  <local_variable id="var_directory_ownership_var_log_audit_path" datatype="string" version="1"
+      comment="Path to log_file">
+    <object_component item_field="path" object_ref="object_directory_ownership_var_log_audit_file" />
+  </local_variable>
+
+  <unix:file_test check="all" check_existence="none_exist"
+      comment="log_file's directory uid root gid root"
+      id="test_user_ownership_var_log_audit_path" version="1">
+    <unix:object object_ref="object_user_ownership_var_log_audit_path" />
+  </unix:file_test>
+
+  <unix:file_object comment="log_file's directory" 
+      id="object_user_ownership_var_log_audit_path" version="1">
+    <unix:path operation="equals" var_ref="var_directory_ownership_var_log_audit_path"/>
+    <unix:filename xsi:nil="true" />
+    <filter action="include">state_owner_not_root_var_log_audit_directories</filter>
+  </unix:file_object>
+  {{% endif %}}
   <unix:file_test check="all" check_existence="none_exist" comment="/var/log/audit directories uid root gid root" id="test_user_ownership_var_log_audit_directories" version="1">
     <unix:object object_ref="object_user_ownership_var_log_audit_directories" />
   </unix:file_test>
 
   <unix:file_object comment="/var/log/audit directories" id="object_user_ownership_var_log_audit_directories" version="1">
+    {{% if product != "ol8" %}}
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1" recurse_file_system="all" />
+    {{% endif %}}
     <unix:path operation="equals">/var/log/audit</unix:path>
     <unix:filename xsi:nil="true" />
     <filter action="include">state_owner_not_root_var_log_audit_directories</filter>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_ownership_var_log_audit/rule.yml
@@ -37,7 +37,21 @@ references:
 ocil_clause: the directory is not owned by root
 
 ocil: |-
-    {{{ describe_file_owner(file="/var/log/audit", owner="root") }}}
+    Determine where the audit logs are stored with the following command:
+
+    $ sudo grep -iw log_file /etc/audit/auditd.conf
+
+    log_file = /var/log/audit/audit.log
+
+    Determine the owner of the audit log directory by using the output of the above command
+    (default: "/var/log/audit/"). Run the following command with the correct audit log directory
+    path:
+
+    $ sudo ls -ld /var/log/audit
+
+    drwx------ 2 root root 23 Jun 11 11:56 /var/log/audit
+
+    The audit log directory must be owned by "root"
 
 srg_requirement: |-
     {{{ full_name }}} audit log directory must be owned by root to prevent unauthorized read access.
@@ -46,4 +60,7 @@ fixtext: |-
     Change the owner of the directory /var/log/audit to root.
     Run the following command:
 
-    $ sudo chown root /var/log/audit
+    $ sudo chown root [audit_log_directory]
+    
+    Replace "[audit_log_directory]" with the correct audit log directory path. By default, this
+    location is usually "/var/log/audit".


### PR DESCRIPTION
#### Description:

- Update OVAL and fixes of `directory_ownership_var_log_audit` to verify the owner of the directory depending on what is defined as `log_file` in `/etc/audit/auditd.conf`

#### Rationale:

- This is to comply more precisely with `OL08-00-030100` & `RHEL-08-030100`
