### PR TITLE
OCP4: Filter out new 4.11 SCCs that allow capabilites in addition to the privileged SCC

### DIFF
--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -42,15 +42,18 @@ ocil: |-
     completely added as a list entry under <tt>allowedCapabilities</tt>,
     or that all the un-required capabilities are dropped for containers and SCCs.
 
+{{% set jqfilter = '[.items[] | select(.metadata.name | test("{{.var_sccs_with_allowed_capabilities_regex}}"; "") | not)] | map(.allowedCapabilities == null)' %}}
+
+
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/apis/security.openshift.io/v1/securitycontextconstraints': '[.items[] | select(.metadata.name != "privileged")] | map(.allowedCapabilities == null)'}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/apis/security.openshift.io/v1/securitycontextconstraints': jqfilter}) | indent(4) }}}
 
 template:
     name: yamlfile_value
     vars:
         ocp_data: "true"
-        filepath: "{{{ openshift_filtered_path('/apis/security.openshift.io/v1/securitycontextconstraints', '[.items[] | select(.metadata.name != \"privileged\")] | map(.allowedCapabilities == null)') }}}"
+        filepath: "{{{ openshift_filtered_path('/apis/security.openshift.io/v1/securitycontextconstraints', jqfilter) }}}"
         yamlpath: "[:]"
         check_existence: "all_exist"
         entity_check: "all"

--- a/applications/openshift/scc/var_sccs_with_allowed_capabilities_regex.var
+++ b/applications/openshift/scc/var_sccs_with_allowed_capabilities_regex.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'Permitted SCCs with allowedCapabilities'
+
+description: 'A regular expression that lists all SCCs that are permitted to set the allowedCapabilities attribute'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+  default: "^privileged$|^hostnetwork-v2$|^restricted-v2$|^nonroot-v2$"


### PR DESCRIPTION
#### Description:

OCP 4.11 adds several new SCCs whose allowedCapabilities are set. All of
their names end with -v2, so let's filter them out as well from the list
of SCCs we check.

#### Rationale:

We need to support OCP 4.11

For the failure, see https://storage.googleapis.com/origin-ci-test/pr-logs/pull/openshift_release/29623/rehearse-29623-pull-ci-ComplianceAsCode-content-master-e2e-aws-ocp4-moderate/1538803521816629248/build-log.txt
