### PR TITLE
Round out the STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000069-GPOS-00037.yml
+++ b/controls/srg_gpos/SRG-OS-000069-GPOS-00037.yml
@@ -8,5 +8,7 @@ controls:
             - accounts_password_pam_enforce_root
             - accounts_password_pam_retry
             - accounts_password_pam_ucredit
+            - accounts_password_pam_pwquality_password_auth
+            - accounts_password_pam_pwquality_system_auth
             - var_password_pam_ucredit=1
         status: automated

--- a/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
+++ b/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
@@ -7,6 +7,7 @@ controls:
             - set_password_hashing_algorithm_libuserconf
             - set_password_hashing_algorithm_logindefs
             - set_password_hashing_algorithm_systemauth
+            - set_password_hashing_min_rounds_logindefs
             - accounts_password_all_shadowed_sha512
             - accounts_password_pam_unix_rounds_password_auth
             - var_password_pam_unix_rounds=5000

--- a/controls/srg_gpos/SRG-OS-000120-GPOS-00061.yml
+++ b/controls/srg_gpos/SRG-OS-000120-GPOS-00061.yml
@@ -10,4 +10,5 @@ controls:
             - package_rsyslog-gnutls_installed
             - libreswan_approved_tunnels
             - configure_kerberos_crypto_policy
+            - set_password_hashing_algorithm_passwordauth
         status: automated

--- a/controls/srg_gpos/SRG-OS-000259-GPOS-00100.yml
+++ b/controls/srg_gpos/SRG-OS-000259-GPOS-00100.yml
@@ -11,6 +11,7 @@ controls:
             - file_ownership_binary_dirs
             - file_ownership_library_dirs
             - file_permissions_binary_dirs
+            - dir_permissions_library_dirs
             - file_permissions_library_dirs
             - root_permissions_syslibrary_files
         status: automated

--- a/controls/srg_gpos/SRG-OS-000355-GPOS-00143.yml
+++ b/controls/srg_gpos/SRG-OS-000355-GPOS-00143.yml
@@ -9,5 +9,7 @@ controls:
             and/or the Global Positioning System (GPS).
         rules:
             - chronyd_or_ntpd_set_maxpoll
+            - chronyd_server_directive
             - package_chrony_installed
+            - service_chronyd_enabled
         status: automated

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -27,6 +27,18 @@ controls:
             - file_owner_etc_gshadow
             - file_owner_etc_passwd
             - file_owner_etc_shadow
+            - file_groupowner_backup_etc_group
+            - file_groupowner_backup_etc_gshadow
+            - file_groupowner_backup_etc_passwd
+            - file_groupowner_backup_etc_shadow
+            - file_owner_backup_etc_group
+            - file_owner_backup_etc_gshadow
+            - file_owner_backup_etc_passwd
+            - file_owner_backup_etc_shadow
+            - file_permissions_backup_etc_group
+            - file_permissions_backup_etc_gshadow
+            - file_permissions_backup_etc_passwd
+            - file_permissions_backup_etc_shadow
             - file_owner_crontab
             - file_permissions_etc_group
             - file_permissions_etc_gshadow

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -28,6 +28,10 @@ controls:
             - file_owner_etc_passwd
             - file_owner_etc_shadow
             - file_owner_crontab
+            - file_permissions_etc_group
+            - file_permissions_etc_gshadow
+            - file_permissions_etc_passwd
+            - file_permissions_etc_shadow
             - file_permissions_cron_d
             - file_permissions_cron_daily
             - file_permissions_cron_hourly

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -23,6 +23,10 @@ controls:
             - file_owner_cron_hourly
             - file_owner_cron_monthly
             - file_owner_cron_weekly
+            - file_owner_etc_group
+            - file_owner_etc_gshadow
+            - file_owner_etc_passwd
+            - file_owner_etc_shadow
             - file_owner_crontab
             - file_permissions_cron_d
             - file_permissions_cron_daily

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -13,6 +13,11 @@ controls:
             - file_groupowner_cron_monthly
             - file_groupowner_cron_weekly
             - file_groupowner_crontab
+            - file_groupowner_etc_group
+            - file_groupowner_etc_gshadow
+            - file_groupowner_etc_passwd
+            - file_groupowner_etc_shadow
+            - file_groupowner_grub2_cfg
             - file_owner_cron_d
             - file_owner_cron_daily
             - file_owner_cron_hourly

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -125,6 +125,7 @@ controls:
             - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
             - sysctl_net_ipv4_tcp_syncookies
             - sysctl_net_ipv4_conf_all_send_redirects
