### PR TITLE
RHEL8: Fix rules breaking sudo command

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/ansible/shared.yml
@@ -89,6 +89,7 @@
       when:
         - result_authselect_check_cmd is success
 
+{{% if product in ["ol8"] %}}
     - name: Define the current authselect profile as a local fact
       ansible.builtin.set_fact:
         authselect_current_profile: "{{ result_authselect_profile.stdout }}"
@@ -198,7 +199,24 @@
         - result_authselect_profile is not skipped
         - result_authselect_features is not skipped
         - result_pam_authselect_select_profile is not skipped
+{{% else %}}
+    - name: Get authselect current features
+      ansible.builtin.shell:
+        cmd: authselect current | tail -n+3 | awk '{ print $2 }'
+      register: result_authselect_features
+      changed_when: false
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_profile is not skipped
 
+    - name: Ensure smartcards are enabled via authselect tool
+      ansible.builtin.command:
+        cmd: authselect enable-feature with-smartcard
+      when:
+        - result_authselect_check_cmd is success
+        - result_authselect_features.stdout is not search("with-smartcard")
+        - result_authselect_profile is not skipped
+{{% endif %}}
     - name: Ensure the custom profile changes are applied
       ansible.builtin.command:
         cmd: authselect apply-changes -b --backup=after-pwhistory-hardening.backup

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -9,6 +9,7 @@
 {{% if product in ["ol8", "rhel8"] %}}
 if [ -f /usr/bin/authselect ]; then
     if authselect check; then
+        {{% if product in ["ol8"] %}}
         CURRENT_PROFILE=$(authselect current -r | awk '{ print $1 }')
         # Standard profiles delivered with authselect should not be modified.
         # If not already in use, a custom profile is created preserving the enabled features.
@@ -37,6 +38,9 @@ if [ -f /usr/bin/authselect ]; then
                                            'sufficient', 
                                            'pam_sss.so',
                                            'try_cert_auth', '', '') }}}
+        {{% else %}}
+        authselect enable-feature with-smartcard
+        {{% endif %}}
         authselect apply-changes -b --backup=after-pwhistory-hardening.backup
     else
         echo "

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/oval/shared.xml
@@ -11,9 +11,11 @@
       <criteria operator="AND">
         <criterion comment="Check pam_cert_auth in /etc/sssd/sssd.conf"
         test_ref="test_sssd_enable_smartcards" />
-        {{% if product in ["ol8", "rhel8"] %}}
+        {{% if product in ["ol8"] %}}
         <criterion comment="Check try_cert_auth or require_cert_auth in /etc/pam.d/smartcard-auth"
         test_ref="test_sssd_enable_smartcards_cert_auth_smartcard_auth" />
+        {{% endif %}}
+        {{% if product in ["ol8", "rhel8"] %}}
         <criterion comment="Check try_cert_auth or require_cert_auth in /etc/pam.d/system-auth"
         test_ref="test_sssd_enable_smartcards_cert_auth_system_auth" />
         {{% endif %}}
@@ -31,7 +33,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product in ["ol8", "rhel8"] %}}
+  {{% if product in ["ol8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the presence of try_cert_auth or require_cert_auth in /etc/pam.d/smartcard-auth"
   id="test_sssd_enable_smartcards_cert_auth_smartcard_auth" version="1">
@@ -43,7 +45,9 @@
     <ind:pattern operation="pattern match">^\s*auth.*?pam_sss\.so(.*)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  {{% endif %}}
 
+  {{% if product in ["ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
   comment="tests the presence of try_cert_auth or require_cert_auth in /etc/pam.d/smartcard-auth"
   id="test_sssd_enable_smartcards_cert_auth_system_auth" version="1">

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/pamd_argument_missing_authselect.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/pamd_argument_missing_authselect.fail.sh
@@ -6,7 +6,12 @@ source common.sh
 
 {{{ bash_package_install("authselect") }}}
 
+{{% if product in ["ol8"] %}}
 authselect create-profile testingProfile --base-on minimal
+{{% else %}}
+# The minimal profile doesn't have with-smartcard feature
+authselect create-profile testingProfile --base-on sssd
+{{% endif %}}
 authselect select --force custom/testingProfile
 
 echo "[pam]" > $SSSD_FILE

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
@@ -71,4 +71,4 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
-        filemode: '0755'
+        filemode: '7755'


### PR DESCRIPTION

#### Description:

- Rule dir_permissions_library_dirs is about preventing group-writable or world-writable directories in the library dirs.
  The Suid bits and the stick bit don't need to be stripped.
- Rule sssd_enable_smartcards was breaking the PAM stack in a way that non-root users were not able to execute commands with `sudo`. The commands are failing with `Sorry, try again` 3 times.

#### Rationale:

- Stripin suid bit from `/usr/bin/sudo` breaks it:
  `sudo: /usr/bin/sudo must be owned by uid 0 and have the setuid bit set`
- Related to #8420
- Related to #8768
