### PR TITLE
Unify the RHEL approach for rule file_permissions_var_log_audit

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/bash/shared.sh
@@ -6,7 +6,7 @@ else
     FILE="/var/log/audit/audit.log"
 fi
 
-{{% if product not in ["ol8", "rhel8"] %}}
+{{% if product not in ["ol8"] and "rhel" not in product %}}
 if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/oval/shared.xml
@@ -2,7 +2,7 @@
   <definition class="compliance" id="file_permissions_var_log_audit" version="2">
     {{{ oval_metadata("Checks for correct permissions for all audit log files.") }}}
     <criteria operator="OR">
-      {{% if product not in ["ol8", "rhel8"] %}}
+      {{% if product not in ["ol8"] and "rhel" not in product %}}
       <criteria operator="AND" comment="log_file set">
         <extend_definition comment="log_file set in auditd.conf" definition_ref="auditd_conf_log_file_not_set" negate="true" />
         <criteria operator="AND" comment="log_group in auditd.conf is not root">
@@ -40,7 +40,7 @@
     <filter action="include">state_not_mode_0600</filter>
   </unix:file_object>
 
-  {{% if product in ["ol8", "rhel8"] %}}
+  {{% if product in ["ol8"] or "rhel" in product %}}
   <unix:file_test check="all" check_existence="at_least_one_exists"
       comment="default audit log files mode 0600"
       id="test_file_permissions_default_audit_log" version="1">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/rule.yml
@@ -5,7 +5,7 @@ prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004
 title: 'System Audit Logs Must Have Mode 0640 or Less Permissive'
 
 description: |-
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or "rhel" in product %}}
     Determine where the audit logs are stored with the following command:
     <pre>$ sudo grep -iw log_file /etc/audit/auditd.conf
     log_file = /var/log/audit/audit.log</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/correct_value_0600.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/correct_value_0600.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
+# packages = audit
 
 source common_0600.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/correct_value_default_file_0600.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/correct_value_default_file_0600.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
+# packages = audit
 
 source common_0600.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/incorrect_value_0600.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/incorrect_value_0600.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
+# packages = audit
 
 source common_0600.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/incorrect_value_default_file_0600.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/tests/incorrect_value_default_file_0600.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
+# packages = audit
 
 source common_0600.sh
 


### PR DESCRIPTION

#### Description:

- RHEL7 and RHEL9 should follow the same approach for RHEL8. i.e.:
  - Look for `log_file` in /etc/audit/auditd.conf` and check that file's permissions

#### Rationale:
- Related https://github.com/ComplianceAsCode/content/pull/8808
- RHEL8 STIG: https://stigs.mab879.com/products/rhel8/v1r6/RHEL-08-030070/
- RHEL7 STIG https://stigs.mab879.com/products/rhel7/v3r7/RHEL-07-910055/
- Fixes #8948 
