### PR TITLE
Update the status with inherently met for OCP4 controls

### DIFF
--- a/controls/srg_ctr/SRG-APP-000033-CTR-000090.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000090.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: Least privilege access and need to know must be required to access the container
     platform registry.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000033-CTR-000095.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000095.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: Least privilege access and need to know must be required to access the container
     platform runtime.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000033-CTR-000100.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000100.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: Least privilege access and need to know must be required to access the container
     platform keystore.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000091-CTR-000160.yml
+++ b/controls/srg_ctr/SRG-APP-000091-CTR-000160.yml
@@ -6,4 +6,4 @@ controls:
     attempts to access privileges occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000095-CTR-000170.yml
+++ b/controls/srg_ctr/SRG-APP-000095-CTR-000170.yml
@@ -6,4 +6,4 @@ controls:
     container platform.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000096-CTR-000175.yml
+++ b/controls/srg_ctr/SRG-APP-000096-CTR-000175.yml
@@ -6,4 +6,4 @@ controls:
     with all events.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000097-CTR-000180.yml
+++ b/controls/srg_ctr/SRG-APP-000097-CTR-000180.yml
@@ -6,4 +6,4 @@ controls:
     occurred.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000098-CTR-000185.yml
+++ b/controls/srg_ctr/SRG-APP-000098-CTR-000185.yml
@@ -6,4 +6,4 @@ controls:
     platform.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000099-CTR-000190.yml
+++ b/controls/srg_ctr/SRG-APP-000099-CTR-000190.yml
@@ -5,4 +5,4 @@ controls:
   title: All audit records must generate the event results within the container platform.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000100-CTR-000195.yml
+++ b/controls/srg_ctr/SRG-APP-000100-CTR-000195.yml
@@ -6,4 +6,4 @@ controls:
     {{{ full_name }}}.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000100-CTR-000200.yml
+++ b/controls/srg_ctr/SRG-APP-000100-CTR-000200.yml
@@ -6,4 +6,4 @@ controls:
     within {{{ full_name }}}.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000116-CTR-000235.yml
+++ b/controls/srg_ctr/SRG-APP-000116-CTR-000235.yml
@@ -6,4 +6,4 @@ controls:
     record time stamps.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000119-CTR-000245.yml
+++ b/controls/srg_ctr/SRG-APP-000119-CTR-000245.yml
@@ -9,4 +9,4 @@ controls:
   - directory_permissions_var_log_kube_audit
   - directory_permissions_var_log_oauth_audit
   - directory_permissions_var_log_ocp_audit
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000120-CTR-000250.yml
+++ b/controls/srg_ctr/SRG-APP-000120-CTR-000250.yml
@@ -9,4 +9,4 @@ controls:
   - directory_permissions_var_log_kube_audit
   - directory_permissions_var_log_oauth_audit
   - directory_permissions_var_log_ocp_audit
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000121-CTR-000255.yml
+++ b/controls/srg_ctr/SRG-APP-000121-CTR-000255.yml
@@ -9,4 +9,4 @@ controls:
   - directory_permissions_var_log_kube_audit
   - directory_permissions_var_log_oauth_audit
   - directory_permissions_var_log_ocp_audit
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000122-CTR-000260.yml
+++ b/controls/srg_ctr/SRG-APP-000122-CTR-000260.yml
@@ -9,4 +9,4 @@ controls:
   - directory_permissions_var_log_kube_audit
   - directory_permissions_var_log_oauth_audit
   - directory_permissions_var_log_ocp_audit
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000131-CTR-000280.yml
+++ b/controls/srg_ctr/SRG-APP-000131-CTR-000280.yml
@@ -7,4 +7,4 @@ controls:
   - reject_unsigned_images_by_default
   - ocp_allowed_registries
   - ocp_allowed_registries_for_import
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000133-CTR-000290.yml
+++ b/controls/srg_ctr/SRG-APP-000133-CTR-000290.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: {{{ full_name }}} must limit privileges to the container platform registry.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000133-CTR-000295.yml
+++ b/controls/srg_ctr/SRG-APP-000133-CTR-000295.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: {{{ full_name }}} must limit privileges to the container platform runtime.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000133-CTR-000300.yml
+++ b/controls/srg_ctr/SRG-APP-000133-CTR-000300.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: {{{ full_name }}} must limit privileges to the container platform keystore.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000133-CTR-000305.yml
+++ b/controls/srg_ctr/SRG-APP-000133-CTR-000305.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: Configuration files for the container platform must be protected.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000133-CTR-000310.yml
+++ b/controls/srg_ctr/SRG-APP-000133-CTR-000310.yml
@@ -3,4 +3,4 @@ controls:
   levels:
   - medium
   title: Authentication files for the container platform must be protected.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000141-CTR-000315.yml
