### PR TITLE
Update sysctl bash template

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1334,7 +1334,8 @@ printf -v formatted_output "{{{ format }}}" "$stripped_key" "{{{ value }}}"
 # We search for the key string followed by a word boundary (matched by \>),
 # so if we search for 'setting', 'setting2' won't match.
 if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
-    "${sed_command[@]}" "s/{{{ key }}}\\>.*/$formatted_output/gi" "{{{ config_file }}}"
+    escaped_formatted_output=$(sed -e 's|/|\\/|g' <<< "$formatted_output")
+    "${sed_command[@]}" "s/{{{ key }}}\\>.*/$escaped_formatted_output/gi" "{{{ config_file }}}"
 else
     # \n is precaution for case where file ends without trailing newline
     {{% if cce_identifiers and 'cce' in cce_identifiers -%}}

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -5,12 +5,17 @@
 # disruption = medium
 
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
+{{% else %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf; do
+{{% endif %}}
   matching_list=$(grep -P '^(?!#).*[\s]*{{{ SYSCTLVAR }}}.*$' $f | uniq )
   if ! test -z "$matching_list"; then
     while IFS= read -r entry; do
+      escaped_entry=$(sed -e 's|/|\\/|g' <<< "$entry")
       # comment out "{{{ SYSCTLVAR }}}" matches to preserve user data
-      sed -i "s/^${entry}$/# &/g" $f
+      sed -i "s/^${escaped_entry}$/# &/g" $f
     done <<< "$matching_list"
   fi
 done

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -111,7 +111,7 @@
                    test_ref="test_static_etc_sysctld_{{{ SYSCTLID }}}"/>
         <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /run/sysctl.d/*.conf"
                    test_ref="test_static_run_sysctld_{{{ SYSCTLID }}}"/>
-{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
         <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /usr/lib/sysctl.d/*.conf"
                    test_ref="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}"/>
 {{% endif %}}
@@ -134,14 +134,14 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_test id="test_static_run_sysctld_{{{ SYSCTLID }}}" version="1" check="all"
-                          comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf">
+                          comment="{{{ SYSCTLVAR }}} static configuration in /run/sysctl.d/*.conf">
     {{{ state_static_sysctld("run_sysctld") }}}
   </ind:textfilecontent54_test>
 
-{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
   <ind:textfilecontent54_test id="test_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1"
                           check="all"
-                          comment="{{{ SYSCTLVAR }}} static configuration in /etc/sysctl.d/*.conf">
+                          comment="{{{ SYSCTLVAR }}} static configuration in /usr/lib/sysctl.d/*.conf">
     {{{ state_static_sysctld("usr_lib_sysctld") }}}
   </ind:textfilecontent54_test>
 {{% endif %}}
@@ -256,7 +256,7 @@
   <ind:textfilecontent54_object id="object_static_run_usr_sysctls_{{{ SYSCTLID }}}" version="1">
     <set>
       <object_reference>object_static_run_sysctld_{{{ SYSCTLID }}}</object_reference>
-{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
       <object_reference>object_static_usr_lib_sysctld_{{{ SYSCTLID }}}</object_reference>
 {{% endif %}}
     </set>
@@ -279,7 +279,7 @@
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
 
-{{% if product not in [ "ol7", "ol8", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
   <ind:textfilecontent54_object id="object_static_usr_lib_sysctld_{{{ SYSCTLID }}}" version="1">
     <ind:path>/usr/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -112,3 +112,16 @@ function call_bash_replace_or_append_w_format {
 
     rm "$tmp_file"
 }
+
+@test "bash_replace_or_append - Remediate value containing forward slash" {
+    tmp_file="$(mktemp)"
+    printf "%s\n" "kernel.core_pattern=|/bin/true" > "$tmp_file"
+    expected_output="kernel.core_pattern=|/bin/false\n"
+
+    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.core_pattern' '|/bin/false' '%s=%s'
+
+    run diff "$tmp_file" <(printf "$expected_output")
+    [ "$status" -eq 0 ]
+
+    rm "$tmp_file"
+}


### PR DESCRIPTION
#### Description:

- Update sysctl bash template so it doesn't fail when config entries contain the `/` character.
- The same update was needed inside the `bash_replace_or_append` bash macro for the formated output.
- Also update sysctl bash template to take into account config files in /usr/lib/sysctl.d/.
- Minor update to sysctl OVAL template comments.

#### Rationale:

- The `/` character is used as control char / command delimiter on the `sed` commands; If the `/` char is present on the text used in the `sed` command, `sed` fails with an "_unknown option to `s'_" error.
- The OVAL content generated by the sysctl template takes into account files in /usr/lib/sysctl.d/ while the bash remediation did not. This resulted in rules evaluated as `fail` after a "successful" execution of the remediation.
- Some comments on the sysctl OVAL template were not mentioning the files they look for.