### PR TITLE
Set pipefail in Ansible shell commands with pipe

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
@@ -20,17 +20,20 @@
     set -o pipefail
     grep -e '$IncludeConfig' {{ rsyslog_etc_config }} | cut -d ' ' -f 2 || true
   register: include_config_output
+  changed_when: False
 
 - name: "Get include files directives"
   shell: |
     set -o pipefail
     grep -oP '^\s*include\s*\(\s*file.*' {{ rsyslog_etc_config }} |cut  -d"\"" -f 2 || true
   register: include_files_output
+  changed_when: False
 
 - name: "List all config files"
   shell: find "$(dirname "{{ item }}" )" -maxdepth 1 -name "$(basename "{{ item }}")"
   loop: "{{ include_config_output.stdout_lines + include_files_output.stdout_lines }}"
   register: rsyslog_config_files
+  changed_when: False
 
 - name: "Extract log files"
   shell: |
@@ -38,6 +41,7 @@
     grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item }}  |awk '{print $NF}'|sed -e 's/^-//'
   loop: "{{ rsyslog_config_files.results|map(attribute='stdout_lines')|list|flatten|unique + [ rsyslog_etc_config ] }}"
   register: log_files
+  changed_when: False
 
 - name: "Setup log files permissions"
   ignore_errors: yes

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
@@ -16,11 +16,15 @@
 # * And also the log file paths listed after rsyslog's $IncludeConfig directive
 #   (store the result into array for the case there's shell glob used as value of IncludeConfig)
 - name: "Get IncludeConfig directive"
-  shell: grep -e '$IncludeConfig' {{ rsyslog_etc_config }} | cut -d ' ' -f 2
+  shell: |
+    set -o pipefail
+    grep -e '$IncludeConfig' {{ rsyslog_etc_config }} | cut -d ' ' -f 2 || true
   register: include_config_output
 
 - name: "Get include files directives"
-  shell: grep -oP '^\s*include\s*\(\s*file.*' {{ rsyslog_etc_config }} |cut  -d"\"" -f 2
+  shell: |
+    set -o pipefail
+    grep -oP '^\s*include\s*\(\s*file.*' {{ rsyslog_etc_config }} |cut  -d"\"" -f 2 || true
   register: include_files_output
 
 - name: "List all config files"
@@ -29,7 +33,9 @@
   register: rsyslog_config_files
 
 - name: "Extract log files"
-  shell: grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item }}  |awk '{print $NF}'|sed -e 's/^-//'
+  shell: |
+    set -o pipefail
+    grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item }}  |awk '{print $NF}'|sed -e 's/^-//'
   loop: "{{ rsyslog_config_files.results|map(attribute='stdout_lines')|list|flatten|unique + [ rsyslog_etc_config ] }}"
   register: log_files
 


### PR DESCRIPTION

#### Description:
- Set pipefail, so that the task fails if any part of the shell command fails.
- The shell commands can fail during the grep command, and that is fine.
  So incorporated the same technique employed in https://github.com/ComplianceAsCode/content/pull/6779 

#### Rationale:
- Fix Ansible role linting for rule rsyslog_files_permissions

