### PR TITLE
Fix template mode

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -286,6 +286,8 @@ class RuleChecker(oscap.Checker):
         # Begin by loading context about our execution environment, if any.
         product = self.test_env.product
         product_yaml = common.get_product_context(product)
+        all_rules_in_benchmark = xml_operations.get_all_rules_in_benchmark(
+            self.datastream, self.benchmark_id)
         rules = []
 
         for dirpath, dirnames, filenames in common.walk_through_benchmark_dirs(
@@ -296,11 +298,14 @@ class RuleChecker(oscap.Checker):
             full_rule_id = OSCAP_RULE + short_rule_id
             if not self._rule_matches_rule_spec(short_rule_id):
                 continue
-            if not xml_operations.find_rule_in_benchmark(
-                    self.datastream, self.benchmark_id, full_rule_id):
-                logging.error(
-                    "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
-                    .format(full_rule_id, self.benchmark_id, self.datastream))
+            if full_rule_id not in all_rules_in_benchmark:
+                # This is an error only if the user specified the rules to be
+                # tested explicitly using command line arguments
+                if self.rule_spec:
+                    logging.error(
+                        "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
+                        .format(
+                            full_rule_id, self.benchmark_id, self.datastream))
                 continue
 
             # Load the rule itself to check for a template.
@@ -387,10 +392,11 @@ class RuleChecker(oscap.Checker):
 
         for filename in local_test_scenarios:
             templated_test_scenarios.pop(filename, None)
-        for filename in self.used_templated_test_scenarios[rule.template]:
-            templated_test_scenarios.pop(filename, None)
-        self.used_templated_test_scenarios[rule.template] |= set(
-            templated_test_scenarios.keys())
+        if self.target_type != "template":
+            for filename in self.used_templated_test_scenarios[rule.template]:
+                templated_test_scenarios.pop(filename, None)
+            self.used_templated_test_scenarios[rule.template] |= set(
+                templated_test_scenarios.keys())
         all_tests.update(templated_test_scenarios)
         all_tests.update(local_test_scenarios)
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -301,7 +301,7 @@ class RuleChecker(oscap.Checker):
             if full_rule_id not in all_rules_in_benchmark:
                 # This is an error only if the user specified the rules to be
                 # tested explicitly using command line arguments
-                if self.rule_spec:
+                if self.target_type == "rule ID":
                     logging.error(
                         "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
                         .format(

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -272,6 +272,17 @@ def find_rule_in_benchmark(datastream, benchmark_id, rule_id, logging=None):
     return rule
 
 
+def get_all_rules_in_benchmark(datastream, benchmark_id, logging=None):
+    """
+    Returns all rule IDs in the given benchmark.
+    """
+    rules = []
+    benchmark_node = _get_benchmark_node(datastream, benchmark_id, logging)
+    for rule in benchmark_node.findall(".//xccdf-1.2:Rule", PREFIX_TO_NS):
+        rules.append(rule.get("id"))
+    return rules
+
+
 def find_fix_in_benchmark(datastream, benchmark_id, rule_id, fix_type='bash', logging=None):
     """
     Return fix from benchmark. None if not found.


### PR DESCRIPTION
- the check for presence of a given rule in the benchmark will be
more efficient because it won't load the whole data stream for each
rule but it will instead read rule IDs from the data stream once
- the situation that a rule isn't present in the benchmark will be
considered an error only when the user specified rule IDs to be
tested as the test suite command line argument, it won't be
considered an error in the template mode
- in the template mode the goal is to test all rules that use that
template, so we won't skip already executed scenarios in the template
mode

Fixes: #8886
