### PR TITLE
Fix rule sysctl_kernel_yama_ptrace_scope and sysctl_kernel_core_pattern

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/tests/ocp4/e2e.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -111,7 +111,7 @@
                    test_ref="test_static_etc_sysctld_{{{ SYSCTLID }}}"/>
         <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /run/sysctl.d/*.conf"
                    test_ref="test_static_run_sysctld_{{{ SYSCTLID }}}"/>
-{{% if product not in [ "ol7", "ol8", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
         <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /usr/lib/sysctl.d/*.conf"
                    test_ref="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}"/>
 {{% endif %}}
@@ -138,7 +138,7 @@
     {{{ state_static_sysctld("run_sysctld") }}}
   </ind:textfilecontent54_test>
 
-{{% if product not in [ "ol7", "ol8", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
   <ind:textfilecontent54_test id="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1"
                           check="all"
                           comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf">
@@ -256,7 +256,7 @@
   <ind:textfilecontent54_object id="object_static_run_usr_sysctls_{{{ SYSCTLID }}}" version="1">
     <set>
       <object_reference>object_static_run_sysctld_{{{ SYSCTLID }}}</object_reference>
-{{% if product not in [ "ol7", "ol8", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
       <object_reference>object_static_usr_lib_sysctld_{{{ SYSCTLID }}}</object_reference>
 {{% endif %}}
     </set>
@@ -279,7 +279,7 @@
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
 
-{{% if product not in [ "ol7", "ol8", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
   <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/usr/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>


### PR DESCRIPTION
Fix rule `sysctl_kernel_yama_ptrace_scope` and `sysctl_kernel_core_pattern` e2e failure, those two rules were failing because `kernel.yama.ptrace_scope` and `kernel.core_pattern` was already defined in `/usr/lib/sysctl.d/10-default-yama-scope.conf` and `/usr/lib/sysctl.d/50-coredump.conf`, and there is one oval condition checks was checking if those are only defined in one file, since OpenShift uses machine config after remediation, it was configured under /etc/sysctl.d, thus the rule failed.

This PR stops checking for /usr/lib/sysctl.d in the template if product is rhcos4