### PR TITLE
remove rule accounts_password_minlen_login_defs from RHEL and Fedora profiles

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -343,9 +343,6 @@ controls:
     # Ensure passwords with minimum of 18 characters
     - var_password_pam_minlen=18
     - accounts_password_pam_minlen
-    # Enforce password lenght for new accounts
-    - var_accounts_password_minlen_login_defs=18
-    - accounts_password_minlen_login_defs
     # Require at Least 1 Special Character in Password
     - var_password_pam_ocredit=1
     - accounts_password_pam_ocredit

--- a/controls/srg_gpos/SRG-OS-000078-GPOS-00046.yml
+++ b/controls/srg_gpos/SRG-OS-000078-GPOS-00046.yml
@@ -6,7 +6,5 @@ controls:
         rules:
             - accounts_password_pam_enforce_root
             - accounts_password_pam_minlen
-            - accounts_password_minlen_login_defs
             - var_password_pam_minlen=15
-            - var_accounts_password_minlen_login_defs=15
         status: automated

--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -1140,9 +1140,7 @@ controls:
         levels:
             - medium
         title: RHEL 8 passwords for new users must have a minimum of 15 characters.
-        rules:
-            - accounts_password_minlen_login_defs
-        status: automated
+        status: inherently met
     -   id: RHEL-08-020240
         levels:
             - medium

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/rule.yml
@@ -45,10 +45,8 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     nist: IA-5(f),IA-5(1)(a),CM-6(a)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FMT_MOF_EXT.1
     srg: SRG-OS-000078-GPOS-00046
     stigid@ol8: OL08-00-020231
-    stigid@rhel8: RHEL-08-020231
 
 ocil_clause: 'it is not set to the required value'
 

--- a/products/fedora/profiles/ospp.profile
+++ b/products/fedora/profiles/ospp.profile
@@ -29,7 +29,6 @@ selections:
     - var_selinux_state=enforcing
     - var_password_pam_minlen=12
     - accounts_password_pam_minlen
-    - accounts_password_minlen_login_defs
     - var_password_pam_ocredit=1
     - accounts_password_pam_ocredit
     - var_password_pam_dcredit=1

--- a/products/fedora/profiles/standard.profile
+++ b/products/fedora/profiles/standard.profile
@@ -26,8 +26,6 @@ selections:
     - accounts_password_all_shadowed
     - gid_passwd_group_same
     - no_netrc_files
-    - var_accounts_password_minlen_login_defs=12
-    - accounts_password_minlen_login_defs
     - var_accounts_minimum_age_login_defs=7
     - accounts_minimum_age_login_defs
     - var_accounts_maximum_age_login_defs=90

--- a/products/rhel7/profiles/cjis.profile
+++ b/products/rhel7/profiles/cjis.profile
@@ -63,7 +63,6 @@ selections:
     - accounts_password_all_shadowed
     - no_empty_passwords
     - display_login_attempts
-    - var_accounts_password_minlen_login_defs=12
     - var_accounts_maximum_age_login_defs=90
     - var_password_pam_unix_remember=10
     - var_account_disable_post_pw_expiration=0

--- a/products/rhel7/profiles/ncp.profile
+++ b/products/rhel7/profiles/ncp.profile
@@ -285,7 +285,6 @@ selections:
     - var_account_disable_post_pw_expiration=35
     - var_accounts_maximum_age_login_defs=60
     - var_accounts_minimum_age_login_defs=7
-    - var_accounts_password_minlen_login_defs=6
     - var_accounts_password_warn_age_login_defs=7
     - var_accounts_tmout=10_min
     - var_password_pam_difok=8

--- a/products/rhel7/profiles/ospp.profile
+++ b/products/rhel7/profiles/ospp.profile
@@ -180,8 +180,6 @@ selections:
 
     ## Configure Minimum Password Length to 12 Characters
     ## IA-5 (1)(a) / FMT_MOF_EXT.1
-    - var_accounts_password_minlen_login_defs=12
-    - accounts_password_minlen_login_defs
     - var_password_pam_minlen=12
     - accounts_password_pam_minlen
 

--- a/products/rhel7/profiles/rhelh-stig.profile
+++ b/products/rhel7/profiles/rhelh-stig.profile
@@ -13,7 +13,6 @@ selections:
     - inactivity_timeout_value=15_minutes
     - var_password_pam_minlen=15
     - accounts_password_pam_minlen
-    - accounts_password_minlen_login_defs
     - var_password_pam_ocredit=1
     - accounts_password_pam_ocredit
     - var_password_pam_dcredit=1
@@ -330,7 +329,6 @@ selections:
     - var_accounts_max_concurrent_login_sessions=10
     - var_accounts_maximum_age_login_defs=60
     - var_accounts_minimum_age_login_defs=7
-    - var_accounts_password_minlen_login_defs=6
     - var_accounts_password_warn_age_login_defs=7
     - var_accounts_tmout=10_min
     - var_password_pam_difok=8

--- a/products/rhel7/profiles/rht-ccp.profile
+++ b/products/rhel7/profiles/rht-ccp.profile
@@ -14,7 +14,6 @@ selections:
     - file_owner_logfiles_value=root
     - file_groupowner_logfiles_value=root
     - sshd_idle_timeout_value=5_minutes
-    - var_accounts_password_minlen_login_defs=6
     - var_accounts_minimum_age_login_defs=7
     - var_accounts_passwords_pam_faillock_deny=5
     - var_accounts_password_warn_age_login_defs=7
