### PR TITLE
Set tmux config files mode

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/bash/shared.sh
@@ -12,4 +12,5 @@ if [ "$PS1" ]; then
   case "$name" in sshd|login) exec tmux ;; esac
 fi
 EOF
+    chmod 0644 /etc/profile.d/tmux.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
@@ -53,4 +53,8 @@ fixtext: |-
         case "$name" in sshd|login) exec tmux ;; esac
     fi
 
+    Then, ensure a correct mode of /etc/profile.d/tmux.sh using this command:
+
+    $ sudo chmod 0644 /etc/profile.d/tmux.sh
+
 srg_requirement: '{{{ full_name }}} must ensure session control is automatically started at shell initialization.'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/bash/shared.sh
@@ -7,4 +7,4 @@ if grep -qP '^\s*set\s+-g\s+lock-after-time' "$tmux_conf" ; then
 else
     echo "set -g lock-after-time 900" >> "$tmux_conf"
 fi
-
+chmod 0644 "$tmux_conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
@@ -4,6 +4,7 @@
     <criteria comment="Configure tmux to lock session after inactivity" operator="AND">
       <criterion comment="check lock-after-time is set to 900 in /etc/tmux.conf"
         test_ref="test_configure_tmux_lock_after_time" />
+      <criterion comment="Check /etc/tmux.conf is readable by others" test_ref="test_configure_tmux_lock_after_time_mode"/>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -26,4 +27,14 @@
   comment="the value is less than or equal to 900">
     <ind:subexpression datatype="int" operation="less than or equal">900</ind:subexpression>
   </ind:textfilecontent54_state>
+  <unix:file_test check="all" comment="Check /etc/tmux.conf is readable by others" id="test_configure_tmux_lock_after_time_mode" version="3">
+    <unix:object object_ref="object_configure_tmux_lock_after_time_mode" />
+    <unix:state state_ref="state_configure_tmux_lock_after_time_mode" />
+  </unix:file_test>
+  <unix:file_object comment="/etc/tmux.conf" id="object_configure_tmux_lock_after_time_mode" version="1">
+    <unix:filepath operation="equals">/etc/tmux.conf</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_configure_tmux_lock_after_time_mode" version="1" operator="AND">
+    <unix:oread datatype="boolean">true</unix:oread>
+  </unix:file_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/oval/shared.xml
@@ -4,7 +4,7 @@
     <criteria comment="Configure tmux to lock session after inactivity" operator="AND">
       <criterion comment="check lock-after-time is set to 900 in /etc/tmux.conf"
         test_ref="test_configure_tmux_lock_after_time" />
-      <criterion comment="Check /etc/tmux.conf is readable by others" test_ref="test_configure_tmux_lock_after_time_mode"/>
+      <extend_definition comment="Check /etc/tmux.conf is readable by others" definition_ref="tmux_conf_readable_by_others"/>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -27,14 +27,4 @@
   comment="the value is less than or equal to 900">
     <ind:subexpression datatype="int" operation="less than or equal">900</ind:subexpression>
   </ind:textfilecontent54_state>
-  <unix:file_test check="all" comment="Check /etc/tmux.conf is readable by others" id="test_configure_tmux_lock_after_time_mode" version="3">
-    <unix:object object_ref="object_configure_tmux_lock_after_time_mode" />
-    <unix:state state_ref="state_configure_tmux_lock_after_time_mode" />
-  </unix:file_test>
-  <unix:file_object comment="/etc/tmux.conf" id="object_configure_tmux_lock_after_time_mode" version="1">
-    <unix:filepath operation="equals">/etc/tmux.conf</unix:filepath>
-  </unix:file_object>
-  <unix:file_state id="state_configure_tmux_lock_after_time_mode" version="1" operator="AND">
-    <unix:oread datatype="boolean">true</unix:oread>
-  </unix:file_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
@@ -42,6 +42,10 @@ fixtext: |-
 
     set -g lock-after-time 900
 
+    Then, ensure a correct mode of /etc/tmux.conf using this command:
+
+    $ sudo chmod 0644 /etc/tmux.conf
+
 srg_requirement: '{{{ full_name }}} must automatically lock command line user sessions after 15 minutes of inactivity.'
 
 platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/rule.yml
@@ -32,9 +32,16 @@ ocil_clause: 'lock-after-time is set to a value greater than 900 or zero'
 ocil: |-
     To verify that session locking after period of inactivity is configured in tmux,
     run the following command:
-    <pre>$ grep lock-after-time /etc/tmux.conf</pre>
+
+    <pre>$ sudo grep lock-after-time /etc/tmux.conf</pre>
+
     The output should return the following:
+
     <pre>set -g lock-after-time 900</pre>
+
+    Then, verify that the /etc/tmux.conf file can be read by other users than root:
+
+    <pre>$ sudo ls -al /etc/tmux.conf
 
 fixtext: |-
     Configure the operating system to enforce session lock after a period of 15 minutes

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/insufficient_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_after_time/tests/insufficient_permissions.fail.sh
@@ -2,4 +2,4 @@
 
 tmux_conf="/etc/tmux.conf"
 echo "set -g lock-after-time 900" > "$tmux_conf"
