### PR TITLE
Remove unsuccessful audit syscall rules from SRG-OS-000468-GPOS-00212

### DIFF
--- a/controls/srg_gpos/SRG-OS-000468-GPOS-00212.yml
+++ b/controls/srg_gpos/SRG-OS-000468-GPOS-00212.yml
@@ -15,9 +15,5 @@ controls:
             - audit_rules_file_deletion_events_rmdir
             - audit_rules_file_deletion_events_unlink
             - audit_rules_file_deletion_events_unlinkat
-            - audit_rules_unsuccessful_file_modification_rename
-            - audit_rules_unsuccessful_file_modification_renameat
-            - audit_rules_unsuccessful_file_modification_unlink
-            - audit_rules_unsuccessful_file_modification_unlinkat
             - audit_rules_privileged_commands_chage
         status: automated


### PR DESCRIPTION
#### Description:

- Remove unsuccessful audit syscall rules from SRG-OS-000468-GPOS-00212
