### PR TITLE
fix bash remediation of configure_libreswan_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/bash/shared.sh
@@ -3,7 +3,8 @@
 function remediate_libreswan_crypto_policy() {
     CONFIG_FILE="/etc/ipsec.conf"
     if ! grep -qP "^\s*include\s+/etc/crypto-policies/back-ends/libreswan.config\s*(?:#.*)?$" "$CONFIG_FILE" ; then
-        echo 'include /etc/crypto-policies/back-ends/libreswan.config' >> "$CONFIG_FILE"
+        # the file might not end with a new line
+        echo -e '\ninclude /etc/crypto-policies/back-ends/libreswan.config' >> "$CONFIG_FILE"
     fi
     return 0
 }


### PR DESCRIPTION
#### Description:

- remediation prepends the include directive with a blank line

#### Rationale:

- the file might not always end with a blank line

- Fixes #9131 
