### PR TITLE
RHEL8 STIG: Select new faillock audit rule and fix network forwarding selections

### DIFF
--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/rule.yml
@@ -37,6 +37,7 @@ references:
     nist-csf: DE.CM-1,PR.DS-4,PR.IP-1,PR.PT-3
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040260
+    stigid@rhel8: RHEL-08-040260
     stigid@sle12: SLES-12-030364
     stigid@sle15: SLES-15-040381
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -1125,8 +1125,11 @@ selections:
     # RHEL-08-040250
     - sysctl_net_ipv6_conf_default_accept_source_route
 
-    # RHEL-08-040260
+    # RHEL-08-040259
     - sysctl_net_ipv4_ip_forward
+
+    # RHEL-08-040260
+    - sysctl_net_ipv6_conf_all_forwarding
 
     # RHEL-08-040261
     - sysctl_net_ipv6_conf_all_accept_ra

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -500,6 +500,7 @@ selections:
     # RHEL-08-020020
 
     # RHEL-08-020021
+    - account_passwords_pam_faillock_audit
 
     # RHEL-08-020022, RHEL-08-020023
     - accounts_passwords_pam_faillock_deny_root

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -31,6 +31,7 @@ reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-s
 selections:
 - account_disable_post_pw_expiration
 - account_emergency_expire_date
+- account_passwords_pam_faillock_audit
 - account_temp_expire_date
 - account_unique_id
 - accounts_authorized_local_users
@@ -403,6 +404,7 @@ selections:
 - sysctl_net_ipv6_conf_all_accept_ra
 - sysctl_net_ipv6_conf_all_accept_redirects
 - sysctl_net_ipv6_conf_all_accept_source_route
+- sysctl_net_ipv6_conf_all_forwarding
 - sysctl_net_ipv6_conf_default_accept_ra
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -42,6 +42,7 @@ reference: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-s
 selections:
 - account_disable_post_pw_expiration
 - account_emergency_expire_date
+- account_passwords_pam_faillock_audit
 - account_temp_expire_date
 - account_unique_id
 - accounts_authorized_local_users
@@ -413,6 +414,7 @@ selections:
 - sysctl_net_ipv6_conf_all_accept_ra
 - sysctl_net_ipv6_conf_all_accept_redirects
 - sysctl_net_ipv6_conf_all_accept_source_route
+- sysctl_net_ipv6_conf_all_forwarding
 - sysctl_net_ipv6_conf_default_accept_ra
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route


### PR DESCRIPTION
#### Description:

- Select new rule `account_passwords_pam_faillock_audit` in RHEL8 STIG (although it doesn't have check nor remediations).
- Fix selection for sysctl network forwarding.
  - RHEL-08-040259 is for IPv4
  - RHEL-08-040260 is for IPv6

#### Rationale:

- Let's keep RHEL8 STIG updated and aligned.
