### PR TITLE
fix dconf_gnome_screensaver_mode_blank rule

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/oval/shared.xml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/oval/shared.xml
@@ -23,7 +23,7 @@
     <!-- GSettings expects proper datatype specifier when setting 'picture-uri' per:
          https://bugzilla.redhat.com/show_bug.cgi?id=1141779#c3
          Thus require 'string' datatype to be specified in 'picture-uri' configuration too -->
-    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver\]([^\n]*\n+)+?picture-uri=\'(\S)*\'$</ind:pattern>
+    <ind:pattern operation="pattern match">^\[org/gnome/desktop/screensaver\]([^\n]*\n+)+?picture-uri=string \'\'$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/rule.yml
@@ -32,7 +32,7 @@ description: |-
     add or set <tt>picture-uri</tt> to <tt>string ''</tt> in
     <tt>/etc/dconf/db/local.d/00-security-settings</tt>. For example:
     <pre>[org/gnome/desktop/screensaver]
-    picture-uri=''
+    picture-uri=string ''
     </pre>
     Once the settings have been added, add a lock to
     <tt>/etc/dconf/db/local.d/locks/00-security-settings-lock</tt> to prevent user modification.
@@ -82,7 +82,7 @@ ocil: |-
     If properly configured, the output should be <tt>/org/gnome/desktop/screensaver/picture-uri</tt>
 
 fixtext: |-
-    {{{ fixtext_dconf_ini_file("org/gnome/desktop/screensaver", "picture-uri", "''") }}}
+    {{{ fixtext_dconf_ini_file("org/gnome/desktop/screensaver", "picture-uri", "string ''") }}}
 
 
 platform: machine

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/comment.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "#picture-uri" "string ''" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "picture-uri" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = inactivity_timeout_value=900
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "picture-uri" "string ''" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "picture-uri" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/correct_value_not_locked.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/correct_value_not_locked.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = inactivity_timeout_value=900
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "picture-uri" "string ''" "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/setting_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = inactivity_timeout_value=900
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "picture-uri" "string 'somestring'" "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "picture-uri" "local.d" "00-security-settings"


### PR DESCRIPTION
#### Description:

- change OVAL to be aligned with the rule
  - change picture-uri='' to picture-uri=string ''
- add tests
- align description and fixtext

#### Rationale:

fixes #8933 