### PR TITLE
Fix auditd_overflow_action OVAL to work properly on RHEL9

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_overflow_action/oval/shared.xml
@@ -1,7 +1,7 @@
-{{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
-{{% set audisp_conf_file = "/auditd.conf" %}}
-{{% else %}}
+{{% if product in ["rhel7", "ol7"] %}}
 {{% set audisp_conf_file = "/audispd.conf" %}}
+{{% else %}}
+{{% set audisp_conf_file = "/auditd.conf" %}}
 {{% endif %}}
 
 {{{ oval_check_config_file(


### PR DESCRIPTION
#### Description:

- Fix auditd_overflow_action OVAL to work properly on RHEL9.

#### Rationale:

- Fixes #9012
