### PR TITLE
Remove rule zip_vsyscall_argument

### DIFF
--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -437,6 +437,3 @@ selections:
     - zipl_audit_backlog_limit_argument
     - zipl_slub_debug_argument
     - zipl_page_poison_argument
-    - zipl_vsyscall_argument
-    - zipl_vsyscall_argument.role=unscored
-    - zipl_vsyscall_argument.severity=info

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -406,6 +406,5 @@ selections:
     - zipl_bootmap_is_up_to_date
     - zipl_audit_argument
     - zipl_audit_backlog_limit_argument
-    - zipl_vsyscall_argument
     - zipl_init_on_alloc_argument
     - zipl_page_alloc_shuffle_argument

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -233,7 +233,6 @@ selections:
 - zipl_bootmap_is_up_to_date
 - zipl_page_poison_argument
 - zipl_slub_debug_argument
-- zipl_vsyscall_argument
 - var_sshd_set_keepalive=0
 - var_rekey_limit_size=1G
 - var_rekey_limit_time=1hour
@@ -265,8 +264,6 @@ selections:
 - grub2_vsyscall_argument.severity=info
 - sysctl_user_max_user_namespaces.role=unscored
 - sysctl_user_max_user_namespaces.severity=info
-- zipl_vsyscall_argument.role=unscored
-- zipl_vsyscall_argument.severity=info
 platforms: !!set {}
 cpe_names: !!set {}
 platform: null


### PR DESCRIPTION
According to
https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html?highlight=vsyscall
vsyscall is applicable to X86-64 but ZIPl is used only on
s390x on RHEL, and likely on other OSes as well.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2060049

