### PR TITLE
Template issue to request merge rights

### DIFF
--- a/.github/ISSUE_TEMPLATE/request_merge_rights.md
+++ b/.github/ISSUE_TEMPLATE/request_merge_rights.md
@@ -7,9 +7,13 @@ labels: governance
 
 * Include the URL for the github profile.
 
+#### About me:
+
+* Could you please introduce yourself briefly and share your interactions with the project?
+
 #### Reason for having merge rights:
 
-* Give a clear and objective context about why do you need merge rights.
+* Please, consult the [list of project areas](https://complianceascode.readthedocs.io/en/latest/manual/developer/01_introduction.html#decomposition) and specify in which area would you like to get merge rights. This will help us to understand the context.
 
 #### List of PRs:
 

--- a/.github/ISSUE_TEMPLATE/request_merge_rights.md
+++ b/.github/ISSUE_TEMPLATE/request_merge_rights.md
@@ -1,0 +1,21 @@
+---
+name: Request Merge Rights
+about: Request merge rights to help on the project maintenance
+labels: governance
+---
+#### Github ID:
+
+* Include the URL for the github profile.
+
+#### Reason for having merge rights:
+
+* Give a clear and objective context about why do you need merge rights.
+
+#### List of PRs:
+
+1. #ID
+1. #ID
+1. #ID
+1. #ID
+1. #ID
+1. #ID

--- a/docs/manual/developer/01_introduction.md
+++ b/docs/manual/developer/01_introduction.md
@@ -152,7 +152,14 @@ The pull request removing the product should include the removal of
 
 TLDR: 6 non-trivial PRs within 6 months => merge rights for 1 year since the last activity.
 
-Contributors can ask for merge rights on the mailing list or on Gitter.
+Contributors can ask for merge rights by opening a Github issue using the `Request Merge Rights` issue template.
+1. The issue must contain the following:
+    1. The Github ID of the user
+    1. The Reasoning for the requested merge rights
+    1. The links for PRs
+
+1. The rights can only be granted after, at least, three maintainers express their approval by commenting on the issue.
+
 Although one can technically merge code, the code contribution guidelines still have to be obeyed.
 
 Loss of merge rights:


### PR DESCRIPTION
#### Description:

It was agreed in some criteria about rights grant in the project.
- https://github.com/ComplianceAsCode/content/blob/master/docs/manual/developer/01_introduction.md#governance 

The initial proposal mentioned that requests should be done via email or Gitter.
This PR updates this part by centralizing these requests in the Project Issues.
This PR also creates an issue template for Merge Rights request, in order to make these requests even easier.

#### Rationale:

It is more transparent to centralize these requests in the project itself.
It also permits an easier tracking of grants and ensure a standard.
Once we have the request filed in a form of an issue, maintainers can easier manifest their approvals or concerns via comments.

This PR is not changing the already defined rules, but only improving how they are supported.