### PR TITLE
Introduce ol7 ncp profile

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/enable_ldap_client/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Enable the LDAP Client For Use in Authconfig'
 

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 
 
 # Use LDAP for authentication

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Configure LDAP Client to Use TLS For All Transactions'
 

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Configure SSSD to Expire SSH Known Hosts'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel
+# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 
 # Drop 'tcp6' and 'udp6' entries from /etc/netconfig to prevent RPC
 # services for NFSv4 from attempting to start IPv6 network listeners

--- a/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/disabling_ipv6/network_ipv6_disable_rpc/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Disable Support for RPC IPv6'
 

--- a/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/service_bluetooth_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhv4
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4
 
 title: 'Disable Bluetooth Service'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_freevxfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804,ubuntu2004
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804,ubuntu2004
 
 title: 'Disable Mounting of freevxfs'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/kubernetes/shared.yml
@@ -1,5 +1,5 @@
 ---
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos,multi_platform_ol
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_jffs2_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804,ubuntu2004
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu1804,ubuntu2004
 
 title: 'Disable Mounting of jffs2'
 

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/kubernetes/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/kubernetes/shared.yml
@@ -1,5 +1,5 @@
 ---
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos,multi_platform_ol
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 spec:

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disable Mounting of squashfs'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Disable the abrt_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_handle_event/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_handle_event/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Disable the abrt_handle_event SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_upload_watch_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_abrt_upload_watch_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Disable the abrt_upload_watch_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_auditadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_auditadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the auditadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_can_relabel/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_can_relabel/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the cron_can_relabel SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_system_cronjob_use_shares/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_system_cronjob_use_shares/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the cron_system_cronjob_use_shares SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_userdomain_transition/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_cron_userdomain_transition/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the cron_userdomain_transition SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_dump_core/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_dump_core/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the daemons_dump_core SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tcp_wrapper/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tcp_wrapper/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the daemons_use_tcp_wrapper SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tty/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_daemons_use_tty/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the daemons_use_tty SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the deny_execmem SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_ptrace/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_ptrace/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the deny_ptrace SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_fd_use/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_fd_use/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the domain_fd_use SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_kernel_load_modules/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_domain_kernel_load_modules/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the domain_kernel_load_modules SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_fips_mode/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_fips_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the fips_mode SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_gpg_web_anon_write/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_gpg_web_anon_write/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the gpg_web_anon_write SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_guest_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_guest_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the guest_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_kerberos_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_kerberos_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the kerberos_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the logadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_can_sendmail/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_can_sendmail/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the logging_syslogd_can_sendmail SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_use_tty/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_logging_syslogd_use_tty/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the logging_syslogd_use_tty SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_login_console_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_login_console_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the login_console_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mmap_low_allowed/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mmap_low_allowed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the mmap_low_allowed SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mock_enable_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mock_enable_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the mock_enable_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_mount_anyfile/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_mount_anyfile/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the mount_anyfile SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the secadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the secure_mode SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_policyload/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_policyload/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the secure_mode_policyload SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_direct_dri_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_direct_dri_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Configure the selinuxuser_direct_dri_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_mysql_connect_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_mysql_connect_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_mysql_connect_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_ping/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_ping/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the selinuxuser_ping SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_postgresql_connect_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_postgresql_connect_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_postgresql_connect_enabled SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_rw_noexattrfile/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_rw_noexattrfile/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_rw_noexattrfile SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_share_music/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_share_music/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_share_music SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_tcp_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_tcp_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_tcp_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_udp_server/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_udp_server/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_udp_server SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_use_ssh_chroot/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_use_ssh_chroot/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the selinuxuser_use_ssh_chroot SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_chroot_rw_homedirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_chroot_rw_homedirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the ssh_chroot_rw_homedirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_keysign/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_keysign/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the ssh_keysign SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_staff_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_staff_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the staff_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_sysadm_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_sysadm_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the sysadm_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_login/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_unconfined_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the unconfined_login SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_use_ecryptfs_home_dirs/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_use_ecryptfs_home_dirs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the use_ecryptfs_home_dirs SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_user_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_user_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Enable the user_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_bind_vnc_tcp_port/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_bind_vnc_tcp_port/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_bind_vnc_tcp_port SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_exec_bootloader/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_exec_bootloader/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_exec_bootloader SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_sysadm_login/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_sysadm_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_sysadm_login SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_write_home/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xdm_write_home/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xdm_write_home SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_connect_network/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_connect_network/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_connect_network SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_exec_content/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_exec_content/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_exec_content SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_mount_media/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_mount_media/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_mount_media SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_use_bluetooth/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xguest_use_bluetooth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xguest_use_bluetooth SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_clients_write_xshm/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_clients_write_xshm/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xserver_clients_write_xshm SELinux Boolean'
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xserver_execmem SELinux Boolean'
 
