### PR TITLE
Update link in PAM group

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/group.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/group.yml
@@ -44,4 +44,4 @@ warnings:
         will re-write the PAM configuration files, destroying any manually
         made changes and replacing them with a series of system defaults.
         One reference to the configuration file syntax can be found at
-        {{{ weblink(link="http://www.linux-pam.org/Linux-PAM-html/sag-configuration-file.html") }}}.
+        {{{ weblink(link="https://fossies.org/linux/Linux-PAM-docs/doc/sag/Linux-PAM_SAG.pdf") }}}.


### PR DESCRIPTION
#### Description:
Previous link doesn't work anymore. The new link references `The Linux-PAM System Administrators' Guide` where 4.1 chapter `Configuration file syntax`.

#### Rationale:
Fixes #9096 