### PR TITLE
Create mount_option_home template and use it in ol8

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -39,7 +39,7 @@ fixtext: '{{{ fixtext_mount_option("/home", "noexec") }}}'
 
 srg_requirement: '{{{ srg_requirement_mount_option("/home", "noexec") }}}'
 
-{{% if product != "ol8" %}}
+{{% if "ol" not in product %}}
 template:
     name: mount_option
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -47,6 +47,17 @@ template:
         mountoption: noexec
         mount_has_to_exist: 'yes'
 {{% else %}}
+warnings:
+    - functionality: |-
+        OVAL looks for partitions whose mount point is a substring of any interactive user's home
+        directory and validates that noexec option is there. Because of this, there could be false
+        negatives when several partitions share a base substring. For example, if there is a home
+        directory in <tt>/var/tmp/user1</tt> and there are partitions mounted in <tt>/var</tt> and
+        <tt>/var/tmp</tt>. The noexec option is only expected in <tt>/var/tmp</tt>, but OVAL will
+        check both.<br/>
+        Bash remediation uses the <tt>df</tt> command to find out the partition where the home
+        directory is mounted. However, if the directory doesn't exist the remediation won't be
+        applied.
 template:
     name: mount_option_home
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -39,9 +39,16 @@ fixtext: '{{{ fixtext_mount_option("/home", "noexec") }}}'
 
 srg_requirement: '{{{ srg_requirement_mount_option("/home", "noexec") }}}'
 
+{{% if product != "ol8" %}}
 template:
     name: mount_option
     vars:
         mountpoint: /home
         mountoption: noexec
         mount_has_to_exist: 'yes'
