### PR TITLE
Follow symlinks in ensure_gpgcheck_local_packages

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -4,11 +4,18 @@
 # complexity = low
 # disruption = medium
 
-- name: Ensure GPG check Enabled for Local Packages (Yum)
-  ini_file:
-    dest: {{{ pkg_manager_config_file }}}
-    section: main
-    option: localpkg_gpgcheck
-    value: 1
-    no_extra_spaces: yes
-    create: True
+- name: Ensure GPG check Enabled for Local Packages ({{{ pkg_manager }}})
+  block:
+    - name: Check stats of {{{ pkg_manager }}}
+      stat:
+        path: {{{ pkg_manager_config_file }}}
+      register: stat_pkg_manager_config_file
+
+    - name: Ensure GPG check Enabled for Local Packages ({{{ pkg_manager }}})
+      ini_file:
+        dest: "{{ stat_pkg_manager_config_file.stat.lnk_target | default('{{{ pkg_manager_config_file }}}') }}"
+        section: main
+        option: localpkg_gpgcheck
+        value: 1
+        no_extra_spaces: yes
+        create: True

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/ansible/shared.yml
@@ -9,11 +9,16 @@
     - name: Check stats of {{{ pkg_manager }}}
       stat:
         path: {{{ pkg_manager_config_file }}}
-      register: stat_pkg_manager_config_file
+      register: pkg
+
+    - name:  Check if config file of {{{ pkg_manager }}} is a symlink
+      ansible.builtin.set_fact:
+        pkg_config_file_symlink: '{{ pkg.stat.lnk_target if pkg.stat.lnk_target is match("^/.*") else "{{{ pkg_manager_config_file }}}" | dirname ~ "/" ~ pkg.stat.lnk_target }}'
+      when: pkg.stat.lnk_target is defined
 
     - name: Ensure GPG check Enabled for Local Packages ({{{ pkg_manager }}})
       ini_file:
-        dest: "{{ stat_pkg_manager_config_file.stat.lnk_target | default('{{{ pkg_manager_config_file }}}') }}"
+        dest: '{{ pkg_config_file_symlink |  default("{{{ pkg_manager_config_file }}}") }}'
         section: main
         option: localpkg_gpgcheck
         value: 1


### PR DESCRIPTION
#### Description:

- This change makes the Ansible task edit the symlink when it is one.
  Note that the ini_file module doesn't have an option to follow symlinks.

#### Rationale:

- In RHEL8, /etc/yum.conf is a symlink to /etc/dnf/dnf.conf.
  The bash remediation preserves the symlink, it follows the remediation and edits /etc/dnf/dnf.conf
  The Ansible remediation breaks the symlink, it creates a new static file.


- Related: https://github.com/ansible/ansible/issues/63383
- Inspired by https://gist.github.com/acataluddi/19f82f6165fc01706fa1453a311039fa#file-change_ini_file_preserving_symlinks-yml
