### PR TITLE
OCP4 STIG: Only use resource_requests_quota directly, not its subtests

### DIFF
--- a/controls/srg_ctr/SRG-APP-000246-CTR-000605.yml
+++ b/controls/srg_ctr/SRG-APP-000246-CTR-000605.yml
@@ -6,7 +6,5 @@ controls:
     defined denial-of-service (DoS) attacks against other information systems.
   rules:
   - resource_requests_quota
-  - resource_requests_quota_cluster
-  - resource_requests_quota_per_project
   - routes_rate_limit
   status: automated

--- a/controls/srg_ctr/SRG-APP-000435-CTR-001070.yml
+++ b/controls/srg_ctr/SRG-APP-000435-CTR-001070.yml
@@ -7,7 +7,5 @@ controls:
     safeguards.
   rules:
   - resource_requests_quota
-  - resource_requests_quota_cluster
-  - resource_requests_quota_per_project
   - routes_rate_limit
   status: automated


### PR DESCRIPTION
#### Description:

We autogenerated the rules that resolve the STIG controls initially. Two
of the controls are addressed by the rule resource_requests_quota
which passes if either resource_requests_quota_cluster or
resource_requests_quota_per_project.

And during e2e tests, the rule resource_requests_quota is remediated by
remediation resource_requests_quota_cluster. But at the same time, the
e2e stanza for resource_requests_quota_cluster only said FAIL because
there's no e2e remediation for that rule specifically. This caused the
e2e tests to fail.

We address this issue by removing the sub-rules from the control files,
which causes only the resource_requests_quota rule result to be checked
regardless of how the rule is addressed.


#### Rationale:

This patch ensures that the e2e tests for the STIG profile pass.