+{{% else %}}
+template:
+    name: mount_option_home
+    vars:
+        mountoption: noexec
+{{% endif %}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -53,10 +53,17 @@ fixtext: |-
 
 srg_requirement: '{{{ srg_requirement_mount_option("/home", "nosuid") }}}'
 
+{{% if product != "ol8" %}}
 template:
     name: mount_option
     vars:
         mountpoint: /home
         mountoption: nosuid
         mount_has_to_exist: 'yes'
+{{% else %}}
+template:
+    name: mount_option_home
+    vars:
+        mountoption: nosuid
+{{% endif %}}
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -61,6 +61,17 @@ template:
         mountoption: nosuid
         mount_has_to_exist: 'yes'
 {{% else %}}
+warnings:
+    - functionality: |-
+        OVAL looks for partitions whose mount point is a substring of any interactive user's home
+        directory and validates that noexec option is there. Because of this, there could be false
+        negatives when several partitions share a base substring. For example, if there is a home
+        directory in <tt>/var/tmp/user1</tt> and there are partitions mounted in <tt>/var</tt> and
+        <tt>/var/tmp</tt>. The noexec option is only expected in <tt>/var/tmp</tt>, but OVAL will
+        check both.<br/>
+        Bash remediation uses the <tt>df</tt> command to find out the partition where the home
+        directory is mounted. However, if the directory doesn't exist the remediation won't be
+        applied.
 template:
     name: mount_option_home
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -53,7 +53,7 @@ fixtext: |-
 
 srg_requirement: '{{{ srg_requirement_mount_option("/home", "nosuid") }}}'
 
-{{% if product != "ol8" %}}
+{{% if "ol" not in product %}}
 template:
     name: mount_option
     vars:

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/fstab.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/fstab.fail.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+{{% if "ol" in product %}}
+# platform = multi_platform_example
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/runtime.pass.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+{{% if "ol" in product %}}
+# platform = multi_platform_example
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 . $SHARED/partition.sh
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/separate.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/tests/separate.fail.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+{{% if "ol" in product %}}
+# platform = multi_platform_example
+{{% else %}}
+# platform = multi_platform_all
+{{% endif %}}
 
 . $SHARED/partition.sh
 

--- a/shared/templates/mount_option_home/bash.template
+++ b/shared/templates/mount_option_home/bash.template
@@ -1,7 +1,8 @@
 # platform = multi_platform_all
 # reboot = false
 
-{{% set non_allowed_partitions = ["/lib",
+{{% set non_allowed_partitions = ["/",
+                                  "/lib",
                                   "/opt",
                                   "/usr",
                                   "/bin",
@@ -12,19 +13,22 @@
 
 function perform_remediation (){
 
-    {{{ bash_ensure_mount_option_in_fstab( "$1" , MOUNTOPTION , FILESYSTEM , TYPE ) | indent(4) }}}
+    {{{ bash_ensure_mount_option_in_fstab( "$1", MOUNTOPTION, FILESYSTEM, TYPE ) | indent(4) }}}
 
     {{{ bash_ensure_partition_is_mounted( "$1" ) | indent(4) }}}
 }
 
-readarray -t all_fstab_partitions  < \
-    <(awk -F':' '{if ($3>=1000 && $3!= 65534) print $6}' /etc/passwd \
-        | xargs df \
-        | awk '/^\/dev/ {print $6}')
+readarray -t home_directories  < \
+    <(awk -F':' '{if ($3>=1000 && $3!= 65534) print $6}' /etc/passwd )
 
-for fstab_partition in "${all_fstab_partitions[@]}"
+
+for home_directory in "${home_directories[@]}"
 do
-    if  ! grep -qP "^{{{ non_allowed_partitions | join("$|^") }}}$" <<< $fstab_partition ; then
-        perform_remediation "$fstab_partition"
+    if [ -d $home_directory ]; then
+        fstab_mount_point=$(df $home_directory | awk '/^\/dev/ {print $6}')
+        if  ! grep -qP "^{{{ non_allowed_partitions | join("$|^") }}}$" <<< $fstab_mount_point
+        then
+            perform_remediation "$fstab_mount_point"
+        fi
     fi
 done

--- a/shared/templates/mount_option_home/bash.template
+++ b/shared/templates/mount_option_home/bash.template
@@ -1,0 +1,18 @@
+# platform = multi_platform_all
+# reboot = false
+
+function perform_remediation (){
+
+    {{{ bash_ensure_mount_option_in_fstab( "$1" , MOUNTOPTION , FILESYSTEM , TYPE ) | indent(4) }}}
+
+    {{{ bash_ensure_partition_is_mounted( "$1" ) | indent(4) }}}
+}
+
+readarray -t all_fstab_partitions  < <(grep -Pv '^\s*#' /etc/fstab | grep -Po '^\S+\s+\S+'| grep -Po '\S+$' | grep -v '^/$')
+
+for fstab_partition in "${all_fstab_partitions[@]}"
+do
+    if [ "$(sudo awk -F':' '{if ($3>=1000 && $3!= 65534) print $6}' /etc/passwd | grep -c $fstab_partition)" -ne 0 ]; then
+        perform_remediation "$fstab_partition"
+    fi
+done

--- a/shared/templates/mount_option_home/bash.template
+++ b/shared/templates/mount_option_home/bash.template
@@ -1,6 +1,15 @@
 # platform = multi_platform_all
 # reboot = false
 
+{{% set non_allowed_partitions = ["/lib",
+                                  "/opt",
+                                  "/usr",
+                                  "/bin",
+                                  "/sbin",
+                                  "/boot",
+                                  "/dev",
+                                  "/proc"] %}}
+
 function perform_remediation (){
 
     {{{ bash_ensure_mount_option_in_fstab( "$1" , MOUNTOPTION , FILESYSTEM , TYPE ) | indent(4) }}}
@@ -8,11 +17,14 @@ function perform_remediation (){
     {{{ bash_ensure_partition_is_mounted( "$1" ) | indent(4) }}}
 }
 
-readarray -t all_fstab_partitions  < <(grep -Pv '^\s*#' /etc/fstab | grep -Po '^\S+\s+\S+'| grep -Po '\S+$' | grep -v '^/$')
+readarray -t all_fstab_partitions  < \
+    <(awk -F':' '{if ($3>=1000 && $3!= 65534) print $6}' /etc/passwd \
+        | xargs df \
+        | awk '/^\/dev/ {print $6}')
 
 for fstab_partition in "${all_fstab_partitions[@]}"
 do
-    if [ "$(sudo awk -F':' '{if ($3>=1000 && $3!= 65534) print $6}' /etc/passwd | grep -c $fstab_partition)" -ne 0 ]; then
+    if  ! grep -qP "^{{{ non_allowed_partitions | join("$|^") }}}$" <<< $fstab_partition ; then
         perform_remediation "$fstab_partition"
     fi
 done

--- a/shared/templates/mount_option_home/oval.template
+++ b/shared/templates/mount_option_home/oval.template
@@ -1,0 +1,49 @@
+<def-group>
+    <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+        {{{ oval_metadata("Home mount points should be mounted with mount option " + MOUNTOPTION + ".") }}}
+        <criteria>
+            <criterion comment="{{{ MOUNTOPTION }}} on Home mount points"
+            test_ref="test_home_partition_{{{ MOUNTOPTION }}}" />
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_object id="object_home_partitions_mount_points_{{{ MOUNTOPTION }}}" version="1">
+        <ind:filepath>/etc/passwd</ind:filepath>
+        <ind:pattern operation="pattern match" var_ref="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}_regex"
+        var_check="at least one"/>
+        <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <linux:partition_object id="object_home_partition_all_partitions_{{{ MOUNTOPTION }}}" version="1">
+        <linux:mount_point operation="not equal">/</linux:mount_point>
+    </linux:partition_object>
+
+    <local_variable id="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}_regex" datatype="string" version="1"
+    comment="Variable including all home dirs from interactive users">
+        <concat>
+            <literal_component>^(?:(?!nobody).*)?:.*?:[1-9]\d{3,}:.*?:.*?:(</literal_component>
+            <object_component item_field="mount_point"
+            object_ref="object_home_partition_all_partitions_{{{ MOUNTOPTION }}}" />
+            <literal_component>).*?:.*</literal_component>
+        </concat>
+    </local_variable>
+
+    <local_variable id="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}" datatype="string" version="1"
+    comment="This variable collects all partition mount points for interactive users">
+        <object_component item_field="subexpression"
+        object_ref="object_home_partitions_mount_points_{{{ MOUNTOPTION }}}" />
+    </local_variable>
+
+    <linux:partition_test check="all" check_existence="all_exist"
+    id="test_home_partition_{{{ MOUNTOPTION }}}" version="1" comment="{{{ MOUNTOPTION }}} on Home mount points">
+        <linux:object object_ref="object_home_partitions_{{{ MOUNTOPTION }}}" />
+        <linux:state state_ref="state_home_partition_{{{ MOUNTOPTION }}}" />
+    </linux:partition_test>
+    <linux:partition_object id="object_home_partitions_{{{ MOUNTOPTION }}}" version="1">
+        <linux:mount_point operation="equals" var_ref="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}"
+        var_check="at least one"/>
+    </linux:partition_object>
+    <linux:partition_state id="state_home_partition_{{{ MOUNTOPTION }}}" version="1">
+        <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
+    </linux:partition_state>
+</def-group>

--- a/shared/templates/mount_option_home/oval.template
+++ b/shared/templates/mount_option_home/oval.template
@@ -1,75 +1,56 @@
-{{% set non_allowed_partitions = ["/lib",
-                                  "/opt",
-                                  "/usr",
-                                  "/bin",
-                                  "/sbin",
-                                  "/boot",
-                                  "/dev",
-                                  "/proc"] %}}
 <def-group>
-    <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
-        {{{ oval_metadata("Home mount points should be mounted with mount option " + MOUNTOPTION + ".") }}}
-        <criteria>
-            <criterion comment="{{{ MOUNTOPTION }}} on Home mount points"
-            test_ref="test_home_partition_{{{ MOUNTOPTION }}}" />
-            <criterion comment="Home directory is not in a unexpected partition"
-            test_ref="test_home_allowed_partition_{{{ MOUNTOPTION }}}" />
-        </criteria>
-    </definition>
+  <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
+    {{{ oval_metadata("Home mount points should be mounted with mount option " +
+    MOUNTOPTION + ".") }}}
+    <criteria operator="AND"
+    comment="All mount points which contain home directories are in expected location and {{{
+    MOUNTOPTION }}} is set">
+      <criterion comment="{{{ MOUNTOPTION }}} on Home mount points"
+      test_ref="test_home_partition_{{{ MOUNTOPTION }}}" />
+    </criteria>
+  </definition>
 
-    <ind:textfilecontent54_object id="object_home_partitions_mount_points_{{{ MOUNTOPTION }}}" version="1">
-        <ind:filepath>/etc/passwd</ind:filepath>
-        <ind:pattern operation="pattern match" var_ref="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}_regex"
-        var_check="at least one"/>
-        <ind:instance datatype="int">1</ind:instance>
-    </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="object_home_partitions_mount_points_{{{ MOUNTOPTION }}}"
+  version="1">
+    <ind:filepath>/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match" var_check="at least one"
+    var_ref="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}_regex"/>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
 
-    <linux:partition_object id="object_home_partition_all_partitions_{{{ MOUNTOPTION }}}" version="1">
-        <linux:mount_point operation="not equal">/</linux:mount_point>
-    </linux:partition_object>
+  <linux:partition_object id="object_home_partition_all_partitions_{{{ MOUNTOPTION }}}"
+  version="1">
+    <linux:mount_point operation="not equal">/</linux:mount_point>
+  </linux:partition_object>
 
-    <local_variable id="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}_regex" datatype="string" version="1"
-    comment="Variable including all home dirs from interactive users">
-        <concat>
-            <literal_component>^(?:(?!nobody).*)?:.*?:[1-9]\d{3,}:.*?:.*?:(</literal_component>
-            <object_component item_field="mount_point"
-            object_ref="object_home_partition_all_partitions_{{{ MOUNTOPTION }}}" />
-            <literal_component>).*?:.*</literal_component>
-        </concat>
-    </local_variable>
+  <local_variable id="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}_regex"
+  datatype="string" version="1"
+  comment="Variable including all home dirs from interactive users">
+    <concat>
+      <literal_component>^(?:(?!nobody).*)?:.*?:[1-9]\d{3,}:.*?:.*?:(</literal_component>
+      <object_component item_field="mount_point"
+      object_ref="object_home_partition_all_partitions_{{{ MOUNTOPTION }}}" />
+      <literal_component>).*?:.*</literal_component>
+    </concat>
+  </local_variable>
 
-    <local_variable id="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}" datatype="string" version="1"
-    comment="This variable collects all partition mount points for interactive users">
-        <object_component item_field="subexpression"
-        object_ref="object_home_partitions_mount_points_{{{ MOUNTOPTION }}}" />
-    </local_variable>
+  <local_variable id="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}" datatype="string"
+  version="1" comment="This variable collects all partition mount points for interactive users">
+    <object_component item_field="subexpression"
+    object_ref="object_home_partitions_mount_points_{{{ MOUNTOPTION }}}" />
+  </local_variable>
 
-    <linux:partition_test check="all" check_existence="all_exist"
-    id="test_home_partition_{{{ MOUNTOPTION }}}" version="1" comment="{{{ MOUNTOPTION }}} on Home mount points">
-        <linux:object object_ref="object_home_partitions_{{{ MOUNTOPTION }}}" />
-        <linux:state state_ref="state_home_partition_{{{ MOUNTOPTION }}}" />
-    </linux:partition_test>
-    <linux:partition_object id="object_home_partitions_{{{ MOUNTOPTION }}}" version="1">
-        <linux:mount_point operation="equals" var_ref="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}"
-        var_check="at least one"/>
-    </linux:partition_object>
-    <linux:partition_state id="state_home_partition_{{{ MOUNTOPTION }}}" version="1">
-        <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
-    </linux:partition_state>
-
-    <ind:variable_test check="none satisfy" check_existence="all_exist"
-    comment="Home mount points aren't in unexpected partition"
-    id="test_home_allowed_partition_{{{ MOUNTOPTION }}}" version="1">
-      <ind:object object_ref="object_home_allowed_partition_{{{ MOUNTOPTION }}}" />
-      <ind:state state_ref="state_home_allowed_partition_{{{ MOUNTOPTION }}}" />
-    </ind:variable_test>
-    <ind:variable_object id="object_home_allowed_partition_{{{ MOUNTOPTION }}}" version="1">
-      <ind:var_ref>var_home_partitions_mount_points_{{{ MOUNTOPTION }}}</ind:var_ref>
-    </ind:variable_object>
-    <ind:variable_state comment="unexpected partition"
-    id="state_home_allowed_partition_{{{ MOUNTOPTION }}}" version="1">
-      <ind:value entity_check="at least one" operation="pattern match"
-      datatype="string">^{{{ non_allowed_partitions | join("$|^") }}}$</ind:value>
-    </ind:variable_state>
-
+  <linux:partition_test check="all" check_existence="any_exist" version="1"
+  id="test_home_partition_{{{ MOUNTOPTION }}}" comment="{{{ MOUNTOPTION }}} on Home mount points">
+    <linux:object object_ref="object_home_partitions_{{{ MOUNTOPTION }}}" />
+    <linux:state state_ref="state_home_partition_{{{ MOUNTOPTION }}}" />
+  </linux:partition_test>
+  <linux:partition_object id="object_home_partitions_{{{ MOUNTOPTION }}}" version="1">
+    <linux:mount_point operation="equals" var_check="at least one"
+    var_ref="var_home_partitions_mount_points_{{{ MOUNTOPTION }}}" />
+  </linux:partition_object>
+  <linux:partition_state id="state_home_partition_{{{ MOUNTOPTION }}}" version="1">
+    <linux:mount_options entity_check="at least one"
+    datatype="string" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
+  </linux:partition_state>
 </def-group>

--- a/shared/templates/mount_option_home/oval.template
+++ b/shared/templates/mount_option_home/oval.template
@@ -1,9 +1,19 @@
+{{% set non_allowed_partitions = ["/lib",
+                                  "/opt",
+                                  "/usr",
+                                  "/bin",
+                                  "/sbin",
+                                  "/boot",
+                                  "/dev",
+                                  "/proc"] %}}
 <def-group>
     <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
         {{{ oval_metadata("Home mount points should be mounted with mount option " + MOUNTOPTION + ".") }}}
         <criteria>
             <criterion comment="{{{ MOUNTOPTION }}} on Home mount points"
             test_ref="test_home_partition_{{{ MOUNTOPTION }}}" />
+            <criterion comment="Home directory is not in a unexpected partition"
+            test_ref="test_home_allowed_partition_{{{ MOUNTOPTION }}}" />
         </criteria>
     </definition>
 
@@ -46,4 +56,20 @@
     <linux:partition_state id="state_home_partition_{{{ MOUNTOPTION }}}" version="1">
         <linux:mount_options datatype="string" entity_check="at least one" operation="equals">{{{ MOUNTOPTION }}}</linux:mount_options>
     </linux:partition_state>
+
+    <ind:variable_test check="none satisfy" check_existence="all_exist"
+    comment="Home mount points aren't in unexpected partition"
+    id="test_home_allowed_partition_{{{ MOUNTOPTION }}}" version="1">
+      <ind:object object_ref="object_home_allowed_partition_{{{ MOUNTOPTION }}}" />
+      <ind:state state_ref="state_home_allowed_partition_{{{ MOUNTOPTION }}}" />
+    </ind:variable_test>
+    <ind:variable_object id="object_home_allowed_partition_{{{ MOUNTOPTION }}}" version="1">
+      <ind:var_ref>var_home_partitions_mount_points_{{{ MOUNTOPTION }}}</ind:var_ref>
+    </ind:variable_object>
+    <ind:variable_state comment="unexpected partition"
+    id="state_home_allowed_partition_{{{ MOUNTOPTION }}}" version="1">
+      <ind:value entity_check="at least one" operation="pattern match"
+      datatype="string">^{{{ non_allowed_partitions | join("$|^") }}}$</ind:value>
+    </ind:variable_state>
+
 </def-group>

--- a/shared/templates/mount_option_home/template.yml
+++ b/shared/templates/mount_option_home/template.yml
@@ -1,0 +1,3 @@
+supported_languages:
+  - bash
+  - oval

--- a/shared/templates/mount_option_home/tests/fstab_template.fail.sh
+++ b/shared/templates/mount_option_home/tests/fstab_template.fail.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+. $SHARED/partition.sh
+
+mkdir -p /srv/home
+awk -F':' '{if ($3>=1000 && $3!= 65534) print $1}' /etc/passwd \
+        | xargs -I{} userdel -r {}
+
+umount /srv || true  # no problem if not mounted
+
+clean_up_partition /srv
+
+create_partition
+
+{{% if MOUNTOPTION != "nodev" %}}
+make_fstab_given_partition_line /srv ext2 nodev
+{{% else %}}
+make_fstab_given_partition_line /srv ext2 noexec
+{{% endif %}}
+
+mount_partition /srv
+
+mkdir -p /srv/home
+useradd -m -d /srv/home/testUser1 testUser1

--- a/shared/templates/mount_option_home/tests/runtime_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/runtime_template.pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+. $SHARED/partition.sh
+
+mkdir -p /srv/home
+awk -F':' '{if ($3>=1000 && $3!= 65534) print $1}' /etc/passwd \
+        | xargs -I{} userdel -r {}
+
+umount /srv || true  # no problem if not mounted
+
+clean_up_partition /srv
+
+create_partition
+
+make_fstab_correct_partition_line /srv
+
+mount_partition /srv
+
+mkdir -p /srv/home
+useradd -m -d /srv/home/testUser1 testUser1

--- a/shared/templates/mount_option_home/tests/separate_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/separate_template.pass.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+. $SHARED/partition.sh
+
+awk -F':' '{if ($3>=1000 && $3!= 65534) print $1}' /etc/passwd \
+        | xargs -I{} userdel -r {}
+
+umount /srv || true  # no problem if not mounted
+
+clean_up_partition /srv
+
+create_partition
+
+{{% if MOUNTOPTION != "nodev" %}}
+make_fstab_given_partition_line /srv ext2 nodev
+{{% else %}}
+make_fstab_given_partition_line /srv ext2 noexec
+{{% endif %}}
+
+mount_partition /srv
+
+mkdir -p /srv/home
+useradd -m -d /srv/home/testUser1 testUser1
+
+umount_partition /srv
+
+# $SHARED/fstab is wrong, but is not mounted.


### PR DESCRIPTION
#### Description:

- Create `mount_option_home` template, this searches in which partitions are located the interactive users and checks that all those partitions have the expected mount option
- Migrate rules `mount_option_home_noexec` and `mount_option_home_nosuid` to a new template for OL8

#### Rationale:

- Covers better the expected behavior of checking the partitions where are the home directories, to have the expected mount options