+            - sysctl_net_ipv4_conf_default_accept_redirects
             - sysctl_net_ipv4_conf_default_send_redirects
             - sysctl_net_ipv4_ip_forward
             - sysctl_kernel_core_pattern

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.d", perms="-rwx--
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/cron.d", perms="-rwx------") }}}
 
-fixtext: '{{{ fixtext_directory_permissions("0600", "/etc/cron.d/") }}}'
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/cron.d/", mode="0600") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0600", "/etc/cron.d") }}}'
+srg_requirement: '{{{ srg_requirement_directory_permission(file="/etc/cron.d", mode="0600") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_daily/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.daily", perms="-r
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/cron.daily", perms="-rwx------") }}}
 
-fixtext: '{{{ fixtext_directory_permissions("0700", "/etc/cron.daily/") }}}'
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/cron.daily/", mode="0700") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0700", "/etc/cron.daily") }}}'
+srg_requirement: '{{{ srg_requirement_directory_permission(file="/etc/cron.daily", mode="0700") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_hourly/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.hourly", perms="-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/cron.hourly", perms="-rwx------") }}}
 
-fixtext: '{{{ fixtext_directory_permissions("0700", "/etc/cron.hourly/") }}}'
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/cron.hourly/", mode="0700") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0700", "/etc/cron.hourly") }}}'
+srg_requirement: '{{{ srg_requirement_directory_permission(file="/etc/cron.hourly", mode="0700") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_monthly/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.monthly", perms="
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/cron.monthly", perms="-rwx------") }}}
 
-fixtext: '{{{ fixtext_directory_permissions("0700", "/etc/cron.monthly/") }}}'
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/cron.monthly/", mode="0700") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0700", "/etc/cron.monthly") }}}'
+srg_requirement: '{{{ srg_requirement_directory_permission(file="/etc/cron.monthly", mode="0700") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_weekly/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cron.weekly", perms="-
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/cron.weekly", perms="-rwx------") }}}
 
-fixtext: '{{{ fixtext_directory_permissions("0700", "/etc/cron.weekly/") }}}'
+fixtext: '{{{ fixtext_directory_permissions(file="/etc/cron.weekly/", mode="0700") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0700", "/etc/cron.weekly") }}}'
+srg_requirement: '{{{ srg_requirement_directory_permission(file="/etc/cron.weekly", mode="0700") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/crontab", perms="-rw--
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/crontab", perms="-rw-------") }}}
 
-fixtext: '{{{ fixtext_file_permissions("0600", "/etc/crontab") }}}'
+fixtext: '{{{ fixtext_file_permissions(file="/etc/cron.weekly/", mode="0600") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0600", "/etc/crontab") }}}'
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/cron.weekly", mode="0600") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
@@ -25,9 +25,16 @@ references:
     stigid@ol8: OL08-00-030740
     stigid@rhel8: RHEL-08-030740
 
-ocil_clause: 'a remote time server is not configured or configured with pool directive'
+ocil_clause: 'an authoritative remote time server is not configured or configured with pool directive'
 
 ocil: |-
     Run the following command and verify that time sources are only configure with <tt>server</tt> directive:
     <pre># grep -E "^(server|pool)" {{{ chrony_conf_path }}}</pre>
     A line with the appropriate server should be returned, any line returned starting with <tt>pool</tt> is a finding.
+
+srg_requirement: '{{{ full_name }}} must securely compare internal information system clocks at least every 24 hours with a server synchronized to an authoritative time source, such as the United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).'
+
+fixtext: |-
+    Configure {{{ full_name }}} to securely compare internal information system clocks at least every 24 hours with an NTP server by adding/modifying the following line in the /etc/chrony.conf file.
+
+    server [ntp.server.name] iburst maxpoll 16

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -35,6 +35,10 @@ ocil_clause: 'the chronyd process is not running'
 ocil: |-
     {{{ ocil_service_enabled(service="chronyd") }}}
 
+fixtext: '{{{ fixtext_service_enabled(service="chronyd") }}}'
+
+srg_requirement: '{{{ srg_requirement_service_enabled(service="chronyd") }}}'
+
 template:
     name: service_enabled
     vars:

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
@@ -29,6 +29,16 @@ references:
 
 ocil_clause: 'pam_pwquality.so is not enabled in password-auth'
 
