### PR TITLE
RHEL8 STIG: Install redhat gpg key

### DIFF
--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -253,6 +253,9 @@ selections:
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
 
+    # Necessary for package installs after gpgcheck is enabled
+    - ensure_redhat_gpgkey_installed
+
     # RHEL-08-010371
     - ensure_gpgcheck_local_packages
 

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -69,10 +69,10 @@ selections:
 - accounts_umask_etc_profile
 - accounts_umask_interactive_users
 - accounts_user_dot_no_world_writable_programs
-- accounts_users_home_files_groupownership
 - accounts_user_home_paths_only
 - accounts_user_interactive_home_directory_defined
 - accounts_user_interactive_home_directory_exists
+- accounts_users_home_files_groupownership
 - accounts_users_home_files_permissions
 - agent_mfetpd_running
 - aide_check_audit_tools
@@ -203,8 +203,9 @@ selections:
 - enable_fips_mode
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated
-- ensure_gpgcheck_never_disabled
 - ensure_gpgcheck_local_packages
+- ensure_gpgcheck_never_disabled
+- ensure_redhat_gpgkey_installed
 - file_audit_tools_group_ownership
 - file_audit_tools_ownership
 - file_audit_tools_permissions

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -80,10 +80,10 @@ selections:
 - accounts_umask_etc_profile
 - accounts_umask_interactive_users
 - accounts_user_dot_no_world_writable_programs
-- accounts_users_home_files_groupownership
 - accounts_user_home_paths_only
 - accounts_user_interactive_home_directory_defined
 - accounts_user_interactive_home_directory_exists
+- accounts_users_home_files_groupownership
 - accounts_users_home_files_permissions
 - agent_mfetpd_running
 - aide_check_audit_tools
@@ -214,8 +214,9 @@ selections:
 - enable_fips_mode
 - encrypt_partitions
 - ensure_gpgcheck_globally_activated
-- ensure_gpgcheck_never_disabled
 - ensure_gpgcheck_local_packages
+- ensure_gpgcheck_never_disabled
+- ensure_redhat_gpgkey_installed
 - file_audit_tools_group_ownership
 - file_audit_tools_ownership
 - file_audit_tools_permissions


### PR DESCRIPTION
#### Description:

- Select rule `ensure_redthat_gpgkey_installed` in RHEL8 STIG

#### Rationale:

- The errors occur even during the remediation run that enabled `gpgcheck=1`.
```console
Title
	Install the tmux Package
Rule
	xccdf_org.ssgproject.content_rule_package_tmux_installed
Ident
	CCE-80644-8
Result
	error
```
- Although the RHEL8 STIG doesn't explicitly instruct to install Red Hat's gpg key, it is necessary when gpgcheck is enabled by rule  `ensure_gpgcheck_globally_activated`
```console
[root@localhost ~]# yum install tmux
Updating Subscription Management repositories.

You have enabled checking of packages via GPG keys. This is a good thing.
However, you do not have any GPG public keys installed. You need to download
the keys for packages you wish to install and install them.
You can do that by running the command:
    rpm --import public.gpg.key

Alternatively you can specify the url to the key you would like to use
for a repository in the 'gpgkey' option in a repository section and YUM
will install it for you.

For more information contact your distribution or package provider.                            
```

- This was originally selected in DRAFT RHEL8 STIG, but was unselected once [RHEL8 STIG V1R1](https://github.com/ComplianceAsCode/content/pull/6579/files#diff-66034bf40f4e0e36d167dce7c8fdad10313a3cc041c6ad61394b93a7cba46fe3L104) came out.
