### PR TITLE
Update the status with not applicable for OCP4 controls

### DIFF
--- a/controls/srg_ctr/SRG-APP-000024-CTR-000060.yml
+++ b/controls/srg_ctr/SRG-APP-000024-CTR-000060.yml
@@ -8,4 +8,4 @@ controls:
   - idp_is_configured
   - ocp_idp_no_htpasswd
   - kubeadmin_removed
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000025-CTR-000065.yml
+++ b/controls/srg_ctr/SRG-APP-000025-CTR-000065.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000026-CTR-000070.yml
+++ b/controls/srg_ctr/SRG-APP-000026-CTR-000070.yml
@@ -6,4 +6,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000027-CTR-000075.yml
+++ b/controls/srg_ctr/SRG-APP-000027-CTR-000075.yml
@@ -6,4 +6,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000028-CTR-000080.yml
+++ b/controls/srg_ctr/SRG-APP-000028-CTR-000080.yml
@@ -6,4 +6,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000029-CTR-000085.yml
+++ b/controls/srg_ctr/SRG-APP-000029-CTR-000085.yml
@@ -6,4 +6,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000065-CTR-000115.yml
+++ b/controls/srg_ctr/SRG-APP-000065-CTR-000115.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000123-CTR-000265.yml
+++ b/controls/srg_ctr/SRG-APP-000123-CTR-000265.yml
@@ -9,4 +9,4 @@ controls:
   - directory_permissions_var_log_kube_audit
   - directory_permissions_var_log_oauth_audit
   - directory_permissions_var_log_ocp_audit
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000149-CTR-000355.yml
+++ b/controls/srg_ctr/SRG-APP-000149-CTR-000355.yml
@@ -6,4 +6,4 @@ controls:
     to privileged accounts.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000150-CTR-000360.yml
+++ b/controls/srg_ctr/SRG-APP-000150-CTR-000360.yml
@@ -6,4 +6,4 @@ controls:
     to non-privileged accounts.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000151-CTR-000365.yml
+++ b/controls/srg_ctr/SRG-APP-000151-CTR-000365.yml
@@ -6,4 +6,4 @@ controls:
     to privileged accounts.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000152-CTR-000370.yml
+++ b/controls/srg_ctr/SRG-APP-000152-CTR-000370.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must use multifactor authentication for local access
     to non-privileged accounts.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000157-CTR-000385.yml
+++ b/controls/srg_ctr/SRG-APP-000157-CTR-000385.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must implement replay-resistant authentication mechanisms
     for network access to non-privileged accounts.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000163-CTR-000395.yml
+++ b/controls/srg_ctr/SRG-APP-000163-CTR-000395.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must disable identifiers (individuals, groups, roles,
     and devices) after 35 days of inactivity.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000164-CTR-000400.yml
+++ b/controls/srg_ctr/SRG-APP-000164-CTR-000400.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: {{{ full_name }}} must enforce a minimum 15-character password length.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000165-CTR-000405.yml
+++ b/controls/srg_ctr/SRG-APP-000165-CTR-000405.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: {{{ full_name }}} must prohibit password reuse for a minimum of 10 generations.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000166-CTR-000410.yml
+++ b/controls/srg_ctr/SRG-APP-000166-CTR-000410.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must enforce password complexity by requiring that
     at least one uppercase character be used.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000167-CTR-000415.yml
+++ b/controls/srg_ctr/SRG-APP-000167-CTR-000415.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must enforce password complexity by requiring that
     at least one lowercase character be used.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000168-CTR-000420.yml
+++ b/controls/srg_ctr/SRG-APP-000168-CTR-000420.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must enforce password complexity by requiring that
     at least one numeric character be used.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000169-CTR-000425.yml
+++ b/controls/srg_ctr/SRG-APP-000169-CTR-000425.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must enforce password complexity by requiring that
     at least one special character be used.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000170-CTR-000430.yml
+++ b/controls/srg_ctr/SRG-APP-000170-CTR-000430.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must require the change of at least 15 of the total
     number of characters when passwords are changed.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000171-CTR-000435.yml
+++ b/controls/srg_ctr/SRG-APP-000171-CTR-000435.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: For container platform using password authentication, the application must
     store only cryptographic representations of passwords.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000172-CTR-000440.yml
+++ b/controls/srg_ctr/SRG-APP-000172-CTR-000440.yml
@@ -5,4 +5,4 @@ controls:
   title: For accounts using password authentication, the container platform must use
     FIPS-validated SHA-2 or later protocol to protect the integrity of the password
     authentication process.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000173-CTR-000445.yml
+++ b/controls/srg_ctr/SRG-APP-000173-CTR-000445.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must enforce 24 hours (one day) as the minimum password
     lifetime.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000174-CTR-000450.yml
