### PR TITLE
Add ansible remediation for postfix_prevent_unrestricted_relay

### DIFF
--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/ansible/shared.yml
@@ -1,0 +1,13 @@
+# platform = multi_platform_all
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+{{{ ansible_set_config_file(file="/etc/postfix/main.cf",
+                  parameter="smtpd_client_restrictions",
+                  value="permit_mynetworks,reject",
+                  create=true,
+                  separator=" = ",
+                  separator_regex="\s*=\s*",
+                  prefix_regex="^[ \\t]*") }}}

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/absent.fail.sh
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/absent.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = postfix
 
 mkdir -p /etc/postfix
 echo > /etc/postfix/main.cf

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/defective.fail.sh
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/defective.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = postfix
 
 mkdir -p /etc/postfix
 echo 'smtpd_client_restrictions = permit_mynetworks,dont_reject' > /etc/postfix/main.cf

--- a/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/ok.pass.sh
+++ b/linux_os/guide/services/mail/postfix_harden_os/postfix_server_cfg/postfix_server_relay/postfix_prevent_unrestricted_relay/tests/ok.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = postfix
 
 mkdir -p /etc/postfix
 echo 'smtpd_client_restrictions = permit_mynetworks,reject' > /etc/postfix/main.cf


### PR DESCRIPTION
#### Description:

- Add ansible remediation for postfix_prevent_unrestricted_relay.
