### PR TITLE
OCP4: configure_network_policies: Calico also supports NetworkPolicies

### DIFF
--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -20,9 +20,11 @@ severity: high
 ocil_clause: 'Support for Network Policies needs review'
 
 ocil: |-
-    Verify on OpenShift that the NetworkPolicy plugin is being used:
-    <pre>$ oc explain networkpolicy</pre>
-    The resulting output should be an explanation of the NetworkPolicy resource.
+    Verify that your CNI plugin supports NetworkPolicies:
+    <pre>$ oc get network cluster -oyaml -ojsonpath='{.spec.networkType}'</pre>
+    The result should list a CNI plugin that supports NetworkPolicies,
+    currently the plugins in the rule's pass list are OpenShiftSDN, OVN
+    and Calico.
 
 {{% set api_path = '/apis/operator.openshift.io/v1/networks/cluster' %}}
 {{% set jqfilter = '[.spec.defaultNetwork.type]' %}}
@@ -48,5 +50,5 @@ template:
     check_existence: "any_exist"
     entity_check: "all"
     values:
-      - value: "OpenShiftSDN|OVN"
+      - value: "OpenShiftSDN|OVN|Calico"
         operation: "pattern match"

--- a/applications/openshift/networking/configure_network_policies/tests/calico.pass.sh
+++ b/applications/openshift/networking/configure_network_policies/tests/calico.pass.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+
+yum install -y jq
+
+kube_filepath_root="/kubernetes-api-resources"
+api_path="/apis/operator.openshift.io/v1/networks/cluster"
+dir="$kube_filepath_root/apis/operator.openshift.io/v1/networks"
+filepath="$kube_filepath_root$api_path"
+
+mkdir -p "$dir"
+
+jq_filter="[.spec.defaultNetwork.type]"
+
+cat <<EOF > "$filepath"
+
+{
+    "apiVersion": "operator.openshift.io/v1",
+    "kind": "Network",
+    "metadata": {
+        "creationTimestamp": "2022-04-25T13:39:15Z",
+        "generation": 61,
+        "name": "cluster",
+        "resourceVersion": "24589",
+        "uid": "089e8ee9-15c4-4868-80af-773df44cafdd"
+    },
+    "spec": {
+        "clusterNetwork": [
+            {
+                "cidr": "10.128.0.0/14",
+                "hostPrefix": 23
+            }
+        ],
+        "defaultNetwork": {
+            "type": "Calico"
+        },
+        "disableNetworkDiagnostics": false,
+        "logLevel": "Normal",
+        "managementState": "Managed",
+        "observedConfig": null,
+        "operatorLogLevel": "Normal",
+        "serviceNetwork": [
+            "172.30.0.0/16"
+        ],
+        "unsupportedConfigOverrides": null
+    },
+    "status": {
+        "conditions": [
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "False",
+                "type": "ManagementStateDegraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:52:19Z",
+                "status": "False",
+                "type": "Degraded"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:39:15Z",
+                "status": "True",
+                "type": "Upgradeable"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:53:53Z",
+                "status": "False",
+                "type": "Progressing"
+            },
+            {
+                "lastTransitionTime": "2022-04-25T13:40:00Z",
+                "status": "True",
+                "type": "Available"
+            }
+        ],
+        "readyReplicas": 0,
+        "version": "4.10.6"
+    }
+}
+EOF
+
+# Get the filepath. This will actually be read by the scan.
+filteredpath="$filepath#$(echo -n "$api_path$jq_filter" | sha256sum | awk '{print $1}')"
+
+jq "$jq_filter" "$filepath" > "$filteredpath"


### PR DESCRIPTION
#### Description:

We used to check only for OpenShiftSDN and OVN. It seems like Calico
also supports NetworkPolicies, so let's add it to the list.

Also fixes the OCIL test that was not reflecting what the rule actually
does.

#### Rationale:

- IBM's ROKS uses calico.

- Fixes #9047
