### PR TITLE
Parametrize the file name of the container used by gitpod integration

### DIFF
--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -65,7 +65,14 @@ jobs:
           body: |
             Start a new ephemeral environment with changes proposed in this pull request:
 
-            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#PRODUCT=${{steps.product.outputs.prop}}/${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
+            ${{steps.product.outputs.prop}} (from CTF) Environment (using Fedora as testing environment)
+            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#PRODUCT=${{steps.product.outputs.prop}},CONTAINER=fedora/${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
+
+            Fedora Testing Environment
+            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
+
+            Oracle Linux 8 Environment
+            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#PRODUCT=ol8/${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
 
           edit-mode: replace
       - name: Create or update a trimmed comment
@@ -77,6 +84,10 @@ jobs:
           body: |
             Start a new ephemeral environment with changes proposed in this pull request:
 
+            Fedora Environment
             [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
+
+            Oracle Linux 8 Environment
+            [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#PRODUCT=ol8/${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.pull_request.number }})
 
           edit-mode: replace

--- a/.gitpod.launch.json
+++ b/.gitpod.launch.json
@@ -8,8 +8,8 @@
       "id": "pickContainerName",
       "description": "Select Container Name",
       "type": "pickString",
-      "options": ["ssg_test_suite"],
-      "default": "ssg_test_suite"
+      "options": ["automatus"],
+      "default": "automatus"
       },
       {
       "id": "pickProductName",
@@ -45,11 +45,11 @@
   ],
   "configurations": [
     {
-      "name": "Run SSGTS using Docker backend",
+      "name": "Run Automatus using Docker backend",
       "type": "python",
       "request": "launch",
       "console": "integratedTerminal",
-      "program": "${workspaceFolder}/tests/test_suite.py",
+      "program": "${workspaceFolder}/tests/automatus.py",
       "args": [
           "rule",
           "--dontclean",
@@ -70,7 +70,7 @@
       ]
     },
     {
-      "name": "Run SSGTS using Docker backend (test_rule_in_container.sh)",
+      "name": "Run Automatus using Docker backend (test_rule_in_container.sh)",
       "type": "bashdb",
       "request": "launch",
       "program": "${workspaceFolder}/tests/test_rule_in_container.sh",

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -20,11 +20,12 @@ tasks:
         sphinx-rtd-theme \
         git+https://github.com/ggbecker/sphinxcontrib.jinjadomain.git#egg=sphinxcontrib-jinjadomain
       [ -z "$PRODUCT" ] && PRODUCT="fedora"
-      [ -z "$CONTAINER" ] && CONTAINER="fedora:34"
+      [ -z "$CONTAINER" ] && CONTAINER=$PRODUCT
+      [ -z "$CONTAINER_VERSION" ] && CONTAINER_VERSION="$CONTAINER:34"
       [ -z "$CPE" ] && CPE="cpe:/o:fedoraproject:fedora:34"
       mkdir -p .vscode && cp .gitpod.launch.json .vscode/launch.json
       sed -i "s/&&DEFAULT_PRODUCT&&/$PRODUCT/g" .vscode/launch.json
       sed -i "s,&&CPE&&,$CPE,g" .vscode/launch.json
       ssh-keygen -N '' -f ~/.ssh/id_rsa
-      docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite --build-arg IMAGE=$CONTAINER -f Dockerfiles/test_suite-fedora .
+      docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t ssg_test_suite --build-arg IMAGE=$CONTAINER_VERSION -f Dockerfiles/test_suite-$CONTAINER .
       ./build_product $PRODUCT --datastream-only


### PR DESCRIPTION
#### Description:

- Parametrize the file name of the container used by gitpod integration.

#### Rationale:

- Other distros can submit new Dockerfiles that can be used in the gitpod integration by using different parameters.
- `PRODUCT` defaults to `fedora` in line 22
