### PR TITLE
The reasons for disabling Ctrl-Alt-Del reboot is audit trail related

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/rule.yml
@@ -69,6 +69,7 @@ references:
     nist: CM-6(a),AC-6(1),CM-6(a)
     nist-csf: PR.AC-4,PR.DS-5
     nist@sle15: CM-6(b),CM-6.1(iv)
+    ospp: FAU_GEN.1.2
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000480-GPOS-00227
     stigid@ol8: OL08-00-040172
     stigid@rhel8: RHEL-08-040172

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/rule.yml
@@ -72,6 +72,7 @@ references:
     nerc-cip: CIP-003-8 R5.1.1,CIP-003-8 R5.3,CIP-004-6 R2.3,CIP-007-3 R2.1,CIP-007-3 R2.2,CIP-007-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R5.1.1,CIP-007-3 R5.1.2
     nist: CM-6(a),AC-6(1)
     nist-csf: PR.AC-4,PR.DS-5
+    ospp: FAU_GEN.1.2
     srg: SRG-OS-000324-GPOS-00125,SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-020230
     stigid@ol8: OL08-00-040170


### PR DESCRIPTION

#### Description:

- The reasons for disabling Ctrl-Alt-Del reboot is audit trail related.

#### Rationale:

- To have the subject identity for the reboot operation.
