### PR TITLE
Remove empty line in ensure_gpgcheck_never_disabled ansible remediation

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_never_disabled/ansible/shared.yml
@@ -6,11 +6,11 @@
 - name: Grep for {{{ pkg_manager }}} repo section names
   shell: |
     set -o pipefail
-{{% if product in ["sle12", "sle15"] %}}
+{{%- if product in ["sle12", "sle15"] %}}
     grep -HEr '^\[.+\]' -r /etc/zypp/repos.d/
-{{% else %}}
+{{%- else %}}
     grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
-{{% endif %}}
+{{%- endif %}}
   register: repo_grep_results
   ignore_errors: True
   changed_when: False


### PR DESCRIPTION
#### Description:
Strip extra whitespace added by Jinja block.

#### Rationale:
Before:
```
  shell: |
    set -o pipefail

    grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
```

After:
```
  shell: |
    set -o pipefail
    grep -HEr '^\[.+\]' -r /etc/yum.repos.d/
```
