### PR TITLE
Remove any ocurrence of silent from /etc/pam.d/postlogin

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
@@ -92,8 +92,8 @@
     - name: Ensure the silent option is not present in the custom profile
       ansible.builtin.replace:
         dest: "/etc/authselect/{{ authselect_custom_profile }}/postlogin"
-        regexp: '^(session.*required.*pam_lastlog.so).*$'
-        replace: '\g<1> showfailed'
+        regexp: '^(session.*pam_lastlog.so.*) silent( .*)$'
+        replace: '\g<1>\g<2>'
       when:
         - result_authselect_profile is not skipped
 
@@ -157,8 +157,8 @@
     - name: Ensure the silent option is not present in PAM files
       ansible.builtin.replace:
         dest: /etc/pam.d/{{{ pam_lastlog_filename }}}
-        regexp: '^(session.*required.*pam_lastlog.so).*$'
-        replace: '\g<1> showfailed'
+        regexp: '^(session.*pam_lastlog.so.*) silent( .*)$'
+        replace: '\g<1>\g<2>'
 
     - name: Ensure the desired configuration is present in PAM files
       ansible.builtin.lineinfile:

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -22,9 +22,9 @@ if [ -f /usr/bin/authselect ]; then
         if [ "$(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN)" -eq 0 ]; then
             sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
         fi
-        if grep -q "^\s*session.*required.*pam_lastlog.so.*silent.*" $CUSTOM_POSTLOGIN; then
+        if grep -q "^\s*session.*pam_lastlog.so.*silent.*" $CUSTOM_POSTLOGIN; then
             # remove 'silent' option
-            sed -i --follow-symlinks 's/^\(session.*required.*pam_lastlog.so\).*/\1 showfailed/g' $CUSTOM_POSTLOGIN
+            sed -i --follow-symlinks 's/^\(session.*pam_lastlog.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
         fi
         authselect apply-changes -b --backup=after-pwhistory-hardening.backup
     else
@@ -45,8 +45,8 @@ else
     if [ "$(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" {{{ pam_lastlog_path }}})" -eq 0 ]; then
         sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' {{{ pam_lastlog_path }}}
     fi
-    if grep -q "^\s*session.*required.*pam_lastlog.so.*silent.*" {{{ pam_lastlog_path }}}; then
+    if grep -q "^\s*session.*pam_lastlog.so.*silent.*" {{{ pam_lastlog_path }}}; then
         # remove 'silent' option
-        sed -i --follow-symlinks 's/^\(session.*required.*pam_lastlog.so\).*/\1 showfailed/g' {{{ pam_lastlog_path }}}
+        sed -i --follow-symlinks 's/^\(session.*pam_lastlog.so.*\) silent\( .*\)/\1\2/g' {{{ pam_lastlog_path }}}
     fi
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/oval/shared.xml
@@ -28,7 +28,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_display_login_attempts_silent" version="1">
     <ind:filepath>{{{ pam_lastlog_path }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*session\s+required\s+pam_lastlog\.so(?:\s+[\w=]+)*\s+silent(\s|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*session\s+.*\s+pam_lastlog\.so(?:\s+[\w=]+)*\s+silent(\s|$)</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/rule.yml
@@ -14,7 +14,8 @@ description: |-
     settings in
     <tt>{{{ pam_lastlog_path }}}</tt> to read as follows:
     <pre>session     required pam_lastlog.so showfailed</pre>
-    And make sure that the <tt>silent</tt> option is not set.
+    And make sure that the <tt>silent</tt> option is not set for
+    <tt>pam_lastlog</tt> module.
 
 rationale: |-
     Users need to be aware of activity that occurs regarding

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_present.pass.sh
@@ -10,4 +10,7 @@ CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
 if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
     sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
 fi
+if [ $(grep -c "^\s*session.*pam_lastlog.so.*silent$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+    sed -i --follow-symlinks 's/^\(session.*pam_lastlog.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
+fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_silent_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_silent_present.fail.sh
@@ -8,6 +8,7 @@ authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
 if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
-    sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so silent showfailed\n&/' $CUSTOM_POSTLOGIN
+    sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
 fi
+echo "session     optional pam_lastlog.so silent showfailed" >> $CUSTOM_POSTLOGIN
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/no_space_before_silent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/no_space_before_silent.pass.sh
@@ -7,6 +7,9 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
+if [ $(grep -c "^\s*session.*pam_lastlog.so.*silent$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+    sed -i --follow-symlinks 's/^\(session.*pam_lastlog.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
+fi
 if [ $(grep -Ec "^\s*session\s+required\s+pam_lastlog\.so(\s.*)?\ssilent($|\s)" $CUSTOM_POSTLOGIN) -eq 0 ]; then
     # If no such line, add
     sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so unknown=silent showfailed\n&/' $CUSTOM_POSTLOGIN

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value_silent.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value_silent.fail.sh
@@ -11,6 +11,5 @@ rm -f {{{ pam_lastlog_path }}}
 
 # pamd ansible module has a bug that if there is only one line in the file it raises an Out of Index exception
 # so let's add more lines there
-echo "session     optional                   pam_umask.so silent" >> {{{ pam_lastlog_path }}}
-echo "session     [success=1 default=ignore] pam_succeed_if.so service !~ gdm* service !~ su* quiet" >> {{{ pam_lastlog_path }}}
-echo "session required pam_lastlog.so silent showfailed" >> {{{ pam_lastlog_path }}}
+echo "session     required pam_lastlog.so showfailed" >> {{{ pam_lastlog_path }}}
+echo "session     optional pam_lastlog.so silent showfailed" >> {{{ pam_lastlog_path }}}


### PR DESCRIPTION

#### Description:

- Update display_login_attempts so that the silent options is not used with module pam_lastlogin.so.

#### Rationale:

- Before, the silent option would be removed only in a very specific condition.
