### PR TITLE
Do not include OCIL content in rules that define OVAL external content

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1640,7 +1640,8 @@ class Rule(XCCDFEntity):
             check_content_ref.set("href", "oval-unlinked.xml")
             check_content_ref.set("name", self.id_)
 
-        if self.ocil or self.ocil_clause:
+        oval_content_only = self.oval_external_content is not None
+        if (self.ocil or self.ocil_clause) and not oval_content_only:
             ocil_check = ET.SubElement(check_parent, "check")
             ocil_check.set("system", ocil_cs)
             ocil_check_ref = ET.SubElement(ocil_check, "check-content-ref")


### PR DESCRIPTION
#### Description:
- Do not include OCIL content in rules that define OVAL external content.
 - Pretty much the rule security_patches_up_to_date that can't have OCIL
content as it fails on SCAP validation.

#### Rationale:

- Fixes #9006