### PR TITLE
Create rule ssh_private_keys_have_passcode to cover OL08-00-010100

### DIFF
--- a/linux_os/guide/services/ssh/ssh_private_keys_have_passcode/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_private_keys_have_passcode/rule.yml
@@ -1,0 +1,38 @@
+documentation_complete: true
+
+prodtype: ol8
+
+title: 'OpenSSH Service Must Use Passcode for Their Private Keys'
+
+description: |-
+    Verify the SSH private key files have a passcode.
+    For each private key stored on the system, use the following command:
+
+    <pre>$ sudo ssh-keygen -y -f /path/to/file</pre>
+
+    If the contents of the key are displayed, without asking a passphrase this is a finding.
+
+rationale: |-
+    If an unauthorized user obtains access to a private key without a passcode, that user would
+    have unauthorized access to any system where the associated public key has been installed.
+
+severity: medium
+
+references:
+    disa: CCI-000186
+    nist: IA-5(2),IA-5(2).1
+    srg: SRG-OS-000067-GPOS-00035
+    stigid@ol8: OL08-00-010100
+
+ocil_clause: Any contents were displayed without asking a passphrase
+
+ocil: |-
+    For each private key stored on the system, use the following command:
+
+    <pre>$ sudo ssh-keygen -y -f /path/to/file</pre>
+
+fixtext: |-
+    Replace existing private keys with new ones protected by a passphrase. Create a new private
+    and public key pair that uses a passcode with the following command:
+
+    $ sudo ssh-keygen -n [passphrase]

--- a/linux_os/guide/services/ssh/ssh_private_keys_have_passcode/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_private_keys_have_passcode/rule.yml
@@ -32,7 +32,6 @@ ocil: |-
     <pre>$ sudo ssh-keygen -y -f /path/to/file</pre>
 
 fixtext: |-
-    Replace existing private keys with new ones protected by a passphrase. Create a new private
-    and public key pair that uses a passcode with the following command:
+    Set a passphrase to all keys that didn't have it with the following command:
 
-    $ sudo ssh-keygen -n [passphrase]
+    <pre>$ sudo ssh-keygen -p -N passphrase -f /path/to/file</pre>

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -108,6 +108,7 @@ selections:
     # OL08-00-010090
 
     # OL08-00-010100
+    - ssh_private_keys_have_passcode
 
     # OL08-00-010110
     - set_password_hashing_algorithm_logindefs


### PR DESCRIPTION
#### Description:

- Create rule.yml file for new rule `ssh_private_keys_have_passcode`
- Add this rule to OL8 STIG profile

#### Rationale:

- This new rule cover stig id `OL08-00-010100`
