### PR TITLE
Fix ubuntu logic in display_login_attempts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_sle,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_wrlinux,multi_platform_ubuntu
 
-{{% if product in ["sle12", "sle15", "ubuntu"] %}}
+{{% if product in ["sle12", "sle15"] or "ubuntu" in product %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/login', 'session', 'required', 'pam_lastlog.so', 'showfailed', '', '^$') }}}
 {{{ bash_remove_pam_module_option_configuration('/etc/pam.d/login', 'session', '', 'pam_lastlog.so', 'silent') }}}
 {{% else %}}


### PR DESCRIPTION
#### Description:

- Commit [df87ca0](https://github.com/ComplianceAsCode/content/commit/df87ca00e87f1af4d2e75d37e2572b69508ad3bb) made the remediation for Ubuntu to not be processed, making the rule fail. This commit fixes it.