### PR TITLE
Build content in debug mode when generating coverage statistics

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
-        run: cmake .. -G Ninja
+        run: cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug
         working-directory: ./build
       - name: Build Guides and Mapping Tables
         run: ninja -j2


### PR DESCRIPTION
#### Description:

- Build content in debug mode when generating coverage statistics

#### Rationale:

- Will enable following files to be included in the build:

```
linux_os/guide/system/network/network-ipv6/configuring_ipv6/disabling_ipv6_autoconfig/rule.yml:
  1: documentation_complete: false
  2  

products/ocp4/profiles/stig-node.profile:
  1: documentation_complete: false
  2  

products/ocp4/profiles/stig.profile:
  1: documentation_complete: false
  2  

products/rhel8/profiles/ospp-mls.profile:
  1: documentation_complete: false
  2  

products/rhel9/profiles/srg_gpos.profile:
  1: documentation_complete: false
  2  
```

We are mostly interested in generating statistics for profiles that use the SRG controls.

Statistics will appear on: https://complianceascode.github.io/content-pages/statistics/index.html
