### PR TITLE
More accurate CodeClimate reporting

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -16,6 +16,13 @@ plugins:
     enabled: true
 
 exclude_patterns:
-  - linux_os/
-  - applications/
-  - products/
+  - "**/"
+
+  - "!build-scripts/*.py"
+  - "!ssg/*.py"
+  - "!utils/*.py"
+
+  - "!shared/**/*.py"
+
+  - "!tests/*.py"
+  - "!tests/ssg_test_suite/**/*.py"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (ENABLE_PYTHON_COVERAGE)
-    set(PYTEST_COVERAGE_OPTIONS --cov-append --cov-report=xml --cov "${CMAKE_SOURCE_DIR}/")
+    set(PYTEST_COVERAGE_OPTIONS --cov-append --cov-report=xml --cov "${CMAKE_SOURCE_DIR}/ssg")
 endif()
 
 macro(ssg_python_unit_tests PYTHON_COMPONENT_ID RELATIVE_PYTHONPATH)


### PR DESCRIPTION
Don't send noise to the CodeClimate website.

- Stop codecov for files that are not unit-testable - Code coverage is misleading when it comes from tests with high lines per asserts ratio. Therefore, it is more accurate to collect coverage data only for files that we aim to cover by unit tests.
- Clean up the file list - exclude everything, include just the things we are interested in.