@@ -43,7 +42,6 @@ selections:
     - no_empty_passwords
     - accounts_password_all_shadowed
     - accounts_no_uid_except_zero
-    - accounts_password_minlen_login_defs
     - accounts_minimum_age_login_defs
     - accounts_password_warn_age_login_defs
     - accounts_password_pam_retry

--- a/products/rhel8/profiles/cjis.profile
+++ b/products/rhel8/profiles/cjis.profile
@@ -63,7 +63,6 @@ selections:
     - accounts_password_all_shadowed
     - no_empty_passwords
     - display_login_attempts
-    - var_accounts_password_minlen_login_defs=12
     - var_accounts_maximum_age_login_defs=90
     - var_password_pam_unix_remember=10
     - var_account_disable_post_pw_expiration=0

--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -264,8 +264,6 @@ selections:
 
     ## Configure Minimum Password Length to 12 Characters
     ## IA-5 (1)(a) / FMT_MOF_EXT.1
-    - var_accounts_password_minlen_login_defs=12
-    - accounts_password_minlen_login_defs
     - var_password_pam_minlen=12
     - accounts_password_pam_minlen
 

--- a/products/rhel8/profiles/rht-ccp.profile
+++ b/products/rhel8/profiles/rht-ccp.profile
@@ -14,7 +14,6 @@ selections:
     - file_owner_logfiles_value=root
     - file_groupowner_logfiles_value=root
     - sshd_idle_timeout_value=5_minutes
-    - var_accounts_password_minlen_login_defs=6
     - var_accounts_minimum_age_login_defs=7
     - var_accounts_passwords_pam_faillock_deny=5
     - var_accounts_password_warn_age_login_defs=7
@@ -43,7 +42,6 @@ selections:
     - no_empty_passwords
     - accounts_password_all_shadowed
     - accounts_no_uid_except_zero
-    - accounts_password_minlen_login_defs
     - accounts_minimum_age_login_defs
     - accounts_password_warn_age_login_defs
     - var_authselect_profile=sssd

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -41,7 +41,6 @@ selections:
     - var_password_pam_remember_control_flag=required
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted
-    - var_accounts_password_minlen_login_defs=15
     - var_password_pam_unix_rounds=5000
     - var_password_pam_minlen=15
     - var_password_pam_ocredit=1
@@ -606,9 +605,6 @@ selections:
 
     # RHEL-08-020230
     - accounts_password_pam_minlen
-
-    # RHEL-08-020231
-    - accounts_password_minlen_login_defs
 
     # RHEL-08-020240
     - account_unique_id

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -211,8 +211,6 @@ selections:
 
     ## Configure Minimum Password Length to 12 Characters
     ## IA-5 (1)(a) / FMT_MOF_EXT.1
-    - var_accounts_password_minlen_login_defs=12
-    - accounts_password_minlen_login_defs
     - var_password_pam_minlen=12
     - accounts_password_pam_minlen
 

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -42,7 +42,6 @@ selections:
     - var_password_pam_remember_control_flag=required
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted
-    - var_accounts_password_minlen_login_defs=15
     - var_password_pam_unix_rounds=5000
     - var_password_pam_minlen=15
     - var_password_pam_ocredit=1
@@ -577,9 +576,6 @@ selections:
 
     # RHEL-08-020230
     - accounts_password_pam_minlen
-
-    # RHEL-08-020231
-    - accounts_password_minlen_login_defs
 
     # RHEL-08-020240
     - account_unique_id

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -23,7 +23,6 @@ metadata:
 reference: https://www.niap-ccevs.org/Profile/PP.cfm
 selections:
 - accounts_max_concurrent_login_sessions
-- accounts_password_minlen_login_defs
 - accounts_password_pam_dcredit
 - accounts_password_pam_difok
 - accounts_password_pam_lcredit
@@ -248,7 +247,6 @@ selections:
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_system_crypto_policy=fips_ospp
-- var_accounts_password_minlen_login_defs=12
 - var_password_pam_minlen=12
 - var_password_pam_ocredit=1
 - var_password_pam_dcredit=1

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -42,7 +42,6 @@ selections:
 - accounts_minimum_age_login_defs
 - accounts_no_uid_except_zero
 - accounts_password_all_shadowed_sha512
-- accounts_password_minlen_login_defs
 - accounts_password_pam_dcredit
 - accounts_password_pam_dictcheck
 - accounts_password_pam_difok
@@ -429,7 +428,6 @@ selections:
 - var_password_pam_remember_control_flag=required
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
-- var_accounts_password_minlen_login_defs=15
 - var_password_pam_unix_rounds=5000
 - var_password_pam_minlen=15
 - var_password_pam_ocredit=1

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -53,7 +53,6 @@ selections:
 - accounts_minimum_age_login_defs
 - accounts_no_uid_except_zero
 - accounts_password_all_shadowed_sha512
-- accounts_password_minlen_login_defs
 - accounts_password_pam_dcredit
 - accounts_password_pam_dictcheck
 - accounts_password_pam_difok
@@ -437,7 +436,6 @@ selections:
 - var_password_pam_remember_control_flag=required
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
-- var_accounts_password_minlen_login_defs=15
 - var_password_pam_unix_rounds=5000
 - var_password_pam_minlen=15
 - var_password_pam_ocredit=1


### PR DESCRIPTION
#### Description:

- remove the rule and associated variable from RHEL and Fedora profiles

#### Rationale:

The parameter is not used by passwd command in RHEL and FEdora distros.