### PR TITLE
Update SRG-OS-000250-GPOS-00093 for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
+++ b/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
@@ -9,9 +9,4 @@ controls:
             - configure_openssl_crypto_policy
             - configure_openssl_tls_crypto_policy
             - configure_ssh_crypto_policy
-            - harden_ssh_client_crypto_policy
-            - harden_sshd_ciphers_openssh_conf_crypto_policy
-            - harden_sshd_ciphers_opensshserver_conf_crypto_policy
-            - harden_sshd_macs_openssh_conf_crypto_policy
-            - harden_sshd_macs_opensshserver_conf_crypto_policy
         status: automated

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -41,11 +41,21 @@ references:
 
 ocil_clause: |-
     the OpenSSL config file doesn't contain the whole section,
-    or that the section doesn't have the <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive
+    or the section doesn't contain the <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive
 
 ocil: |-
     To verify that OpenSSL uses the system crypto policy, check out that the OpenSSL config file
     <pre>{{{ openssl_cnf_path }}}</pre> contains the <pre>[ crypto_policy ]</pre> section with the
     <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive:
-    <pre>grep '\.include\s* /etc/crypto-policies/back-ends/opensslcnf.config$' {{{ openssl_cnf_path }}}</pre>.
 
+    <pre>$ sudo grep '\.include\s* /etc/crypto-policies/back-ends/opensslcnf.config$' {{{ openssl_cnf_path }}}</pre>.
+
+fixtext: |-
+    Configure OpenSSL to use the system cryptography policy.
+
+    Add or edit the "[ crypto_policy ]" section in "{{{ openssl_cnf_path }}}" to contain the following line:
+
+    .include /etc/crypto-policies/back-ends/opensslcnf.config
+
+srg_requirement: |-
+    {{{ full_name }}} must implement DoD-approved encryption in the OpenSSL package.

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/rule.yml
@@ -10,6 +10,12 @@ title: 'Configure OpenSSL library to use System Crypto Policy'
   {{%- set openssl_cnf_path="/etc/pki/tls/openssl.cnf" %}}
 {{%- endif %}}
 
+{{% if product in ["fedora", "rhel9"] %}}
+    {{% set include_directive = ".include = /etc/crypto-policies/back-ends/opensslcnf.config" %}}
+{{% else %}}
+    {{% set include_directive = ".include /etc/crypto-policies/back-ends/opensslcnf.config" %}}
+{{% endif %}}
+
 description: |-
     Crypto Policies provide a centralized control over crypto algorithms usage of many packages.
     OpenSSL is supported by crypto policy, but the OpenSSL configuration may be
@@ -17,7 +23,7 @@ description: |-
     To check that Crypto Policies settings are configured correctly, you have to examine the OpenSSL config file
     available under <tt>{{{ openssl_cnf_path }}}</tt>.
     This file has the <tt>ini</tt> format, and it enables crypto policy support
-    if there is a <tt>[ crypto_policy ]</tt> section that contains the <tt>.include /etc/crypto-policies/back-ends/opensslcnf.config</tt> directive.
+    if there is a <tt>[ crypto_policy ]</tt> section that contains the <tt>{{{ include_directive }}}</tt> directive.
 
 rationale: |-
     Overriding the system crypto policy makes the behavior of the Java runtime violates expectations,
@@ -41,12 +47,12 @@ references:
 
 ocil_clause: |-
     the OpenSSL config file doesn't contain the whole section,
-    or the section doesn't contain the <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive
+    or the section doesn't contain the <pre>{{{ include_directive }}}</pre> directive
 
 ocil: |-
     To verify that OpenSSL uses the system crypto policy, check out that the OpenSSL config file
     <pre>{{{ openssl_cnf_path }}}</pre> contains the <pre>[ crypto_policy ]</pre> section with the
-    <pre>.include /etc/crypto-policies/back-ends/opensslcnf.config</pre> directive:
+    <pre>{{{ include_directive }}}</pre> directive:
 
     <pre>$ sudo grep '\.include\s* /etc/crypto-policies/back-ends/opensslcnf.config$' {{{ openssl_cnf_path }}}</pre>.
 
@@ -55,7 +61,7 @@ fixtext: |-
 
     Add or edit the "[ crypto_policy ]" section in "{{{ openssl_cnf_path }}}" to contain the following line:
 
-    .include /etc/crypto-policies/back-ends/opensslcnf.config
+    {{{ include_directive }}}
 
 srg_requirement: |-
     {{{ full_name }}} must implement DoD-approved encryption in the OpenSSL package.

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/rule.yml
@@ -55,8 +55,18 @@ ocil: |-
     and verify that the value is
     <pre>TLSv1.2</pre>
 
+fixtext: |-
+    Configure {{{ full_name }}} to use the {{{ xccdf_value("var_system_crypto_policy") }}} crypto policy.
+
+    Run the following command:
+
+    <pre>$ sudo update-crypto-policies --set {{{ xccdf_value("var_system_crypto_policy") }}}</pre>
+
 warnings:
     - general: |-
         This rule doesn't come with a remediation, automatically changing the crypto-policies may be too disruptive.
         Ensure the variable <tt>xccdf_org.ssgproject.content_value_var_system_crypto_policy</tt> is set to a
         Crypto Policy that satisfies OpenSSL minimum TLS protocol version 1.2. Custom policies may be applied too.
+
+srg_requirement: |-
+    {{{ full_name }}} must implement DoD-approved TLS encryption in the OpenSSL package.

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/rule.yml
@@ -32,8 +32,23 @@ references:
     stigid@ol8: OL08-00-010287
     stigid@rhel8: RHEL-08-010287
 
-ocil_clause: 'the CRYPTO_POLICY variable is not set or is commented in the /etc/sysconfig/sshd'
+ocil_clause: 'the CRYPTO_POLICY variable is set or is not commented out in the /etc/sysconfig/sshd'
 
 ocil: |-
-    Check that the <tt>CRYPTO_POLICY</tt> variable is not set or is commented in the
+    Verify that sshd isn't configured to ignore the system wide cryptographic policy.
+
+    Check that the <tt>CRYPTO_POLICY</tt> variable is not set or is commented out in the
     <tt>/etc/sysconfig/sshd</tt>.
+
+    Run the following command:
+
+    $ sudo grep CRYPTO_POLICY /etc/sysconfig/sshd
+
+fixtext: |-
+    Configure OpenSSH to not ignore the system wide cryptographic policy.
+    Run the following command:
+
+    $ sudo sed -i "/^\s*CRYPTO_POLICY.*$/Id" /etc/sysconfig/sshd
+
+srg_requirement: |-
+    {{{ full_name }}} must implement DoD-approved encryption in the OpenSSH package.


### PR DESCRIPTION
#### Description:
Update OCIL, add fixtext and SRG requirement where missing.
Remove RHEL 8 Common Criteria rules overriding the system wide cryptographic policy.
#### Rationale:
RHEL 9 STIG