+++ b/controls/srg_ctr/SRG-APP-000141-CTR-000315.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must be configured with only essential configurations.
   rules:
   - configure_network_policies_namespaces
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000148-CTR-000335.yml
+++ b/controls/srg_ctr/SRG-APP-000148-CTR-000335.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must uniquely identify and authenticate users.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000148-CTR-000340.yml
+++ b/controls/srg_ctr/SRG-APP-000148-CTR-000340.yml
@@ -6,4 +6,4 @@ controls:
     identify and authenticate users.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000148-CTR-000345.yml
+++ b/controls/srg_ctr/SRG-APP-000148-CTR-000345.yml
@@ -6,4 +6,4 @@ controls:
     acting on behalf of the users.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000148-CTR-000350.yml
+++ b/controls/srg_ctr/SRG-APP-000148-CTR-000350.yml
@@ -6,4 +6,4 @@ controls:
     identify and authenticate processes acting on behalf of the users.
   rules:
   - ocp_idp_no_htpasswd
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000153-CTR-000375.yml
+++ b/controls/srg_ctr/SRG-APP-000153-CTR-000375.yml
@@ -7,4 +7,4 @@ controls:
   rules:
   - ocp_idp_no_htpasswd
   - kubeadmin_removed
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000158-CTR-000390.yml
+++ b/controls/srg_ctr/SRG-APP-000158-CTR-000390.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must uniquely identify all network-connected nodes
     before establishing any connection.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000178-CTR-000470.yml
+++ b/controls/srg_ctr/SRG-APP-000178-CTR-000470.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must obscure feedback of authentication information
     during the authentication process to protect the information from possible exploitation/use
     by unauthorized individuals.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000185-CTR-000490.yml
+++ b/controls/srg_ctr/SRG-APP-000185-CTR-000490.yml
@@ -6,4 +6,4 @@ controls:
     of non-local maintenance and diagnostic sessions.
   rules:
   - kubeadmin_removed
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000211-CTR-000530.yml
+++ b/controls/srg_ctr/SRG-APP-000211-CTR-000530.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must separate user functionality (including user interface
     services) from information system management functionality.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000225-CTR-000570.yml
+++ b/controls/srg_ctr/SRG-APP-000225-CTR-000570.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} runtime must fail to a secure state if system initialization
     fails, shutdown fails, or aborts fail.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000226-CTR-000575.yml
+++ b/controls/srg_ctr/SRG-APP-000226-CTR-000575.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must preserve any information necessary to determine
     the cause of the disruption or failure.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000233-CTR-000585.yml
+++ b/controls/srg_ctr/SRG-APP-000233-CTR-000585.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} runtime must isolate security functions from non-security
     functions.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000234-CTR-000590.yml
+++ b/controls/srg_ctr/SRG-APP-000234-CTR-000590.yml
@@ -8,4 +8,4 @@ controls:
   - idp_is_configured
   - ocp_idp_no_htpasswd
   - kubeadmin_removed
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000243-CTR-000600.yml
+++ b/controls/srg_ctr/SRG-APP-000243-CTR-000600.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must prevent unauthorized and unintended information
     transfer via shared system resources.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000266-CTR-000625.yml
+++ b/controls/srg_ctr/SRG-APP-000266-CTR-000625.yml
@@ -7,4 +7,4 @@ controls:
     by adversaries.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000290-CTR-000670.yml
+++ b/controls/srg_ctr/SRG-APP-000290-CTR-000670.yml
@@ -6,4 +6,4 @@ controls:
     of audit tools.
   rules:
   - audit_log_forwarding_uses_tls
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000343-CTR-000780.yml
+++ b/controls/srg_ctr/SRG-APP-000343-CTR-000780.yml
@@ -7,4 +7,4 @@ controls:
   - directory_access_var_log_kube_audit
   - directory_access_var_log_oauth_audit
   - directory_access_var_log_ocp_audit
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000360-CTR-000815.yml
+++ b/controls/srg_ctr/SRG-APP-000360-CTR-000815.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must provide an immediate real-time alert to the SA
     and ISSO, at a minimum, of all audit failure events requiring real-time alerts.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000374-CTR-000865.yml
