### PR TITLE
Properly exclude all files from analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,10 +24,8 @@ plugins:
     enabled: true
 
 exclude_patterns:
-  - "**/"
-  - "*"
-  - ".*"
-  - ".*/"
+  - "**/*"
+  - "**/.*"
 
   - "!build-scripts/*.py"
   - "!ssg/*.py"


### PR DESCRIPTION
... unless specified otherwise later.

The PR #8946 got the exclusion somehow wrong, it looks like that no files are excluded. The current approach should work though - at least according to https://github.com/codeclimate/codeclimate/issues/891