### PR TITLE
Remove sysctl_fs_protected_* rules from RHEL 9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -141,10 +141,6 @@ selections:
     - sysctl_net_core_bpf_jit_harden
     - service_kdump_disabled
 
-    ## File System Settings
-    - sysctl_fs_protected_hardlinks
-    - sysctl_fs_protected_symlinks
-
     ### Audit
     - service_auditd_enabled
     - var_auditd_flush=incremental_async


### PR DESCRIPTION
The sysctl_fs_protected_hardlinks and sysctl_fs_protected_symlinks rules
reenforce the RHEL 9 default value. While that protection is useful,
there is no specific OSPP SFR or other reason for the SCAP rules in the
OSPP profile.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2081719

