### PR TITLE
Fix failing test scenarios in rule audit_rules_login_events

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/bash/shared.sh
@@ -2,11 +2,17 @@
 
 # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
 
+{{% if product in ["rhel8", "rhel9"] %}}
+{{% set faillock_path = "/var/log/faillock" %}}
+{{% else %}}
+{{% set faillock_path = "/var/run/faillock" %}}
+{{% endif %}}
+
 {{{ bash_fix_audit_watch_rule("auditctl", "/var/log/tallylog", "wa", "logins") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/var/log/tallylog", "wa", "logins") }}}
 
-{{{ bash_fix_audit_watch_rule("auditctl", "/var/run/faillock", "wa", "logins") }}}
-{{{ bash_fix_audit_watch_rule("augenrules", "/var/run/faillock", "wa", "logins") }}}
+{{{ bash_fix_audit_watch_rule("auditctl", faillock_path, "wa", "logins") }}}
+{{{ bash_fix_audit_watch_rule("augenrules", faillock_path, "wa", "logins") }}}
 
 {{{ bash_fix_audit_watch_rule("auditctl", "/var/log/lastlog", "wa", "logins") }}}
 {{{ bash_fix_audit_watch_rule("augenrules", "/var/log/lastlog", "wa", "logins") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/rule.yml
@@ -4,6 +4,12 @@ prodtype: alinux2,debian10,debian11,debian9,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rh
 
 title: 'Record Attempts to Alter Logon and Logout Events'
 
+{{% if product in ["rhel8", "rhel9"] %}}
+{{% set faillock_path = "/var/log/faillock" %}}
+{{% else %}}
+{{% set faillock_path = "/var/run/faillock" %}}
+{{% endif %}}
+
 description: |-
     The audit system already collects login information for all users
     and root. If the <tt>auditd</tt> daemon is configured to use the
@@ -12,14 +18,14 @@ description: |-
     directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w /var/run/faillock -p wa -k logins
+    -w {{{ faillock_path }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w /var/run/faillock -p wa -k logins
+    -w {{{ faillock_path }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>
 
 rationale: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
@@ -5,7 +5,7 @@
 {{% if product in ["rhel8", "rhel9"] %}}
 {{% set faillock_path="/var/log/faillock" %}}
 {{% else %}}
-{{% set faillock_path="{{{ faillock_path }}}" %}}
+{{% set faillock_path="/var/run/faillock" %}}
 {{% endif %}}
 
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events/tests/default.pass.sh
@@ -2,6 +2,13 @@
 # packages = audit
 # remediation = bash
 
-echo "-w /var/run/faillock -p wa -k logins" >> /etc/audit/rules.d/logins.rules
+{{% if product in ["rhel8", "rhel9"] %}}
+{{% set faillock_path="/var/log/faillock" %}}
+{{% else %}}
+{{% set faillock_path="{{{ faillock_path }}}" %}}
+{{% endif %}}
+
+
+echo "-w {{{ faillock_path }}} -p wa -k logins" >> /etc/audit/rules.d/logins.rules
 echo "-w /var/log/lastlog -p wa -k logins" >> /etc/audit/rules.d/logins.rules
 echo "-w /var/log/tallylog -p wa -k logins" >> /etc/audit/rules.d/logins.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/group.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/group.yml
@@ -2,6 +2,12 @@ documentation_complete: true
 
 title: 'Record Attempts to Alter Logon and Logout Events'
 
+{{% if product in ["rhel8", "rhel9"] %}}
+{{% set faillock_path = "/var/log/faillock" %}}
+{{% else %}}
+{{% set faillock_path = "/var/run/faillock" %}}
+{{% endif %}}
+
 description: |-
     The audit system already collects login information for all users
     and root. If the <tt>auditd</tt> daemon is configured to use the
@@ -10,12 +16,12 @@ description: |-
     directory <tt>/etc/audit/rules.d</tt> in order to watch for attempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w /var/run/faillock/ -p wa -k logins
+    -w {{{ faillock_path }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following lines to
     <tt>/etc/audit/audit.rules</tt> file in order to watch for unattempted manual
     edits of files involved in storing logon events:
     <pre>-w /var/log/tallylog -p wa -k logins
-    -w /var/run/faillock/ -p wa -k logins
+    -w {{{ faillock_path }}} -p wa -k logins
     -w /var/log/lastlog -p wa -k logins</pre>


### PR DESCRIPTION
#### Description:
RHEL 8 and 9 use different path of the fallock binary, we need to do similar change as we did in https://github.com/ComplianceAsCode/content/commit/4eeab7a1277cc932563b32dfbb542504e456be3c.

Depending on the system the faillock binary can be located either in /var/log or /var/run. We recently fixed this problem  in rule
`audit_rules_login_events_faillock`. However, the rule `audit_rules_login_events` uses the OVAL from `audit_rules_login_events_faillock` because it uses an extend_definition in the OVAL and this extend_defintion references OVAL from `audit_rules_login_events_faillock`. Therefore, the test scenarios started to fail, because the OVAL on RHEL 8 adn RHEL 9 started to expect a different path in the audit rules.

#### Rationale:
Fixes #9038
