### PR TITLE
products/alinux2: Add CIS Alibaba Cloud Linux (Aliyun Linux) 2 profiles

### DIFF
--- a/controls/cis_alinux2.yml
+++ b/controls/cis_alinux2.yml
@@ -1,0 +1,1763 @@
+policy: 'CIS benchmark for Aliyun Linux 2'
+title: 'CIS benchmark for Aliyun Linux 2'
+id: cis_alinux2
+version: '1.0.0'
+source: https://www.cisecurity.org/cis-benchmarks/aliyun_linux
+levels:
+  - id: l1
+  - id: l2
+    inherits_from:
+    - l1
+
+controls:
+  - id: 1.1.1
+    title: Ensure mounting of squashfs filesystems is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - kernel_module_squashfs_disabled
+
+  - id: 1.1.2
+    title: Ensure /tmp is configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - partition_for_tmp
+
+  - id: 1.1.3
+    title: Ensure nodev option set on /tmp partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_tmp_nodev
+
+  - id: 1.1.4
+    title: Ensure nosuid option set on /tmp partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_tmp_nosuid
+
+  - id: 1.1.5
+    title: Ensure noexec option set on /tmp partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_tmp_noexec
+
+  - id: 1.1.6
+    title: Ensure separate partition exists for /var (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - partition_for_var
+
+  - id: 1.1.7
+    title: Ensure separate partition exists for /var/tmp (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - partition_for_var_tmp
+
+  - id: 1.1.8
+    title: Ensure nodev option set on /var/tmp partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_var_tmp_nodev
+
+  - id: 1.1.9
+    title: Ensure nosuid option set on /var/tmp partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_var_tmp_nosuid
+
+  - id: 1.1.10
+    title: Ensure noexec option set on /var/tmp partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_var_tmp_noexec
+
+  - id: 1.1.11
+    title: Ensure separate partition exists for /var/log (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - partition_for_var_log
+
+  - id: 1.1.12
+    title: Ensure separate partition exists for /var/log/audit (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - partition_for_var_log_audit
+
+  - id: 1.1.13
+    title: Ensure separate partition exists for /home (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - partition_for_home
+
+  - id: 1.1.14
+    title: Ensure nodev option set on /home partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_home_nodev
+
+  - id: 1.1.15
+    title: Ensure nodev option set on /dev/shm partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_dev_shm_nodev
+
+  - id: 1.1.16
+    title: Ensure nosuid option set on /dev/shm partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_dev_shm_nosuid
+
+  - id: 1.1.17
+    title: Ensure noexec option set on /dev/shm partition (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - mount_option_dev_shm_noexec
+
+  - id: 1.1.18
+    title: Ensure sticky bit is set on all world-writable directories (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - dir_perms_world_writable_sticky_bits
+
+  - id: 1.1.19
+    title: Disable Automounting (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_autofs_disabled
+
+  - id: 1.2.1
+    title: Ensure package manager repositories are configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 1.2.2
+    title: Ensure GPG keys are configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 1.2.3
+    title: Ensure gpgcheck is globally activated (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - ensure_gpgcheck_globally_activated
+    - ensure_gpgcheck_never_disabled
+
+  - id: 1.3.1
+    title: Ensure AIDE is installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_aide_installed
+    - aide_build_database
+
+  - id: 1.3.2
+    title: Ensure filesystem integrity is regularly checked (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - aide_periodic_cron_checking
+
+  - id: 1.4.1
+    title: Ensure permissions on bootloader config are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_grub2_cfg
+    - file_owner_grub2_cfg
+    - file_permissions_grub2_cfg
+    - file_groupowner_efi_grub2_cfg
+    - file_owner_efi_grub2_cfg
+    - file_permissions_efi_grub2_cfg
+
+  - id: 1.4.2
+    title: Ensure authentication required for single user mode (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - require_emergency_target_auth
+    - require_singleuser_auth
+
+  - id: 1.5.1
+    title: Ensure core dumps are restricted (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - disable_users_coredumps
+    - sysctl_fs_suid_dumpable
+    - coredump_disable_backtraces
+    - coredump_disable_storage
+
+  - id: 1.5.2
+    title: Ensure address space layout randomization (ASLR) is enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_kernel_randomize_va_space
+
+  - id: 1.5.3
+    title: Ensure prelink is disabled (Scored)
+    levels:
+    - l1
+    status: planned
+    rules:
+    - disable_prelink
+
+  - id: 1.6.1.1
+    title: Ensure SELinux is not disabled in bootloader configuration (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - grub2_enable_selinux # the rule does not check for uefi configuration
+
+  - id: 1.6.1.2
+    title: Ensure the SELinux state is enforcing (Scored)
+    levels:
+    - l2
+    status: automated
+    notes: >-
+      The SELinux mode is set to "enforcing" by default.
+    rules:
+    - selinux_state
+    - var_selinux_state=enforcing
+
+  - id: 1.6.1.3
+    title: Ensure SELinux policy is configured (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - selinux_policytype
+    - var_selinux_policy_name=targeted
+
+  - id: 1.6.1.4
+    title: Ensure SETroubleshoot is not installed (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - package_setroubleshoot_removed
+
+  - id: 1.6.1.5
+    title: Ensure the MCS Translation Service (mcstrans) is not installed (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - package_mcstrans_removed
+
+  - id: 1.6.1.6
+    title: Ensure no unconfined daemons exist (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - selinux_confinement_of_daemons
+
+  - id: 1.6.2
+    title: Ensure SELinux is installed (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - package_libselinux_installed
+
+  - id: 1.7.1.1
+    title: Ensure message of the day is configured properly (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - banner_etc_motd
+    - login_banner_text=cis_banners
+
+  - id: 1.7.1.2
+    title: Ensure local login warning banner is configured properly (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - banner_etc_issue
+    - login_banner_text=cis_banners
+
+  - id: 1.7.1.3
+    title: Ensure remote login warning banner is configured properly (Scored)
+    levels:
+    - l1
+    automated: no # rule is missing
+
+  - id: 1.7.1.4
+    title: Ensure permissions on /etc/motd are configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+    rules:
+    - file_groupowner_etc_motd
+    - file_owner_etc_motd
+    - file_permissions_etc_motd
+
+  - id: 1.7.1.5
+    title: Ensure permissions on /etc/issue are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_etc_issue
+    - file_owner_etc_issue
+    - file_permissions_etc_issue
+
+  - id: 1.7.1.6
+    title: Ensure permissions on /etc/issue.net are configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 1.8
+    title: Ensure updates, patches, and additional security software are installed (Scored)
+    levels:
+    - l1
+    automated: no # rule is missing
+
+  - id: 2.1.1.1
+    title: Ensure time synchronization is in use (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 2.1.1.2
+    title: Ensure ntp is configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_ntpd_enabled
+    - ntpd_configure_restrictions
+    - ntpd_specify_remote_server
+    - ntpd_run_as_ntp_user
+
+  - id: 2.1.1.3
+    title: Ensure chrony is configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - chronyd_specify_remote_server
+    - var_multiple_time_servers=rhel
+    - chronyd_run_as_chrony_user
+
+  - id: 2.1.2
+    title: Ensure X Window System is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    notes: >-
+      The rule also configures correct run level to prevent unbootable system.
+    rules:
+    - xwindows_remove_packages
+
+  - id: 2.1.3
+    title: Ensure Avahi Server is not enabled (Scored)
+    levels:
+    - l1
+    status: partial # rule for package removal is missing
+    rules:
+    - service_avahi-daemon_disabled
+
+  - id: 2.1.4
+    title: Ensure CUPS is not enabled (Scored)
+    levels:
+    - l1
+    automated: no # rule for package removal is missing
+
+  - id: 2.1.5
+    title: Ensure DHCP Server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_dhcpd_disabled
+
+  - id: 2.1.6
+    title: Ensure LDAP server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_slapd_disabled
+
+  - id: 2.1.7
+    title: Ensure NFS and RPC are not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_nfs_disabled
+    - service_rpcbind_disabled
+
+  - id: 2.1.8
+    title: Ensure DNS Server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_named_disabled
+
+  - id: 2.1.9
+    title: Ensure FTP Server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_vsftpd_disabled
+
+  - id: 2.1.10
+    title: Ensure HTTP server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_httpd_disabled
+
+  - id: 2.1.11
+    title: Ensure IMAP and POP3 server is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_dovecot_removed
+
+  - id: 2.1.12
+    title: Ensure Samba is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_smb_disabled
+
+  - id: 2.1.13
+    title: Ensure HTTP Proxy Server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_squid_disabled
+
+  - id: 2.1.14
+    title: Ensure SNMP Server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_snmpd_disabled
+
+  - id: 2.1.15
+    title: Ensure mail transfer agent is configured for local-only mode (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - postfix_network_listening_disabled
+    - var_postfix_inet_interfaces=loopback-only
+
+  - id: 2.1.16
+    title: Ensure NIS Server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_ypserv_disabled
+
+  - id: 2.1.17
+    title: Ensure rsh server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_rsh_disabled
+
+  - id: 2.1.18
+    title: Ensure telnet server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_telnet_disabled
+
+  - id: 2.1.19
+    title: Ensure tftp server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_tftp_disabled
+
+  - id: 2.1.20
+    title: Ensure rsync service is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_rsyncd_disabled
+
+  - id: 2.1.21
+    title: Ensure talk server is not enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_talk-server_removed
+
+  - id: 2.2.1
+    title: Ensure NIS Client is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_ypbind_removed
+
+  - id: 2.2.2
+    title: Ensure rsh client is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_rsh_removed
+
+  - id: 2.2.3
+    title: Ensure talk client is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_talk_removed
+
+  - id: 2.2.4
+    title: Ensure telnet client is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_telnet_removed
+
+  - id: 2.2.5
+    title: Ensure LDAP client is not installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_openldap-clients_removed
+
+  - id: 3.1.1
+    title: Ensure IP forwarding is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_ip_forward
+    - sysctl_net_ipv6_conf_all_forwarding
+    - sysctl_net_ipv6_conf_all_forwarding_value=disabled
+
+  - id: 3.1.2
+    title: Ensure packet redirect sending is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_conf_all_send_redirects
+    - sysctl_net_ipv4_conf_default_send_redirects
+
+  - id: 3.2.1
+    title: Ensure source routed packets are not accepted (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_conf_all_accept_source_route
+    - sysctl_net_ipv4_conf_all_accept_source_route_value=disabled
+    - sysctl_net_ipv4_conf_default_accept_source_route
+    - sysctl_net_ipv4_conf_default_accept_source_route_value=disabled
+    - sysctl_net_ipv6_conf_all_accept_source_route
+    - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
+    - sysctl_net_ipv6_conf_default_accept_source_route
+    - sysctl_net_ipv6_conf_default_accept_source_route_value=disabled
+
+  - id: 3.2.2
+    title: Ensure ICMP redirects are not accepted (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_conf_all_accept_redirects
+    - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+    - sysctl_net_ipv4_conf_default_accept_redirects
+    - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
+    - sysctl_net_ipv6_conf_all_accept_redirects
+    - sysctl_net_ipv6_conf_all_accept_redirects_value=disabled
+    - sysctl_net_ipv6_conf_default_accept_redirects
+    - sysctl_net_ipv6_conf_default_accept_redirects_value=disabled
+
+  - id: 3.2.3
+    title: Ensure secure ICMP redirects are not accepted (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_conf_all_secure_redirects
+    - sysctl_net_ipv4_conf_all_secure_redirects_value=disabled
+    - sysctl_net_ipv4_conf_default_secure_redirects
+    - sysctl_net_ipv4_conf_default_secure_redirects_value=disabled
+
+  - id: 3.2.4
+    title: Ensure suspicious packets are logged (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_conf_all_log_martians
+    - sysctl_net_ipv4_conf_all_log_martians_value=enabled
+    - sysctl_net_ipv4_conf_default_log_martians
+    - sysctl_net_ipv4_conf_default_log_martians_value=enabled
+
+  - id: 3.2.5
+    title: Ensure broadcast ICMP requests are ignored (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
+    - sysctl_net_ipv4_icmp_echo_ignore_broadcasts_value=enabled
+
+  - id: 3.2.6
+    title: Ensure bogus ICMP responses are ignored (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
+    - sysctl_net_ipv4_icmp_ignore_bogus_error_responses_value=enabled
+
+  - id: 3.2.7
+    title: Ensure Reverse Path Filtering is enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_conf_all_rp_filter
+    - sysctl_net_ipv4_conf_all_rp_filter_value=enabled
+    - sysctl_net_ipv4_conf_default_rp_filter
+    - sysctl_net_ipv4_conf_default_rp_filter_value=enabled
+
+  - id: 3.2.8
+    title: Ensure TCP SYN Cookies is enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv4_tcp_syncookies
+    - sysctl_net_ipv4_tcp_syncookies_value=enabled
+
+  - id: 3.2.9
+    title: Ensure IPv6 router advertisements are not accepted (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sysctl_net_ipv6_conf_all_accept_ra
+    - sysctl_net_ipv6_conf_all_accept_ra_value=disabled
+    - sysctl_net_ipv6_conf_default_accept_ra
+    - sysctl_net_ipv6_conf_default_accept_ra_value=disabled
+
+  - id: 3.3.1
+    title: Ensure TCP Wrappers is installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_tcp_wrappers_installed
+
+  - id: 3.3.2
+    title: Ensure /etc/hosts.allow is configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 3.3.3
+    title: Ensure /etc/hosts.deny is configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 3.3.4
+    title: Ensure permissions on /etc/hosts.allow are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_permissions_etc_hosts_allow
+
+  - id: 3.3.5
+    title: Ensure permissions on /etc/hosts.deny are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_permissions_etc_hosts_deny
+
+  - id: 3.4.1
+    title: Ensure DCCP is disabled (Not Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - kernel_module_dccp_disabled
+
+  - id: 3.4.2
+    title: Ensure SCTP is disabled (Not Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - kernel_module_sctp_disabled
+
+  - id: 3.4.3
+    title: Ensure RDS is disabled (Not Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - kernel_module_rds_disabled
+
+  - id: 3.4.4
+    title: Ensure TIPC is disabled (Not Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - kernel_module_tipc_disabled
+
+  - id: 3.5.1.1
+    title: Ensure default deny firewall policy (Scored)
+    levels:
+    - l1
+    automated: no # rule not completed
+
+  - id: 3.5.1.2
+    title: Ensure loopback traffic is configured (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 3.5.1.3
+    title: Ensure outbound and established connections are configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 3.5.1.4
+    title: Ensure firewall rules exist for all open ports (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 3.5.2.1
+    title: Ensure IPv6 default deny firewall policy (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 3.5.2.2
+    title: Ensure IPv6 loopback traffic is configured (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 3.5.2.3
+    title: Ensure IPv6 outbound and established connections are configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 3.5.2.4
+    title: Ensure IPv6 firewall rules exist for all open ports (Not Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 3.5.3
+    title: Ensure iptables is installed (Scored)
+    levels:
+    - l1
+    automated: no
+    notes: <-
+      CIS benchmark allows to choose from several firewall applications. This interpretation of the benchmark chose the Firewalld application and other subsections are not automated.
+    related_rules:
+    - package_iptables_installed
+
+  - id: 3.6
+    title: Disable IPv6 (Not Scored)
+    levels:
+    - l2
+    status: manual # rule missing
+
+  - id: 4.1.1.1
+    title: Ensure audit log storage size is configured (Not Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - auditd_data_retention_max_log_file
+    - var_auditd_max_log_file=6
+
+  - id: 4.1.1.2
+    title: Ensure system is disabled when audit logs are full (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - auditd_data_retention_space_left_action
+    - var_auditd_space_left_action=email
+    - auditd_data_retention_action_mail_acct
+    - var_auditd_action_mail_acct=root
+    - auditd_data_retention_admin_space_left_action
+    - var_auditd_admin_space_left_action=halt 
+
+  - id: 4.1.1.3
+    title: Ensure audit logs are not automatically deleted (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - auditd_data_retention_max_log_file_action
+    - var_auditd_max_log_file_action=keep_logs
+ 
+  - id: 4.1.2
+    title: Ensure auditd service is enabled (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - service_auditd_enabled
+
+  - id: 4.1.3
+    title: Ensure auditing for processes that start prior to auditd is enabled (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - grub2_audit_argument
+
+  - id: 4.1.4
+    title: Ensure events that modify date and time information are collected (Scored)
+    levels:
+    - l2
+    status: partial # we do not have rule for clock_settime
+    rules:
+    - audit_rules_time_adjtimex
+    - audit_rules_time_settimeofday
+    - audit_rules_time_stime
+    - audit_rules_time_watch_localtime
+
+  - id: 4.1.5
+    title: Ensure events that modify user/group information are collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_usergroup_modification_group
+    - audit_rules_usergroup_modification_gshadow
+    - audit_rules_usergroup_modification_opasswd
+    - audit_rules_usergroup_modification_passwd
+    - audit_rules_usergroup_modification_shadow
+
+  - id: 4.1.6
+    title: Ensure events that modify the system's network environment are collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_networkconfig_modification
+
+  - id: 4.1.7
+    title: Ensure events that modify the system's Mandatory Access Controls are collected (Scored)
+    levels:
+    - l2
+    status: partial # rule for checking audit watch on /usr/share/selinux is missing
+    rules:
+    - audit_rules_mac_modification
+
+  - id: 4.1.8
+    title: Ensure login and logout events are collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_login_events_faillock
+    - audit_rules_login_events_lastlog
+
+  - id: 4.1.9
+    title: Ensure session initiation information is collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_session_events
+
+  - id: 4.1.10
+    title: Ensure discretionary access control permission modification events are collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_dac_modification_fchmod
+    - audit_rules_dac_modification_fchmodat
+    - audit_rules_dac_modification_chmod
+    - audit_rules_dac_modification_fchown
+    - audit_rules_dac_modification_fchownat
+    - audit_rules_dac_modification_chown
+    - audit_rules_dac_modification_lchown
+    - audit_rules_dac_modification_fremovexattr
+    - audit_rules_dac_modification_fsetxattr
+    - audit_rules_dac_modification_lremovexattr
+    - audit_rules_dac_modification_lsetxattr
+    - audit_rules_dac_modification_removexattr
+    - audit_rules_dac_modification_setxattr
+
+  - id: 4.1.11
+    title: Ensure unsuccessful unauthorized file access attempts are collected (Scored)
+    levels:
+    - l2_server
+    status: automated
+    rules:
+    - audit_rules_unsuccessful_file_modification_creat
+    - audit_rules_unsuccessful_file_modification_open
+    - audit_rules_unsuccessful_file_modification_openat
+    - audit_rules_unsuccessful_file_modification_truncate
+    - audit_rules_unsuccessful_file_modification_ftruncate
+
+  - id: 4.1.12
+    title: Ensure use of privileged commands is collected (Automated)
+    levels:
+    - l2
+    automated: no # we have audit_rules_privileged_commands, but it does not set perm=x
+
+  - id: 4.1.13
+    title: Ensure successful file system mounts are collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_media_export
+
+  - id: 4.1.14
+    title: Ensure file deletion events by users are collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_file_deletion_events_rename
+    - audit_rules_file_deletion_events_renameat
+    - audit_rules_file_deletion_events_unlink
+    - audit_rules_file_deletion_events_unlinkat
+
+  - id: 4.1.15
+    title: Ensure changes to system administration scope (sudoers) is collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_sysadmin_actions
+
+  - id: 4.1.16
+    title: Ensure system administrator actions (sudolog) are collected (Scored)
+    levels:
+    - l2
+    automated: no # missing rule
+
+  - id: 4.1.17
+    title: Ensure kernel module loading and unloading is collected (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_privileged_commands_insmod
+    - audit_rules_privileged_commands_rmmod
+    - audit_rules_privileged_commands_modprobe
+    - audit_rules_kernel_module_loading_delete
+    - audit_rules_kernel_module_loading_init
+
+  - id: 4.1.18
+    title: Ensure the audit configuration is immutable (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - audit_rules_immutable
+
+  - id: 4.2.1.1
+    title: Ensure rsyslog Service is enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_rsyslog_enabled
+
+  - id: 4.2.1.2
+    title: Ensure logging is configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 4.2.1.3
+    title: Ensure rsyslog default file permissions configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - rsyslog_files_permissions
+
+  - id: 4.2.1.4
+    title: Ensure rsyslog is configured to send logs to a remote log host (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - rsyslog_remote_loghost
+
+  - id: 4.2.1.5
+    title: Ensure remote rsyslog messages are only accepted on designated log hosts. (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 4.2.2
+    title: Ensure rsyslog is installed (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - package_rsyslog_installed
+
+  - id: 4.2.3
+    title: Ensure permissions on all logfiles are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_permissions_var_log
+
+  - id: 4.3
+    title: Ensure logrotate is configured (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 5.1.1
+    title: Ensure cron daemon is enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - service_crond_enabled
+
+  - id: 5.1.2
+    title: Ensure permissions on /etc/crontab are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_crontab
+    - file_owner_crontab
+    - file_permissions_crontab
+
+  - id: 5.1.3
+    title: Ensure permissions on /etc/cron.hourly are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_cron_hourly
+    - file_owner_cron_hourly
+    - file_permissions_cron_hourly
+
+  - id: 5.1.4
+    title: Ensure permissions on /etc/cron.daily are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_cron_daily
+    - file_owner_cron_daily
+    - file_permissions_cron_daily
+
+  - id: 5.1.5
+    title: Ensure permissions on /etc/cron.weekly are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_cron_weekly
+    - file_owner_cron_weekly
+    - file_permissions_cron_weekly
+
+  - id: 5.1.6
+    title: Ensure permissions on /etc/cron.monthly are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_cron_monthly
+    - file_owner_cron_monthly
+    - file_permissions_cron_monthly
+
+  - id: 5.1.7
+    title: Ensure permissions on /etc/cron.d are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_cron_d
+    - file_owner_cron_d
+    - file_permissions_cron_d
+
+  - id: 5.1.8
+    title: Ensure at/cron is restricted to authorized users (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_cron_allow
+    - file_owner_cron_allow
+    - file_cron_deny_not_exist
+    - file_permissions_cron_allow
+    - file_groupowner_at_allow
+    - file_owner_at_allow
+    - file_at_deny_not_exist
+    - file_permissions_at_allow
+
+  - id: 5.2.1
+    title: Ensure permissions on /etc/ssh/sshd_config are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_sshd_config
+    - file_owner_sshd_config
+    - file_permissions_sshd_config
+
+  - id: 5.2.2
+    title: Ensure SSH Protocol is set to 2 (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_allow_only_protocol2 
+
+  - id: 5.2.3
+    title: Ensure permissions on SSH private host key files are configured (Scored)
+    levels:
+    - l1
+    automated: no # rule missing (we have similar)
+
+  - id: 5.2.4
+    title: Ensure permissions on SSH public host key files are configured (Scored)
+    levels:
+    - l1
+    status: partial # missing rules for ownership
+    rules:
+    - file_permissions_sshd_pub_key
+
+  - id: 5.2.5
+    title: Ensure SSH LogLevel is appropriate (Scored)
+    levels:
+    - l1
+    notes: <-
+      The default rule is configured to enforce the "verbose" log level. Use
+      tailoring to change it to "info" level.
+    status: automated # we have two rules either for info or verbose, no way to select
+    related_rules:
+    - sshd_set_loglevel_info
+    rules:
+    - sshd_set_loglevel_verbose
+
+  - id: 5.2.6
+    title: Ensure SSH X11 forwarding is disabled (Scored)
+    levels:
+    - l2
+    status: automated
+    rules:
+    - sshd_disable_x11_forwarding
+
+  - id: 5.2.7
+    title: Ensure SSH MaxAuthTries is set to 4 or less (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_set_max_auth_tries
+    - sshd_max_auth_tries_value=4
+
+  - id: 5.2.8
+    title: Ensure SSH IgnoreRhosts is enabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_disable_rhosts
+
+  - id: 5.2.9
+    title: Ensure SSH HostbasedAuthentication is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - disable_host_auth
+
+  - id: 5.2.10
+    title: Ensure SSH root login is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_disable_root_login
+
+  - id: 5.2.11
+    title: Ensure SSH PermitEmptyPasswords is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_disable_empty_passwords
+
+  - id: 5.2.12
+    title: Ensure SSH PermitUserEnvironment is disabled (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_do_not_permit_user_env
+
+  - id: 5.2.13
+    title: Ensure only strong MAC algorithms are used (Scored)
+    levels:
+    - l1
+    status: automated
+    notes: <-
+      The rule checks for default list of MACs provided in the benchmark.
+    rules:
+    - sshd_approved_macs=cis_rhel7
+    - sshd_use_approved_macs
+
+  - id: 5.2.14
+    title: Ensure SSH Idle Timeout Interval is configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_set_idle_timeout
+    - sshd_idle_timeout_value=15_minutes
+    - sshd_set_keepalive
+    - var_sshd_set_keepalive=0
+
+  - id: 5.2.15
+    title: Ensure SSH LoginGraceTime is set to one minute or less (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+      - sshd_set_login_grace_time
+      - var_sshd_set_login_grace_time=60
+
+  - id: 5.2.16
+    title: Ensure only strong Key Exchange algorithms are used (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 5.2.17
+    title: Ensure only strong Ciphers are used (Scored)
+    levels:
+    - l1
+    status: automated
+    notes: <-
+      The rule checks for default list of ciphers provided in the benchmark.
+    rules:
+    - sshd_approved_ciphers=cis_rhel7
+    - sshd_use_approved_ciphers
+
+  - id: 5.2.18
+    title: Ensure SSH access is limited (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_limit_user_access
+
+  - id: 5.2.19
+    title: Ensure SSH warning banner is configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - sshd_enable_warning_banner
+
+  - id: 5.3.1
+    title: Ensure password creation requirements are configured (Scored)
+    levels:
+    - l1
+    status: partial # rule checking for retry needs modification and we are missing rule for try_first_pass
+    notes: <-
+      There are two ways how to check this control.
+      One way is to check for minclass, this is currently selected.
+      Another way is to check for dcredit, lcredit,ocredit, ucredit, this is shown in rleated_rules.
+    related_rules:
+    - accounts_password_pam_dcredit
+    - var_password_pam_dcredit=1
+    - accounts_password_pam_ucredit
+    - var_password_pam_ucredit=1
+    - accounts_password_pam_lcredit
+    - var_password_pam_lcredit=1
+    - accounts_password_pam_ocredit
+    - var_password_pam_ocredit=1
+    rules:
+    - accounts_password_pam_minlen
+    - var_password_pam_minlen=14
+    - accounts_password_pam_minclass
+    - var_password_pam_minclass=4
+
+  - id: 5.3.2
+    title: Ensure lockout for failed password attempts is configured (Scored)
+    levels:
+    - l1
+    automated: no # we can check only certain parts, we need probably some complex rule for this
+
+  - id: 5.3.3
+    title: Ensure password reuse is limited (Scored)
+    levels:
+    - l1
+    status: automated
+    notes: |-
+      Usage of pam_unix.so module together with "remember" option is deprecated and is not supported by this policy interpretation.
+      See here for more details about pam_unix.so:
+      https://bugzilla.redhat.com/show_bug.cgi?id=1778929
+    rules:
+    - var_password_pam_remember=5
+    - var_password_pam_remember_control_flag=required
+    - accounts_password_pam_pwhistory_remember_system_auth
+    - accounts_password_pam_pwhistory_remember_password_auth
+
+  - id: 5.3.4
+    title: Ensure password hashing algorithm is SHA-512 (Scored)
+    levels:
+    - l1
+    status: partial # our rule does not check for password-auth
+    rules:
+    - set_password_hashing_algorithm_systemauth
+
+  - id: 5.4.1.1
+    title: Ensure password expiration is 365 days or less (Scored)
+    levels:
+    - l1
+    status: partial # missing rule for checking of /etc/shadow
+    rules:
+    - accounts_maximum_age_login_defs
+    - var_accounts_maximum_age_login_defs=365
+
+  - id: 5.4.1.2
+    title: Ensure minimum days between password changes is 7 or more (Scored)
+    levels:
+    - l1
+    status: partial # missing rule for checking of /etc/shadow
+    rules:
+    - accounts_minimum_age_login_defs
+    - var_accounts_minimum_age_login_defs=1
+
+  - id: 5.4.1.3
+    title: Ensure password expiration warning days is 7 or more (Scored)
+    levels:
+    - l1
+    status: partial # missing rule for checking of /etc/shadow
+    rules:
+    - accounts_password_warn_age_login_defs
+    - var_accounts_password_warn_age_login_defs=7
+
+  - id: 5.4.1.4
+    title: Ensure inactive password lock is 30 days or less (Scored)
+    levels:
+    - l1
+    status: partial # we do not check /et/shadow
+    rules:
+    - account_disable_post_pw_expiration
+    - var_account_disable_post_pw_expiration=30
+
+  - id: 5.4.1.5
+    title: Ensure all users last password change date is in the past (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 5.4.2
+    title: Ensure system accounts are non-login (Scored)
+    levels:
+    - l1
+    status: partial # missing rule for locking of accounts
+    rules:
+    - no_shelllogin_for_systemaccounts
+
+  - id: 5.4.3
+    title: Ensure default group for the root account is GID 0 (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+      - accounts_root_gid_zero
+
+  - id: 5.4.4
+    title: Ensure default user umask is 027 or more restrictive (Scored)
+    levels:
+    - l1
+    status: partial # checking only for numeric umask and we do not check for user_enab in /etc/login.defs
+    rules:
+    - accounts_umask_etc_bashrc
+    - accounts_umask_etc_login_defs
+    - accounts_umask_etc_profile
+    - var_accounts_user_umask=027
+
+  - id: 5.4.5
+    title: Ensure default user shell timeout is 900 seconds or less (Scored)
+    levels:
+    - l1
+    status: partial # we check only for value of tmout variable, no export or readonly and we do not check /etc/bashrc
+    rules:
+    - accounts_tmout
+    - var_accounts_tmout=15_min
+
+  - id: 5.5
+    title: Ensure root login is restricted to system console (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 5.6
+    title: Ensure access to the su command is restricted (Scored)
+    levels:
+    - l1
+    status: partial  # we check only for usage of use_uid with pam_su, not for the group
+    rules:
+    - use_pam_wheel_for_su
+
+  - id: 6.1.1
+    title: Audit system file permissions (Not Scored)
+    levels:
+    - l2
+    status: manual
+
+  - id: 6.1.2
+    title: Ensure permissions on /etc/passwd are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_etc_passwd
+    - file_owner_etc_passwd
+    - file_permissions_etc_passwd
+
+  - id: 6.1.3
+    title: Ensure permissions on /etc/shadow are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_etc_shadow
+    - file_owner_etc_shadow
+    - file_permissions_etc_shadow
+
+  - id: 6.1.4
+    title: Ensure permissions on /etc/group are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_etc_group
+    - file_owner_etc_group
+    - file_permissions_etc_group
+
+  - id: 6.1.5
+    title: Ensure permissions on /etc/gshadow are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_etc_gshadow
+    - file_owner_etc_gshadow
+    - file_permissions_etc_gshadow
+
+  - id: 6.1.6
+    title: Ensure permissions on /etc/passwd- are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_backup_etc_passwd
+    - file_owner_backup_etc_passwd
+    - file_permissions_backup_etc_passwd
+
+  - id: 6.1.7
+    title: Ensure permissions on /etc/shadow- are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_backup_etc_shadow
+    - file_owner_backup_etc_shadow
+    - file_permissions_backup_etc_shadow
+
+  - id: 6.1.8
+    title: Ensure permissions on /etc/group- are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_backup_etc_group
+    - file_owner_backup_etc_group
+    - file_permissions_backup_etc_group
+
+  - id: 6.1.9
+    title: Ensure permissions on /etc/gshadow- are configured (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_groupowner_backup_etc_gshadow
+    - file_owner_backup_etc_gshadow
+    - file_permissions_backup_etc_gshadow
+
+  - id: 6.1.10
+    title: Ensure no world writable files exist (Not Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_permissions_unauthorized_world_writable
+
+  - id: 6.1.11
+    title: Ensure no unowned files or directories exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - no_files_unowned_by_user
+
+  - id: 6.1.12
+    title: Ensure no ungrouped files or directories exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_permissions_ungroupowned
+
+  - id: 6.1.13
+    title: Audit SUID executables (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 6.1.14
+    title: Audit SGID executables (Not Scored)
+    levels:
+    - l1
+    status: manual
+
+  - id: 6.2.1
+    title: Ensure password fields are not empty (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 6.2.2
+    title: Ensure no legacy "+" entries exist in /etc/passwd (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - no_legacy_plus_entries_etc_passwd
+
+  - id: 6.2.3
+    title: Ensure no legacy "+" entries exist in /etc/shadow (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - no_legacy_plus_entries_etc_shadow
+
+  - id: 6.2.4
+    title: Ensure no legacy "+" entries exist in /etc/group (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - no_legacy_plus_entries_etc_group
+
+  - id: 6.2.5
+    title: Ensure root is the only UID 0 account (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - accounts_no_uid_except_zero
+
+  - id: 6.2.6
+    title: Ensure root PATH Integrity (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - accounts_root_path_dirs_no_write
+    - root_path_no_dot
+
+  - id: 6.2.7
+    title: Ensure all users' home directories exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - accounts_user_interactive_home_directory_exists
+
+  - id: 6.2.8
+    title: Ensure users' home directories permissions are 750 or more restrictive (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_permissions_home_directories
+
+  - id: 6.2.9
+    title: Ensure users own their home directories (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - file_ownership_home_directories
+
+  - id: 6.2.10
+    title: Ensure users' dot files are not group or world writable (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 6.2.11
+    title: Ensure no users have .forward files (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 6.2.12
+    title: Ensure no users have .netrc files (Scored)
+    levels:
+    - l1
+    status: automated
+    notes: <-
+      The rule is checking only for existence of files, not for their permissions.
+    rules:
+    - no_netrc_files
+
+  - id: 6.2.13
+    title: Ensure users' .netrc Files are not group or world accessible (Scored)
+    levels:
+    - l1
+    automated: no # rule missing
+
+  - id: 6.2.14
+    title: Ensure no users have .rhosts files (Scored)
+    levels:
+    - l1
+    status: automated
+    notes: The rule also removes /etc/hosts.equiv
+    rules:
+    - no_rsh_trust_files
+
+  - id: 6.2.15
+    title: Ensure all groups in /etc/passwd exist in /etc/group (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - gid_passwd_group_same
+
+  - id: 6.2.16
+    title: Ensure no duplicate UIDs exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - account_unique_id
+
+  - id: 6.2.17
+    title: Ensure no duplicate GIDs exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+      - group_unique_id
+
+  - id: 6.2.18
+    title: Ensure no duplicate user names exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+    - account_unique_name
+
+  - id: 6.2.19
+    title: Ensure no duplicate group names exist (Scored)
+    levels:
+    - l1
+    status: automated
+    rules:
+      - group_unique_name

--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Disable Avahi Server Software'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 2.1.3
     cis@rhel7: 2.2.3
     cis@rhel8: 2.2.4
     cis@sle12: 2.2.3

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns cron.d'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.7
     cis@rhel7: 5.1.7
     cis@rhel8: 5.1.7
     cis@sle12: 5.2.7

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns cron.daily'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.4
     cis@rhel7: 5.1.4
     cis@rhel8: 5.1.4
     cis@sle12: 5.2.4

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns cron.hourly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.3
     cis@rhel7: 5.1.3
     cis@rhel8: 5.1.3
     cis@sle12: 5.2.3

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns cron.monthly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.6
     cis@rhel7: 5.1.6
     cis@rhel8: 5.1.6
     cis@sle12: 5.2.6

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns cron.weekly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.5
     cis@rhel7: 5.1.5
     cis@rhel8: 5.1.5
     cis@sle12: 5.2.5

--- a/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns Crontab'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.2
     cis@rhel7: 5.1.2
     cis@rhel8: 5.1.2
     cis@sle12: 5.2.2

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_d/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on cron.d'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.7
     cis@rhel7: 5.1.7
     cis@rhel8: 5.1.7
     cis@sle12: 5.2.7

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_daily/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on cron.daily'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.4
     cis@rhel7: 5.1.4
     cis@rhel8: 5.1.4
     cis@sle12: 5.2.4

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_hourly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on cron.hourly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.3
     cis@rhel7: 5.1.3
     cis@rhel8: 5.1.3
     cis@sle12: 5.2.3

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_monthly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on cron.monthly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.6
     cis@rhel7: 5.1.6
     cis@rhel8: 5.1.6
     cis@sle12: 5.2.6

--- a/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_cron_weekly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on cron.weekly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.5
     cis@rhel7: 5.1.5
     cis@rhel8: 5.1.5
     cis@sle12: 5.2.5

--- a/linux_os/guide/services/cron_and_at/file_owner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_owner_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on crontab'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.2
     cis@rhel7: 5.1.2
     cis@rhel8: 5.1.2
     cis@sle12: 5.2.2

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on cron.d'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.7
     cis@rhel7: 5.1.7
     cis@rhel8: 5.1.7
     cis@sle12: 5.2.7

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on cron.daily'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.4
     cis@rhel7: 5.1.4
     cis@rhel8: 5.1.4
     cis@sle12: 5.2.4

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on cron.hourly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.3
     cis@rhel7: 5.1.3
     cis@rhel8: 5.1.3
     cis@sle12: 5.2.3

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on cron.monthly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.6
     cis@rhel7: 5.1.6
     cis@rhel8: 5.1.6
     cis@sle12: 5.2.6

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on cron.weekly'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.5
     cis@rhel7: 5.1.5
     cis@rhel8: 5.1.5
     cis@sle12: 5.2.5

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on crontab'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.2
     cis@rhel7: 5.1.2
     cis@rhel8: 5.1.2
     cis@sle12: 5.2.2

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_at_deny_not_exist/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_at_deny_not_exist/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: alinux2,fedora,rhel7,rhel8,rhel9
 
 title: 'Ensure that /etc/at.deny does not exist'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-86946-1
 
 references:
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.9
     cis@rhel8: 5.1.8
 

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,fedora,rhel7,rhel8,rhel9,sle15
 
 title: 'Ensure that /etc/cron.deny does not exist'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-86850-5
 
 references:
+    cis@alinxu2: 5.1.8
     cis@rhel7: 5.1.8
     cis@rhel8: 5.1.8
     cis@sle15: 5.1.8

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns /etc/at.allow file'
 
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel9: CCE-87103-8
 
 references:
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.9
     cis@rhel8: 5.1.8
     cis@sle12: 5.2.9

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify Group Who Owns /etc/cron.allow file'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.8
     cis@rhel8: 5.1.8
     cis@sle12: 5.2.8

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_at_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004
+prodtype: alinux2,sle12,sle15,ubuntu2004
 
 title: 'Verify User Who Owns /etc/at.allow file'
 
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel9: CCE-86346-4
 
 references:
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.9
     cis@rhel8: 5.1.8
     cis@sle12: 5.2.9

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_owner_cron_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify User Who Owns /etc/cron.allow file'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.8
     cis@rhel8: 5.1.8
     cis@sle12: 5.2.8

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on /etc/at.allow file'
 
@@ -30,6 +30,7 @@ identifiers:
     cce@rhel9: CCE-86904-0
 
 references:
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.9
     cis@rhel8: 5.1.8
     cis@sle12: 5.2.9

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,sle15,ubuntu2004
 
 title: 'Verify Permissions on /etc/cron.allow file'
 
@@ -30,6 +30,7 @@ identifiers:
     cce@rhel9: CCE-86877-8
 
 references:
+    cis@alinux2: 5.1.8
     cis@rhel7: 5.1.8
     cis@rhel8: 5.1.8
     cis@sle15: 5.1.8

--- a/linux_os/guide/services/cron_and_at/service_crond_enabled/rule.yml
+++ b/linux_os/guide/services/cron_and_at/service_crond_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Enable cron Service'
 
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 5.1.2
     cis@rhel7: 5.1.1
     cis@rhel8: 5.1.1
     cis@sle12: 5.2.1

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable DHCP Service'
 
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 2.1.5
     cis@rhel7: 2.2.5
     cis@rhel8: 2.2.15
     cis@sle15: 2.2.5

--- a/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
+++ b/linux_os/guide/services/dns/disabling_dns_server/service_named_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable named Service'
 
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 2.1.8
     cis@rhel7: 2.2.8
     cis@rhel8: 2.2.11
     cis@sle15: 2.2.8

--- a/linux_os/guide/services/ftp/disabling_vsftpd/service_vsftpd_disabled/rule.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/service_vsftpd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable vsftpd Service'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 2.1.9
     cis@rhel7: 2.2.9
     cis@rhel8: 2.2.10
     cis@sle15: 2.2.9

--- a/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/service_httpd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable httpd Service'
 
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 2.1.10
     cis@rhel7: 2.2.10
     cis@rhel8: 2.2.9
     cis@sle15: 2.2.10

--- a/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_dovecot/package_dovecot_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Uninstall dovecot Package'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-80295-9
 
 references:
+    cis@alinux2: 2.1.11
     cis@rhel7: 2.2.10
     cis@sle12: 2.2.10
     cis@sle15: 2.2.12

--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-90831-9
 
 references:
+    cis@alinux2: 2.2.5
     cis@rhel7: 2.3.5
     cis@rhel8: 2.3.3
     cis@sle12: 2.3.5

--- a/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/service_slapd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: alinux2,rhel8,rhel9
 
 title: 'Disable LDAP Server (slapd)'
 
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel9: CCE-87263-0
 
 references:
+    cis@alinux2: 2.1.6
     cis@rhel8: 2.2.14
 
 ocil_clause: |-

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disable Postfix Network Listening'
 
@@ -24,6 +24,7 @@ identifiers:
 references:
     anssi: BP28(R48)
     cis-csc: 11,14,3,9
+    cis@alinux2: 2.1.15
     cis@rhel7: 2.2.16
     cis@rhel8: 2.2.18
     cis@sle12: 2.2.19

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disable rpcbind Service'
 
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel9: CCE-84245-0
 
 references:
+    cis@alinux2: 2.1.7
     cis@rhel7: 2.2.18
     cis@rhel8: 2.2.13
     cis@sle12: 2.2.17

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/disabling_nfsd/service_nfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9
+prodtype: alinux2,fedora,rhel7,rhel8,rhel9
 
 title: 'Disable Network File System (nfs)'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,14,15,16,18,3,5
+    cis@alinux2: 2.1.7
     cis@rhel7: 2.2.7
     cis@rhel8: 2.2.12
     cis@sle15: 2.2.7

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure that chronyd is running under chrony user account'
 
@@ -24,6 +24,7 @@ severity: medium
 platform: chrony
 
 references:
+    cis@alinux2: 2.1.1.3
     cis@rhel7: 2.2.1.2
     cis@rhel8: 2.2.1.2
     cis@sle12: 2.2.1.3

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     anssi: BP28(R43)
+    cis@alinux2: 2.1.1.3
     cis@rhel7: 2.2.1.2
     cis@rhel8: 2.2.1.2
     cis@sle12: 2.2.1.3

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,sle12
+prodtype: alinux2,fedora,rhel7,sle12
 
 title: 'Configure server restrictions for ntpd'
 
@@ -24,6 +24,7 @@ severity: medium
 platform: ntp
 
 references:
+    cis@alinux2: 2.1.1.2
     cis@rhel7: 2.2.1.3
     cis@sle12: 2.2.1.4
 

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,sle12
+prodtype: alinux2,fedora,rhel7,sle12
 
 title: 'Configure ntpd To Run As ntp User'
 
@@ -25,6 +25,7 @@ severity: medium
 platform: ntp
 
 references:
+    cis@alinux2: 2.1.1.2
     cis@rhel7: 2.2.1.3
     cis@sle12: 2.2.1.4
 

--- a/linux_os/guide/services/ntp/ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_specify_remote_server/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 1,14,15,16,3,5,6
+    cis@alinux2: 2.1.1.2
     cis@rhel7: 2.2.1.3
     cis@sle12: 2.2.1.4
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01

--- a/linux_os/guide/services/ntp/service_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntpd_enabled/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis-csc: 1,14,15,16,3,5,6
+    cis@alinux2: 2.1.1.2
     cis@rhel7: 2.2.1.3
     cis@sle12: 2.2.1.4
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/file_permissions_etc_hosts_allow/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/file_permissions_etc_hosts_allow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel7
+prodtype: alinux2,ol7,rhel7
 
 title: 'Verify Permissions on /etc/hosts.allow'
 
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel7: CCE-83828-4
 
 references:
+    cis@alinux2: 3.3.4
     cis@rhel7: 3.4.4
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/hosts.allow", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/file_permissions_etc_hosts_deny/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/file_permissions_etc_hosts_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel7
+prodtype: alinux2,ol7,rhel7
 
 title: 'Verify Permissions on /etc/hosts.deny'
 
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel7: CCE-84035-5
 
 references:
+    cis@alinux2: 3.3.5
     cis@rhel7: 3.4.5
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/hosts.deny", perms="-rw-r--r--") }}}'

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_tcp_wrappers_installed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_tcp_wrappers_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,sle15
+prodtype: alinux2,rhel7,sle15
 
 title: 'Install tcp_wrappers Package'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 11,3,9
+    cis@alinux2: 3.3.1
     cis@rhel7: 3.4.1
     cis@sle15: 3.4.1
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Remove NIS Client'
 
@@ -27,6 +27,7 @@ identifiers:
 
 references:
     anssi: BP28(R1)
+    cis@alinux2: 2.2.1
     cis@rhel7: 2.3.1
     cis@rhel8: 2.3.1
     cis@sle12: 2.3.1

--- a/linux_os/guide/services/obsolete/nis/service_ypserv_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/service_ypserv_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: alinux2,rhel8,rhel9
 
 title: 'Disable ypserv Service'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-86122-9
 
 references:
+    cis@alinux2: 2.1.16
     cis@rhel8: 2.2.17
 
 ocil_clause: |-

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,14,15,3,8,9
+    cis@alinux2: 6.2.14
     cis@rhel7: 6.2.14
     cis@rhel8: 6.2.13
     cis@sle12: 6.2.12

--- a/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/package_rsh_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Uninstall rsh Package'
 
@@ -34,6 +34,7 @@ identifiers:
 
 references:
     anssi: BP28(R1)
+    cis@alinux2: 2.2.2
     cis@rhel7: 2.3.2
     cis@sle12: 2.3.2
     cis@sle15: 2.3.2

--- a/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhv4
 
 title: 'Disable rsh Service'
 
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,14,15,16,3,5,8,9
+    cis@alinux2: 2.1.17
     cis@rhel7: 2.2.17
     cobit5: APO13.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.06,DSS06.10
     cui: 3.1.13,3.4.7

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Ensure rsyncd service is diabled'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-84140-3
 
 references:
+    cis@alinux2: 2.1.20
     cis@rhel7: 2.2.19
     cis@rhel8: 2.2.3
     cis@sle12: 2.2.18

--- a/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Uninstall talk-server Package'
 
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     anssi: BP28(R1)
+    cis@alinux2: 2.1.21
     cis@rhel7: 2.2.18
     hipaa: 164.308(a)(4)(i),164.308(b)(1),164.308(b)(3),164.310(b),164.312(e)(1),164.312(e)(2)(ii)
 

--- a/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/talk/package_talk_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Uninstall talk Package'
 
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     anssi: BP28(R1)
+    cis@alinux2: 2.2.3
     cis@rhel7: 2.3.3
     cis@sle12: 2.3.3
     cis@sle15: 2.3.3

--- a/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Remove telnet Clients'
 
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     anssi: BP28(R1)
+    cis@alinux2: 2.2.4
     cis@rhel7: 2.3.4
     cis@rhel8: 2.3.2
     cis@sle12: 2.3.4

--- a/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Disable telnet Service'
 
@@ -46,6 +46,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,14,15,16,3,5,8,9
+    cis@alinux2: 2.1.18
     cis@rhel7: 2.2.19
     cobit5: APO13.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.06,DSS06.10
     cui: 3.1.13,3.4.7

--- a/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/service_tftp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,sle15
+prodtype: alinux2,rhel7,rhel8,sle15
 
 title: 'Disable tftp Service'
 
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,14,15,3,8,9
+    cis@alinux2: 2.1.19
     cis@rhel7: 2.2.20
     cis@sle15: 2.1.9
     cobit5: APO13.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.05,DSS06.06

--- a/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
+++ b/linux_os/guide/services/proxy/disabling_squid/service_squid_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable Squid'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel9: CCE-84239-3
 
 references:
+    cis@alinux2: 2.1.13
     cis@rhel7: 2.2.13
     cis@rhel8: 2.2.6
     cis@sle15: 2.2.13

--- a/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/service_smb_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable Samba'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel9: CCE-84201-3
 
 references:
+    cis@alinux2: 2.1.12
     cis@rhel7: 2.2.12
     cis@rhel8: 2.2.7
     cis@sle15: 2.2.12

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,debian10,debian11,debian9,rhel7,rhel8,rhel9,sle15
 
 title: 'Disable snmpd Service'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel9: CCE-90832-7
 
 references:
+    cis@alinux2: 2.1.14
     cis@rhel7: 2.2.14
     cis@rhel8: 2.2.5
     cis@sle15: 2.2.14

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Group Who Owns SSH Server config file'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.2.1
     cis@rhel7: 5.3.1
     cis@rhel8: 5.2.1
     cis@sle12: 5.3.1

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Owner on SSH Server config file'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.2.1
     cis@rhel7: 5.3.1
     cis@rhel8: 5.2.1
     cis@sle12: 5.3.1

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify Permissions on SSH Server config file'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.2.1
     cis@rhel7: 5.3.1
     cis@rhel8: 5.2.1
     cis@sle12: 5.3.1

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.2.3
     cis@rhel8: 5.2.3
     cis@sle12: 5.3.2
     cis@sle15: 5.2.2

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 5.2.4
     cis@rhel7: 5.3.3
     cis@rhel8: 5.2.4
     cis@sle12: 5.3.3

--- a/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/disable_host_auth/rule.yml
@@ -30,6 +30,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,14,15,16,18,3,5,9
+    cis@alinux2: 5.2.9
     cis@rhel7: 5.3.9
     cis@rhel8: 5.2.9
     cis@sle12: 5.3.10

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: NT007(R1)
     cis-csc: 1,12,15,16,5,8
+    cis@alinux2: 5.2.2
     cis@rhel7: 5.2.2
     cis@sle12: 5.3.4
     cjis: 5.5.6

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_empty_passwords/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 references:
     anssi: NT007(R17)
     cis-csc: 11,12,13,14,15,16,18,3,5,9
+    cis@alinux2: 5.2.11
     cis@rhel7: 5.3.11
     cis@rhel8: 5.2.11
     cis@sle12: 5.3.12

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,14,15,16,18,3,5,9
+    cis@alinux2: 5.2.8
     cis@rhel7: 5.3.8
     cis@rhel8: 5.2.8
     cis@sle12: 5.3.9

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_root_login/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     anssi: BP28(R19),NT007(R21)
     cis-csc: 1,11,12,13,14,15,16,18,3,5
+    cis@alinux2: 5.2.10
     cis@rhel7: 5.3.10
     cis@rhel8: 5.2.10
     cis@sle12: 5.3.11

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_x11_forwarding/rule.yml
@@ -33,6 +33,7 @@ identifiers:
     cce@sle15: CCE-85707-8
 
 references:
+    cis@alinux2: 5.2.6
     cis@rhel7: 5.3.6
     cis@rhel8: 5.2.6
     cis@sle12: 5.3.7

--- a/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_do_not_permit_user_env/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 
 references:
     cis-csc: 11,3,9
+    cis@alinux2: 5.2.12
     cis@rhel7: 5.3.12
     cis@rhel8: 5.2.12
     cis@sle12: 5.3.13

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_warning_banner/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16
+    cis@alinux2: 5.2.19
     cis@rhel7: 5.2.15
     cis@rhel8: 5.2.15
     cis@sle12: 5.3.19

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_user_access/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,14,15,16,18,3,5
+    cis@alinux2: 5.2.18
     cis@rhel7: 5.2.14
     cis@sle15: 5.2.18
     cobit5: DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.03,DSS06.06

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -35,6 +35,7 @@ identifiers:
 references:
     anssi: BP28(R29)
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    cis@alinux2: 5.2.14
     cis@rhel7: 5.3.16
     cis@rhel8: 5.2.13
     cis@sle12: 5.3.17

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 references:
     anssi: BP28(R29)
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    cis@alinux2: 5.2.14
     cis@rhel7: 5.3.16
     cis@rhel8: 5.2.13
     cis@sle12: 5.3.17

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_login_grace_time/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_login_grace_time/rule.yml
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-86552-7
 
 references:
+    cis@alinux2: 5.2.15
     cis@rhel7: 5.3.17
     cis@rhel8: 5.2.14
     cis@sle15: 5.2.14

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/rule.yml
@@ -28,6 +28,7 @@ identifiers:
     cce@rhel9: CCE-90813-7
 
 references:
+    cis@alinux2: 5.2.5
     cis@debian10: 9.3.2
     cis@debian11: 9.3.2
     cis@rhel7: 5.3.5

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/rule.yml
@@ -28,6 +28,7 @@ identifiers:
     cce@sle15: CCE-83270-9
 
 references:
+    cis@alinux2: 5.2.5
     cis@rhel7: 5.3.5
     cis@rhel8: 5.2.5
     cis@sle12: 5.3.6

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_max_auth_tries/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel9: CCE-90810-3
 
 references:
+    cis@alinux2: 5.2.7
     cis@debian11: 9.3.5
     cis@debian9: 9.3.5
     cis@rhel7: 5.3.7

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004,wrlinux1019,wrlinux8
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004,wrlinux1019,wrlinux8
 
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 
@@ -53,6 +53,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,14,15,16,18,3,5,6,8,9
+    cis@alinux2: 5.2.17
     cis@rhel7: 5.3.13
     cis@sle12: 5.3.14
     cis@sle15: 5.2.13

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Use Only FIPS 140-2 Validated MACs'
 
@@ -47,6 +47,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,13,15,16,5,8
+    cis@alinux2: 5.2.13
     cis@rhel7: 5.3.14
     cis@sle12: 5.3.15
     cis@sle15: 5.2.14

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_remove_packages/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disable graphical user interface'
 
@@ -32,6 +32,7 @@ identifiers:
     cce@rhel9: CCE-84106-4
 
 references:
+    cis@alinux2: 2.1.2
     cis@rhel7: 2.2.2
     cis@rhel8: 2.2.2
     cis@sle12: 2.2.2

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_issue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Modify the System Login Banner'
 
@@ -96,6 +96,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16
+    cis@alinux2: 1.7.1.2
     cis@rhel7: 1.7.2
     cis@rhel8: 1.8.1.2
     cis@sle12: 1.7.1.2

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Modify the System Message of the Day Banner'
 
@@ -54,6 +54,7 @@ identifiers:
     cce@rhel9: CCE-83559-5
 
 references:
+    cis@alinux2: 1.7.1.1
     cis@rhel7: 1.7.1
     cis@rhel8: 1.8.1.1
     cis@sle12: 1.7.1.1

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify Group Ownership of System Login Banner'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel8: CCE-83708-8
 
 references:
+    cis@alinux2: 1.7.1.5
     cis@rhel7: 1.7.5
     cis@rhel8: 1.8.1.5
     cis@sle12: 1.7.1.5

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify Group Ownership of Message of the Day Banner'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel8: CCE-83728-6
 
 references:
+    cis@alinux2: 1.7.1.4
     cis@rhel7: 1.7.4
     cis@rhel8: 1.8.1.4
     cis@sle12: 1.7.1.4

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_issue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify ownership of System Login Banner'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel8: CCE-83718-7
 
 references:
+    cis@alinux2: 1.7.1.5
     cis@rhel7: 1.7.5
     cis@rhel8: 1.8.1.5
     cis@sle12: 1.7.1.5

--- a/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_owner_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify ownership of Message of the Day Banner'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel8: CCE-83738-5
 
 references:
+    cis@alinux2: 1.7.1.4
     cis@rhel7: 1.7.4
     cis@rhel8: 1.8.1.4
     cis@sle12: 1.7.1.4

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_issue/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify permissions on System Login Banner'
 
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel9: CCE-83551-2
 
 references:
+    cis@alinux2: 1.7.1.5
     cis@rhel7: 1.7.5
     cis@rhel8: 1.8.1.5
     cis@sle12: 1.7.1.5

--- a/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_permissions_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Verify permissions on Message of the Day Banner'
 
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel9: CCE-83554-6
 
 references:
+    cis@alinux2: 1.7.1.4
     cis@rhel7: 1.7.4
     cis@rhel8: 1.8.1.4
     cis@sle12: 1.7.1.4

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Limit Password Reuse: password-auth'
 
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.3
     cis@rhel7: 5.4.4
     cis@rhel8: 5.4.3
     cjis: 5.6.2.1.1

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,wrlinux1019
 
 title: 'Limit Password Reuse: system-auth'
 
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.3
     cis@rhel7: 5.4.4
     cis@rhel8: 5.4.3
     cjis: 5.6.2.1.1

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Digit Characters'
 
@@ -34,6 +34,7 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
     cis@sle12: 5.4.1
     cis@sle15: 5.3.1

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Lowercase Characters'
 
@@ -34,6 +34,7 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
     cis@sle12: 5.4.1
     cis@sle15: 5.3.1

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,ubuntu2004,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Different Categories'
 
@@ -43,6 +43,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
     cis@rhel8: 5.4.1
     cis@ubuntu2004: 5.3.1

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Length'
 
@@ -31,6 +31,7 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
     cis@rhel8: 5.4.1
     cis@sle12: 5.4.1

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Special Characters'
 
@@ -36,6 +36,7 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
     cis@sle12: 5.4.1
     cis@sle15: 5.3.1

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Uppercase Characters'
 
@@ -31,6 +31,7 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
     cis@sle12: 5.4.1
     cis@sle15: 5.3.1

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: "Set PAM's Password Hashing Algorithm"
 
@@ -53,6 +53,7 @@ identifiers:
 references:
     anssi: BP28(R32)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.3.4
     cis@rhel7: 5.4.3
     cis@rhel8: 5.4.4
     cjis: 5.6.2.2

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Require Authentication for Emergency Systemd Target'
 
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,14,15,16,18,3,5
+    cis@alinux2: 1.4.2
     cis@rhel7: 1.4.3
     cis@rhel8: 1.5.3
     cis@sle12: 1.4.3

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Require Authentication for Single User Mode'
 
@@ -30,6 +30,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,14,15,16,18,3,5
+    cis@alinux2: 1.4.2
     cis@rhel7: 1.4.3
     cis@rhel8: 1.5.3
     cis@sle12: 1.4.3

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Set Account Expiration Following Inactivity'
 
@@ -34,6 +34,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    cis@alinux2: 5.4.1.4
     cis@rhel7: 5.5.1.4
     cis@rhel8: 5.5.1.4
     cis@sle12: 5.5.1.5

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_name/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_unique_name/rule.yml
@@ -20,6 +20,7 @@ identifiers:
     cce@sle15: CCE-85845-6
 
 references:
+    cis@alinux2: 6.2.18
     cis@rhel7: 6.2.5
     cis@rhel8: 6.2.17
     cis@sle12: 6.2.16

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Ensure All Accounts on the System Have Unique User IDs'
 
@@ -18,6 +18,7 @@ identifiers:
     cce@sle15: CCE-83277-4
 
 references:
+    cis@alinux2: 6.2.16
     cis@rhel7: 6.2.7
     cis@rhel8: 6.2.15
     cis@sle12: 6.2.14

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,fedora,rhel7,rhel8,rhel9,sle15
 
 title: 'Ensure All Groups on the System Have Unique Group ID'
 
@@ -16,6 +16,7 @@ identifiers:
     cce@rhel9: CCE-86043-7
 
 references:
+    cis@alinux2: 6.2.17
     cis@rhel7: 6.2.7
     cis@rhel8: 6.2.16
     cis@sle15: 6.2.15

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_name/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_name/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,sle15
+prodtype: alinux2,fedora,rhel7,rhel8,sle15
 
 title: 'Ensure All Groups on the System Have Unique Group Names'
 
@@ -16,6 +16,7 @@ identifiers:
 
 
 references:
+    cis@alinux2: 6.2.19
     cis@rhel7: 6.2.6
     cis@rhel8: 6.2.18
     cis@sle15: 6.2.17

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_maximum_age_login_defs/rule.yml
@@ -34,6 +34,7 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.4.1.1
     cis@rhel7: 5.5.1.1
     cis@rhel8: 5.5.1.1
     cis@sle12: 5.5.1.2

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_minimum_age_login_defs/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 5.4.1.2
     cis@rhel7: 5.5.1.2
     cis@rhel8: 5.5.1.2
     cis@sle12: 5.5.1.3

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    cis@alinux2: 5.4.1.3
     cis@rhel7: 5.5.1.3
     cis@rhel8: 5.5.1.3
     cis@sle12: 5.5.1.4

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/gid_passwd_group_same/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 6.2.15
     cis@rhel7: 6.2.3
     cis@sle12: 6.2.13
     cis@sle15: 6.2.13

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure there are no legacy + NIS entries in /etc/passwd'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-83620-5
 
 references:
+    cis@alinux2: 6.2.2
     cis@rhel7: 6.2.2
     cis@rhel8: 6.2.2
     cis@sle15: 6.2.2

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure there are no legacy + NIS entries in /etc/shadow'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-83612-2
 
 references:
+    cis@alinux2: 6.2.3
     cis@rhel7: 6.2.3
     cis@rhel8: 6.2.4
     cis@sle15: 6.2.4

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_netrc_files/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,14,15,16,18,3,5
+    cis@alinux2: 6.2.12
     cis@rhel7: 6.2.16
     cis@rhel8: 6.2.11
     cis@ubuntu2004: 6.2.9

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5
+    cis@alinux2: 6.2.5
     cis@rhel7: 6.2.9
     cis@rhel8: 6.2.6
     cis@sle12: 6.2.3

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/rule.yml
@@ -16,6 +16,7 @@ identifiers:
     cce@rhel9: CCE-86298-7
 
 references:
+    cis@alinux2: 5.4.3
     cis@rhel7: 5.5.3
     cis@rhel8: 5.5.4
     cis@sle15: 5.4.3

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure that System Accounts Do Not Run a Shell Upon Login'
 
@@ -34,6 +34,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8
+    cis@alinux2: 5.4.2
     cis@rhel7: 5.5.2
     cis@rhel8: 5.5.2
     cis@sle12: 5.5.2

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,ubuntu2004
 
 title: 'Enforce usage of pam_wheel for su authentication'
 
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel9: CCE-90085-2
 
 references:
+    cis@alinux2: "5.6"
     cis@rhel7: "5.7"
     cis@rhel8: "5.7"
     cis@ubuntu2004: "5.6"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Set Interactive Session Timeout'
 
@@ -36,6 +36,7 @@ identifiers:
 references:
     anssi: BP28(R29)
     cis-csc: 1,12,15,16
+    cis@alinux2: 5.4.5
     cis@rhel7: 5.5.4
     cis@rhel8: 5.5.3
     cis@sle12: 5.5.4

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'All Interactive Users Home Directories Must Exist'
 
@@ -27,6 +27,7 @@ identifiers:
     cce@sle15: CCE-85628-6
 
 references:
+    cis@alinux2: 6.2.7
     cis@rhel7: 6.2.11
     cis@rhel8: 6.2.20
     cis@sle12: 6.2.5

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,wrlinux1019
 
 title: 'All Interactive User Home Directories Must Be Owned By The Primary User'
 
@@ -26,6 +26,7 @@ identifiers:
     cce@rhel8: CCE-86131-0
 
 references:
+    cis@alinux2: 6.2.9
     cis@rhel7: 6.2.12
     cis@rhel8: 6.2.8
     cis@sle12: 6.2.7

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'All Interactive User Home Directories Must Have mode 0750 Or Less Permissive'
 
@@ -24,6 +24,7 @@ identifiers:
     cce@sle15: CCE-85629-4
 
 references:
+    cis@alinux2: 6.2.8
     cis@rhel7: 6.2.13
     cis@rhel8: 6.2.7
     cis@sle12: 6.2.6

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/accounts_root_path_dirs_no_write/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 11,3,9
+    cis@alinux2: 6.2.6
     cis@rhel7: 6.2.10
     cis@rhel8: 6.2.3
     cis@sle12: 6.2.4

--- a/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/root_paths/root_path_no_dot/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     cis-csc: 11,3,9
+    cis@alinux2: 6.2.6
     cis@rhel7: 6.2.10
     cis@rhel8: 6.2.3
     cis@sle12: 6.2.4

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure the Default Bash Umask is Set Correctly'
 
@@ -32,6 +32,7 @@ identifiers:
 references:
     anssi: BP28(R35)
     cis-csc: '18'
+    cis@alinux2: 5.4.4
     cis@rhel7: 5.5.5
     cis@rhel8: 5.5.4
     cis@sle12: 5.5.5

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 references:
     anssi: BP28(R35)
     cis-csc: 11,18,3,9
+    cis@alinux2: 5.4.4
     cis@rhel7: 5.5.5
     cis@rhel8: 5.5.5
     cis@sle12: 5.5.5

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 references:
     anssi: BP28(R35)
     cis-csc: '18'
+    cis@alinux2: 5.4.4
     cis@rhel7: 5.5.5
     cis@rhel8: 5.5.4
     cis@sle12: 5.5.5

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/rule.yml
@@ -39,6 +39,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -53,6 +53,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -48,6 +48,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/rule.yml
@@ -36,6 +36,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -53,6 +53,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -48,6 +48,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -52,6 +52,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -48,6 +48,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.10
     cis@rhel7: 4.1.9
     cis@rhel8: 4.1.9
     cis@sle12: 4.1.9

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.14
     cis@rhel7: 4.1.13
     cis@rhel8: 4.1.14
     cis@sle12: 4.1.13

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.14
     cis@rhel7: 4.1.13
     cis@rhel8: 4.1.14
     cis@sle12: 4.1.13

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.14
     cis@rhel7: 4.1.13
     cis@rhel8: 4.1.14
     cis@sle12: 4.1.13

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/rule.yml
@@ -32,6 +32,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.14
     cis@rhel7: 4.1.13
     cis@rhel8: 4.1.14
     cis@sle12: 4.1.13

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - creat'
 
@@ -42,6 +42,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.11
     cis@rhel7: 4.1.10
     cis@rhel8: 4.1.10
     cis@sle12: 4.1.10

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - ftruncate'
 
@@ -45,6 +45,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.11
     cis@rhel7: 4.1.10
     cis@rhel8: 4.1.10
     cis@sle12: 4.1.10

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - open'
 
@@ -45,6 +45,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.11
     cis@rhel7: 4.1.10
     cis@rhel8: 4.1.10
     cis@sle12: 4.1.10

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - openat'
 
@@ -45,6 +45,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.11
     cis@rhel7: 4.1.10
     cis@rhel8: 4.1.10
     cis@sle12: 4.1.10

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Unsuccessful Access Attempts to Files - truncate'
 
@@ -45,6 +45,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.11
     cis@rhel7: 4.1.10
     cis@rhel8: 4.1.10
     cis@sle12: 4.1.10

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_module'
 
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.17
     cis@rhel7: 4.1.16
     cis@rhel8: 4.1.15
     cis@sle12: 4.1.16

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure auditd Collects Information on Kernel Module Loading - init_module'
 
@@ -36,6 +36,7 @@ identifiers:
     cce@sle15: CCE-85750-8
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.17
     cis@rhel7: 4.1.16
     cis@rhel8: 4.1.15
     cis@sle12: 4.1.16

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - faillock'
 
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.8
     cis@rhel7: 4.1.7
     cis@rhel8: 4.1.4
     cis@sle12: 4.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_lastlog/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Attempts to Alter Logon and Logout Events - lastlog'
 
@@ -34,6 +34,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.8
     cis@rhel7: 4.1.7
     cis@rhel8: 4.1.4
     cis@sle12: 4.1.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,sle12,sle15,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - insmod'
 
@@ -32,6 +32,7 @@ identifiers:
     cce@sle15: CCE-85744-1
 
 references:
+    cis@alinux2: 4.1.17
     cis@rhel7: 4.1.16
     cis@rhel8: 4.1.15
     cis@sle12: 4.1.16

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,sle12,sle15,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - modprobe'
 
@@ -36,6 +36,7 @@ identifiers:
     cce@sle15: CCE-85731-8
 
 references:
+    cis@alinux2: 4.1.17
     cis@rhel7: 4.1.16
     cis@rhel8: 4.1.15
     cis@sle12: 4.1.16

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,sle12,sle15,ubuntu2004
+prodtype: alinux2,rhel7,sle12,sle15,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - rmmod'
 
@@ -32,6 +32,7 @@ identifiers:
     cce@sle15: CCE-85732-6
 
 references:
+    cis@alinux2: 4.1.17
     cis@rhel7: 4.1.16
     cis@rhel8: 4.1.15
     cis@sle12: 4.1.16

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,3,4,5,6,7,8
+    cis@alinux2: 4.1.18
     cis@rhel7: 4.1.17
     cis@rhel8: 4.1.17
     cis@sle12: 4.1.17

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_mac_modification/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.7
     cis@rhel7: 4.1.6
     cis@rhel8: 4.1.7
     cis@sle12: 4.1.6

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/rule.yml
@@ -34,6 +34,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.13
     cis@rhel7: 4.1.12
     cis@rhel8: 4.1.12
     cis@sle12: 4.1.12

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
@@ -39,6 +39,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.6
     cis@rhel7: 4.1.5
     cis@rhel8: 4.1.8
     cis@sle12: 4.1.5

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_session_events/rule.yml
@@ -35,6 +35,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.9
     cis@rhel7: 4.1.8
     cis@rhel8: 4.1.5
     cis@sle12: 4.1.8

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sysadmin_actions/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.15
     cis@rhel7: 4.1.14
     cis@rhel8: 4.1.3
     cis@sle12: 4.1.14

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/group'
 
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.5
     cis@rhel7: 4.1.4
     cis@rhel8: 4.1.11
     cis@sle12: 4.1.4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/gshadow'
 
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.5
     cis@rhel7:  4.1.4
     cis@rhel8: 4.1.11
     cis@sle12: 4.1.4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/security/opasswd'
 
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.5
     cis@rhel7: 4.1.4
     cis@rhel8: 4.1.11
     cis@sle12: 4.1.4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/passwd'
 
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.5
     cis@rhel7: 4.1.4
     cis@rhel8: 4.1.11
     cis@sle12: 4.1.4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Record Events that Modify User/Group Information - /etc/shadow'
 
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.5
     cis@rhel7: 4.1.4
     cis@rhel8: 4.1.11
     cis@sle12: 4.1.4

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/rule.yml
@@ -39,6 +39,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.4
     cis@rhel7: 4.1.3
     cis@rhel8: 4.1.6
     cis@sle12: 4.1.3

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/rule.yml
@@ -39,6 +39,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.4
     cis@rhel7: 4.1.3
     cis@rhel8: 4.1.6
     cis@sle12: 4.1.3

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_stime/rule.yml
@@ -43,6 +43,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.4
     cis@rhel7: 4.1.3
     cis@rhel8: 4.1.6
     cis@sle12: 4.1.3

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_watch_localtime/rule.yml
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.4
     cis@rhel7: 4.1.3
     cis@rhel8: 4.1.6
     cis@sle12: 4.1.3

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8
+    cis@alinux2: 4.1.1.2
     cis@rhel7: 4.1.2.3
     cis@rhel8: 4.1.2.3
     cis@sle12: 4.1.2.3

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8
+    cis@alinux2: 4.1.1.2
     cis@rhel7: 4.1.2.3
     cis@rhel8: 4.1.2.3
     cis@sle12: 4.1.2.3

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,3,4,5,6,7,8
+    cis@alinxu2: 4.1.1.1
     cis@rhel7: 4.1.2.1
     cis@rhel8: 4.1.2.1
     cis@sle12: 4.1.2.1

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8
+    cis@alinux2: 4.1.1.3
     cis@rhel7: 4.1.2.2
     cis@rhel8: 4.1.2.2
     cis@sle12: 4.1.2.2

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/rule.yml
@@ -37,6 +37,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8
+    cis@alinux2: 4.1.1.2
     cis@rhel7: 4.1.2.3
     cis@rhel8: 4.1.2.3
     cis@sle12: 4.1.2.3

--- a/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,3,4,5,6,7,8
+    cis@alinux2: 4.1.3
     cis@rhel7: 4.1.1.3
     cis@rhel8: 4.1.1.3
     cis@sle12: 4.1.1.3

--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -33,6 +33,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
+    cis@alinux2: 4.1.2
     cis@rhel7: 4.1.1.2
     cis@rhel8: 4.1.1.2
     cis@sle12: 4.1.1.2

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Verify {{{ grub2_boot_path }}}/grub.cfg Group Ownership'
 
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.4.1
     cis@rhel7: 1.4.2
     cis@rhel8: 1.5.1
     cis@sle12: 1.4.2

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify {{{ grub2_boot_path }}}/grub.cfg User Ownership'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.4.1
     cis@rhel7: 1.4.2
     cis@rhel8: 1.5.1
     cis@sle12: 1.4.2

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Verify {{{ grub2_boot_path }}}/grub.cfg Permissions'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.4.1
     cis@rhel7: 1.4.2
     cis@rhel8: 1.5.1
     cis@sle12: 1.4.2

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Verify the UEFI Boot Loader grub.cfg Group Ownership'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.4.1
     cis@rhel7: 1.4.2
     cis@rhel8: 1.5.1
     cjis: 5.5.2.2

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Verify the UEFI Boot Loader grub.cfg User Ownership'
 
@@ -20,6 +20,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.4.1
     cis@rhel7: 1.4.2
     cis@rhel8: 1.5.1
     cjis: 5.5.2.2

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9
 
 
 title: 'Verify the UEFI Boot Loader grub.cfg Permissions'
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.4.1
     cis@rhel7: 1.4.2
     cis@rhel8: 1.5.1
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     anssi: BP28(R36)
+    cis@alinux2: 4.2.1.3
     cis@rhel7: 4.2.1.3
     cis@rhel8: 4.2.1.3
     disa: CCI-001314

--- a/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/rule.yml
@@ -19,6 +19,7 @@ identifiers:
 references:
     anssi: BP28(R5),NT28(R46)
     cis-csc: 1,14,15,16,3,5,6
+    cis@alinux2: 4.2.2
     cis@rhel7: 4.2.1.1
     cis@rhel8: 4.2.1.1
     cis@sle12: 4.2.1.1

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -45,6 +45,7 @@ identifiers:
 references:
     anssi: BP28(R7),NT28(R43),NT12(R5)
     cis-csc: 1,13,14,15,16,2,3,5,6
+    cis@alinux2: 4.2.1.4
     cis@rhel7: 4.2.1.4
     cis@rhel8: 4.2.1.5
     cis@sle12: 4.2.1.5

--- a/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
+++ b/linux_os/guide/system/logging/service_rsyslog_enabled/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 references:
     anssi: BP28(R5),NT28(R46)
     cis-csc: 1,12,13,14,15,16,2,3,5,6,7,8,9
+    cis@alinux2: 4.2.1.1
     cis@rhel7: 4.2.1.2
     cis@rhel8: 4.2.1.2
     cis@sle12: 4.2.1.2

--- a/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/package_iptables_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Install iptables Package'
 
@@ -20,6 +20,7 @@ identifiers:
     cce@rhel8: CCE-82982-0
 
 references:
+    cis@alinux2: 3.5.3
     cis@rhel7: 3.5.1.1,3.5.3.1.1
     cis@rhel8: 3.4.1.1
     cis@sle12: 3.5.1.1

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Configure Accepting Router Advertisements on All IPv6 Interfaces'
 
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.2.9
     cis@rhel7: 3.3.9
     cis@rhel8: 3.2.9
     cis@sle12: 3.3.9

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Accepting ICMP Redirects for All IPv6 Interfaces'
 
@@ -21,6 +21,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.2.2
     cis@rhel7: 3.3.2
     cis@rhel8: 3.2.2
     cis@sle12: 3.3.2

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv6 Interfaces'
 
@@ -29,6 +29,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,12,13,14,15,16,18,4,6,8,9
+    cis@alinux2: 3.2.1
     cis@rhel7: 3.3.1
     cis@rhel8: 3.2.1
     cis@sle12: 3.3.1

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Kernel Parameter for IPv6 Forwarding'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,2,3,7,8,9
+    cis@alinux2: 3.1.1
     cis@rhel7: 3.2.1
     cis@rhel8: 3.1.1
     cis@sle12: 3.2.1

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Accepting Router Advertisements on all IPv6 Interfaces by Default'
 
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.2.9
     cis@rhel7: 3.3.9
     cis@rhel8: 3.2.9
     cis@sle12: 3.3.9

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv6 Interfaces'
 
@@ -21,6 +21,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.2.2
     cis@rhel7: 3.3.2
     cis@rhel8: 3.2.2
     cis@sle12: 3.3.2

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on IPv6 Interfaces by Default'
 
@@ -29,6 +29,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,12,13,14,15,16,18,4,6,8,9
+    cis@alinux2: 3.2.1
     cis@rhel7: 3.3.1
     cis@rhel8: 3.2.1
     cis@sle12: 3.3.1

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Accepting ICMP Redirects for All IPv4 Interfaces'
 
@@ -28,6 +28,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,2,3,7,8,9
+    cis@alinux2: 3.2.2
     cis@rhel7: 3.3.2
     cis@rhel8: 3.2.2
     cis@sle12: 3.3.2

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on all IPv4 Interfaces'
 
@@ -29,6 +29,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.2.1
     cis@rhel7: 3.3.1
     cis@rhel8: 3.2.1
     cis@sle12: 3.3.1

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable Kernel Parameter to Log Martian Packets on all IPv4 Interfaces'
 
@@ -23,6 +23,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,2,3,7,8,9
+    cis@alinux2: 3.2.4
     cis@rhel7: 3.3.4
     cis@rhel8: 3.2.4
     cis@sle12: 3.3.4

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces'
 
@@ -24,6 +24,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,12,13,14,15,16,18,2,4,6,7,8,9
+    cis@alinux2: 3.2.7
     cis@rhel7: 3.3.7
     cis@rhel8: 3.2.7
     cis@sle12: 3.3.7

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_secure_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Kernel Parameter for Accepting Secure ICMP Redirects on all IPv4 Interfaces'
 
@@ -22,6 +22,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.2.3
     cis@rhel7: 3.3.3
     cis@rhel8: 3.2.3
     cis@sle12: 3.3.3

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable Kernel Parameter for Accepting ICMP Redirects by Default on IPv4 Interfaces'
 
@@ -27,6 +27,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.2.2
     cis@rhel7: 3.3.2
     cis@rhel8: 3.2.2
     cis@sle12: 3.3.3

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Kernel Parameter for Accepting Source-Routed Packets on IPv4 Interfaces by Default'
 
@@ -29,6 +29,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.2.1
     cis@rhel7: 3.3.1
     cis@rhel8: 3.2.1
     cis@sle12: 3.3.1

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_log_martians/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable Kernel Paremeter to Log Martian Packets on all IPv4 Interfaces by Default'
 
@@ -22,6 +22,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,2,3,7,8,9
+    cis@alinux2: 3.2.4
     cis@rhel7: 3.3.4
     cis@rhel8: 3.2.4
     cis@sle12: 3.3.4

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable Kernel Parameter to Use Reverse Path Filtering on all IPv4 Interfaces by Default'
 
@@ -24,6 +24,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,12,13,14,15,16,18,2,4,6,7,8,9
+    cis@alinux2: 3.2.7
     cis@rhel7: 3.3.7
     cis@rhel8: 3.2.7
     cis@sle12: 3.3.7

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_secure_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Configure Kernel Parameter for Accepting Secure Redirects By Default'
 
@@ -22,6 +22,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.2.3
     cis@rhel7: 3.3.3
     cis@rhel8: 3.2.3
     cis@sle12: 3.3.2

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Enable Kernel Parameter to Ignore ICMP Broadcast Echo Requests on IPv4 Interfaces'
 
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.2.5
     cis@rhel7: 3.3.5
     cis@rhel8: 3.2.5
     cis@sle12: 3.3.5

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable Kernel Parameter to Ignore Bogus ICMP Error Responses on IPv4 Interfaces'
 
@@ -21,6 +21,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,2,3,7,8,9
+    cis@alinux2: 3.2.6
     cis@rhel7: 3.3.6
     cis@rhel8: 3.2.6
     cis@sle12: 3.3.6

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable Kernel Parameter to Use TCP Syncookies on Network Interfaces'
 
@@ -27,6 +27,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,12,13,14,15,16,18,2,4,6,7,8,9
+    cis@alinux2: 3.2.8
     cis@rhel7: 3.3.8
     cis@rhel8: 3.2.8
     cis@sle12: 3.3.8

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces'
 
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.1.2
     cis@rhel7: 3.2.2
     cis@rhel8: 3.1.2
     cis@sle12: 3.2.2

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Kernel Parameter for Sending ICMP Redirects on all IPv4 Interfaces by Default'
 
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,18,2,3,4,6,7,8,9
+    cis@alinux2: 3.1.2
     cis@rhel7: 3.2.2
     cis@rhel8: 3.1.2
     cis@sle12: 3.2.2

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Kernel Parameter for IP Forwarding on IPv4 Interfaces'
 
@@ -24,6 +24,7 @@ identifiers:
 references:
     anssi: BP28(R22)
     cis-csc: 1,11,12,13,14,15,16,2,3,7,8,9
+    cis@alinux2: 3.1.1
     cis@rhel7: 3.2.1
     cis@rhel8: 3.1.1
     cis@sle12: 3.2.1

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable DCCP Support'
 
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.4.1
     cis@rhel7: 3.4.1
     cis@rhel8: 3.3.1
     cis@sle12: 3.4.1

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rds_disabled/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.4.3
     cis@rhel7: 3.5.3
     cis@rhel8: 3.3.3
     cis@ubuntu2004: 3.4.3

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_sctp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Disable SCTP Support'
 
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.4.2
     cis@rhel7: 3.4.2
     cis@rhel8: 3.3.2
     cis@sle12: 3.5.1.1

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 3.4.4
     cis@rhel7: 3.5.4
     cis@rhel8: 3.3.4
     cis@ubuntu2004: 3.4.4

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/rule.yml
@@ -41,6 +41,7 @@ identifiers:
 references:
     anssi: BP28(R40)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 1.1.18
     cis@rhel7: 1.1.22
     cis@rhel8: 1.1.21
     cis@sle12: 1.1.22

--- a/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_unauthorized_world_writable/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     anssi: BP28(R40)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.10
     cis@rhel7: 6.1.10
     cis@rhel8: 6.1.10
     cis@sle12: 6.1.8

--- a/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_ungroupowned/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,wrlinux1019
 
 title: 'Ensure All Files Are Owned by a Group'
 
@@ -35,6 +35,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.12
     cis@rhel7: 6.1.12
     cis@rhel8: 6.1.12
     cis@sle12: 6.1.10

--- a/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
+++ b/linux_os/guide/system/permissions/files/no_files_unowned_by_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Ensure All Files Are Owned by a User'
 
@@ -35,6 +35,7 @@ identifiers:
 
 references:
     cis-csc: 11,12,13,14,15,16,18,3,5,9
+    cis@alinux2: 6.1.11
     cis@rhel7: 6.1.11
     cis@rhel8: 6.1.11
     cis@sle12: 6.1.9

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel9: CCE-83928-2
 
 references:
+    cis@alinux2: 6.1.8
     cis@rhel7: 6.1.9
     cis@rhel8: 6.1.9
     cis@sle12: 6.1.7

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel9: CCE-83951-4
 
 references:
+    cis@alinux2: 6.1.9
     cis@rhel7: 6.1.6
     cis@rhel8: 6.1.7
     cis@ubuntu2004: 6.1.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel9: CCE-83933-2
 
 references:
+    cis@alinux2: 6.1.6
     cis@rhel7: 6.1.3
     cis@rhel8: 6.1.3
     cis@sle12: 6.1.5

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel9: CCE-83938-1
 
 references:
+    cis@alinux2: 6.1.7
     cis@rhel7: 6.1.5
     cis@rhel8: 6.1.5
     cis@sle12: 6.1.6

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.4
     cis@rhel7: 6.1.8
     cis@rhel8: 6.1.8
     cis@sle12: 6.1.4

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.5
     cis@rhel7: 6.1.7
     cis@rhel8: 6.1.6
     cis@ubuntu2004: 6.1.9

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.2
     cis@rhel7: 6.1.2
     cis@rhel8: 6.1.2
     cis@sle12: 6.1.2

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.3
     cis@rhel7: 6.1.4
     cis@rhel8: 6.1.4
     cis@sle12: 6.1.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel9: CCE-83944-9
 
 references:
+    cis@alinux2: 6.1.8
     cis@rhel7: 6.1.9
     cis@rhel8: 6.1.9
     cis@sle12: 6.1.7

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
@@ -16,6 +16,7 @@ identifiers:
     cce@rhel9: CCE-83929-0
 
 references:
+    cis@alinux2: 6.1.9
     cis@rhel7: 6.1.6
     cis@rhel8: 6.1.7
     cis@ubuntu2004: 6.1.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel9: CCE-83947-2
 
 references:
+    cis@alinux2: 6.1.6
     cis@rhel7: 6.1.3
     cis@rhel8: 6.1.3
     cis@sle12: 6.1.5

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel9: CCE-83949-8
 
 references:
+    cis@alinux2: 6.1.7
     cis@rhel7: 6.1.5
     cis@rhel8: 6.1.5
     cis@sle12: 6.1.6

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.4
     cis@rhel7: 6.1.8
     cis@rhel8: 6.1.8
     cis@sle12: 6.1.4

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.5
     cis@rhel7: 6.1.7
     cis@rhel8: 6.1.6
     cis@ubuntu2004: 6.1.9

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
@@ -18,6 +18,7 @@ identifiers:
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.2
     cis@rhel7: 6.1.2
     cis@rhel8: 6.1.2
     cis@sle12: 6.1.2

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.3
     cis@rhel7: 6.1.4
     cis@rhel8: 6.1.4
     cis@sle12: 6.1.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel9: CCE-83939-9
 
 references:
+    cis@alinux2: 6.1.8
     cis@rhel7: 6.1.9
     cis@rhel8: 6.1.9
     cis@sle12: 6.1.7

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel9: CCE-83942-3
 
 references:
+    cis@alinux2: 6.1.9
     cis@rhel7: 6.1.6
     cis@rhel8: 6.1.7
     cis@sle15: 6.1.3

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
@@ -18,6 +18,7 @@ identifiers:
     cce@rhel9: CCE-83940-7
 
 references:
+    cis@alinux2: 6.1.6
     cis@rhel7: 6.1.3
     cis@rhel8: 6.1.3
     cis@sle12: 6.1.5

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -26,6 +26,7 @@ identifiers:
     cce@rhel9: CCE-83935-7
 
 references:
+    cis@alinux2: 6.1.7
     cis@rhel7: 6.1.5
     cis@rhel8: 6.1.5
     cis@sle12: 6.1.6

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -20,6 +20,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.4
     cis@rhel7: 6.1.8
     cis@rhel8: 6.1.8
     cis@sle12: 6.1.4

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.5
     cis@rhel7: 6.1.7
     cis@rhel8: 6.1.6
     cis@sle15: 6.1.2

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.2
     cis@rhel7: 6.1.2
     cis@rhel8: 6.1.2
     cis@sle12: 6.1.2

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -31,6 +31,7 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@alinux2: 6.1.3
     cis@rhel7: 6.1.4
     cis@rhel8: 6.1.4
     cis@sle12: 6.1.3

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_permissions_var_log/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel9: CCE-83917-5
 
 references:
+    cis@alinux2: 4.2.3
     disa: CCI-001314
     srg: SRG-OS-000206-GPOS-00084
     stigid@ol8: OL08-00-010240

--- a/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_squashfs_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,fedora,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disable Mounting of squashfs'
 
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     cis-csc: 11,14,3,9
+    cis@alinux2: 1.1.1
     cis@rhel7: 1.1.1.2
     cis@rhel8: 1.1.1.3
     cis@sle12: 1.1.1.2

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/rule.yml
@@ -34,6 +34,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,15,16,5
+    cis@alinux2: 1.1.19
     cis@rhel7: 1.1.23
     cis@rhel8: 1.1.22
     cis@sle12: 1.1.23

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 11,13,14,3,8,9
+    cis@alinux2: 1.1.15
     cis@rhel7: 1.1.8
     cis@rhel8: 1.1.15
     cis@sle12: 1.1.8

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804,ubuntu2004
 
 title: 'Add noexec Option to /dev/shm'
 
@@ -27,6 +27,7 @@ identifiers:
 
 references:
     cis-csc: 11,13,14,3,8,9
+    cis@alinux2: 1.1.17
     cis@rhel7: 1.1.7
     cis@rhel8: 1.1.17
     cis@sle12: 1.1.7

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 11,13,14,3,8,9
+    cis@alinux2: 1.1.16
     cis@rhel7: 1.1.9
     cis@rhel8: 1.1.16
     cis@sle12: 1.1.9

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
 
 title: 'Add nodev Option to /home'
 
@@ -28,6 +28,7 @@ identifiers:
 
 references:
     anssi: BP28(R12)
+    cis@alinux2: 1.1.14
     cis@rhel7: 1.1.18
     cis@rhel8: 1.1.14
     cis@sle12: 1.1.18

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
 
 title: 'Add nodev Option to /tmp'
 
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: BP28(R12)
     cis-csc: 11,13,14,3,8,9
+    cis@alinux2: 1.1.3
     cis@rhel7: 1.1.4
     cis@rhel8: 1.1.3
     cis@sle12: 1.1.4

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Add noexec Option to /tmp'
 
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: BP28(R12)
     cis-csc: 11,13,14,3,8,9
+    cis@alinux2: 1.1.5
     cis@rhel7: 1.1.3
     cis@rhel8: 1.1.5
     cis@sle12: 1.1.3

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
 
 title: 'Add nosuid Option to /tmp'
 
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: BP28(R12)
     cis-csc: 11,13,14,3,8,9
+    cis@alinux2: 1.1.4
     cis@rhel7: 1.1.5
     cis@rhel8: 1.1.4
     cis@sle12: 1.1.5

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
 
 title: 'Add nodev Option to /var/tmp'
 
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     anssi: BP28(R12)
+    cis@alinux2: 1.1.8
     cis@rhel7: 1.1.13
     cis@rhel8: 1.1.8
     cis@sle12: 1.1.13

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
 
 title: 'Add noexec Option to /var/tmp'
 
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     anssi: BP28(R12)
+    cis@alinux2: 1.1.10
     cis@rhel7: 1.1.12
     cis@rhel8: 1.1.10
     cis@sle12: 1.1.12

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804
 
 title: 'Add nosuid Option to /var/tmp'
 
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     anssi: BP28(R12)
+    cis@alinux2: 1.1.9
     cis@rhel7: 1.1.14
     cis@rhel8: 1.1.9
     cis@sle12: 1.1.14

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_backtraces/rule.yml
@@ -29,6 +29,7 @@ identifiers:
     cce@rhel9: CCE-83984-5
 
 references:
+    cis@alinux2: 1.5.1
     cis@rhel7: 1.5.1
     cis@rhel8: 1.6.1
     cis@sle12: 1.5.1

--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
@@ -25,6 +25,7 @@ identifiers:
     cce@rhel9: CCE-83979-5
 
 references:
+    cis@alinux2: 1.5.1
     cis@rhel7: 1.5.1
     cis@rhel8: 1.6.1
     cis@sle12: 1.5.1

--- a/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/disable_users_coredumps/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Disable Core Dumps for All Users'
 
@@ -25,6 +25,7 @@ identifiers:
 
 references:
     cis-csc: 1,12,13,15,16,2,7,8
+    cis@alinux2: 1.5.1
     cis@rhel7: 1.5.1
     cis@rhel8: 1.6.1
     cis@sle12: 1.5.1

--- a/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
@@ -21,6 +21,7 @@ identifiers:
 
 references:
     anssi: BP28(R23)
+    cis@alinux2: 1.5.1
     cis@rhel7: 1.5.1
     cis@rhel8: 1.6.1
     cis@sle12: 1.5.1

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
@@ -23,6 +23,7 @@ identifiers:
 
 references:
     anssi: BP28(R23)
+    cis@alinux2: 1.5.2
     cis@rhel7: 1.5.3
     cis@rhel8: 1.6.2
     cis@sle12: 1.5.3

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure SELinux Not Disabled in /etc/default/grub'
 
@@ -26,6 +26,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,3,4,5,6,8,9
+    cis@alinux2: 1.6.1.1
     cis@rhel7: 1.6.1.2
     cis@rhel8: 1.7.1.2
     cobit5: APO01.06,APO11.04,APO13.01,BAI03.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.03,DSS06.06,MEA02.01

--- a/linux_os/guide/system/selinux/package_libselinux_installed/rule.yml
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Install libselinux Package'
 
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel9: CCE-84069-4
 
 references:
+    cis@alinux2: 1.6.2
     cis@rhel7: 1.6.1.1
     cis@rhel8: 1.7.1.1
 

--- a/linux_os/guide/system/selinux/package_mcstrans_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_mcstrans_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,fedora,rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall mcstrans Package'
 
@@ -22,6 +22,7 @@ identifiers:
     cce@rhel9: CCE-84072-8
 
 references:
+    cis@alinux2: 1.6.1.5
     cis@rhel7: 1.6.1.8
     cis@rhel8: 1.7.1.7
 

--- a/linux_os/guide/system/selinux/package_setroubleshoot_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_setroubleshoot_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15
 
 title: 'Uninstall setroubleshoot Package'
 
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     anssi: BP28(R68)
+    cis@alinux2: 1.6.1.4
     cis@rhel7: 1.6.1.7
     cis@rhel8: 1.7.1.6
 

--- a/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_confinement_of_daemons/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
 
 title: 'Ensure No Daemons are Unconfined by SELinux'
 
@@ -29,6 +29,7 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,18,3,5,6,9
+    cis@alinux2: 1.6.1.6
     cis@rhel7: 1.6.1.6
     cis@rhel8: 1.7.1.5
     cobit5: APO01.06,APO11.04,BAI03.05,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.06,MEA02.01

--- a/linux_os/guide/system/selinux/selinux_policytype/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_policytype/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,wrlinux1019
 
 title: 'Configure SELinux Policy'
 
@@ -37,6 +37,7 @@ identifiers:
 references:
     anssi: BP28(R66)
     cis-csc: 1,11,12,13,14,15,16,18,3,4,5,6,8,9
+    cis@alinux2: 1.6.1.3
     cis@rhel7: 1.6.1.3
     cis@rhel8: 1.7.1.3
     cobit5: APO01.06,APO11.04,APO13.01,BAI03.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.03,DSS06.06,MEA02.01

--- a/linux_os/guide/system/selinux/selinux_state/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_state/rule.yml
@@ -29,6 +29,7 @@ identifiers:
 references:
     anssi: BP28(R4),BP28(R66)
     cis-csc: 1,11,12,13,14,15,16,18,3,4,5,6,8,9
+    cis@alinux2: 1.6.1.2
     cis@rhel7: 1.6.1.4,1.6.1.5
     cis@rhel8: 1.7.1.4
     cobit5: APO01.06,APO11.04,APO13.01,BAI03.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.03,DSS06.06,MEA02.01

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     anssi: BP28(R12)
     cis-csc: 12,15,8
+    cis@alinux2: 1.1.13
     cis@rhel7: 1.1.17
     cis@rhel8: 1.1.13
     cis@sle12: 1.1.17

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 references:
     anssi: BP28(R12)
     cis-csc: 12,15,8
+    cis@alinux2: 1.1.2
     cis@rhel7: 1.1.2
     cis@rhel8: 1.1.2
     cis@sle12: 1.1.2

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/rule.yml
@@ -26,6 +26,7 @@ identifiers:
 references:
     anssi: BP28(R12)
     cis-csc: 12,15,8
+    cis@alinux2: 1.1.6
     cis@rhel7: 1.1.10
     cis@rhel8: 1.1.6
     cis@sle12: 1.1.10

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/rule.yml
@@ -22,6 +22,7 @@ identifiers:
 references:
     anssi: BP28(R12),BP28(R47)
     cis-csc: 1,12,14,15,16,3,5,6,8
+    cis@alinux2: 1.1.11
     cis@rhel7: 1.1.15
     cis@rhel8: 1.1.11
     cis@sle12: 1.1.15

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     anssi: BP28(R43)
     cis-csc: 1,12,13,14,15,16,2,3,5,6,8
+    cis@alinux2: 1.1.12
     cis@rhel7: 1.1.16
     cis@rhel8: 1.1.12
     cis@sle12: 1.1.16

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804,ubuntu2004
+prodtype: alinux2,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15,ubuntu1804,ubuntu2004
 
 title: 'Ensure /var/tmp Located On Separate Partition'
 
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     anssi: BP28(R12)
+    cis@alinux2: 1.1.7
     cis@rhel7: 1.1.11
     cis@rhel8: 1.1.7
     cis@sle12: 1.1.11

--- a/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhcos4,rhel7,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,ol7,rhcos4,rhel7,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Disable Prelinking'
 
@@ -24,6 +24,7 @@ identifiers:
 
 references:
     cis-csc: 11,13,14,2,3,9
+    cis@alinux2: 1.5.3
     cis@rhel7: 1.5.4
     cis@sle12: 1.5.4
     cis@sle15: 1.6.4

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -53,6 +53,7 @@ identifiers:
 references:
     anssi: BP28(R51)
     cis-csc: 1,11,12,13,14,15,16,2,3,5,7,8,9
+    cis@alinux2: 1.3.1
     cis@rhel7: 1.3.1
     cis@sle12: 1.3.1
     cis@sle15: 1.4.1

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Configure Periodic Execution of AIDE'
 
@@ -40,6 +40,7 @@ identifiers:
 references:
     anssi: BP28(R51)
     cis-csc: 1,11,12,13,14,15,16,2,3,5,7,8,9
+    cis@alinux2: 1.3.2
     cis@rhel7: 1.3.2
     cis@rhel8: 1.4.2
     cis@sle12: 1.3.2

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
+prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,wrlinux1019
 
 title: 'Install AIDE'
 
@@ -21,6 +21,7 @@ identifiers:
 references:
     anssi: BP28(R51)
     cis-csc: 1,11,12,13,14,15,16,2,3,5,7,8,9
+    cis@alinux2: 1.3.1
     cis@rhel7: 1.3.1
     cis@rhel8: 1.4.1
     cis@sle12: 1.3.1

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/rule.yml
@@ -40,6 +40,7 @@ identifiers:
 references:
     anssi: BP28(R15)
     cis-csc: 11,2,3,9
+    cis@alinux2: 1.2.3
     cis@rhel7: 1.2.3
     cis@rhel8: 1.2.4
     cis@sle12: 1.2.3

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -28,6 +28,7 @@ identifiers:
 references:
     anssi: BP28(R15)
     cis-csc: 11,2,3,9
+    cis@alinux2: 1.2.3
     cis@rhel7: 1.2.3
     cis@sle12: 1.2.3
     cis@sle15: 1.2.3

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu1604,ubuntu1804
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu1604,ubuntu1804
 
 title: 'Ensure Software Patches Installed'
 
@@ -48,6 +48,7 @@ identifiers:
 references:
     anssi: BP28(R08)
     cis-csc: 18,20,4
+    cis@alinux2: "1.8"
     cis@rhel7: "1.8"
     cis@rhel8: "1.9"
     cjis: 5.10.4.1

--- a/products/alinux2/profiles/cis.profile
+++ b/products/alinux2/profiles/cis.profile
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+metadata:
+    version: 1.0.0
+    SMEs:
+        - hustliyilin
+        - rain-Qing
+
+reference: https://www.cisecurity.org/benchmark/aliyun_linux
+
+
+title: 'CIS Aliyun Linux 2 Benchmark for Level 2'
+
+description: |-
+    This profile defines a baseline that aligns to the "Level 2"
+    configuration from the Center for Internet Security® Aliyun
+    Linux 2 Benchmark™, v1.0.0, released 08-16-2019.
+
+    This profile includes Center for Internet Security®
+    Aliyun Linux 2 CIS Benchmarks™ content.
+
+selections:
+    - cis_alinux2:all:l2

--- a/products/alinux2/profiles/cis_l1.profile
+++ b/products/alinux2/profiles/cis_l1.profile
@@ -1,0 +1,23 @@
+documentation_complete: true
+
+metadata:
+    version: 1.0.0
+    SMEs:
+        - hustliyilin
+        - rain-Qing
+
+reference: https://www.cisecurity.org/benchmark/aliyun_linux
+
+
+title: 'CIS Aliyun Linux 2 Benchmark for Level 1'
+
+description: |-
+    This profile defines a baseline that aligns to the "Level 1"
+    configuration from the Center for Internet Security® Aliyun
+    Linux 2 Benchmark™, v1.0.0, released 08-16-2019.
+
+    This profile includes Center for Internet Security®
+    Aliyun Linux 2 CIS Benchmarks™ content.
+
+selections:
+    - cis_alinux2:all:l1


### PR DESCRIPTION
#### Description:

- CIS Aliyun Linux 2 Benchmark v1.0.0
(https://workbench.cisecurity.org/benchmarks/2228) was published
on Aug 16th 2019. Aliyun Linux 2 is compatible with CentOS 7 and it's
further renamed as Alibaba Cloud Linux 2.


#### Rationale:

- I add the CIS Alibaba Cloud Linux (Aliyun Linux) 2 controls in the OpenSCAP
according to CIS Aliyun Linux 2 Benchmark v1.0.0
(https://workbench.cisecurity.org/benchmarks/2228)

- Fixes: #8895 

