### PR TITLE
Remove unnecessary rule test scenario for RHEL7 and STIG profile

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig_rhel7.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig_rhel7.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# packages = audit
-# profiles = xccdf_org.ssgproject.content_profile_stig
-# platform = Red Hat Enterprise Linux 7
-
-. $SHARED/auditd_utils.sh
-prepare_auditd_test_enviroment
-set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "rotate"


### PR DESCRIPTION
The `auditd_data_retention_max_log_file_action` was missing in the STIG profile for RHEL7, causing error with the test scenarios.

After investigating the current and older versions of STIG Benchmark for RHEL7, the requirement related to the `auditd_data_retention_max_log_file_action` rule was not found, like in RHEL6 and RHEL8.

It was also not possible to confirm which change started generating this error. Actually, it seems to be an old issue only detected now. The proper solution here is simply removing the test scenario for RHEL7 + STIG.