### PR TITLE
Add python vscode extension to the gitpod environment

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -9,6 +9,7 @@ vscode:
     - rogalmic.bash-debug # support bashdb debug configurations
     - eamodio.gitlens # cool git extension with a bunch of extra features
     - twxs.cmake # support to CMakeLists.txt syntax highlighting and more
+    - ms-python.python # running python configurations
 
 tasks:
   - name: Prepare Env


### PR DESCRIPTION
So python run configurations can be executed.

#### Description:

- Add python vscode extension to the gitpod environment.
  - So python run configurations can be executed.

#### Rationale:

- New users will need this extension to be able to run tests. If you install it once, you don't need to install it in further deployment, that's why it was not noticed.
