### PR TITLE
Adjust bash to correspond to rule.yml for correct value of TimedLoginEnable

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/gnome_gdm_disable_guest_login/bash/shared.sh
@@ -5,8 +5,8 @@ then
 	if ! grep -q "^TimedLoginEnable=" /etc/gdm/custom.conf
 	then
 		sed -i "/^\[daemon\]/a \
-		TimedLoginEnable=False" /etc/gdm/custom.conf
+		TimedLoginEnable=false" /etc/gdm/custom.conf
 	else
-		sed -i "s/^TimedLoginEnable=.*/TimedLoginEnable=False/g" /etc/gdm/custom.conf
+		sed -i "s/^TimedLoginEnable=.*/TimedLoginEnable=false/g" /etc/gdm/custom.conf
 	fi
 fi


### PR DESCRIPTION
#### Description:

Updates 'Disable GDM Guest Login' rule to match its OCIL checklist item.

#### Rationale:

According to STIG guideline for RHEL7 and the rule.yml for this check, `TimedLoginEnable=false` is the correct value and other check tools such as Teneble's SecurityCenter feed don't assume a case-insensitive check, and manual checks against the OCIL should match the automated remediation and/or description.

Additionally, the[ GDM configuration file documentation](https://help.gnome.org/admin/gdm/stable/configuration.html.en) indicates that the correct configuration value is `false`