### PR TITLE
Create rule to cover OL08-00-010572

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -1,0 +1,39 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'Add nosuid Option to /boot/efi'
+
+description: |-
+    The <tt>nosuid</tt> mount option can be used to prevent
+    execution of setuid programs in <tt>/boot/efi</tt>. The SUID and SGID permissions
+    should not be required on the boot partition.
+    {{{ describe_mount(option="nosuid", part="/boot/efi") }}}
+
+rationale: |-
+    The presence of SUID and SGID executables should be tightly controlled. Users
+    should not be able to execute SUID or SGID binaries from boot partitions.
+
+{{{ complete_ocil_entry_mount_option("/boot/efi", "nosuid") }}}
+
+severity: medium
+
+references:
+    disa: CCI-000366
+    nist: CM-6(b),CM-6.1(iv)
+    srg: SRG-OS-000480-GPOS-00227
+    stigid@ol8: OL08-00-010572
+
+platform: machine
+
+template:
+    name: mount_option
+    vars:
+        mountpoint: /boot/efi
+        mountoption: nosuid
+        mount_has_to_exist: "no"
+
+fixtext: |-
+    {{{ fixtext_mount_option("/boot/efi", "nosuid") }}}
+
+srg_requirement: '{{{ srg_requirement_mount_option("/boot/efi", "nosuid") }}}'

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -378,6 +378,7 @@ selections:
     - mount_option_boot_nosuid
 
     # OL08-00-010572
+    - mount_option_boot_efi_nosuid
 
     # OL08-00-010580
     - mount_option_nodev_nonroot_local_partitions


### PR DESCRIPTION
#### Description:

- Created rule `mount_option_boot_efi_nosuid`

#### Rationale:

- This new rule covers DISA STIG ID `OL08-00-010572`
