### PR TITLE
Let's not Jinja process Vi swp files

### DIFF
--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -180,6 +180,9 @@ class Builder(object):
                 continue
 
             for filename in filenames:
+                if filename.endswith(".swp"):
+                    continue
+
                 # Relative path to the file becomes our results key.
                 absolute_path = os.path.abspath(os.path.join(dirpath, filename))
                 relative_path = os.path.relpath(absolute_path, base_dir)


### PR DESCRIPTION
#### Description:

- When walking directories, do not try to macro expand a swp file

#### Rationale:

- Jinja has trouble processing a swp file:
`RuntimeError: Error reading file /home/wsato/git/content/shared/templates/kernel_module_disabled/tests/.correct_value_modules_load_d.pass.sh.swp: 'utf-8' codec can't decode byte 0xc0 in position 16: invalid start byte                                                                                                  `