### PR TITLE
Add 4.11 test manifests to several rules

### DIFF
--- a/applications/openshift/api-server/api_server_kubelet_client_cert/tests/ocp4/4.11.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/tests/ocp4/4.11.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/api-server/api_server_kubelet_client_key/tests/ocp4/4.11.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/tests/ocp4/4.11.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/tests/ocp4/4.11.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/tests/ocp4/4.11.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/tests/ocp4/4.11.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/tests/ocp4/4.11.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+


### PR DESCRIPTION

#### Description:

We had versioned test results for these rules, but didn't add the 4.11
manifests. This patch adds them.

The only rule I didn't touch was the flowcontrol one which needs to be
adjusted for 4.11.

#### Rationale:

- OCP tests currently don't work on 4.11