-chmod 0644 "/etc/tmux.conf"
+chmod 0600 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/bash/shared.sh
@@ -7,4 +7,4 @@ if grep -qP '^\s*set\s+-g\s+lock-command' "$tmux_conf" ; then
 else
     echo "set -g lock-command vlock" >> "$tmux_conf"
 fi
-
+chmod 0644 "$tmux_conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
@@ -4,6 +4,7 @@
     <criteria comment="Configure the tmux Lock Command" operator="AND">
       <criterion comment="check lock-command is set to vlock in /etc/tmux.conf"
         test_ref="test_configure_tmux_lock_command" />
+      <criterion comment="Check /etc/tmux.conf is readable by others" test_ref="test_configure_tmux_lock_command_mode"/>
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -16,4 +17,14 @@
     <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  <unix:file_test check="all" comment="Check /etc/tmux.conf is readable by others" id="test_configure_tmux_lock_command_mode" version="3">
+    <unix:object object_ref="object_configure_tmux_lock_command_mode" />
+    <unix:state state_ref="state_configure_tmux_lock_command_mode" />
+  </unix:file_test>
+  <unix:file_object comment="/etc/tmux.conf" id="object_configure_tmux_lock_command_mode" version="1">
+    <unix:filepath operation="equals">/etc/tmux.conf</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_configure_tmux_lock_command_mode" version="1" operator="AND">
+    <unix:oread datatype="boolean">true</unix:oread>
+  </unix:file_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/oval/shared.xml
@@ -4,7 +4,7 @@
     <criteria comment="Configure the tmux Lock Command" operator="AND">
       <criterion comment="check lock-command is set to vlock in /etc/tmux.conf"
         test_ref="test_configure_tmux_lock_command" />
