### PR TITLE
Fix #9039

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -23,6 +23,8 @@ references:
     srg: SRG-OS-000021-GPOS-00005
     stigid@rhel8: RHEL-08-020027
 
+platform: machine
+
 ocil_clause: 'the security context type of the non-default tally directory is not "faillog_t"'
 
 ocil: |-

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
@@ -21,6 +21,8 @@ references:
     srg: SRG-OS-000095-GPOS-00049,SRG-OS-000370-GPOS-00155
     stigid@rhel8: RHEL-08-040020
 
+platform: machine
+
 ocil_clause: 'the command does not return any output, or the line is commented out, and the collaborative computing device has not been authorized for use'
 
 ocil: |-


### PR DESCRIPTION
#### Description:
Add platform machine to two rules
    
 * kernel_module_uvcvideo_disabled
* account_password_selinux_faillock_dir

#### Rationale:

- Fixes #9039 
