### PR TITLE
EKS: Fix typo

### DIFF
--- a/controls/cis_eks.yml
+++ b/controls/cis_eks.yml
@@ -1105,7 +1105,7 @@ controls:
       levels:
       - level_1
       rules:
-      - confirure_network_policy
+      - configure_network_policy
     - id: 5.4.5
       title: >-
         5.4.5 Encrypt traffic to HTTPS load balancers with TLS certificates


### PR DESCRIPTION
#### Description:

- s/confirure/configure/

#### Rationale:

- Point to an existing rule
