### PR TITLE
Select the correct macro for set_password_hashing_algorithm_passwordauth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhv,multi_platform_ol
 
-{{{ bash_ensure_pam_module_options('/etc/pam.d/password-auth', 'password', 'sufficient', 'pam_unix.so', 'sha512', '', '') }}}
+{{{ bash_provide_pam_module_options('/etc/pam.d/password-auth', 'password', 'sufficient', 'pam_unix.so', 'sha512', '', '') }}}


### PR DESCRIPTION
The `bash_ensure_pam_module_options` macro was replaced by
the `bash_provide_pam_module_options` macro for `set_password_hashing_algorithm_passwordauth` rule.

Although similar, the former selected macro was changing more than
necessary. This was not caught by test scenarios but by observation.

More details on issue https://github.com/ComplianceAsCode/content/issues/8959