+fixtext: |-
+    Configure {{{ full_name }}} to use "pwquality" to enforce password complexity rules.
+
+    Add the following line to the "/etc/pam.d/password-auth" file (or modify the line to have the required value):
+
+    password required pam_pwquality.so
+
+srg_requirement: '{{{ full_name }}} must ensure the password complexity module is enabled in the password-auth file.'
+
+
 ocil: |-
     To check if pam_pwhistory.so is enabled in password-auth, run the following command:
     <pre>$ grep pam_pwquality /etc/pam.d/password-auth</pre></pre>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
@@ -29,6 +29,15 @@ references:
 
 ocil_clause: 'pam_pwquality.so is not enabled in system-auth'
 
+fixtext: |-
+    Configure {{{ full_name }}} to use "pwquality" to enforce password complexity rules.
+
+    Add the following line to the "/etc/pam.d/system-auth" file(or modify the line to have the required value):
+
+    password required pam_pwquality.so
+
+srg_requirement: '{{{ full_name }}} must ensure the password complexity module is enabled in the system-auth file.'
+
 ocil: |-
     To check if pam_pwhistory.so is enabled in system-auth, run the following command:
     <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre></pre>

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
@@ -70,4 +70,15 @@ ocil: |-
     <tt>sha512</tt>:
     <pre>$ grep sha512 /etc/pam.d/password-auth</pre>
 
+{{% if product in ['rhel9'] %}}
+srg_requirement: 'The RHEL 9 pam_unix.so module must be configured in the password-auth file to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.'
+
+fixtext: |-
+    Configure {{{ full_name }}}} to use a FIPS 140-3 approved cryptographic hashing algorithm for system authentication.
+
+    Edit/modify the following line in the "/etc/pam.d/password-auth" file to include the sha512 option for pam_unix.so:
+
+    password sufficient pam_unix.so sha512
+{{% endif %}}
+
 platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
@@ -45,3 +45,12 @@ ocil: |-
     Inspect <tt>/etc/login.defs</tt> and ensure that if eihter
     <tt>SHA_CRYPT_MIN_ROUNDS</tt> or <tt>SHA_CRYPT_MAX_ROUNDS</tt>
     are set, they must have the minimum value of <tt>5000</tt>.
+
+srg_requirement: '{{{ full_name }}} shadow password suite must be configured to use a sufficient number of hashing rounds.'
+
+fixtext: |-
+    Configure {{{ full_name }}} to encrypt all stored passwords with a strong cryptographic hash.
+
+    Edit/modify the following line in the "/etc/login.defs" file and set "SHA_CRYPT_MIN_ROUNDS" to a value no lower than "5000":
+
+    SHA_CRYPT_MIN_ROUNDS 5000

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_lastlog/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_lastlog/rule.yml
@@ -24,9 +24,9 @@ ocil_clause: '{{{ ocil_clause_file_permissions(file="/usr/bin/lastlog", perms="-
 ocil: |-
     {{{ ocil_file_permissions(file="/usr/bin/lastlog", perms="-rwxr-x---") }}}
 
-fixtext: '{{{ fixtext_directory_permissions("0750", "/usr/bin/lastlog/") }}}'
+fixtext: '{{{ fixtext_directory_permissions(file="/usr/bin/lastlog/", mode="0750") }}}'
 
-srg_requirement: '{{{ srg_requirement_directory_permission("0750", "/usr/bin/lastlog") }}}'
+srg_requirement: '{{{ srg_requirement_directory_permission(file="/usr/bin/lastlog", mode="0750") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/rule.yml
@@ -69,3 +69,5 @@ fixtext: |-
     -e 2
 
     Note: Once set, the system must be rebooted for auditing to be changed.  It is recommended to add this option as the last step in securing the system.
+
+srg_requirement: '{{{ full_name }}} audit system must protect auditing rules from unauthorized change.'

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -40,11 +40,16 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
 
 ocil: |-
     {{{ ocil_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -42,14 +42,14 @@ references:
     pcidss: Req-7.1
     srg: SRG-OS-000480-GPOS-00227
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(grub2_boot_path + "/grub.cfg", "root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}
+    {{{ ocil_file_group_owner(file=grub2_boot_path + "/grub.cfg", group="root") }}}
 
-fixtext: '{{{ fixtext_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
+fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path + "/grub.cfg", "root") }}}'
 
