### PR TITLE
Add a markdown output target to create_srg_export

### DIFF
--- a/utils/convert_srg_export_to_md.py
+++ b/utils/convert_srg_export_to_md.py
@@ -1,0 +1,47 @@
+import create_srg_export
+
+
+def get_heading(row: dict) -> str:
+    if row['STIGID'] != '':
+        return row['STIGID']
+    else:
+        return row['SRGID']
+
+
+def get_content(header, output, row):
+    if row[header] is None:
+        output.append('')
+    else:
+        output.append(row[header])
+
+
+def write_md_file(output, output_path):
+    with open(output_path, 'w') as f:
+        output_lines = '\n'.join(output)
+        f.write(output_lines)
+
+
+def handle_dict(data: list, output_path: str, title: str) -> None:
+    """
+    Given a dict with the fields for the srg export, create a formatted Markdown file
+
+    To convert to a DOCX
+    sudo dnf install pandoc texlive
+    pip3 install git+https://github.com/pandocker/pandoc-docx-pagebreak-py
+    pandoc -f markdown -t docx -o docx.docx --filter=pandoc-docx-pagebreakpy output.md
+
+    """
+    output = []
+    for row in data:
+        heading = get_heading(row)
+        output.append(f'# {heading}')
+        output.append('')
+        for _, header in create_srg_export.COLUMN_MAPPINGS.items():
+            output.append(f'## {header}')
+            get_content(header, output, row)
+            output.append('')
+        output.append('')
+        output.append('\\newpage')
+        output.append('')
+
+    write_md_file(output, output_path)

--- a/utils/convert_srg_export_to_md.py
+++ b/utils/convert_srg_export_to_md.py
@@ -8,7 +8,7 @@ def get_heading(row: dict) -> str:
         return row['SRGID']
 
 
-def get_content(header, output, row):
+def get_content(header: str, row: dict) -> str:
     if row[header] is None:
         output.append('')
     else:

--- a/utils/convert_srg_export_to_md.py
+++ b/utils/convert_srg_export_to_md.py
@@ -1,3 +1,5 @@
+import re
+
 import create_srg_export
 
 
@@ -10,9 +12,12 @@ def get_heading(row: dict) -> str:
 
 def get_content(header: str, row: dict) -> str:
     if row[header] is None:
-        output.append('')
+        return ''
     else:
-        output.append(row[header])
+        content = row[header]
+        content = content.replace('\n', '\n\n')
+        content = content.replace('*', '&#42;')
+        return content
 
 
 def write_md_file(output, output_path):
@@ -38,7 +43,8 @@ def handle_dict(data: list, output_path: str, title: str) -> None:
         output.append('')
         for _, header in create_srg_export.COLUMN_MAPPINGS.items():
             output.append(f'## {header}')
-            get_content(header, output, row)
+            content = get_content(header, row)
+            output.append(content)
             output.append('')
         output.append('')
         output.append('\\newpage')

--- a/utils/create_srg_export.py
+++ b/utils/create_srg_export.py
@@ -16,6 +16,7 @@ import xml.etree.ElementTree as ET
 
 import convert_srg_export_to_xlsx
 import convert_srg_export_to_html
+import convert_srg_export_to_md
 
 try:
     import ssg.build_stig
@@ -402,7 +403,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("-m", "--manual", type=str, action="store",
                         help="Path to XML XCCDF manual file to use as the source of the SRGs",
                         default=SRG_PATH)
-    parser.add_argument("-f", "--out-format", type=str, choices=("csv", "xlsx", "html"),
+    parser.add_argument("-f", "--out-format", type=str, choices=("csv", "xlsx", "html", "md"),
                         action="store", help="The format the output should take. Defaults to csv",
                         default="csv")
     return parser.parse_args()
@@ -548,11 +549,21 @@ def handle_html_output(output, product, results):
     return output
 
 
+def handle_md_output(output, product, results):
+    output = output.replace('.csv', '.md')
+    for row in results:
+        row['IA Control'] = get_iacontrol(row['SRGID'])
+    convert_srg_export_to_md.handle_dict(results, output, f'{product} SRG Mapping')
+    return output
+
+
 def handle_output(output: str, results: list, format_type: str, product: str) -> None:
     if format_type == 'csv':
         handle_csv_output(output, results)
     elif format_type == 'xlsx':
         output = handle_xlsx_output(output, product, results)
+    elif format_type == 'md':
+        output = handle_md_output(output, product, results)
     elif format_type == 'html':
         output = handle_html_output(output, product, results)
 

--- a/utils/create_srg_export.py
+++ b/utils/create_srg_export.py
@@ -526,14 +526,15 @@ def get_policy(args, env_yaml) -> ssg.controls.Policy:
     return policy
 
 
-def handle_csv_output(output, results):
+def handle_csv_output(output: str, results: list) -> str:
     with open(output, 'w') as csv_file:
         csv_writer = setup_csv_writer(csv_file)
         for row in results:
             csv_writer.writerow(row)
+        return output
 
 
-def handle_xlsx_output(output, product, results):
+def handle_xlsx_output(output: str, product: str, results: list) -> str:
     output = output.replace('.csv', '.xlsx')
     for row in results:
         row['IA Control'] = get_iacontrol(row['SRGID'])
@@ -541,7 +542,7 @@ def handle_xlsx_output(output, product, results):
     return output
 
 
-def handle_html_output(output, product, results):
+def handle_html_output(output: str, product: str, results: list) -> str:
     for row in results:
         row['IA Control'] = get_iacontrol(row['SRGID'])
     output = output.replace('.csv', '.html')
@@ -549,7 +550,7 @@ def handle_html_output(output, product, results):
     return output
 
 
-def handle_md_output(output, product, results):
+def handle_md_output(output: str, product: str, results: list) -> str:
     output = output.replace('.csv', '.md')
     for row in results:
         row['IA Control'] = get_iacontrol(row['SRGID'])
@@ -559,7 +560,7 @@ def handle_md_output(output, product, results):
 
 def handle_output(output: str, results: list, format_type: str, product: str) -> None:
     if format_type == 'csv':
-        handle_csv_output(output, results)
+        output = handle_csv_output(output, results)
     elif format_type == 'xlsx':
         output = handle_xlsx_output(output, product, results)
     elif format_type == 'md':


### PR DESCRIPTION
#### Description:

Add a markdown output target to the create_srg_export script.

#### Rationale:

To make creating a PDF easy during the review process.