### PR TITLE
Cleanup RHEL7 stigids and fix rule sections

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -51,7 +51,6 @@ references:
     pcidss: Req-8.1.8
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
     stigid@ol7: OL07-00-040340
-    stigid@rhel7: RHEL-07-040340
     stigid@sle12: SLES-12-030191
     stigid@ubuntu2004: UBTU-20-010036
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/rule.yml
@@ -42,7 +42,6 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.PT-4
     srg: SRG-OS-000480-GPOS-00227
-    stigid@rhel7: RHEL-07-040730
 
 ocil_clause: 'the X Windows package group or xorg-x11-server-common has not be removed'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -41,7 +41,6 @@ references:
     nist@sle15: IA-5(1)(e),IA-5(1).1(v)
     pcidss: Req-8.2.5
     srg: SRG-OS-000077-GPOS-00045
-    stigid@rhel7: RHEL-07-010270
     stigid@sle15: SLES-15-020250
     stigid@ubuntu2004: UBTU-20-010070
     vmmsrg: SRG-OS-000077-VMM-000440

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
@@ -44,7 +44,6 @@ references:
     srg: SRG-OS-000080-GPOS-00048
     stigid@ol7: OL07-00-010481
     stigid@ol8: OL08-00-010152
-    stigid@rhel7: RHEL-07-010481
     stigid@rhel8: RHEL-08-010152
 
 ocil_clause: 'the output is different'

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
@@ -49,7 +49,6 @@ references:
     pcidss: Req-10.7
     srg: SRG-OS-000343-GPOS-00134
     stigid@ol7: OL07-00-030340
-    stigid@rhel7: RHEL-07-030340
 
 ocil_clause: 'the system is not configured to switch to single user mode for corrective action'
 

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -90,6 +90,7 @@ selections:
     - accounts_password_pam_maxrepeat
     - accounts_password_pam_maxclassrepeat
     - set_password_hashing_algorithm_systemauth
+    - set_password_hashing_algorithm_passwordauth
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_libuserconf
     - accounts_minimum_age_login_defs

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -97,7 +97,8 @@ selections:
     - accounts_password_set_min_life_existing
     - accounts_maximum_age_login_defs
     - accounts_password_set_max_life_existing
-    - accounts_password_pam_unix_remember
+    - accounts_password_pam_pwhistory_remember_password_auth
+    - accounts_password_pam_pwhistory_remember_system_auth
     - accounts_password_pam_minlen
     - no_empty_passwords
     - sshd_disable_empty_passwords


### PR DESCRIPTION
#### Description:

- Remove RHEL7 stigids from rules not selected in RHEL7 STIG profile
- Fix rule selection for a few STIG items. See commit messages for more detailed explanation

#### Rationale:
- Rule metadata cleanup
- Prevent noise in results from `utils/compare_results.py`.
