### PR TITLE
Update configure_tmux_lock_after_time check conditions

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
@@ -10,10 +10,20 @@
   comment="check lock-after-time is set to 900 in /etc/tmux.conf"
   id="test_configure_tmux_lock_after_time" version="1">
     <ind:object object_ref="obj_configure_tmux_lock_after_time" />
+    <ind:state state_ref="state_configure_tmux_lock_after_time_lower_boundary" />
+    <ind:state state_ref="state_configure_tmux_lock_after_time_upper_boundary" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_configure_tmux_lock_after_time" version="1">
+  <ind:textfilecontent54_object id="obj_configure_tmux_lock_after_time" version="2">
     <ind:filepath>/etc/tmux.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-after-time\s+900\s*(?:#.*)?$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-after-time\s+(\d+)\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_configure_tmux_lock_after_time_lower_boundary" version="1"
+  comment="the value is greater than zero">
+    <ind:subexpression datatype="int" operation="greater than">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+  <ind:textfilecontent54_state id="state_configure_tmux_lock_after_time_upper_boundary" version="1"
+  comment="the value is less than or equal to 900">
+    <ind:subexpression datatype="int" operation="less than or equal">900</ind:subexpression>
+  </ind:textfilecontent54_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
@@ -7,8 +7,8 @@ title: 'Configure tmux to lock session after inactivity'
 description: |-
     To enable console screen locking in <tt>tmux</tt> terminal multiplexer
     after a period of inactivity,
-    the <tt>lock-after-time</tt> option has to be set to nonzero value in
-    <tt>/etc/tmux.conf</tt>.
+    the <tt>lock-after-time</tt> option has to be set to a value greater than 0 and less than
+    or equal to 900 in <tt>/etc/tmux.conf</tt>.
 
 rationale: |-
     Locking the session after a period of inactivity limits the
@@ -27,7 +27,7 @@ references:
     stigid@ol8: OL08-00-020070
     stigid@rhel8: RHEL-08-020070
 
-ocil_clause: 'lock-after-time is not set to 900 or set to zero'
+ocil_clause: 'lock-after-time is set to a value greater than 900 or zero'
 
 ocil: |-
     To verify that session locking after period of inactivity is configured in tmux,

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/correct_value.pass.sh
@@ -1,0 +1,4 @@
+# packages = tmux
+
+tmux_conf="/etc/tmux.conf"
+echo "set -g lock-after-time 900" > "$tmux_conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/lenient_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/lenient_value.fail.sh
@@ -1,0 +1,4 @@
+# packages = tmux
+
+tmux_conf="/etc/tmux.conf"
+echo "set -g lock-after-time 901" > "$tmux_conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/stricter_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/stricter_value.pass.sh
@@ -1,0 +1,4 @@
+# packages = tmux
+
+tmux_conf="/etc/tmux.conf"
+echo "set -g lock-after-time 800" > "$tmux_conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/zero_as_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/zero_as_value.fail.sh
@@ -1,0 +1,4 @@
+# packages = tmux
+
+tmux_conf="/etc/tmux.conf"
+echo "set -g lock-after-time 0" > "$tmux_conf"


### PR DESCRIPTION
#### Description:

- Update OVAL in  `configure_tmux_lock_after_time` to allow values between 1 and 900
- Update rule description to match this behavior
- Added tests to this rule

#### Rationale:

- There was the possibility for a compliant system to fail this rule if this wasn't set to lock tmux after exactly 900 seconds
