### PR TITLE
The separate partition is to meet FMT_SMF_EXT.1's Configure local audit storage capacity.

### DIFF
--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log_audit/rule.yml
@@ -44,6 +44,7 @@ references:
     nerc-cip: CIP-007-3 R6.5
     nist: CM-6(a),AU-4,SC-5(2)
     nist-csf: PR.DS-4,PR.PT-1,PR.PT-4
+    ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000341-GPOS-00132,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-021330
     stigid@ol8: OL08-00-010542


### PR DESCRIPTION

#### Description:

- The separate partition is to meet FMT_SMF_EXT.1's Configure local audit storage capacity.

#### Rationale:

- FMT_SMF_EXT.1's Configure local audit storage capacity management function is listed in https://www.niap-ccevs.org/MMO/PP/-442-/#FMT_SMF_EXT.1
