### PR TITLE
Add missing OL7 stig IDs

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -2,13 +2,15 @@
     {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" %}}
 {{%- elif product in ["ubuntu2004"] %}}
     {{%- set kmod_audit="-w /bin/kmod -p x -k modules" %}}
+{{%- elif product in ["ol7"] %}}
+    {{%- set kmod_audit="-w /usr/bin/kmod -p x -F auid!=unset -k modules" %}}
 {{%- else %}}
     {{%- set kmod_audit="-w /usr/bin/kmod -p x -k modules" %}}
 {{%- endif %}}
 
 documentation_complete: true
 
-prodtype: ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
+prodtype: ol7,ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands - kmod'
 
@@ -45,6 +47,7 @@ references:
     disa: CCI-000130,CCI-000169,CCI-000172,CCI-002884
     nist: AU-3,AU-3.1,AU-12(a),AU-12.1(ii),AU-12.1(iv)AU-12(c),MA-4(1)(a)
     srg: SRG-OS-000037-GPOS-00015,SRG-OS-000042-GPOS-00020,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215,SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222
+    stigid@ol7: OL07-00-030840
     stigid@ol8: OL08-00-030580
     stigid@rhel8: RHEL-08-030580
     stigid@sle12: SLES-12-020360

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/rule.yml
@@ -42,6 +42,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.AC-6
     srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227
+    stigid@ol7: OL07-00-020111
     stigid@rhel7: RHEL-07-020111
 
 ocil_clause: 'GNOME automounting is not disabled'

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/rule.yml
@@ -43,8 +43,8 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.AC-6
     srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227
+    stigid@ol7: OL07-00-020111
     stigid@rhel7: RHEL-07-020111
-
 
 ocil_clause: 'GNOME automounting is not disabled'
 

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/rule.yml
@@ -43,8 +43,8 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.AC-3,PR.AC-6
     srg: SRG-OS-000114-GPOS-00059,SRG-OS-000378-GPOS-00163,SRG-OS-000480-GPOS-00227
+    stigid@ol7: OL07-00-020111
     stigid@rhel7: RHEL-07-020111
-
 
 ocil_clause: 'GNOME autorun is not disabled'
 

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -317,3 +317,4 @@ selections:
     - sudoers_default_includedir
     - disallow_bypass_password_sudo
     - no_empty_passwords_etc_shadow
+    - audit_rules_privileged_commands_kmod


### PR DESCRIPTION
#### Description:

- Add stigid@ol7 in following rules:
  - audit_rules_privileged_commands_kmod
  - dconf_gnome_disable_automount
  - dconf_gnome_disable_automount_open
  - dconf_gnome_disable_autorun
- Also add audit_rules_privileged_commands_kmod to OL7 stig profile

#### Rationale:

- OL7 STIG profile efforts
