### PR TITLE
Increase Cognitive Complexity threshold

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,6 +11,10 @@ checks:
          python:
            threshold: 40
 
+  method-complexity:
+    config:
+      threshold: 7
+
 plugins:
   markdownlint:
     enabled: true


### PR DESCRIPTION
Increase the CodeClimate Cognitive Complexity maintainability check
threshold from deafult 5 to 7.
https://docs.codeclimate.com/docs/cognitive-complexity

We can reduce the noise in the CodeClimate report to help focus
on big issues.
