### PR TITLE
Set OL8 stig_gui profile metadata and update rule rationale

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_rng/rule.yml
@@ -13,10 +13,11 @@ description: |-
     <pre>SSH_USE_STRONG_RNG=32</pre>
 
 rationale: |-
-    SSH implementation in RHEL8 uses the openssl library, which doesn't use high-entropy sources by default.
-    Randomness is needed to generate data-encryption keys, and as plaintext padding and initialization vectors
-    in encryption algorithms, and high-quality entropy elliminates the possibility that the output of
-    the random number generator used by SSH would be known to potential attackers.
+    SSH implementation in {{{ full_name }}} uses the openssl library, which doesn't use
+    high-entropy sources by default. Randomness is needed to generate data-encryption keys, and as
+    plaintext padding and initialization vectors in encryption algorithms, and high-quality
+    entropy elliminates the possibility that the output of the random number generator used by SSH
+    would be known to potential attackers.
 
 severity: low
 

--- a/products/ol8/profiles/stig_gui.profile
+++ b/products/ol8/profiles/stig_gui.profile
@@ -1,10 +1,13 @@
 documentation_complete: true
 
+metadata:
+    version: V1R2
+
 title: 'DISA STIG with GUI for Oracle Linux 8'
 
 description: |-
     This profile contains configuration checks that align to the
-    DISA STIG with GUI for Oracle Linux V1R1.
+    DISA STIG with GUI for Oracle Linux V1R2.
 
     Warning: The installation and use of a Graphical User Interface (GUI)
     increases your attack vector and decreases your overall security posture. If


### PR DESCRIPTION
#### Description:

- Set OL8 `stig_gui` profile metadata
- Update `sshd_use_strong_rng` rationale to show Oracle Linux 8, or any other product name when needed instead of having RHEL8 hardcoded

#### Rationale:

- This documents better OL8
