### PR TITLE
usbguard_generate_policy: handle also systems without USBs

### DIFF
--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/ansible/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/ansible/shared.yml
@@ -29,6 +29,13 @@
       mode: 0600
     when: not policy_file.stat.exists or policy_file.stat.size == 0
 
+  - name: Add comment into {{{ usbguard_config_path }}} when system has no USB devices
+    lineinfile:
+      path: "{{{ usbguard_config_path }}}"
+      line: "# No USB devices found"
+      state: present
+    when: policy.stdout | length == 0
+
   - name: Enable service usbguard
     service:
       name: "usbguard"

--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/bash/shared.sh
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/bash/shared.sh
@@ -10,6 +10,12 @@ then
     USBGUARD_CONF=/etc/usbguard/rules.conf
     if [ ! -f "$USBGUARD_CONF" ] || [ ! -s "$USBGUARD_CONF" ]; then
         usbguard generate-policy > $USBGUARD_CONF
+        if [ ! -s "$USBGUARD_CONF" ]; then
+            # make sure OVAL check doesn't fail on systems where
+            # generate-policy doesn't find any USB devices (for
+            # example a system might not have a USB bus)
+            echo "# No USB devices found" > $USBGUARD_CONF
+        fi
         # make sure it has correct permissions
         chmod 600 $USBGUARD_CONF
 

--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/tests/comment_no_usb.pass.sh
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/tests/comment_no_usb.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = usbguard
+
+echo "# No USB devices found" > /etc/usbguard/rules.conf


### PR DESCRIPTION
#### Description:

Make sure OVAL check doesn't fail on systems where
`generate-policy` doesn't find any USB devices (for
example a system might not have a USB bus).