### PR TITLE
Fix Ansible remediation for accounts_umask_etc_profile

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_postfix_root_mail_alias") }}}
 
-- name: Make sure that that "/etc/aliases" has a defined value for root
+- name: Make sure that "/etc/aliases" has a defined value for root
   lineinfile:
     path: "/etc/aliases"
     line: "root: {{ var_postfix_root_mail_alias }}"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
@@ -5,16 +5,24 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
+- name: Check if umask is already set
+  ansible.builtin.lineinfile:
+    path: /etc/profile
+    regexp: (^[\s]*[^#]umask)\s+(\d+)
+    state: absent
+  check_mode: yes
+  changed_when: false
+  register: result_umask_is_set
+
 - name: Replace user umask in /etc/profile
-  replace:
+  ansible.builtin.replace:
     path: /etc/profile
     regexp: '^[^#]*umask'
     replace: "umask {{ var_accounts_user_umask }}"
-  register: umask_replace
 
 - name: Append user umask in /etc/profile
-  lineinfile:
+  ansible.builtin.lineinfile:
     create: yes
     path: /etc/profile
     line: "umask {{ var_accounts_user_umask }}"
-  when: umask_replace is not changed
+  when: result_umask_is_set.found == 0


### PR DESCRIPTION
#### Description:

The Ansible remediation was using a regex which was causing inconsistency
to the /etc/profile file by removing unnecessary content. In another case, it was
creating a new entry where the existing entries were already in compliance.

During the fix of this specific Ansible remediation, it was noticed similar rules with duplicated code.
An issue was created to improve this in another opportunity: https://github.com/ComplianceAsCode/content/issues/8919