### PR TITLE
Fix a python2 syntax issue in the Test Suite

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -88,8 +88,8 @@ def _apply_script(rule_dir, test_env, script):
 
         try:
             error_msg_template = (
-                f"Rule '{rule_name}' test setup script '{script}' "
-                "failed with exit code {rc}"
+                "Rule '{0}' test setup script '{1}' "
+                "failed with exit code {2}".format(rule_name, script, rc)
             )
             test_env.execute_ssh_command(
                 command, log_file, error_msg_template=error_msg_template)


### PR DESCRIPTION


#### Description:
- Fix a python2 syntax issue in the Test Suite
  - Python2 doesn't support python format string and cannot be used because
this code runs on RHEL7 testing environment that only has python2
available.

#### Rationale:

- Fixes #8856
