### PR TITLE
Fix usage of an undefined variable

### DIFF
--- a/build-scripts/build_profile_remediations.py
+++ b/build-scripts/build_profile_remediations.py
@@ -86,7 +86,7 @@ def main():
             output_dir, template
         )
 
-        for remediation_path in role_paths:
+        for remediation_path in remediation_paths:
             print(remediation_path)
 
         sys.exit(0)


### PR DESCRIPTION


#### Description:
Fix usage of an undefined variable


#### Rationale:
The correct name of the variable is `remediation_paths`.

