### PR TITLE
Make krb5 rules applicable only to older versions of certain package

### DIFF
--- a/controls/srg_gpos/SRG-OS-000120-GPOS-00061.yml
+++ b/controls/srg_gpos/SRG-OS-000120-GPOS-00061.yml
@@ -6,7 +6,6 @@ controls:
             federal laws, Executive orders, directives, policies, regulations, standards,
             and guidance for authentication to a cryptographic module.
         rules:
-            - kerberos_disable_no_keytab
             - accounts_password_all_shadowed_sha512
             - package_rsyslog-gnutls_installed
             - libreswan_approved_tunnels

--- a/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
+++ b/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9
+prodtype: ol7,ol8,rhel7,rhel8
 
 title: 'Remove the Kerberos Server Package'
 
@@ -29,6 +29,12 @@ references:
     srg: SRG-OS-000120-GPOS-00061
     stigid@ol8: OL08-00-010163
     stigid@rhel8: RHEL-08-010163
+
+{{% if product in ["ol8", "rhel8"] %}}
+platforms:
+    - krb5_server_older_than_1_17-18
+    - krb5_workstation_older_than_1_17-18
+{{% endif %}}
 
 ocil_clause: 'the package is installed'
 

--- a/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Uninstall krb5-workstation Package'
 
@@ -10,9 +10,6 @@ description: |-
 rationale: |-
     Kerberos is a network authentication system. The <tt>krb5-workstation</tt> package contains the basic
     Kerberos programs (<tt>kinit</tt>, <tt>klist</tt>, <tt>kdestroy</tt>, <tt>kpasswd</tt>).
-
-    Currently, Kerberos does not utilize FIPS 140-2 cryptography and is not permitted on Government networks,
-    nor is it permitted in many regulatory environments such as HIPAA.
 
 severity: medium
 
@@ -29,6 +26,10 @@ references:
 
 platforms:
 {{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
+{{%- if product in ["ol8", "rhel8"] %}}
+    - krb5_server_older_than_1_17-18
+    - krb5_workstation_older_than_1_17-18
+{{% endif %}}
 
 warnings:
 {{{ warning_ovirt_rule_notapplicable("RHV hosts require ipa-client package, which has dependency on krb5-workstation") | indent(4) }}}

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -187,7 +187,6 @@ selections:
     - package_iprutils_removed
     - package_gssproxy_removed
     - package_nfs-utils_removed
-    - package_krb5-workstation_removed
 
     ### Login
     - disable_users_coredumps
@@ -394,9 +393,6 @@ selections:
     # Configure TLS for remote logging
     - rsyslog_remote_tls
     - rsyslog_remote_tls_cacert
-
-    # Prevent Kerberos use by system daemons
-    - kerberos_disable_no_keytab
 
     # set ssh client rekey limit
     - ssh_client_rekey_limit

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -153,12 +153,6 @@ selections:
     # RHEL-08-010160
     - set_password_hashing_algorithm_systemauth
 
-    # RHEL-08-010161
-    - kerberos_disable_no_keytab
-
-    # RHEL-08-010162
-    - package_krb5-workstation_removed
-
     # RHEL-08-010170
     - selinux_state
 


### PR DESCRIPTION


#### Description:
- Make krb5 rules applicable only to older versions of certain package.
  - Remove these rules from RHEL9 scope as it already contains a newer
version of the package that is FIPS compatible and can be used in
government deployments for example.

#### Rationale:

- Rules are applicable only to certain systems.
