### PR TITLE
remove Rsyslog related rules from RHEL9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -146,9 +146,6 @@ selections:
     - package_openssh-server_installed
     - package_openssh-clients_installed
     - package_policycoreutils-python-utils_installed
-    - package_rsyslog_installed
-    - package_rsyslog-gnutls_installed
-    - package_audispd-plugins_installed
     - package_chrony_installed
     - package_gnutls-utils_installed
 
@@ -363,10 +360,6 @@ selections:
 
     # Enable dnf-automatic Timer
     - timer_dnf-automatic_enabled
-
-    # Configure TLS for remote logging
-    - rsyslog_remote_tls
-    - rsyslog_remote_tls_cacert
 
     # set ssh client rekey limit
     - ssh_client_rekey_limit


### PR DESCRIPTION
#### Description:

- remove rules related to remote logging requirement from RHEL9 OSPP profile

#### Rationale:

- trusted channel for audit server will not be claimed in RHEL 9 ospp