### PR TITLE
SLE15 SP4 audit_rules_augenrules broken.

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
@@ -9,7 +9,7 @@
 
 - name: Check the rules script being used
   command:
-    grep '^ExecStartPost' /usr/lib/systemd/system/auditd.service
+    grep -E '^(ExecStartPost|Requires)' /usr/lib/systemd/system/auditd.service
   register: check_rules_scripts_result
 
 - name: Find audit rules in /etc/audit/rules.d

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/bash/shared.sh
@@ -1,9 +1,9 @@
 # platform = multi_platform_sle
 
 if [ -f "/usr/lib/systemd/system/auditd.service" ] ; then
-    EXECSTARTPOST_SCRIPT=$(grep '^ExecStartPost=' /usr/lib/systemd/system/auditd.service | sed 's/ExecStartPost=//')
+    IS_AUGENRULES=$(grep -E "^(ExecStartPost=|Requires=augenrules\.service)" /usr/lib/systemd/system/auditd.service)
 
-    if [[ "$EXECSTARTPOST_SCRIPT" == *"augenrules"* ]] ; then
+    if [[ "$IS_AUGENRULES" == *"augenrules"* ]] ; then
         for f in /etc/audit/rules.d/*.rules ; do
             sed -E -i --follow-symlinks 's/^(\s*-a\s+task,never)/#\1/' "$f"
         done

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -20,7 +20,7 @@
 {{% if init_system == "systemd" %}}
   <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
     <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
-    <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/augenrules.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(ExecStartPost=\-\/sbin\/augenrules.*$|Requires=augenrules.service)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% else %}}


### PR DESCRIPTION
SLE 15 SP4 changed how augenrules was enabled
in file /usr/lib/systemd/system/auditd.service
pre-SLE15 SP4 had:
ExecStartPost=-/sbin/augenrules --load

This changed in SLE15 SP4 to:
Requires=augenrules.service

Changes:
shared/checks/oval/audit_rules_augenrules.xml change to allow for Requires=augenrules.service

linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/ansible/shared.yml
linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_enable_syscall_auditing/bash/shared.sh
These remdiations also checked for "ExecStartPost=-/sbin/augenrules --load"
and were updated to allow for "Requires=augenrules.service"

#### Description:

- allow for either:
ExecStartPost=-/sbin/augenrules --load
or
Requires=augenrules.service

to specify augenrules in /usr/lib/systemd/system/auditd.service

#### Rationale:

- SLE 15 SP4 uses Requires=augenrules.service tu specify augenrules 
