### PR TITLE
Fix regular expression in Ansible remediation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_profile/ansible/shared.yml
@@ -17,8 +17,8 @@
 - name: Replace user umask in /etc/profile
   ansible.builtin.replace:
     path: /etc/profile
-    regexp: '^[^#]*umask'
-    replace: "umask {{ var_accounts_user_umask }}"
+    regexp: '^(\s*)umask\s+\d+'
+    replace: '\1umask {{ var_accounts_user_umask }}'
 
 - name: Append user umask in /etc/profile
   ansible.builtin.lineinfile:


### PR DESCRIPTION
Ansible remediation of accounts_umask_etc_profile breaks the
/etc/profile syntax because the regex in task "Replace user umask in
/etc/profile" is wrong. The regex in ansible.builtin.replace
module is considered multiline, it matches everything except hash sign
but including newlines, so it "eats" all the lines before the "umask"
string if these lines don't contain the hash sign.

Fixes: #9053

