### PR TITLE
BUG: 2105878 OCP: Fix rule ocp4-kubelet-enable-streaming-connections

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/rule.yml
@@ -49,6 +49,6 @@ template:
     vars:
         filepath: {{{ kubeletconf_path }}}
         yamlpath: ".streamingConnectionIdleTimeout"
-        check_existence: "any_exist"
+        check_existence: "all_exist"
         xccdf_variable: var_streaming_connection_timeouts
         regex_data: true

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/notset.fail.sh
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/notset.fail.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# remediation = none
+
+yum install -y jq
+
+mkdir -p "/etc/kubernetes"
+
+cat << EOF > /etc/kubernetes/kubelet.conf
+{
+  "kind": "KubeletConfiguration",
+  "apiVersion": "kubelet.config.k8s.io/v1beta1",
+  "staticPodPath": "/etc/kubernetes/manifests",
+  "syncFrequency": "0s",
+  "fileCheckFrequency": "0s",
+  "httpCheckFrequency": "0s",
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+  ],
+  "tlsMinVersion": "VersionTLS12",
+  "rotateCertificates": true,
+  "serverTLSBootstrap": true,
+  "authentication": {
+    "x509": {
+      "clientCAFile": "/etc/kubernetes/kubelet-ca.crt"
+    },
+    "webhook": {
+      "cacheTTL": "0s"
+    },
+    "anonymous": {
+      "enabled": false
+    }
+  },
+  "authorization": {
+    "webhook": {
+      "cacheAuthorizedTTL": "0s",
+      "cacheUnauthorizedTTL": "0s"
+    }
+  },
+  "clusterDomain": "cluster.local",
+  "clusterDNS": [
+    "172.30.0.10"
+  ],
+  "nodeStatusUpdateFrequency": "0s",
+  "nodeStatusReportFrequency": "0s",
+  "imageMinimumGCAge": "0s",
+  "volumeStatsAggPeriod": "0s",
+  "systemCgroups": "/system.slice",
+  "cgroupRoot": "/",
+  "cgroupDriver": "systemd",
+  "cpuManagerReconcilePeriod": "0s",
+  "runtimeRequestTimeout": "0s",
+  "maxPods": 250,
+  "kubeAPIQPS": 50,
+  "kubeAPIBurst": 100,
+  "serializeImagePulls": false,
+  "evictionPressureTransitionPeriod": "0s",
+  "featureGates": {
+    "APIPriorityAndFairness": true,
+    "CSIMigrationAWS": false,
+    "CSIMigrationAzureDisk": false,
+    "CSIMigrationAzureFile": false,
+    "CSIMigrationGCE": false,
+    "CSIMigrationOpenStack": false,
+    "CSIMigrationvSphere": false,
+    "DownwardAPIHugePages": true,
+    "LegacyNodeRoleBehavior": false,
+    "NodeDisruptionExclusion": true,
+    "PodSecurity": true,
+    "RotateKubeletServerCertificate": true,
+    "ServiceNodeExclusion": true,
+    "SupportPodPidsLimit": true
+  },
+  "memorySwap": {},
+  "containerLogMaxSize": "50Mi",
+  "systemReserved": {
+    "ephemeral-storage": "1Gi"
+  },
+  "logging": {
+    "flushFrequency": 0,
+    "verbosity": 0,
+    "options": {
+      "json": {
+        "infoBufferSize": "0"
+      }
+    }
+  },
+  "shutdownGracePeriod": "0s",
+  "shutdownGracePeriodCriticalPods": "0s"
+}
+EOF
+

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/ocp4/e2e.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections/tests/ocp4/e2e.yml
@@ -1,3 +1,4 @@
 ---
-default_result: PASS
+default_result: FAIL
+result_after_remediation: PASS
 


### PR DESCRIPTION
Rule `ocp4-kubelet-enable-streaming-connections` gave false-positive results on not set kubelet configuration, this PR fixes that issue by check the existence of that configuration.

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2105878