+++ b/controls/srg_ctr/SRG-APP-000374-CTR-000865.yml
@@ -5,4 +5,4 @@ controls:
   title: All audit records must use UTC or GMT time stamps.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000375-CTR-000870.yml
+++ b/controls/srg_ctr/SRG-APP-000375-CTR-000870.yml
@@ -6,4 +6,4 @@ controls:
     a granularity of one second for a minimum degree of precision.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000378-CTR-000880.yml
+++ b/controls/srg_ctr/SRG-APP-000378-CTR-000880.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must prohibit the installation of patches and updates
     without explicit privileged status.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000378-CTR-000885.yml
+++ b/controls/srg_ctr/SRG-APP-000378-CTR-000885.yml
@@ -4,4 +4,4 @@ controls:
   - high
   title: {{{ full_name }}} runtime must prohibit the instantiation of container
     images without explicit privileged status.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000378-CTR-000890.yml
+++ b/controls/srg_ctr/SRG-APP-000378-CTR-000890.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} registry must prohibit installation or modification
     of container images without explicit privileged status.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000380-CTR-000900.yml
+++ b/controls/srg_ctr/SRG-APP-000380-CTR-000900.yml
@@ -6,4 +6,4 @@ controls:
     configuration changes.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000381-CTR-000905.yml
+++ b/controls/srg_ctr/SRG-APP-000381-CTR-000905.yml
@@ -6,4 +6,4 @@ controls:
     of the enforcement actions.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000383-CTR-000910.yml
+++ b/controls/srg_ctr/SRG-APP-000383-CTR-000910.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: All non-essential, unnecessary, and unsecure DoD ports, protocols, and services
     must be disabled in the container platform.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000384-CTR-000915.yml
+++ b/controls/srg_ctr/SRG-APP-000384-CTR-000915.yml
@@ -9,4 +9,4 @@ controls:
   - reject_unsigned_images_by_default
   - ocp_allowed_registries
   - ocp_allowed_registries_for_import
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000386-CTR-000920.yml
+++ b/controls/srg_ctr/SRG-APP-000386-CTR-000920.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} registry must employ a deny-all, permit-by-exception
     (whitelist) policy to allow only authorized container images in the container
     platform.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000389-CTR-000925.yml
+++ b/controls/srg_ctr/SRG-APP-000389-CTR-000925.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must require users to reauthenticate when organization-defined
     circumstances or situations require reauthentication.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000390-CTR-000930.yml
+++ b/controls/srg_ctr/SRG-APP-000390-CTR-000930.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must require devices to reauthenticate when organization-defined
     circumstances or situations requiring reauthentication.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000400-CTR-000960.yml
+++ b/controls/srg_ctr/SRG-APP-000400-CTR-000960.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must prohibit the use of cached authenticators after
     an organization-defined time period.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000409-CTR-000990.yml
+++ b/controls/srg_ctr/SRG-APP-000409-CTR-000990.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must audit non-local maintenance and diagnostic sessions'
     organization-defined audit events associated with non-local maintenance.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000431-CTR-001065.yml
+++ b/controls/srg_ctr/SRG-APP-000431-CTR-001065.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} runtime must maintain separate execution domains for
     each container by assigning each container a separate address space.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000441-CTR-001090.yml
+++ b/controls/srg_ctr/SRG-APP-000441-CTR-001090.yml
@@ -16,4 +16,4 @@ controls:
   - kubelet_configure_tls_key
   - kubelet_configure_tls_key_pre_4_9
   - routes_protected_by_tls
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000442-CTR-001095.yml
+++ b/controls/srg_ctr/SRG-APP-000442-CTR-001095.yml
@@ -14,4 +14,4 @@ controls:
   - kubelet_configure_tls_cert
   - kubelet_configure_tls_key
   - routes_protected_by_tls
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000447-CTR-001100.yml
+++ b/controls/srg_ctr/SRG-APP-000447-CTR-001100.yml
@@ -4,4 +4,4 @@ controls:
   - medium
   title: {{{ full_name }}} must behave in a predictable and documented manner
     that reflects organizational and system objectives when invalid inputs are received.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000492-CTR-001220.yml
