### PR TITLE
Create rule to cover OL08-00-030030

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/ansible/shared.yml
@@ -1,4 +1,8 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
 
 {{{ ansible_set_config_file(file="/etc/aliases",
                             parameter='postmaster',

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/ansible/shared.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_all
+
+{{{ ansible_set_config_file(file="/etc/aliases",
+                            parameter='postmaster',
+                            separator=': ',
+                            separator_regex='\s*:\s*',
+                            value='root',
+                            create='yes') }}}
+
+- name: Update postfix aliases
+  ansible.builtin.command:
+    cmd: newaliases
+

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/bash/shared.sh
@@ -1,4 +1,8 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
 
 {{{ set_config_file(path="/etc/aliases",
                     parameter="postmaster",

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/bash/shared.sh
@@ -1,0 +1,10 @@
+# platform = multi_platform_all
+
+{{{ set_config_file(path="/etc/aliases",
+                    parameter="postmaster",
+                    value="root",
+                    create=true,
+                    separator=": ",
+                    separator_regex="\s*:\s*") }}}
+
+newaliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/oval/shared.xml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/oval/shared.xml
@@ -1,0 +1,26 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Check if postmaster has the correct mail alias.") }}}
+    <criteria comment="Check if postmaster has the correct mail alias.">
+      <criterion comment="Check if postmaster has the correct mail alias."
+      test_ref="test_postfix_client_configure_mail_alias_postmaster"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="Check if postmaster has the correct mail alias"
+  id="test_postfix_client_configure_mail_alias_postmaster" version="1" >
+    <ind:object object_ref="obj_postmaster_mail_alias"/>
+    <ind:state state_ref="state_postmaster_mail_alias"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_postmaster_mail_alias" version="1">
+    <ind:filepath operation="equals">/etc/aliases</ind:filepath>
+    <ind:pattern operation="pattern match">^(?i)postmaster\s*:\s*(.+)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_postmaster_mail_alias" version="1" comment="postmaster email alias">
+    <ind:subexpression operation="pattern match">(?i)root</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/rule.yml
@@ -45,3 +45,6 @@ fixtext: |-
     Then, run the following command:
 
     $ sudo newaliases
+
+srg_requirement: |-
+    {{{ full_name }}} must forward mails from postmaster to the root account using a postfix alias

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/rule.yml
@@ -1,0 +1,47 @@
+documentation_complete: true
+
+title: 'Configure System to Forward All Mail From Postmaster to The Root Account'
+
+description: |-
+    Verify the administrators are notified in the event of an audit processing failure.
+    Check that the "/etc/aliases" file has a defined value for "root".
+    <pre>$ sudo grep "postmaster:\s*root$" /etc/aliases
+
+    postmaster: root</pre>
+
+rationale: |-
+    It is critical for the appropriate personnel to be aware if a system is at risk of failing to
+    process audit logs as required. Without this notification, the security personnel may be
+    unaware of an impending failure of the audit capability, and system operation may be adversely
+    affected.
+    
+    Audit processing failures include software/hardware errors, failures in the audit capturing
+    mechanisms, and audit storage capacity being reached or exceeded.
+
+severity: medium
+
+references:
+    disa: CCI-000139
+    nist: AU-5(a),AU-5.1(ii)
+    srg: SRG-OS-000046-GPOS-00022
+    stigid@ol8: OL08-00-030030
+
+ocil_clause: 'the alias is not set or is not root'
+
+ocil: |-
+    Find the list of alias maps used by the Postfix mail server:
+    <pre>$ sudo postconf alias_maps</pre>
+    Query the Postfix alias maps for an alias for the <i>postmaster</i> user:
+    <pre>$ sudo postmap -q postmaster hash:/etc/aliases</pre>
+    The output should return root.
+
+fixtext: |-
+    Configure a valid email address as an alias for the root account.
+
+    Append the following line to "/etc/aliases":
+
+    postmaster: root
+
+    Then, run the following command:
+
+    $ sudo newaliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/correct.pass.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/correct.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = postfix
+
+echo "postmaster: root" > /etc/aliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/file_missing.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = postfix
+
+rm -f /etc/aliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/no_postmaster_alias.fail.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/no_postmaster_alias.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = postfix
+
+sed -i '/postmaster/d' /etc/aliases

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/wrong.fail.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/tests/wrong.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = postfix
+
+echo "postmaster: adm" > /etc/aliases

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -694,7 +694,7 @@ selections:
     - auditd_data_retention_action_mail_acct
 
     # OL08-00-030030
-    - postfix_client_configure_mail_alias
+    - postfix_client_configure_mail_alias_postmaster
 
     # OL08-00-030040
     - auditd_data_disk_error_action


### PR DESCRIPTION
#### Description:

- Add rule `postfix_client_configure_mail_alias_postmaster`

#### Rationale:

- This is to cover the DISA STIG ID `OL08-00-030030` for Oracle Linux 8
