### PR TITLE
Add missing ocil_clause for audit rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
@@ -29,7 +29,7 @@ references:
     stigid@sle15: SLES-15-040000
     stigid@ubuntu2004: UBTU-20-010075
 
-ocil_clause: 'that is not the case'
+ocil_clause: 'the value of delay is not set properly or the line is commented or missing'
 
 ocil: |-
     Verify that the {{{ full_name }}} operating system enforces a minimum delay betweeen

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/rule.yml
@@ -44,7 +44,7 @@ references:
     stigid@sle15: SLES-15-020010
     stigid@ubuntu2004: UBTU-20-010072
 
-ocil_clause: 'that is not the case'
+ocil_clause: 'the account option is missing or commented out'
 
 ocil: |-
     Check that the systems locks a user account after - at most - <tt>{{{ xccdf_value("var_password_pam_tally2") }}}</tt>

--- a/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/pam_disable_automatic_configuration/rule.yml
@@ -29,7 +29,7 @@ references:
     stigid@sle12: SLES-12-010910
     stigid@sle15: SLES-15-040220
 
-ocil_clause: 'that is not the case'
+ocil_clause: 'there is output'
 
 ocil: |-
     Check that soft links between PAM configuration files are removed with the following command:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -62,7 +62,7 @@ references:
     srg: SRG-OS-000327-GPOS-00127
     vmmsrg: SRG-OS-000471-VMM-001910
 
-ocil_clause: 'it is not the case'
+ocil_clause: "any setuid or setgid programs doesn't have a line in the audit rules"
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the
@@ -72,7 +72,7 @@ ocil: |-
     Run the following command to verify entries in the audit rules for all programs
     found with the previous command:
     <pre>$ sudo grep path /etc/audit/audit.rules</pre>
-    It should be the case that all relevant setuid / setgid programs have a line
+    All relevant setuid / setgid programs have a line
     in the audit rules.
 
 warnings:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_at/rule.yml
@@ -46,7 +46,7 @@ references:
     ospp: FAU_GEN.1.1.c
     vmmsrg: SRG-OS-000471-VMM-001910
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chfn/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chfn/rule.yml
@@ -39,7 +39,7 @@ references:
     stigid@sle15: SLES-15-030340
     stigid@ubuntu2004: UBTU-20-010137
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_fdisk/rule.yml
@@ -23,7 +23,7 @@ references:
     srg: SRG-OS-000477-GPOS-00222
     stigid@ubuntu2004: UBTU-20-010298
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_insmod/rule.yml
@@ -43,7 +43,7 @@ references:
     srg: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
     stigid@sle15: SLES-15-030380
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_modprobe/rule.yml
@@ -48,7 +48,7 @@ references:
     stigid@sle15: SLES-15-030400
     stigid@ubuntu2004: UBTU-20-010296
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgidmap/rule.yml
@@ -47,7 +47,7 @@ references:
     ospp: FAU_GEN.1.1.c
     vmmsrg: SRG-OS-000471-VMM-001910
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newuidmap/rule.yml
@@ -47,7 +47,7 @@ references:
     ospp: FAU_GEN.1.1.c
     vmmsrg: SRG-OS-000471-VMM-001910
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passmass/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passmass/rule.yml
@@ -40,7 +40,7 @@ references:
     stigid@sle12: SLES-12-020670
     stigid@sle15: SLES-15-030490
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_rmmod/rule.yml
@@ -43,7 +43,7 @@ references:
     srg: SRG-OS-000037-GPOS-00015,SRG-OS-000062-GPOS-00031,SRG-OS-000392-GPOS-00172,SRG-OS-000462-GPOS-00206,SRG-OS-000471-GPOS-00215
     stigid@sle15: SLES-15-030390
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
@@ -53,7 +53,7 @@ references:
     stigid@sle15: SLES-15-030110
     vmmsrg: SRG-OS-000471-VMM-001910
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usernetctl/rule.yml
@@ -46,7 +46,7 @@ references:
     ospp: FAU_GEN.1.1.c
     vmmsrg: SRG-OS-000471-VMM-001910
 
-ocil_clause: 'it is not the case'
+ocil_clause: '{{{ ocil_clause_audit() }}}'
 
 ocil: |-
     To verify that auditing of privileged command use is configured, run the


### PR DESCRIPTION
#### Description:

- Add missing ocil_clause for audit rules.

#### Rationale:

- Fix the infamous `is it the case that is not the case` phrase: https://github.com/ComplianceAsCode/content/issues/3150#issuecomment-408003903
- Fix #3150 this should be the last items so this issue can be closed.

@jan-cerny 
