### PR TITLE
Add ensure_gpgcheck_never_disabled to STIG in OL8 and RHEL8

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Ensure gpgcheck Enabled for All {{{ pkg_manager }}} Package Repositories'
 
@@ -44,6 +44,8 @@ references:
     ospp: FPT_TUD_EXT.1,FPT_TUD_EXT.2
     pcidss: Req-6.2
     srg: SRG-OS-000366-GPOS-00153
+    stigid@ol8: OL08-00-010370
+    stigid@rhel8: RHEL-08-010370
     vmmsrg: SRG-OS-000366-VMM-001430,SRG-OS-000370-VMM-001460,SRG-OS-000404-VMM-001650
 
 ocil_clause: 'GPG checking is disabled'

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -230,6 +230,7 @@ selections:
 
     # OL08-00-010370
     - ensure_gpgcheck_globally_activated
+    - ensure_gpgcheck_never_disabled
 
     # OL08-00-010371
     - ensure_gpgcheck_local_packages

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -251,6 +251,7 @@ selections:
 
     # RHEL-08-010370
     - ensure_gpgcheck_globally_activated
+    - ensure_gpgcheck_never_disabled
 
     # RHEL-08-010371
     - ensure_gpgcheck_local_packages

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -202,6 +202,7 @@ selections:
 - enable_fips_mode
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated
+- ensure_gpgcheck_never_disabled
 - ensure_gpgcheck_local_packages
 - file_audit_tools_group_ownership
 - file_audit_tools_ownership

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -213,6 +213,7 @@ selections:
 - enable_fips_mode
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated
+- ensure_gpgcheck_never_disabled
 - ensure_gpgcheck_local_packages
 - file_audit_tools_group_ownership
 - file_audit_tools_ownership


### PR DESCRIPTION
#### Description:

- Add rule ensure_gpgcheck_never_disabled to STIG profiles in OL8 and RHEL8

#### Rationale:

- This complements coverage of STIG requirements in OL8 and RHEL8 for `OL08-00-010370` & `RHEL-08-010370`