-srg_requirement: '{{{ srg_requirement_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}'
+srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path + "/grub.cfg", "root") }}}'
 
 platform: machine
 

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -23,11 +23,18 @@ references:
     cis@sle12: 6.1.7
     cis@sle15: 6.1.7
     cis@ubuntu2004: 6.1.8
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group-", group="root") }}}'
 
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/group-", group="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/group-", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/group-", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -26,11 +26,18 @@ references:
     cis@rhel7: 6.1.6
     cis@rhel8: 6.1.7
     cis@ubuntu2004: 6.1.3
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'
 
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/gshadow-", group=target_group) }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/gshadow-", group=target_group) }}}'
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -23,11 +23,18 @@ references:
     cis@sle12: 6.1.5
     cis@sle15: 6.1.5
     cis@ubuntu2004: 6.1.6
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd-", group="root") }}}'
 
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/passwd-", group="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/passwd-", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/passwd-", group="root") }}}'
 
 template:
     name: file_groupowner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -35,6 +35,10 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow-", group=target
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/shadow-", group=target_group) }}}
 
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/shadow-", group=target_group) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/shadow-", group=target_group) }}}'
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -39,6 +39,10 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/group", group="root") 
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/group", group="root") }}}
 
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/group", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/group", group="root") }}}'
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -40,6 +40,10 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/gshadow", group=target
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/gshadow", group=target_group) }}}
 
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/gshadow", group=target_group) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/gshadow", group=target_group) }}}'
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
@@ -39,6 +39,10 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/passwd", group="root")
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/passwd", group="root") }}}
 
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/passwd", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/passwd", group="root") }}}'
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -45,6 +45,10 @@ ocil_clause: '{{{ ocil_clause_file_group_owner(file="/etc/shadow", group=target_
 ocil: |-
     {{{ ocil_file_group_owner(file="/etc/shadow", group=target_group) }}}
 
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/shadow", group=target_group) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/shadow", group=target_group) }}}'
+
 template:
     name: file_groupowner
     vars:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
@@ -23,11 +23,18 @@ references:
     cis@sle12: 6.1.7
     cis@sle15: 6.1.7
     cis@ubuntu2004: 6.1.8
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group-", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/group-", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/group-", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/group-", group="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/rule.yml
@@ -20,11 +20,19 @@ references:
     cis@rhel7: 6.1.6
     cis@rhel8: 6.1.7
     cis@ubuntu2004: 6.1.3
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow-", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/gshadow-", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/gshadow-", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/gshadow-", group="root") }}}'
+
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
@@ -23,11 +23,18 @@ references:
     cis@sle12: 6.1.5
     cis@sle15: 6.1.5
     cis@ubuntu2004: 6.1.6
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd-", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/passwd-", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/passwd-", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/passwd-", group="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/rule.yml
@@ -23,11 +23,18 @@ references:
     cis@sle12: 6.1.6
     cis@sle15: 6.1.6
     cis@ubuntu2004: 6.1.7
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow-", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/shadow-", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_group_owner(file="/etc/shadow-", group="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_group_owner(file="/etc/shadow-", group="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/rule.yml
@@ -26,6 +26,7 @@ references:
     cis@ubuntu2004: 6.1.5
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
@@ -33,11 +34,16 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/group", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/group", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/group", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/group", owner="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -24,17 +24,23 @@ references:
     cis@rhel8: 6.1.6
     cis@ubuntu2004: 6.1.9
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     nerc-cip: CIP-003-8 R5.1.1,CIP-003-8 R5.3,CIP-004-6 R2.3,CIP-007-3 R2.1,CIP-007-3 R2.2,CIP-007-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R5.1.1,CIP-007-3 R5.1.2
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/gshadow", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/gshadow", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/gshadow", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/gshadow", owner="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/rule.yml
@@ -26,6 +26,7 @@ references:
     cis@ubuntu2004: 6.1.2
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
@@ -33,11 +34,16 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/passwd", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/passwd", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/passwd", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/passwd", owner="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/rule.yml
@@ -31,6 +31,7 @@ references:
     cis@ubuntu2004: 6.1.4
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
@@ -38,11 +39,16 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_owner(file="/etc/shadow", owner="root") }}}'
 
 ocil: |-
     {{{ ocil_file_owner(file="/etc/shadow", owner="root") }}}
