### PR TITLE
Don't fail utils/compare_results.py when idref/result is missing, just add placeholder to inform

### DIFF
--- a/utils/compare_results.py
+++ b/utils/compare_results.py
@@ -125,7 +125,10 @@ def get_results(xml: ElementTree.ElementTree) -> dict:
     for result in results_xml:
         idref = result.attrib['idref']
         idref = idref.replace("xccdf_mil.disa.stig_rule_", "")
-        rules[idref] = result.find('xccdf-1.2:result', PREFIX_TO_NS).text
+        try:
+            rules[idref] = result.find('xccdf-1.2:result', PREFIX_TO_NS).text
+        except AttributeError:
+            rules[idref] = "MISSING_RESULT"
 
     return rules
 
@@ -137,7 +140,10 @@ def get_identifiers(xml: ElementTree.ElementTree) -> dict:
     for result in results_xml:
         idref = result.attrib['idref']
         idref = idref.replace("xccdf_mil.disa.stig_rule_", "")
-        rules[idref] = result.find('xccdf-1.2:ident', PREFIX_TO_NS).text
+        try:
+            rules[idref] = result.find('xccdf-1.2:ident', PREFIX_TO_NS).text
+        except AttributeError:
+            rules[idref] = "MISSING_IDREF"
 
     return rules
 


### PR DESCRIPTION
#### Description:
Add `MISSING_RESULT`/`MISSING_IDREF` placeholder when result misses result/idref.
Reproducer:
`python3 utils/compare_results.py ssg-stig-viewer.xml disa-xccdf-arf-results.xml`

#### Rationale:
To avoid throwing attribute errors - `AttributeError: 'NoneType' object has no attribute 'text'` - when element is missing in results.

Before
```
Traceback (most recent call last):
  File "/tmp/tmp.05llzMGKk9/rpmbuild/BUILD/scap-security-guide-0.1.63/utils/compare_results.py", line 246, in <module>
    main()
  File "/tmp/tmp.05llzMGKk9/rpmbuild/BUILD/scap-security-guide-0.1.63/utils/compare_results.py", line 236, in main
    base_ident = get_identifiers(base_tree)
  File "/tmp/tmp.05llzMGKk9/rpmbuild/BUILD/scap-security-guide-0.1.63/utils/compare_results.py", line 140, in get_identifiers
    rules[idref] = result.find('xccdf-1.2:ident', PREFIX_TO_NS).text
```
after
```
...
  CCE-80371-8 CCE-80371-8 - SV-204399r603261_rule                                                         notapplicable - pass
  CCE-27275-7 SV-86899 - SV-204605r603261_rule                                                         pass - fail     
  MISSING_IDREF SV-95715 - SV-204405r603261_rule                                                         notselected - pass
  CCE-26970-4 CCE-26970-4 - SV-204393r603261_rule                                                         notapplicable - pass
...
```