### PR TITLE
Proper home directory regex in `accounts_user_interactive_home_directory_defined` OVAL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/oval/shared.xml
@@ -23,7 +23,7 @@
 
   <!-- #### creation of state #### -->
   <unix:password_state id="state_accounts_user_interactive_home_directory_defined" version="1">
-    <unix:home_dir operation="pattern match">^\/\w*\/\w{1,}[\/\w]*$</unix:home_dir>
+    <unix:home_dir operation="pattern match">^\/[^\/\n]*\/[^\/\n]{1,}.*$</unix:home_dir>
   </unix:password_state>
 
   <!-- #### creation of test #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/home_dir_special_chars.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/home_dir_special_chars.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Special characters in username and in created home dir
+useradd some-user.


### PR DESCRIPTION
#### Description:
Do not restrict home dir regex only to `\w`.
`\w` matches `[a-zA-Z0-9_]`. But home directory can contain arbitrary character except `/`

#### Rationale:
Fixes #9042 