+
+fixtext: '{{{ fixtext_file_owner(file="/etc/shadow", owner="root") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_owner(file="/etc/shadow", owner="root") }}}'
 
 template:
     name: file_owner

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
@@ -24,11 +24,18 @@ references:
     cis@sle12: 6.1.7
     cis@sle15: 6.1.7
     cis@ubuntu2004: 6.1.8
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/group-", perms="-rw-r--r--") }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/group-", perms="-rw-r--r--") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/passwd-", mode="0644") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/passwd-", mode="0644") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/rule.yml
@@ -30,11 +30,19 @@ references:
     cis@rhel8: 6.1.7
     cis@sle15: 6.1.3
     cis@ubuntu2004: 6.1.3
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow-", perms=target_perms) }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/gshadow-", perms=target_perms) }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/gshadow-", mode=target_perms_octal) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/gshadow-", mode=target_perms_octal) }}}'
+
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
@@ -24,11 +24,19 @@ references:
     cis@sle12: 6.1.5
     cis@sle15: 6.1.5
     cis@ubuntu2004: 6.1.6
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd-", perms="-rw-r--r--") }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/passwd-", perms="-rw-r--r--") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/passwd-", mode="0644") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/passwd-", mode="0644") }}}'
+
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/rule.yml
@@ -32,11 +32,19 @@ references:
     cis@sle12: 6.1.6
     cis@sle15: 6.1.6
     cis@ubuntu2004: 6.1.7
+    disa: CCI-002223
+    nist: AC-6 (1)
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/shadow-", perms=target_perms) }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/shadow-", perms=target_perms) }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/shadow-", mode=target_perms_octal) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/shadow-", mode=target_perms_octal) }}}'
+
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/rule.yml
@@ -29,6 +29,7 @@ references:
     cis@ubuntu2004: 6.1.5
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
@@ -36,11 +37,17 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
+    srg: SRG-OS-000480-GPOS-00227
+
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/group", perms="-rw-r--r--") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/group", mode="0644") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/group", mode="0644") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
@@ -34,17 +34,23 @@ references:
     cis@sle15: 6.1.2
     cis@ubuntu2004: 6.1.9
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
     nerc-cip: CIP-003-8 R5.1.1,CIP-003-8 R5.3,CIP-004-6 R2.3,CIP-007-3 R2.1,CIP-007-3 R2.2,CIP-007-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R5.1.1,CIP-007-3 R5.1.2
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/gshadow", perms=target_perms) }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/gshadow", perms=target_perms) }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/gshadow", mode=target_perms_octal) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/gshadow", mode=target_perms_octal) }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/rule.yml
@@ -31,6 +31,7 @@ references:
     cis@ubuntu2004: 6.1.2
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
@@ -38,11 +39,16 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/passwd", perms="-rw-r--r--") }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/group", mode="0644") }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/group", mode="0644") }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/rule.yml
@@ -40,6 +40,7 @@ references:
     cis@ubuntu2004: 6.1.4
     cjis: 5.5.2.2
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02
+    disa: CCI-002223
     isa-62443-2009: 4.3.3.7.3
     isa-62443-2013: 'SR 2.1,SR 5.2'
     iso27001-2013: A.10.1.1,A.11.1.4,A.11.1.5,A.11.2.1,A.13.1.1,A.13.1.3,A.13.2.1,A.13.2.3,A.13.2.4,A.14.1.2,A.14.1.3,A.6.1.2,A.7.1.1,A.7.1.2,A.7.3.1,A.8.2.2,A.8.2.3,A.9.1.1,A.9.1.2,A.9.2.3,A.9.4.1,A.9.4.4,A.9.4.5
@@ -47,11 +48,16 @@ references:
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-8.7.c
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/shadow", perms=target_perms) }}}'
 
 ocil: |-
     {{{ ocil_file_permissions(file="/etc/shadow", perms=target_perms) }}}
+
+fixtext: '{{{ fixtext_file_permissions(file="/etc/shadow", mode=target_perms_octal) }}}'
+
+srg_requirement: '{{{ srg_requirement_file_permission(file="/etc/shadow", mode=target_perms_octal) }}}'
 
 template:
     name: file_permissions

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/rule.yml
@@ -62,6 +62,13 @@ ocil: |-
     run the following command for each directory <i>DIR</i> which contains shared libraries:
     <pre>$ sudo find -L <i>DIR</i> -perm /022 -type d</pre>
 
+fixtext: |-
+    Configure the {{{ full_name }}} library directories to be protected from unauthorized access. Run the following command, replacing "[DIRECTORY]" with any library directory with a mode more permissive than 755.
+
+    $ sudo chmod 755 [DIRECTORY]
+
+srg_requirement: '{{{ full_name }}} library directories must have mode 755 or less permissive.'
+
 template:
     name: file_permissions
     vars:


### PR DESCRIPTION
#### Description:
This PR adds missing rules based on comparing the RHEL8 STIG and RHEL8 CIS Level 1 benchmarks to the current RHEL9 STIG.

#### Rationale:

To ensure that RHEL9 STIG contains rules that are needed.