-      <criterion comment="Check /etc/tmux.conf is readable by others" test_ref="test_configure_tmux_lock_command_mode"/>
+      <extend_definition comment="Check /etc/tmux.conf is readable by others" definition_ref="tmux_conf_readable_by_others" />
     </criteria>
   </definition>
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
@@ -17,14 +17,4 @@
     <ind:pattern operation="pattern match">^\s*set\s+-g\s+lock-command\s+vlock\s*(?:#.*)?$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <unix:file_test check="all" comment="Check /etc/tmux.conf is readable by others" id="test_configure_tmux_lock_command_mode" version="3">
-    <unix:object object_ref="object_configure_tmux_lock_command_mode" />
-    <unix:state state_ref="state_configure_tmux_lock_command_mode" />
-  </unix:file_test>
-  <unix:file_object comment="/etc/tmux.conf" id="object_configure_tmux_lock_command_mode" version="1">
-    <unix:filepath operation="equals">/etc/tmux.conf</unix:filepath>
-  </unix:file_object>
-  <unix:file_state id="state_configure_tmux_lock_command_mode" version="1" operator="AND">
-    <unix:oread datatype="boolean">true</unix:oread>
-  </unix:file_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
@@ -37,9 +37,16 @@ ocil_clause: 'lock-command is not set'
 
 ocil: |-
     To verify that vlock is configured as a locking mechanism in tmux, run the following command:
-    <pre>$ grep lock-command /etc/tmux.conf</pre>
+
+    <pre>$ sudo grep lock-command /etc/tmux.conf</pre>
+
     The output should return the following:
+
     <pre>set -g lock-command vlock</pre>
+
+    Then, verify that the /etc/tmux.conf file can be read by other users than root:
+
+    <pre>$ sudo ls -al /etc/tmux.conf
 
 fixtext: |-
     Add the following line to the file "/etc/tmux.conf":

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/rule.yml
@@ -46,6 +46,10 @@ fixtext: |-
 
     <pre>set -g lock-command vlock</pre>
 
+    Then, ensure a correct mode of /etc/tmux.conf using this command:
+
+    $ sudo chmod 0644 /etc/tmux.conf
+
 srg_requirement: '{{{ full_name }}} must enable a user session lock until that user re-establishes access using established identification and authentication procedures for command line sessions.'
 
 platform: machine

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/correct.pass.sh
@@ -2,3 +2,4 @@
 # platform = multi_platform_fedora,Red Hat Enterprise Linux 8
 
 echo 'set -g lock-command vlock' >> '/etc/tmux.conf'
+chmod 0644 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_permissions.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+
+echo 'set -g lock-command vlock' >> '/etc/tmux.conf'
+chmod 0600 "/etc/tmux.conf"

--- a/shared/checks/oval/tmux_conf_readable_by_others.xml
+++ b/shared/checks/oval/tmux_conf_readable_by_others.xml
@@ -1,0 +1,18 @@
+<def-group>
+  <definition class="compliance" id="tmux_conf_readable_by_others" version="1">
+    {{{ oval_metadata("Check /etc/tmux.conf is readable by others", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <criterion comment="Check /etc/tmux.conf is readable by others" test_ref="test_tmux_conf_readable_by_others"/>
+    </criteria>
+  </definition>
+  <unix:file_test check="all" comment="Check /etc/tmux.conf is readable by others" id="test_tmux_conf_readable_by_others" version="1">
+    <unix:object object_ref="object_tmux_conf_readable_by_others" />
+    <unix:state state_ref="state_tmux_conf_readable_by_others" />
+  </unix:file_test>
+  <unix:file_object comment="/etc/tmux.conf" id="object_tmux_conf_readable_by_others" version="1">
+    <unix:filepath operation="equals">/etc/tmux.conf</unix:filepath>
+  </unix:file_object>
+  <unix:file_state id="state_tmux_conf_readable_by_others" version="1" operator="AND">
+    <unix:oread datatype="boolean">true</unix:oread>
+  </unix:file_state>
+</def-group>

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -26,13 +26,16 @@ value: :code:`Setting={{ varname1 }}`
 
   Note that all string-like parameters are single quoted in the YAML.
 #}}
-{{%- macro ansible_lineinfile(msg='', path='', regex='', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='', check_mode=False) -%}}
+{{%- macro ansible_lineinfile(msg='', path='', mode='', regex='', new_line='', create='no', state='present', with_items='', register='', when='', validate='', insert_after='', insert_before='', check_mode=False) -%}}
 - name: "{{{ msg or rule_title }}}"
   lineinfile:
     path: '{{{ path }}}'
     create: {{{ create }}}
     {{%- if regex %}}
     regexp: '{{{ regex }}}'
+    {{%- endif %}}
+    {{%- if mode %}}
+    mode: '{{{ mode }}}'
     {{%- endif %}}
     {{%- if state == 'present' %}}
     line: '{{{ new_line }}}'
@@ -113,17 +116,17 @@ value: :code:`Setting={{ varname1 }}`
   value is approved. All lines matching the regex are first removed and then
   the new line is appended to the file.
 #}}
-{{%- macro ansible_only_lineinfile(msg, path, line_regex, new_line, create='no', block=False, validate='', insert_after='', insert_before='') -%}}
+{{%- macro ansible_only_lineinfile(msg, path, line_regex, new_line, create='no', block=False, validate='', insert_after='', insert_before='', mode='') -%}}
 {{%- if block %}}
 - name: "{{{ msg or rule_title }}}"
   block:
-    {{{ ansible_lineinfile("Check for duplicate values", path, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True)|indent }}}
-    {{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
-    {{{ ansible_lineinfile("Insert correct line to " + path, path, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
+    {{{ ansible_lineinfile("Check for duplicate values", path, mode=mode, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True)|indent }}}
+    {{{ ansible_lineinfile("Deduplicate values from " + path, path, mode=mode, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1')|indent }}}
+    {{{ ansible_lineinfile("Insert correct line to " + path, path, mode=mode, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before)|indent }}}
 {{%- else %}}
-{{{ ansible_lineinfile("Check for duplicate values", path, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True) }}}
-{{{ ansible_lineinfile("Deduplicate values from " + path, path, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1') }}}
-{{{ ansible_lineinfile("Insert correct line into " + path, path, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{{ ansible_lineinfile("Check for duplicate values", path, mode=mode, regex=line_regex, create='no', state='absent', register='dupes', check_mode=True) }}}
+{{{ ansible_lineinfile("Deduplicate values from " + path, path, mode=mode, regex=line_regex, create='no', state='absent', when='dupes.found is defined and dupes.found > 1') }}}
+{{{ ansible_lineinfile("Insert correct line into " + path, path, mode=mode, regex=line_regex, new_line=new_line, create=create, state='present', validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
 {{%- endif %}}
 {{%- endmacro %}}
 
@@ -134,8 +137,8 @@ value: :code:`Setting={{ varname1 }}`
   ini configuration files are best served with the ini Ansible module
   instead of lineinfile-based solutions.
 #}}
-{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='', escape_regex=False) %}}
-{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex, parameter + separator + value, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before) }}}
+{{%- macro ansible_set_config_file(msg, file, parameter, separator=' ', separator_regex='\s+', value='', prefix_regex='^\s*', create='no', validate='', insert_after='', insert_before='', escape_regex=False, mode='') %}}
+{{{ ansible_only_lineinfile(msg, file, prefix_regex + parameter + separator_regex, parameter + separator + value, create=create, block=True, validate=validate, insert_after=insert_after, insert_before=insert_before, mode=mode) }}}
 {{%- endmacro %}}
 
 
@@ -235,7 +238,7 @@ value: :code:`Setting={{ varname1 }}`
 
 #}}
 {{%- macro ansible_tmux_set(msg='', parameter='', value='') %}}
-{{{ ansible_set_config_file(msg, "/etc/tmux.conf", "set -g " + parameter, value=value, create="yes") }}}
+{{{ ansible_set_config_file(msg, "/etc/tmux.conf", "set -g " + parameter, value=value, create="yes", mode="0644") }}}
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
Ansible remediation should create the /etc/tmux.conf file with explicit
permissions 0644, otherwise the /etc/tmux.conf's mode will be affected
by umask and might be created with different permissions than 0644 but
that will cause a Permission denied error and a huge delay on each login.

A similar situation happens also when /etc/profile.d/tmux.sh mode is not
set correctly it causes that tmux is not executed after login.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2064696
