### PR TITLE
Add DISA STIG ids to `when` conditions in ansible roles

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -211,7 +211,7 @@ class PlaybookToRoleConverter():
             elif isinstance(task["when"], str):
                 task["when"] = [task["when"]]
 
-            variables_to_add = {tag.replace("-", "_") for tag in task["tags"] if self._tag_is_valid_variable(tag) or "DISA-STIG" in tag}
+            variables_to_add = {self._sanitize_tag(tag) for tag in task["tags"] if self._tag_is_valid_variable(tag)}
             task["when"] = ["{varname} | bool".format(varname=v) for v in sorted(variables_to_add)] + task["when"]
             variables.update(variables_to_add)
 
@@ -320,7 +320,12 @@ class PlaybookToRoleConverter():
         return galaxy_tags
 
     def _tag_is_valid_variable(self, tag):
+        if "DISA-STIG" in tag:
+            return True
         return '-' not in tag and tag != 'always'
+
+    def _sanitize_tag(self, tag):
+        return tag.replace("-", "_")
 
     def file(self, filepath):
         if filepath == 'tasks/main.yml':

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -211,8 +211,10 @@ class PlaybookToRoleConverter():
             elif isinstance(task["when"], str):
                 task["when"] = [task["when"]]
 
-            variables_to_add = {self._sanitize_tag(tag) for tag in task["tags"] if self._tag_is_valid_variable(tag)}
-            task["when"] = ["{varname} | bool".format(varname=v) for v in sorted(variables_to_add)] + task["when"]
+            variables_to_add = {self._sanitize_tag(tag)
+                                for tag in task["tags"] if self._tag_is_valid_variable(tag)}
+            task["when"] = ["{varname} | bool".format(
+                varname=v) for v in sorted(variables_to_add)] + task["when"]
             variables.update(variables_to_add)
 
             if not task["when"]:

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -211,7 +211,7 @@ class PlaybookToRoleConverter():
             elif isinstance(task["when"], str):
                 task["when"] = [task["when"]]
 
-            variables_to_add = {tag for tag in task["tags"] if self._tag_is_valid_variable(tag)}
+            variables_to_add = {tag.replace("-", "_") for tag in task["tags"] if self._tag_is_valid_variable(tag) or "DISA-STIG" in tag}
             task["when"] = ["{varname} | bool".format(varname=v) for v in sorted(variables_to_add)] + task["when"]
             variables.update(variables_to_add)
 

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -324,6 +324,12 @@ class PlaybookToRoleConverter():
     def _tag_is_valid_variable(self, tag):
         if "DISA-STIG" in tag:
             return True
+
+        # rules of kind package_* and service_* can have hyphen in their rule IDs
+        pattern = re.compile('(package_.*_(installed|removed))|(service_.*_(enabled|disabled))')
+        if pattern.match(tag):
+            return True
+
         return '-' not in tag and tag != 'always'
 
     def _sanitize_tag(self, tag):


### PR DESCRIPTION
#### Description:

- Add DISA STIG ids to `when` conditions in ansible roles.

#### Rationale:

- Tasks can be controlled by the STIG id.

Fixes: https://github.com/ComplianceAsCode/content/issues/7092 in commit ff5d600328f9ec4e5de248e003d349c24903bad4
