### PR TITLE
Make rule audit_access_success in OSPP profile unenforcing

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -372,6 +372,8 @@ selections:
     - audit_modify_success
     - audit_access_failed
     - audit_access_success
+    - audit_access_success.severity=info
+    - audit_access_success.role=unscored
     - audit_delete_failed
     - audit_delete_success
     - audit_perm_change_failed


### PR DESCRIPTION
Set severity to info and role to unscored, because the rule
creates an audit rule that creates generating huge amounts
of audit records generated.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2058154