+++ b/controls/srg_ctr/SRG-APP-000492-CTR-001220.yml
@@ -6,4 +6,4 @@ controls:
     attempts to access security objects occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000493-CTR-001225.yml
+++ b/controls/srg_ctr/SRG-APP-000493-CTR-001225.yml
@@ -6,4 +6,4 @@ controls:
     attempts to access security levels occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000494-CTR-001230.yml
+++ b/controls/srg_ctr/SRG-APP-000494-CTR-001230.yml
@@ -6,4 +6,4 @@ controls:
     attempts to access categories of information (e.g., classification levels) occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000495-CTR-001235.yml
+++ b/controls/srg_ctr/SRG-APP-000495-CTR-001235.yml
@@ -6,4 +6,4 @@ controls:
     attempts to modify privileges occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000496-CTR-001240.yml
+++ b/controls/srg_ctr/SRG-APP-000496-CTR-001240.yml
@@ -6,4 +6,4 @@ controls:
     attempts to modify security objects occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000497-CTR-001245.yml
+++ b/controls/srg_ctr/SRG-APP-000497-CTR-001245.yml
@@ -6,4 +6,4 @@ controls:
     attempts to modify security levels occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000498-CTR-001250.yml
+++ b/controls/srg_ctr/SRG-APP-000498-CTR-001250.yml
@@ -6,4 +6,4 @@ controls:
     attempts to modify categories of information (e.g., classification levels) occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000499-CTR-001255.yml
+++ b/controls/srg_ctr/SRG-APP-000499-CTR-001255.yml
@@ -6,4 +6,4 @@ controls:
     attempts to delete privileges occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000500-CTR-001260.yml
+++ b/controls/srg_ctr/SRG-APP-000500-CTR-001260.yml
@@ -6,4 +6,4 @@ controls:
     attempts to delete security levels occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000501-CTR-001265.yml
+++ b/controls/srg_ctr/SRG-APP-000501-CTR-001265.yml
@@ -6,4 +6,4 @@ controls:
     attempts to delete security objects occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000502-CTR-001270.yml
+++ b/controls/srg_ctr/SRG-APP-000502-CTR-001270.yml
@@ -6,4 +6,4 @@ controls:
     attempts to delete categories of information (e.g., classification levels) occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000504-CTR-001280.yml
+++ b/controls/srg_ctr/SRG-APP-000504-CTR-001280.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must generate audit record for privileged activities.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000507-CTR-001295.yml
+++ b/controls/srg_ctr/SRG-APP-000507-CTR-001295.yml
@@ -6,4 +6,4 @@ controls:
     attempts to access objects occur.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000508-CTR-001300.yml
+++ b/controls/srg_ctr/SRG-APP-000508-CTR-001300.yml
@@ -5,4 +5,4 @@ controls:
   title: Direct access to the container platform must generate audit records.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000509-CTR-001305.yml
+++ b/controls/srg_ctr/SRG-APP-000509-CTR-001305.yml
@@ -6,4 +6,4 @@ controls:
     modifications, disabling, and termination events.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000510-CTR-001310.yml
+++ b/controls/srg_ctr/SRG-APP-000510-CTR-001310.yml
@@ -6,4 +6,4 @@ controls:
     shutdown, restart events, and program initiations.
   rules:
   - audit_profile_set
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000516-CTR-001330.yml
+++ b/controls/srg_ctr/SRG-APP-000516-CTR-001330.yml
@@ -199,4 +199,4 @@ controls:
   - file_permissions_worker_ca
   - file_permissions_worker_kubeconfig
   - file_permissions_worker_service
-  status: automated
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000605-CTR-001380.yml
+++ b/controls/srg_ctr/SRG-APP-000605-CTR-001380.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must validate certificates used for Transport Layer
     Security (TLS) functions by performing an RFC 5280-compliant certification path
     validation.
-  status: pending
+  status: inherently met

--- a/controls/srg_ctr/SRG-APP-000645-CTR-001410.yml
+++ b/controls/srg_ctr/SRG-APP-000645-CTR-001410.yml
@@ -7,4 +7,4 @@ controls:
     for transmission.
   rules:
   - configure_network_policies_namespaces
-  status: automated
+  status: inherently met


### PR DESCRIPTION
#### Description:

- Update the control status with `inherently met`

#### Rationale:

- OCP4 STIG content
