### PR TITLE
Remove test scenario that is no longer relevant

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/file_not_identical.fail.sh
+++ b/linux_os/guide/system/auditing/policy_rules/audit_immutable_login_uids/tests/file_not_identical.fail.sh
@@ -1,4 +1,0 @@
-# packages = audit
-
-cp $SHARED/audit/11-loginuid.rules /etc/audit/rules.d/
-echo "some additional text" >> /etc/audit/rules.d/11-loginuid.rules


### PR DESCRIPTION
In https://github.com/ComplianceAsCode/content/pull/8860 we have changed the rule audit_immutable_login_uids to use the `lineinfile` template which checks only for a specific line in the configuration file instead of the `audit_file_contents` template which checks that the contents of the configuration file is exactly the same as the image. This check is more flexible. The rule now checks for occurrence of a specific option. However, that means that we can't expect that the rule will fail if the configuration fail contains additional content. The rule is expected to pass in such situation. So the test scenario `file_not_identical.fail.sh` isn't relevant now and we will remove this scenario.

Fixes: #9049

