### PR TITLE
Update the status with does not meet for OCP4 controls

### DIFF
--- a/controls/srg_ctr/SRG-APP-000090-CTR-000155.yml
+++ b/controls/srg_ctr/SRG-APP-000090-CTR-000155.yml
@@ -6,4 +6,4 @@ controls:
     appointed by the ISSM) to select which auditable events are to be audited.
   rules:
   - audit_profile_set
-  status: automated
+  status: does not meet

--- a/controls/srg_ctr/SRG-APP-000109-CTR-000215.yml
+++ b/controls/srg_ctr/SRG-APP-000109-CTR-000215.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must take appropriate action upon an audit failure.
   rules:
   - audit_error_alert_exists
-  status: automated
+  status: does not meet

--- a/controls/srg_ctr/SRG-APP-000118-CTR-000240.yml
+++ b/controls/srg_ctr/SRG-APP-000118-CTR-000240.yml
@@ -10,4 +10,4 @@ controls:
   - directory_permissions_var_log_kube_audit
   - directory_permissions_var_log_oauth_audit
   - directory_permissions_var_log_ocp_audit
-  status: automated
+  status: does not meet

--- a/controls/srg_ctr/SRG-APP-000142-CTR-000325.yml
+++ b/controls/srg_ctr/SRG-APP-000142-CTR-000325.yml
@@ -6,4 +6,4 @@ controls:
     that adhere to the PPSM CAL.
   rules:
   - configure_network_policies_namespaces
-  status: automated
+  status: does not meet

--- a/controls/srg_ctr/SRG-APP-000474-CTR-001180.yml
+++ b/controls/srg_ctr/SRG-APP-000474-CTR-001180.yml
@@ -7,4 +7,4 @@ controls:
     security functions are discovered.
   rules:
   - file_integrity_exists
-  status: automated
+  status: does not meet

--- a/controls/srg_ctr/SRG-APP-000516-CTR-000790.yml
+++ b/controls/srg_ctr/SRG-APP-000516-CTR-000790.yml
@@ -5,4 +5,4 @@ controls:
   title: {{{ full_name }}} must provide the configuration for organization-identified
     individuals or roles to change the auditing to be performed on all components,
     based on all selectable event criteria within organization-defined time thresholds.
-  status: pending
+  status: does not meet


### PR DESCRIPTION
#### Description:

- Update the control status with `does not meet`

#### Rationale:

- OCP4 STIG content
