### PR TITLE
Unify the OSPP references for the tmux-based session locking rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
@@ -25,7 +25,7 @@ identifiers:
 
 references:
     disa: CCI-000056,CCI-000058
-    ospp: FMT_SMF_EXT.1
+    ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000031-GPOS-00012,SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020041
     stigid@rhel8: RHEL-08-020041

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
@@ -22,7 +22,7 @@ identifiers:
 
 references:
     disa: CCI-000057,CCI-000060
-    ospp: FMT_SMF_EXT.1
+    ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000029-GPOS-00010,SRG-OS-000031-GPOS-00012
     stigid@ol8: OL08-00-020070
     stigid@rhel8: RHEL-08-020070

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
@@ -27,6 +27,7 @@ identifiers:
 references:
     disa: CCI-000056,CCI-000058
     nist: AC-11(a),AC-11(b),CM-6(a)
+    ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020040
     stigid@rhel8: RHEL-08-020040

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/rule.yml
@@ -23,7 +23,7 @@ identifiers:
 references:
     disa: CCI-000056,CCI-000058
     nist: CM-6
-    ospp: FMT_SMF_EXT.1
+    ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
     stigid@ol8: OL08-00-020042
     stigid@rhel8: RHEL-08-020042

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/rule.yml
@@ -40,7 +40,7 @@ references:
     iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
     nist: CM-6(a)
     nist-csf: PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000030-GPOS-00011,SRG-OS-000028-GPOS-00009
     stigid@ol8: OL08-00-020039
     stigid@rhel8: RHEL-08-020039


### PR DESCRIPTION

#### Description:

- Unify the OSPP references for the tmux-based session locking rules.
- Add the implicitly satisfied FTA_SSL.1.

#### Rationale:

- All five rules aim to ensure sessions get locked. Their `ospp` references should therefore match.