### PR TITLE
Introduce rules for lastlog permissions and ownerships

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_lastlog/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_lastlog/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'Verify Group Who Owns lastlog Command'
+
+description: |-
+    {{{ describe_file_group_owner(file="/var/log/lastlog", group="root") }}}
+
+rationale: |-
+    Unauthorized disclosure of the contents of the /var/log/lastlog file can reveal system data to
+    attackers, thus compromising its confidentiality.
+
+severity: medium
+
+references:
+    disa: CCI-001314
+    nist: SI-11(b),SI-11(c),SI-11.1(iv)
+    srg: SRG-OS-000206-GPOS-00084
+    stigid@ol8: OL08-00-020264
+
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/var/log/lastlog", group="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_group_owner(file="/var/log/lastlog", group="root") }}}
+
+fixtext: '{{{ fixtext_directory_group_owner(file="/var/log/lastlog", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_directory_group_owner(file="/var/log/lastlog", group="root") }}}'
+
+template:
+    name: file_groupowner
+    vars:
+        filepath: /usr/bin/lastlog
+        filegid: '0'

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_lastlog/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_lastlog/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'Verify Owner on lastlog Command'
+
+description: |-
+    {{{ describe_file_owner(file="/usr/bin/lastlog", owner="root") }}}
+
+rationale: |-
+    Unauthorized disclosure of the contents of the /var/log/lastlog file can reveal system data to
+    attackers, thus compromising its confidentiality.
+
+severity: medium
+
+references:
+    disa: CCI-001314
+    nist: SI-11(b),SI-11(c),SI-11.1(iv)
+    srg: SRG-OS-000206-GPOS-00084
+    stigid@ol8: OL08-00-020263
+
+ocil_clause: '{{{ ocil_clause_file_owner(file="/usr/bin/lastlog", owner="root") }}}'
+
+ocil: |-
+    {{{ ocil_file_owner(file="/usr/bin/lastlog", owner="root") }}}
+
+fixtext: '{{{ fixtext_directory_owner(file="/var/log/lastlog", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_directory_owner(file="/usr/bin/lastlog", owner="root") }}}'
+
+template:
+    name: file_owner
+    vars:
+        filepath: /usr/bin/lastlog
+        fileuid: '0'

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_lastlog/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_lastlog/rule.yml
@@ -1,0 +1,35 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'Verify Permissions on lastlog Command'
+
+description: |-
+    {{{ describe_file_permissions(file="/usr/bin/lastlog", perms="0750") }}}
+
+rationale: |-
+    Unauthorized disclosure of the contents of the /var/log/lastlog file can reveal system data to
+    attackers, thus compromising its confidentiality.
+
+severity: medium
+
+references:
+    disa: CCI-001314
+    nist: SI-11(b),SI-11(c),SI-11.1(iv)
+    srg: SRG-OS-000206-GPOS-00084
+    stigid@ol8: OL08-00-020262
+
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/usr/bin/lastlog", perms="-rwxr-x---") }}}'
+
+ocil: |-
+    {{{ ocil_file_permissions(file="/usr/bin/lastlog", perms="-rwxr-x---") }}}
+
+fixtext: '{{{ fixtext_directory_permissions("0750", "/usr/bin/lastlog/") }}}'
+
+srg_requirement: '{{{ srg_requirement_directory_permission("0750", "/usr/bin/lastlog") }}}'
+
+template:
+    name: file_permissions
+    vars:
+        filepath: /usr/bin/lastlog
+        filemode: '0750'

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -635,10 +635,13 @@ selections:
     # OL08-00-020261
 
     # OL08-00-020262
+    - file_permissions_lastlog
 
     # OL08-00-020263
+    - file_ownership_lastlog
 
     # OL08-00-020264
+    - file_groupownership_lastlog
 
     # OL08-00-020270
     - account_emergency_expire_date

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
    {{% if FILEPATH is not string %}}
-      {{{ oval_metadata("This test makes sure that FILEPATH is group owned by " + FILEGID + ".") }}}
+      {{{ oval_metadata("This test makes sure that " + FILEPATH|join(", ") + " is group owned by " + FILEGID + ".") }}}
       <criteria>
     {{% for filepath in FILEPATH %}}
       <criterion comment="Check file group ownership of {{{ filepath }}}" test_ref="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />

--- a/shared/templates/file_owner/oval.template
+++ b/shared/templates/file_owner/oval.template
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
   {{% if FILEPATH is not string %}}
-    {{{ oval_metadata("This test makes sure that FILEPATH is owned by " + FILEUID + ".") }}}
+    {{{ oval_metadata("This test makes sure that " + FILEPATH|join(", ") + " is owned by " + FILEUID + ".") }}}
      <criteria>
    {{% for filepath in FILEPATH %}}
      <criterion comment="Check file ownership of {{{ filepath }}}" test_ref="test_file_owner{{{ FILEID }}}_{{{ loop.index0 }}}" />

--- a/shared/templates/file_permissions/oval.template
+++ b/shared/templates/file_permissions/oval.template
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
   {{% if FILEPATH is not string %}}
-    {{{ oval_metadata("This test makes sure that FILEPATH has mode " + FILEMODE + ".
+    {{{ oval_metadata("This test makes sure that " + FILEPATH|join(", ") + " has mode " + FILEMODE + ".
       If the target file or directory has an extended ACL, then it will fail the mode check.
       ") }}}
     <criteria>

--- a/shared/templates/file_permissions/tests/stricter_permisions.pass.sh
+++ b/shared/templates/file_permissions/tests/stricter_permisions.pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+{{% for path in FILEPATH %}}
+{{% if IS_DIRECTORY and FILE_REGEX %}}
+echo "Create specific tests for this rule because of regex"
+{{% elif IS_DIRECTORY and RECURSIVE %}}
+find -L {{{ path }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
+{{% else %}}
+if [ ! -f {{{ path }}} ]; then
+    mkdir -p "$(dirname '{{{ path }}}')"
+    touch {{{ path }}}
+fi
+chmod 000 {{{ path }}}
+{{% endif %}}
+{{% endfor %}}


### PR DESCRIPTION
#### Description:

- Introduced rules:
  - `file_groupownership_lastlog`
  - `file_ownership_lastlog`
  - `file_permissions_lastlog`

#### Rationale:

- These rules comply with DISA STIG IDs `OL08-00-020264`,` OL08-00-020263` & `OL08-00-020262` For Oracle Linux 8 systems