+++ b/controls/srg_ctr/SRG-APP-000174-CTR-000450.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: {{{ full_name }}} must enforce a 60-day maximum password lifetime restriction.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000177-CTR-000465.yml
+++ b/controls/srg_ctr/SRG-APP-000177-CTR-000465.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must map the authenticated identity to the individual
     user or group account for PKI-based authentication.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000181-CTR-000485.yml
+++ b/controls/srg_ctr/SRG-APP-000181-CTR-000485.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - audit_log_forwarding_enabled
   - audit_profile_set
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000291-CTR-000675.yml
+++ b/controls/srg_ctr/SRG-APP-000291-CTR-000675.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000292-CTR-000680.yml
+++ b/controls/srg_ctr/SRG-APP-000292-CTR-000680.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000293-CTR-000685.yml
+++ b/controls/srg_ctr/SRG-APP-000293-CTR-000685.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000294-CTR-000690.yml
+++ b/controls/srg_ctr/SRG-APP-000294-CTR-000690.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000317-CTR-000735.yml
+++ b/controls/srg_ctr/SRG-APP-000317-CTR-000735.yml
@@ -6,4 +6,4 @@ controls:
     members leave the group.
   rules:
   - kubeadmin_removed
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000318-CTR-000740.yml
+++ b/controls/srg_ctr/SRG-APP-000318-CTR-000740.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must enforce organization-defined circumstances and/or
     usage conditions for organization-defined accounts.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000319-CTR-000745.yml
+++ b/controls/srg_ctr/SRG-APP-000319-CTR-000745.yml
@@ -6,4 +6,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000320-CTR-000750.yml
+++ b/controls/srg_ctr/SRG-APP-000320-CTR-000750.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000345-CTR-000785.yml
+++ b/controls/srg_ctr/SRG-APP-000345-CTR-000785.yml
@@ -8,4 +8,4 @@ controls:
   rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000357-CTR-000800.yml
+++ b/controls/srg_ctr/SRG-APP-000357-CTR-000800.yml
@@ -8,4 +8,4 @@ controls:
   - partition_for_var_log_kube_apiserver
   - partition_for_var_log_oauth_apiserver
   - partition_for_var_log_openshift_apiserver
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000358-CTR-000805.yml
+++ b/controls/srg_ctr/SRG-APP-000358-CTR-000805.yml
@@ -5,4 +5,4 @@ controls:
   title: Audit records must be stored at a secondary location.
   rules:
   - audit_log_forwarding_enabled
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000359-CTR-000810.yml
+++ b/controls/srg_ctr/SRG-APP-000359-CTR-000810.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must provide an immediate warning to the SA and ISSO
     (at a minimum) when allocated audit record storage volume reaches 75 percent of
     repository maximum audit record storage capacity.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000391-CTR-000935.yml
+++ b/controls/srg_ctr/SRG-APP-000391-CTR-000935.yml
@@ -6,4 +6,4 @@ controls:
     for user authentication.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000397-CTR-000955.yml
+++ b/controls/srg_ctr/SRG-APP-000397-CTR-000955.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must allow the use of a temporary password for system
     logons with an immediate change to a permanent password.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000401-CTR-000965.yml
+++ b/controls/srg_ctr/SRG-APP-000401-CTR-000965.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}}, for PKI-based authentication, must implement a local
     cache of revocation data to support path discovery and validation in case of the
     inability to access revocation information via the network.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000402-CTR-000970.yml
+++ b/controls/srg_ctr/SRG-APP-000402-CTR-000970.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must accept Personal Identity Verification (PIV) credentials
     from other federal agencies.
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000456-CTR-001130.yml
+++ b/controls/srg_ctr/SRG-APP-000456-CTR-001130.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} runtime must have updates installed within the time
     period directed by an authoritative source (e.g., IAVM, CTOs, DTMs, and STIGs).
-  status: pending
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000503-CTR-001275.yml
+++ b/controls/srg_ctr/SRG-APP-000503-CTR-001275.yml
@@ -6,4 +6,4 @@ controls:
     logon attempts occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000505-CTR-001285.yml
+++ b/controls/srg_ctr/SRG-APP-000505-CTR-001285.yml
@@ -6,4 +6,4 @@ controls:
     times.
   rules:
   - audit_profile_set
-  status: automated
+  status: not applicable

--- a/controls/srg_ctr/SRG-APP-000506-CTR-001290.yml
+++ b/controls/srg_ctr/SRG-APP-000506-CTR-001290.yml
@@ -6,4 +6,4 @@ controls:
     from different workstations and systems occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: not applicable


### PR DESCRIPTION
#### Description:

- Update the control status with `not applicable`

#### Rationale:

- OCP4 STIG content
