### PR TITLE
Align kernel module rules  with DISA STIG Benchmarks

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -426,12 +426,15 @@ The only way to remediate is to recompile and reinstall the kernel, so no remedi
 
 #### kernel_module_disabled
 -   Checks if the given Linux kernel module is disabled.
+    The default method is to check the `install` keyword.
+    On OL and RHEL products the `blacklist` keyword is also checked.
+    The SLE products only check for  the `blacklist` keyword.
 
 -   Parameters:
 
     -   **kernmodule** - name of the Linux kernel module, eg. `cramfs`
 
--   Languages: Ansible, Bash, OVAL
+-   Languages: Ansible, Bash, Kubernetes, OVAL
 
 #### lineinfile
 -   Checks that the given text is present in a file.

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -233,6 +233,11 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
     To configure the system to prevent the <code>{{{ module }}}</code>
     kernel module from being loaded, add the following line to the file <code>/etc/modprobe.d/{{{ module }}}.conf</code>:
     <pre>install {{{ module }}} /bin/true</pre>
+    {{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+    To configure the system to prevent the <code>{{{ module }}}</code> from being used,
+    add the following line to file <code>/etc/modprobe.d/{{{ module }}}.conf</code>:
+    <pre>blacklist {{{ module }}}</pre>
+    {{% endif %}}
 {{%- endmacro %}}
 
 

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -754,8 +754,11 @@ ocil_clause: "no line is returned"
 #}}
 {{%- macro ocil_module_disable(module) %}}
     If the system is configured to prevent the loading of the <code>{{{ module }}}</code> kernel module,
-    it will contain lines inside any file in <code>/etc/modprobe.d</code> or the deprecated<code>/etc/modprobe.conf</code>.
+    it will contain lines inside any file in <code>/etc/modprobe.d</code> or the deprecated<code> /etc/modprobe.conf</code>.
     These lines instruct the module loading system to run another program (such as <code>/bin/true</code>) upon a module <code>install</code> event.
+    {{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+    These lines can also instruct the module loading system to ignore the <code>{{{ module }}}</code> kernel module via <code>blacklist</code> keyword.
+    {{% endif %}}
     Run the following command to search for such lines in all files in <code>/etc/modprobe.d</code> and the deprecated <code>/etc/modprobe.conf</code>:
     <pre>$ grep -r {{{ module }}} /etc/modprobe.conf /etc/modprobe.d</pre>
 {{%- endmacro %}}

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -17,4 +17,12 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: '{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+- name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
+  lineinfile:
+    create: yes
+    dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
+    regexp: '^blacklist {{{ KERNMODULE }}}$'
+    line: "blacklist {{{ KERNMODULE }}}"
+{{% endif %}}
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -18,4 +18,9 @@ else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
+	echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+fi
+{{% endif %}}
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/kubernetes.template
+++ b/shared/templates/kernel_module_disabled/kubernetes.template
@@ -13,7 +13,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,install%20{{{ KERNMODULE | urlencode }}}%20/bin/true%0A
+          source: data:,install%20{{{ KERNMODULE | urlencode }}}%20/bin/true%0Ablacklist%20{{{ KERNMODULE }}}%0A
         mode: 0644
         path: /etc/modprobe.d/75-kernel_module_{{{ KERNMODULE }}}_disabled.conf
         overwrite: true

--- a/shared/templates/kernel_module_disabled/kubernetes.template
+++ b/shared/templates/kernel_module_disabled/kubernetes.template
@@ -13,7 +13,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:,install%20{{{ KERNMODULE | urlencode }}}%20/bin/true%0Ablacklist%20{{{ KERNMODULE }}}%0A
+          source: data:,install%20{{{ KERNMODULE | urlencode }}}%20/bin/true%0Ablacklist%20{{{ KERNMODULE | urlencode }}}%0A
         mode: 0644
         path: /etc/modprobe.d/75-kernel_module_{{{ KERNMODULE }}}_disabled.conf
         overwrite: true

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -3,12 +3,13 @@
   id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
-      comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
-{{% if product in ["sle12", "sle15"] %}}
+      {{% if product in ["sle12", "sle15"] %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
       comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
-{{% endif %}}
+      {{% else %}}
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
+      comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
+      {{% endif %}}
 {{% if "ubuntu" not in product %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 {{% endif %}}
@@ -16,6 +17,7 @@
     </criteria>
   </definition>
 
+{{% if product not in ["sle12", "sle15"] %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_disabled" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} disabled">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_disabled" />
@@ -38,6 +40,7 @@
     <value>/usr/lib/modprobe.d</value>
     <value>/usr/lib/modules-load.d</value>
   </constant_variable>
+{{% endif %}}
 
 {{% if product in ["sle12", "sle15"] %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -6,6 +6,13 @@
       {{% if product in ["sle12", "sle15"] %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
       comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
+      {{% elif product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+      <criteria operator="AND">
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
+        comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
+        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
+        comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
+      </criteria>
       {{% else %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
       comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
@@ -42,7 +49,7 @@
   </constant_variable>
 {{% endif %}}
 
-{{% if product in ["sle12", "sle15"] %}}
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8", "sle12", "sle15"] %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} blacklisted">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted" />
@@ -50,7 +57,12 @@
 
   <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_blacklisted"
   version="1" comment="kernel module {{{ KERNMODULE }}} blacklisted">
+    {{% if product in ["sle12", "sle15"] %}}
     <ind:filepath>/etc/modprobe.d/50-blacklist.conf</ind:filepath>
+    {{% else %}}
+    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one" />
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{% endif %}}
     <ind:pattern operation="pattern match">^blacklist\s+{{{ KERNMODULE }}}$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -17,7 +17,7 @@
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
       comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
       {{% endif %}}
-{{% if "ubuntu" not in product %}}
+{{% if "ubuntu" not in product and "rhel" not in product%}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 {{% endif %}}
 
@@ -68,7 +68,7 @@
   </ind:textfilecontent54_object>
 {{% endif %}}
 
-{{% if "ubuntu" not in product %}}
+{{% if "ubuntu" not in product and "rhel" not in product %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf" />

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -6,7 +6,7 @@
       {{% if product in ["sle12", "sle15"] %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
       comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
-      {{% elif product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+      {{% elif product in ["ol7", "ol8", "rhcos4", "rhel7", "rhel8"] %}}
       <criteria operator="AND">
         <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
         comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
@@ -49,7 +49,7 @@
   </constant_variable>
 {{% endif %}}
 
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8", "sle12", "sle15"] %}}
+{{% if product in ["ol7", "ol8", "rhcos4", "rhel7", "rhel8", "sle12", "sle15"] %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} blacklisted">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted" />

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+{{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modules_load_d.pass.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modules-load.d/{{{ KERNMODULE }}}.conf
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+echo "blacklist {{{ KERNMODULE }}}" >> /etc/modules-load.d/{{{ KERNMODULE }}}.conf
+{{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
@@ -4,3 +4,6 @@ if [[ ! -d /run/modprobe.d ]]; then
     mkdir -p /run/modprobe.d
 fi
 echo "install {{{ KERNMODULE }}} /bin/true" > /run/modprobe.d/{{{ KERNMODULE }}}.conf
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+echo "blacklist {{{ KERNMODULE }}}" >> /run/modprobe.d/{{{ KERNMODULE }}}.conf
+{{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modules_load_d.pass.sh
@@ -5,3 +5,6 @@ if [[ ! -d /run/modules-load.d ]]; then
 fi
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /run/modules-load.d/{{{ KERNMODULE }}}.conf
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+echo "blacklist {{{ KERNMODULE }}}" >> /run/modules-load.d/{{{ KERNMODULE }}}.conf
+{{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
+{{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modules_load_d.pass.sh
@@ -1,3 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modules-load.d/{{{ KERNMODULE }}}.conf
+{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modules-load.d/{{{ KERNMODULE }}}.conf
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- Better align the `kernel_module_disabled` template with DISA STIG Benchmarks
  - In SLE products, don't check for `install` keyword any more
  - In OL and RHEL products, add a check for `blacklist` keyword
- Stop checking `/etc/modprobe.conf` in RHEL, it was deprecated.

#### Rationale:

- Improve alignment of OL and RHEL kernel modules disabled rules with DISA Benchmark
