### PR TITLE
controls/cis_alinux2.yml: modify the check value error of some rules

### DIFF
--- a/controls/cis_alinux2.yml
+++ b/controls/cis_alinux2.yml
@@ -389,7 +389,7 @@ controls:
     status: automated
     rules:
     - chronyd_specify_remote_server
-    - var_multiple_time_servers=rhel
+    - var_multiple_time_servers=alinux
     - chronyd_run_as_chrony_user
 
   - id: 2.1.2
@@ -1291,7 +1291,7 @@ controls:
     notes: <-
       The rule checks for default list of MACs provided in the benchmark.
     rules:
-    - sshd_approved_macs=cis_rhel7
+    - sshd_approved_macs=cis_alinux2
     - sshd_use_approved_macs
 
   - id: 5.2.14
@@ -1328,7 +1328,7 @@ controls:
     notes: <-
       The rule checks for default list of ciphers provided in the benchmark.
     rules:
-    - sshd_approved_ciphers=cis_rhel7
+    - sshd_approved_ciphers=cis_alinux2
     - sshd_use_approved_ciphers
 
   - id: 5.2.18
@@ -1384,8 +1384,6 @@ controls:
     status: automated
     notes: |-
       Usage of pam_unix.so module together with "remember" option is deprecated and is not supported by this policy interpretation.
-      See here for more details about pam_unix.so:
-      https://bugzilla.redhat.com/show_bug.cgi?id=1778929
     rules:
     - var_password_pam_remember=5
     - var_password_pam_remember_control_flag=required

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -59,6 +59,8 @@ description: |-
         {{{ weblink(link="https://help.ubuntu.com/lts/serverguide/NTP.html") }}}
     {{% elif "debian" in product %}}
         {{{ weblink(link="https://wiki.debian.org/NTP") }}}
+    {{% elif "alinux" in product %}}
+        {{{ weblink(link="https://www.alibabacloud.com/help/en/elastic-compute-service/latest/alibaba-cloud-ntp-server") }}}
     {{% else %}}
         {{{ weblink(link="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/servers/Configuring_NTP_Using_the_chrony_Suite/") }}}
     {{% endif %}}

--- a/linux_os/guide/services/ntp/var_multiple_time_servers.var
+++ b/linux_os/guide/services/ntp/var_multiple_time_servers.var
@@ -14,3 +14,4 @@ options:
     rhel: "0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org"
     ol: "0.pool.ntp.org,1.pool.ntp.org,2.pool.ntp.org,3.pool.ntp.org"
     suse: "0.suse.pool.ntp.org,1.suse.pool.ntp.org,2.suse.pool.ntp.org,3.suse.pool.ntp.org"
+    alinux: "0.ntp.cloud.aliyuncs.com,1.ntp.aliyun.com,2.ntp1.aliyun.com,3.ntp1.cloud.aliyuncs.com"

--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -16,3 +16,4 @@ options:
     cis_rhel7: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
     cis_sle12: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
     cis_sle15: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
+    cis_alinux2: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/services/ssh/sshd_approved_macs.var
+++ b/linux_os/guide/services/ssh/sshd_approved_macs.var
@@ -16,3 +16,4 @@ options:
     cis_rhel7: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com
     cis_sle12: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com
     cis_sle15: umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com
+    cis_alinux2: hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512,hmac-sha2-256


### PR DESCRIPTION
#### Description:

- There are some rules in cis_alinux2.yml whose check value should be alinux2 or aliyun instead of rhel7, such as https://github.com/ComplianceAsCode/content/blob/master/controls/cis_alinux2.yml#L392 , so we need to fix it.

- Fixes #9121 
