### PR TITLE
accounts_tmout: Export and readonly TMOUT

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,4 +5,4 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_tmout") }}}
 
-{{{ ansible_set_config_file(file='/etc/profile.d/tmout.sh', parameter='TMOUT', separator='=', separator_regex='=', value='{{ var_accounts_tmout }}', create='yes') }}}
+{{{ ansible_only_lineinfile(path='/etc/profile.d/tmout.sh', line_regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}', create='yes') }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -7,12 +7,12 @@ tmout_found=0
 
 for f in /etc/profile /etc/profile.d/*.sh; do
     if grep --silent '^\s*TMOUT' $f; then
-        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/\1TMOUT=$var_accounts_tmout\3/g" $f
+        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/declare -xr TMOUT=$var_accounts_tmout\3/g" $f
         tmout_found=1
     fi
 done
 
 if [ $tmout_found -eq 0 ]; then
         echo -e "\n# Set TMOUT to $var_accounts_tmout per security requirements" >> /etc/profile.d/tmout.sh
-        echo "TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
+        echo "declare -xr TMOUT=$var_accounts_tmout" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -28,7 +28,7 @@
     {{% if product in ['sle12', 'sle15'] %}}
     <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+)[\s]*readonly TMOUT[\s]*export TMOUT$</ind:pattern>
     {{% else %}}
-    <ind:pattern operation="pattern match">^[\s]*TMOUT=([\w$]+).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*declare[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
     {{% endif %}}
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -6,7 +6,9 @@ title: 'Set Interactive Session Timeout'
 
 description: |-
     Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that
-    all user sessions will terminate based on inactivity. The <tt>TMOUT</tt>
+    all user sessions will terminate based on inactivity.
+    The value of TMOUT should be exported and read only.
+    The <tt>TMOUT</tt>
     {{% if product in ["sle12", "sle15"] %}}
     setting in <tt>/etc/profile.d/autologout.sh</tt> should read as follows:
     <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
@@ -15,7 +17,7 @@ description: |-
     {{% else %}}
     setting in a file loaded by <tt>/etc/profile</tt>, e.g.
     <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
-    <pre>TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
+    <pre>declare -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     {{% endif %}}
 
 rationale: |-

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile.pass.sh
@@ -5,7 +5,7 @@
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile
 else
-	echo "TMOUT=700" >> /etc/profile
+	echo "declare -xr TMOUT=700" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_profile_d.pass.sh
@@ -9,7 +9,7 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 test -f $TEST_FILE || touch $TEST_FILE
 
 if grep -q "TMOUT" $TEST_FILE; then
-	sed -i "s/.*TMOUT.*/TMOUT=700/" $TEST_FILE
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" $TEST_FILE
 else
-	echo "TMOUT=700" >> $TEST_FILE
+	echo "declare -xr TMOUT=700" >> $TEST_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
@@ -5,9 +5,9 @@
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile
-	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile
+	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
 else
-	echo "TMOUT=700" >> /etc/profile
-	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=700" >> /etc/profile
+	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
@@ -5,9 +5,9 @@
 sed -i "/.*TMOUT.*/d" /etc/profile
 
 if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
-	sed -i "s/.*TMOUT.*/TMOUT=700/" /etc/profile.d/tmout.sh
-	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
 else
-	echo "TMOUT=700" >> /etc/profile.d/tmout.sh
-	echo "TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=700" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# platform = multi_platform_sle
 # variables = var_accounts_tmout=700
 
 if grep -q "TMOUT" /etc/profile; then

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# platform = multi_platform_sle
 # variables = var_accounts_tmout=900
 
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# platform = multi_platform_sle
 # variables = var_accounts_tmout=900
 
 TEST_FILE=/etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/multiline_profile_d.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# platform = multi_platform_sle
 # variables = var_accounts_tmout=700
 
 TEST_FILE=/etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile.pass.sh
@@ -5,7 +5,7 @@
 sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
-	sed -i "s/.*TMOUT.*/TMOUT=800/" /etc/profile
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=800/" /etc/profile
 else
-	echo "TMOUT=800" >> /etc/profile
+	echo "declare -xr TMOUT=800" >> /etc/profile
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/supercompliance_profile_d.pass.sh
@@ -9,7 +9,7 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 test -f $TEST_FILE || touch $TEST_FILE
 
 if grep -q "TMOUT" $TEST_FILE; then
-	sed -i "s/.*TMOUT.*/TMOUT=800/" $TEST_FILE
+	sed -i "s/.*TMOUT.*/declare -xr TMOUT=800/" $TEST_FILE
 else
-	echo "TMOUT=800" >> $TEST_FILE
+	echo "declare -xr TMOUT=800" >> $TEST_FILE
 fi


### PR DESCRIPTION
#### Description:

- Change `accounts_tmout` rule so that it checks that TMOUT is exported and readonly

#### Rationale:

- This change supports OL8 and RHEL8 STIG along with RHEL7 and RHEL8 CIS Benchmarks.

#### Other info:
- Related: https://github.com/ComplianceAsCode/content/pull/6424
