### PR TITLE
Do not include symlink tests into OVAL 5.10

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/oval/shared.xml
+++ b/linux_os/guide/system/accounts/enable_authselect/oval/shared.xml
@@ -5,7 +5,7 @@
     "smartcard": "smartcard-auth",
     "system": "system-auth",
 } -%}}
-
+{{% if target_oval_version >= [5, 11] %}}
 <def-group>
 	<definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Check that authselect is enabled") }}}
@@ -34,4 +34,4 @@
   </unix:symlink_state>
   {{% endfor %}}
 </def-group>
-
+{{% endif %}}


### PR DESCRIPTION


#### Description:
- Do not include symlink tests into OVAL 5.10.
 - This OVAL test is not supported in OVAL 5.10 thus needs to be kept out
of 5.10 OVAL datastreams.

#### Rationale:

- OVAL check introduced in: https://github.com/ComplianceAsCode/content/pull/8250/files#diff-9629464f7e96729d5b6a05e9c1ff3308cf1073490de06ca6b25be3a70226c56e
- Fixes https://github.com/ComplianceAsCode/content/runs/7051288549?check_suite_focus=true
