### PR TITLE
Add sysctl rules to anssi

### DIFF
--- a/products/sle15/profiles/anssi_bp28_minmal.profile
+++ b/products/sle15/profiles/anssi_bp28_minmal.profile
@@ -28,3 +28,5 @@ selections:
   - file_permissions_etc_passwd
   - file_permissions_unauthorized_world_writable
   - package_tftp-server_removed
+  - sysctl_net_ipv4_conf_default_accept_redirects
+  - sysctl_net_ipv4_conf_default_accept_source_route


### PR DESCRIPTION
#### Description:

- sysctl_net_ipv4_conf_default_accept_source_route
- sysctl_net_ipv4_conf_default_accept_redirects

#### Rationale:
