### PR TITLE
Add OL9 Dockerfile

### DIFF
--- a/Dockerfiles/test_suite-ol9
+++ b/Dockerfiles/test_suite-ol9
@@ -1,0 +1,23 @@
+# This Dockerfile is a minimal example for an OL9-based SSG test suite target container.
+FROM oraclelinux:9
+
+ENV AUTH_KEYS=/root/.ssh/authorized_keys
+
+ARG CLIENT_PUBLIC_KEY
+ARG ADDITIONAL_PACKAGES
+
+# Install Python so Ansible remediations can work
+# Don't clean all, as the test scenario may require package install.
+RUN true \
+        && dnf install -y openssh-clients openssh-server openscap-scanner \
+        python3 tar \
+        $ADDITIONAL_PACKAGES \
+        && true
+
+RUN true \
+        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+        && mkdir -p /root/.ssh \
+        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+&& true

--- a/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_oracle_gpgkey_installed/bash/shared.sh
@@ -1,6 +1,5 @@
 # platform = multi_platform_ol
-# OL fingerprints below retrieved from Oracle Linux Yum Server "Frequently Asked Questions"
-# https://yum.oracle.com/faq.html#a10
+# OL fingerprints below retrieved from: https://linux.oracle.com/security/gpg/#gpg
 readonly OL_RELEASE_FINGERPRINT="{{{ release_key_fingerprint }}}"
 readonly OL_AUXILIARY_FINGERPRINT="{{{ auxiliary_key_fingerprint }}}"
 

--- a/products/ol9/product.yml
+++ b/products/ol9/product.yml
@@ -17,6 +17,7 @@ pkg_version: "8d8b756f"
 aux_pkg_release: "629ec292"
 aux_pkg_version: "8b4efbe6"
 
+# OL fingerprints below retrieved from: https://linux.oracle.com/security/gpg/#gpg
 release_key_fingerprint: "3E6D826D3FBAB389C2F38E34BC4D06A08D8B756F"
 auxiliary_key_fingerprint: "982231759C7467065D0CE9B2A7DD07088B4EFBE6"
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -424,7 +424,7 @@ def select_templated_tests(test_dir_config, available_scenarios_basenames):
             test_name for test_name in available_scenarios_basenames
             if test_name in allow_scenarios
         }
-    
+
     allowed_and_denied = deny_scenarios.intersection(allow_scenarios)
     if allowed_and_denied:
         msg = (
@@ -498,6 +498,7 @@ INSTALL_COMMANDS = dict(
     fedora=("dnf", "install", "-y"),
     ol7=("yum", "install", "-y"),
     ol8=("yum", "install", "-y"),
+    ol9=("yum", "install", "-y"),
     rhel7=("yum", "install", "-y"),
     rhel8=("yum", "install", "-y"),
     rhel9=("yum", "install", "-y"),


### PR DESCRIPTION
#### Description:

- Add Dockerfile for OL9
- Update Oracle links to security site with GPG keys fingerprints and info

#### Rationale:

- SCAP and automated test content for OL9 product efforts
