### PR TITLE
Enforce rule sysctl_user_max_user_namespaces in RHEL 9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -135,8 +135,6 @@ selections:
     - sysctl_kernel_yama_ptrace_scope
     - sysctl_kernel_perf_event_paranoid
     - sysctl_user_max_user_namespaces
-    - sysctl_user_max_user_namespaces.role=unscored
-    - sysctl_user_max_user_namespaces.severity=info
     - sysctl_kernel_unprivileged_bpf_disabled
     - sysctl_net_core_bpf_jit_harden
     - service_kdump_disabled


### PR DESCRIPTION
Removal of the role and severity attributes will cause that
the rule will start to be evaluated and remediation will
actually disable the user namespaces on the target system.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2083716