@@ -19,7 +19,7 @@ identifiers:
 
 references:
     anssi: BP28(R67)
-    
+
 {{{ complete_ocil_entry_sebool_disabled(sebool="xserver_execmem") }}}
 
 template:

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_object_manager/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_xserver_object_manager/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
 title: 'Disable the xserver_object_manager SELinux Boolean'
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_thumbnailers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable All GNOME3 Thumbnailers'
 

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_create/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable WIFI Network Connection Creation in GNOME3'
 

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_network_settings/dconf_gnome_disable_wifi_notification/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable WIFI Network Notification in GNOME3'
 

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_geolocation/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Disable Geolocation in GNOME3'
 

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -16,6 +16,8 @@ pkg_version: "ec551f03"
 
 release_key_fingerprint: "42144123FECFC55B9086313D72F97B74EC551F03"
 
+grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
+
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
 cpes_root: "../../shared/applicability"

--- a/products/ol7/profiles/ncp.profile
+++ b/products/ol7/profiles/ncp.profile
@@ -1,0 +1,341 @@
+documentation_complete: true
+
+title: 'NIST National Checklist Program Security Guide'
+
+description: |-
+    This compliance profile reflects the core set of security
+    related configuration settings for deployment of {{{ full_name}}} into U.S.
+    Defense, Intelligence, and Civilian agencies. Development partners and
+    sponsors include the U.S. National Institute of Standards and Technology
+    (NIST), U.S. Department of Defense, the National Security Agency, and Red Hat.
+
+    This baseline implements configuration requirements from the following
+    sources:
+
+    - Committee on National Security Systems Instruction No. 1253 (CNSSI 1253)
+    - NIST Controlled Unclassified Information (NIST 800-171)
+    - NIST 800-53 control selections for MODERATE impact systems (NIST 800-53)
+    - U.S. Government Configuration Baseline (USGCB)
+    - NIAP Protection Profile for General Purpose Operating Systems v4.2.1 (OSPP v4.2.1)
+    - DISA Operating System Security Requirements Guide (OS SRG)
+
+    For any differing configuration requirements, e.g. password lengths, the stricter
+    security setting was chosen. Security Requirement Traceability Guides (RTMs) and
+    sample System Security Configuration Guides are provided via the
+    scap-security-guide-docs package.
+
+    This profile reflects U.S. Government consensus content and is developed through
+    the OpenSCAP/SCAP Security Guide initiative, championed by the National
+    Security Agency. Except for differences in formatting to accommodate
+    publishing processes, this profile mirrors OpenSCAP/SCAP Security Guide
+    content as minor divergences, such as bugfixes, work through the
+    consensus and release processes.
+
+extends: ospp
+
+selections:
+    - installed_OS_is_vendor_supported
+    - login_banner_text=usgcb_default
+    - inactivity_timeout_value=15_minutes
+    - var_password_pam_minlen=15
+    - accounts_password_all_shadowed
+    - grub2_password
+    - no_direct_root_logins
+    - restrict_serial_port_logins
+    - var_accounts_fail_delay=4
+    - var_password_pam_retry=3
+    - accounts_logon_fail_delay
+    - accounts_password_pam_retry
+    - accounts_passwords_pam_faillock_deny_root
+    - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+    - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+    - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+    - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+    - sysctl_net_ipv4_tcp_syncookies_value=enabled
+    - set_firewalld_default_zone
+    - firewalld_sshd_port_enabled
+    - sysctl_net_ipv6_conf_all_disable_ipv6
+    - sysctl_net_ipv6_conf_all_forwarding
+    - auditd_audispd_syslog_plugin_activated
+    - rsyslog_remote_loghost
+    - var_auditd_action_mail_acct=root
+    - var_auditd_admin_space_left_action=single
+    - var_auditd_flush=data
+    - var_auditd_max_log_file_action=rotate
+    - var_auditd_max_log_file=6
+    - var_auditd_num_logs=5
+    - var_auditd_space_left_action=email
+    - auditd_data_retention_action_mail_acct
+    - auditd_data_retention_admin_space_left_action
+    - auditd_data_retention_max_log_file_action
+    - auditd_data_retention_max_log_file
+    - auditd_data_retention_num_logs
+    - auditd_data_retention_space_left_action
+    - file_permissions_var_log_audit
+    - audit_rules_dac_modification_chmod
+    - audit_rules_dac_modification_chown
+    - audit_rules_dac_modification_fchmodat
+    - audit_rules_dac_modification_fchmod
+    - audit_rules_dac_modification_fchownat
+    - audit_rules_dac_modification_fchown
+    - audit_rules_dac_modification_fremovexattr
+    - audit_rules_dac_modification_fsetxattr
+    - audit_rules_dac_modification_lchown
+    - audit_rules_dac_modification_lremovexattr
+    - audit_rules_dac_modification_lsetxattr
+    - audit_rules_dac_modification_removexattr
+    - audit_rules_dac_modification_setxattr
+    - audit_rules_execution_chcon
+    - audit_rules_execution_restorecon
+    - audit_rules_execution_semanage
+    - audit_rules_execution_setsebool
+    - audit_rules_file_deletion_events_renameat
+    - audit_rules_file_deletion_events_rename
+    - audit_rules_file_deletion_events_rmdir
+    - audit_rules_file_deletion_events
+    - audit_rules_file_deletion_events_unlinkat
+    - audit_rules_file_deletion_events_unlink
+    - audit_rules_immutable
+    - audit_rules_kernel_module_loading_delete
+    - audit_rules_kernel_module_loading_init
+    - audit_rules_login_events_faillock
+    - audit_rules_login_events_lastlog
+    - audit_rules_login_events_tallylog
+    - audit_rules_mac_modification
+    - audit_rules_media_export
+    - audit_rules_networkconfig_modification
+    - audit_rules_privileged_commands_chage
+    - audit_rules_privileged_commands_chsh
+    - audit_rules_privileged_commands_crontab
+    - audit_rules_privileged_commands_gpasswd
+    - audit_rules_privileged_commands_newgrp
+    - audit_rules_privileged_commands_pam_timestamp_check
+    - audit_rules_privileged_commands_passwd
+    - audit_rules_privileged_commands_postdrop
+    - audit_rules_privileged_commands_postqueue
+    - audit_rules_privileged_commands
+    - audit_rules_privileged_commands_ssh_keysign
+    - audit_rules_privileged_commands_sudoedit
+    - audit_rules_privileged_commands_sudo
+    - audit_rules_privileged_commands_su
+    - audit_rules_privileged_commands_umount
+    - audit_rules_privileged_commands_unix_chkpwd
+    - audit_rules_privileged_commands_userhelper
+    - audit_rules_session_events
+    - audit_rules_sysadmin_actions
+    - audit_rules_system_shutdown
+    - audit_rules_time_adjtimex
+    - audit_rules_time_clock_settime
+    - audit_rules_time_settimeofday
+    - audit_rules_time_stime
+    - audit_rules_time_watch_localtime
+    - audit_rules_unsuccessful_file_modification_creat
+    - audit_rules_unsuccessful_file_modification_ftruncate
+    - audit_rules_unsuccessful_file_modification_openat
+    - audit_rules_unsuccessful_file_modification_open_by_handle_at
+    - audit_rules_unsuccessful_file_modification_open
+    - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_usergroup_modification_group
+    - audit_rules_usergroup_modification_gshadow
+    - audit_rules_usergroup_modification_opasswd
+    - audit_rules_usergroup_modification_passwd
+    - audit_rules_usergroup_modification_shadow
+    - rsyslog_cron_logging
+    - rsyslog_nolisten
+    - var_multiple_time_servers=rhel
+    - chronyd_or_ntpd_specify_remote_server
+    - chronyd_or_ntpd_specify_multiple_servers
+    - service_chronyd_or_ntpd_enabled
+    - security_patches_up_to_date
+    - wireless_disable_interfaces
+    - service_bluetooth_disabled
+    - libreswan_approved_tunnels
+    - no_rsh_trust_files
+    - package_rsh_removed
+    - package_rsh-server_removed
+    - package_talk_removed
+    - package_talk-server_removed
+    - package_telnet_removed
+    - package_telnet-server_removed
+    - package_xinetd_removed
+    - package_ypbind_removed
+    - package_ypserv_removed
+    - service_crond_enabled
+    - service_rexec_disabled
+    - service_rlogin_disabled
+    - service_rsh_disabled
+    - sshd_required=yes
+    - service_sshd_enabled
+    - service_telnet_disabled
+    - service_xinetd_disabled
+    - service_ypbind_disabled
+    - service_zebra_disabled
+    - use_kerberos_security_all_exports
+    - sshd_allow_only_protocol2
+    - sshd_disable_compression
+    - sshd_do_not_permit_user_env
+    - sshd_use_priv_separation
+    - var_accounts_user_umask=077
+    - accounts_no_uid_except_zero
+    - accounts_umask_etc_login_defs
+    - dir_perms_world_writable_system_owned
+    - grub2_enable_selinux
+    - file_groupowner_grub2_cfg
+    - file_groupowner_cron_allow
+    - file_owner_cron_allow
+    - file_ownership_var_log_audit
+    - file_permissions_grub2_cfg
+    - file_permissions_sshd_private_key
+    - file_permissions_sshd_pub_key
+    - file_permissions_ungroupowned
+    - file_owner_grub2_cfg
+    - gid_passwd_group_same
+    - mount_option_krb_sec_remote_filesystems
+    - mount_option_nodev_remote_filesystems
+    - mount_option_nodev_removable_partitions
+    - mount_option_noexec_removable_partitions
+    - mount_option_nosuid_remote_filesystems
+    - mount_option_nosuid_removable_partitions
+    - no_files_unowned_by_user
+    - rpm_verify_permissions
+    - sebool_abrt_anon_write
+    - sebool_abrt_handle_event
+    - sebool_abrt_upload_watch_anon_write
+    - sebool_auditadm_exec_content
+    - sebool_cron_can_relabel
+    - sebool_cron_system_cronjob_use_shares
+    - sebool_cron_userdomain_transition
+    - sebool_daemons_dump_core
+    - sebool_daemons_use_tcp_wrapper
+    - sebool_daemons_use_tty
+    - sebool_deny_execmem
+    - sebool_deny_ptrace
+    - sebool_domain_fd_use
+    - sebool_domain_kernel_load_modules
+    - sebool_fips_mode
+    - sebool_gpg_web_anon_write
+    - sebool_guest_exec_content
+    - sebool_kerberos_enabled
+    - sebool_logadm_exec_content
+    - sebool_logging_syslogd_can_sendmail
+    - sebool_logging_syslogd_use_tty
+    - sebool_login_console_enabled
+    - sebool_mmap_low_allowed
+    - sebool_mock_enable_homedirs
+    - sebool_mount_anyfile
+    - sebool_polyinstantiation_enabled
+    - sebool_secadm_exec_content
+    - sebool_secure_mode
+    - sebool_secure_mode_insmod
+    - sebool_secure_mode_policyload
+    - sebool_selinuxuser_direct_dri_enabled
+    - sebool_selinuxuser_execheap
+    - sebool_selinuxuser_execmod
+    - sebool_selinuxuser_execstack
+    - sebool_selinuxuser_mysql_connect_enabled
+    - sebool_selinuxuser_ping
+    - sebool_selinuxuser_postgresql_connect_enabled
+    - sebool_selinuxuser_rw_noexattrfile
+    - sebool_selinuxuser_share_music
+    - sebool_selinuxuser_tcp_server
+    - sebool_selinuxuser_udp_server
+    - sebool_selinuxuser_use_ssh_chroot
+    - sebool_ssh_chroot_rw_homedirs
+    - sebool_ssh_keysign
+    - sebool_ssh_sysadm_login
+    - sebool_staff_exec_content
+    - sebool_sysadm_exec_content
+    - sebool_unconfined_login
+    - sebool_use_ecryptfs_home_dirs
+    - sebool_user_exec_content
+    - sebool_xdm_bind_vnc_tcp_port
+    - sebool_xdm_exec_bootloader
+    - sebool_xdm_sysadm_login
+    - sebool_xdm_write_home
+    - sebool_xguest_connect_network
+    - sebool_xguest_exec_content
+    - sebool_xguest_mount_media
+    - sebool_xguest_use_bluetooth
+    - sebool_xserver_clients_write_xshm
+    - sebool_xserver_execmem
+    - sebool_xserver_object_manager
+    - selinux_all_devicefiles_labeled
+    - selinux_confinement_of_daemons
+    - aide_build_database
+    - aide_periodic_cron_checking
+    - aide_scan_notification
+    - aide_use_fips_hashes
+    - aide_verify_acls
+    - aide_verify_ext_attributes
+    - disable_prelink
+    - install_antivirus
+    - install_hids
+    - ldap_client_start_tls
+    - package_aide_installed
+    - rpm_verify_hashes
+    - sysctl_fs_suid_dumpable
+    - sysctl_kernel_randomize_va_space
+    - var_account_disable_post_pw_expiration=35
+    - var_accounts_maximum_age_login_defs=60
+    - var_accounts_minimum_age_login_defs=7
+    - var_accounts_password_minlen_login_defs=6
+    - var_accounts_password_warn_age_login_defs=7
+    - var_accounts_tmout=10_min
+    - var_password_pam_difok=8
+    - var_password_pam_minclass=4
+    - account_disable_post_pw_expiration
+    - accounts_maximum_age_login_defs
+    - accounts_minimum_age_login_defs
+    - accounts_password_pam_minclass
+    - accounts_password_warn_age_login_defs
+    - accounts_tmout
+    - banner_etc_issue
+    - display_login_attempts
+    - set_password_hashing_algorithm_libuserconf
+    - set_password_hashing_algorithm_logindefs
+    - set_password_hashing_algorithm_systemauth
+    - package_opensc_installed
+    - var_smartcard_drivers=cac
+    - configure_opensc_nss_db
+    - configure_opensc_card_drivers
+    - force_opensc_card_drivers
+    - package_pcsc-lite_installed
+    - service_pcscd_enabled
+    - sssd_enable_smartcards
+    - sssd_ssh_known_hosts_timeout
+    - encrypt_partitions
+    - network_sniffer_disabled
+    - network_ipv6_disable_rpc
+    - network_ipv6_privacy_extensions
+    - dconf_db_up_to_date
+    - dconf_gnome_banner_enabled
+    - dconf_gnome_disable_automount
+    - dconf_gnome_disable_automount_open
+    - dconf_gnome_disable_autorun
+    - dconf_gnome_disable_ctrlaltdel_reboot
+    - dconf_gnome_disable_geolocation
+    - dconf_gnome_disable_restart_shutdown
+    - dconf_gnome_disable_thumbnailers
+    - dconf_gnome_disable_user_admin
+    - dconf_gnome_disable_user_list
+    - dconf_gnome_disable_wifi_create
+    - dconf_gnome_disable_wifi_notification
+    - dconf_gnome_enable_smartcard_auth
+    - dconf_gnome_login_banner_text
+    - dconf_gnome_login_retries
+    - dconf_gnome_remote_access_credential_prompt
+    - dconf_gnome_remote_access_encryption
+    - dconf_gnome_screensaver_idle_activation_enabled
+    - dconf_gnome_screensaver_idle_delay
+    - dconf_gnome_screensaver_lock_delay
+    - dconf_gnome_screensaver_lock_enabled
+    - dconf_gnome_screensaver_mode_blank
+    - dconf_gnome_screensaver_user_info
+    - dconf_gnome_screensaver_user_locks
+    - dconf_gnome_session_idle_user_locks
+    - enable_dconf_user_profile
+    - sshd_enable_x11_forwarding
+    - gnome_gdm_disable_automatic_login
+    - gnome_gdm_disable_guest_login
+    - clean_components_post_updating
+    - kernel_module_freevxfs_disabled

--- a/products/ol7/profiles/ncp.profile
+++ b/products/ol7/profiles/ncp.profile
@@ -339,3 +339,5 @@ selections:
     - gnome_gdm_disable_guest_login
     - clean_components_post_updating
     - kernel_module_freevxfs_disabled
+    - kernel_module_jffs2_disabled
+    - kernel_module_squashfs_disabled

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -164,7 +164,7 @@
   <ind:textfilecontent54_object id="object_{{{ base_name }}}"
   version="1">
     <ind:filepath>{{{ path }}}</ind:filepath>
-    {{% if product in ["rhel7"] or 'ubuntu' in product %}}
+    {{% if product in ["rhel7", "ol7"] or 'ubuntu' in product %}}
       <ind:pattern operation="pattern match">^.*/vmlinuz.*(root=.*)$</ind:pattern>
     {{% else %}}
       <ind:pattern operation="pattern match">^set default_kernelopts=(.*)$</ind:pattern>


### PR DESCRIPTION
#### Description:

- Introduce NCP profile for OL7
- Add OL7 prodtype and platform to rules and remediations part of its NCP profile
- Define grub2 efi boot path for OL7

#### Rationale:

- OL7 SCAP content efforts
