### PR TITLE
usbguard_generate_policy: fix Ansible remediation

### DIFF
--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/ansible/shared.yml
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/ansible/shared.yml
@@ -34,7 +34,7 @@
       path: "{{{ usbguard_config_path }}}"
       line: "# No USB devices found"
       state: present
-    when: policy.stdout | length == 0
+    when: not policy_file.stat.exists or policy_file.stat.size == 0
 
   - name: Enable service usbguard
     service:


### PR DESCRIPTION
Fixes issue introduced in 987a968b6e6fc111d059694656a11d6cea9fac64 (introduced in https://github.com/ComplianceAsCode/content/pull/9059)
where the newly added Ansible snippet would fail in case that
`policy_file` is not empty.

