### PR TITLE
Include SRG reference for dconf_gnome_disable_user_list

### DIFF
--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -2731,7 +2731,9 @@ controls:
         levels:
             - medium
         title: RHEL 8 must disable the user list at logon for graphical user interfaces.
-        status: pending
+        status: automated
+        rules:
+            - dconf_gnome_disable_user_list
     -   id: RHEL-08-020039
         levels:
             - medium

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/rule.yml
@@ -36,6 +36,7 @@ references:
     cis@rhel7: 1.8.3
     cis@ubuntu2004: '1.10'
     nist: CM-6(a),AC-23
+    srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-020032
     stigid@rhel8: RHEL-08-020032
 


### PR DESCRIPTION
#### Description:

Include SRG reference for dconf_gnome_disable_user_list
The controlfile was also updated at the id RHEL-08-020032

#### Rationale:

- Fixes https://github.com/ComplianceAsCode/content/issues/8911
