### PR TITLE
Enable all `rhel8` profiles in `centos8` product

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -97,8 +97,8 @@ def main():
         raise RuntimeError("No Benchmark found!")
 
     for namespace, benchmark in benchmarks:
-        if args[1] != "cs9":
-            # In CentOS Stream 9 profiles are kept because it is a system
+        if args[1] != "cs9" and args[1] != "centos8":
+            # In CentOS Stream 8 and 9, profiles are kept because they are systems
             # intended to test content that will get into RHEL
             ssg.build_derivatives.profile_handling(benchmark, namespace)
         if not ssg.build_derivatives.add_cpes(benchmark, namespace, mapping):


### PR DESCRIPTION
#### Description:
Do not select only `standard` and `pci-dss` profiles in `centos8` product - select everything from its base profile (`rhel8`).

#### Rationale:
As `centos8` content is shipped in CentOS Stream 8 where `rhel8` testing is done, the `centos8` must be same as `rhel8`.