### PR TITLE
correctly load compiled content with multiple dots in file names

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -338,7 +338,7 @@ class XCCDFEntity(object):
         - `definition_location` as the original location whenre the entity got defined.
         """
         file_basename = os.path.basename(yaml_file)
-        entity_id = os.path.splitext(file_basename)[0]
+        entity_id = derive_id_from_file_name(file_basename)
         if file_basename == cls.GENERIC_FILENAME:
             entity_id = os.path.basename(os.path.dirname(yaml_file))
 
@@ -2150,3 +2150,7 @@ def add_platform_if_not_defined(platform, product_cpes):
             return p
     product_cpes.platforms[platform.id_] = platform
     return platform
+
+
+def derive_id_from_file_name(filename):
+    return os.path.splitext(filename)[0]

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -338,7 +338,7 @@ class XCCDFEntity(object):
         - `definition_location` as the original location whenre the entity got defined.
         """
         file_basename = os.path.basename(yaml_file)
-        entity_id = file_basename.split(".")[0]
+        entity_id = os.path.splitext(file_basename)[0]
         if file_basename == cls.GENERIC_FILENAME:
             entity_id = os.path.basename(os.path.dirname(yaml_file))
 

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -260,3 +260,9 @@ def test_platform_as_dict(product_cpes):
     assert d["ansible_conditional"] == "( \"chrony\" in ansible_facts.packages )"
     assert d["bash_conditional"] == "( rpm --quiet -q chrony )"
     assert "xml_content" in d
+
+
+def test_derive_id_from_file_name():
+    assert ssg.build_yaml.derive_id_from_file_name("rule.yml") == "rule"
+    assert ssg.build_yaml.derive_id_from_file_name("id.with.dots.yaml") == "id.with.dots"
+    assert ssg.build_yaml.derive_id_from_file_name("my_id") == "my_id"


### PR DESCRIPTION
#### Description:

- when loading compiled content, an entity ID is generated from the file name
- change the behavior so that the whole file name without extension is used as ID

#### Rationale:

- fixing problem when for example entities loaded from files called ocp4.10.yml and ocp4.9.yml would get the same ID - ocp4

- Fixes #8853 
