### PR TITLE
Update faillock related macros

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/conflicting_settings_authselect.fail.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+pam_files=("password-auth" "system-auth")
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
+
+authselect select --force custom/testingProfile
+
+truncate -s 0 /etc/security/faillock.conf
+
+echo "deny = 3" > /etc/security/faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+
+for file in ${pam_files[@]}; do
+    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
+        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/deny=3/" \
+            "$CUSTOM_PROFILE_DIR/$file"
+    else 
+        sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth deny=3" \
+        "$CUSTOM_PROFILE_DIR/$file"
+    fi
+done
+
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/conflicting_settings_authselect.fail.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+pam_files=("password-auth" "system-auth")
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
+
+authselect select --force custom/testingProfile
+
+truncate -s 0 /etc/security/faillock.conf
+
+echo "even_deny_root" > /etc/security/faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+
+for file in ${pam_files[@]}; do
+    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
+        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/even_deny_root/" \
+            "$CUSTOM_PROFILE_DIR/$file"
+    else 
+        sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth even_deny_root" \
+        "$CUSTOM_PROFILE_DIR/$file"
+    fi
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/conflicting_settings_authselect.fail.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+pam_files=("password-auth" "system-auth")
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
+
+authselect select --force custom/testingProfile
+
+truncate -s 0 /etc/security/faillock.conf
+
+echo "fail_interval = 900" > /etc/security/faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+
+for file in ${pam_files[@]}; do
+    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
+        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/fail_interval=900/" \
+            "$CUSTOM_PROFILE_DIR/$file"
+    else 
+        sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth fail_interval=900" \
+        "$CUSTOM_PROFILE_DIR/$file"
+    fi
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/conflicting_settings_authselect.fail.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+pam_files=("password-auth" "system-auth")
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
+
+authselect select --force custom/testingProfile
+
+truncate -s 0 /etc/security/faillock.conf
+
+echo "unlock_time=600" > /etc/security/faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+
+for file in ${pam_files[@]}; do
+    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
+        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/unlock_time=600/" \
+            "$CUSTOM_PROFILE_DIR/$file"
+    else 
+        sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth unlock_time=600" \
+        "$CUSTOM_PROFILE_DIR/$file"
+    fi
+done
+
+
+authselect apply-changes

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -857,7 +857,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{#
   This macro make sure the informed parameter from pam_faillock.so PAM module is properly set. In
   case the file /etc/security/faillock.conf is present in the system, the option is removed from
-  pam files since it is not needed there in that case.
+  PAM files since it is not needed there in that case.
 
   :param parameter:         The pam_faillock.so parameter name.
   :param faillock_var_name: If the parameter expects a value from a variable, the variable name is informed here.

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -855,7 +855,9 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- endmacro -%}}
 
 {{#
-  This macro make sure the informed parameter from pam_faillock.so PAM module is properly set.
+  This macro make sure the informed parameter from pam_faillock.so PAM module is properly set. In
+  case the file /etc/security/faillock.conf is present in the system, the option is removed from
+  pam files since it is not needed there in that case.
 
   :param parameter:         The pam_faillock.so parameter name.
   :param faillock_var_name: If the parameter expects a value from a variable, the variable name is informed here.
@@ -884,6 +886,14 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     state: present
   when:
     - result_faillock_conf_check.stat.exists
+
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so {{{ parameter }}} parameter not in PAM files
+  block:
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
+  when:
+    - result_faillock_conf_check.stat.exists
+
 
 - name: {{{ rule_title }}} - Ensure the pam_faillock.so {{{ parameter }}} parameter in PAM files
   block:

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1014,7 +1014,9 @@ fi
 {{%- endmacro -%}}
 
 {{#
-    Sets PAM faillock module options and values.
+    Sets PAM faillock module options and values. In case the file
+    /etc/security/faillock.conf is present in the system, the option is removed from pam files
+    since it is not needed there in that case.
     It also adds pam_faillock.so as required module for account.
 
 :param option: faillock option eg. deny, unlock_time, fail_interval
@@ -1022,6 +1024,7 @@ fi
 
 #}}
 {{%- macro bash_pam_faillock_parameter_value(option, value='') -%}}
+AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
 FAILLOCK_CONF="/etc/security/faillock.conf"
 if [ -f $FAILLOCK_CONF ]; then
     {{%- if value == '' %}}
@@ -1037,11 +1040,14 @@ if [ -f $FAILLOCK_CONF ]; then
     fi
     {{%- else %}}
     else
-        sed -i --follow-symlinks 's/^\s*\({{{ option }}}\s*=\s*\)\([0-9]\+\)/\1'"{{{ value }}}"'/g' $FAILLOCK_CONF
+        sed -i --follow-symlinks 's|^\s*\({{{ option }}}\s*=\s*\)\(\S\+\)|\1'"{{{ value }}}"'|g' $FAILLOCK_CONF
     fi
     {{%- endif %}}
+    for pam_file in "${AUTH_FILES[@]}"
+    do
+        {{{ bash_remove_pam_module_option_configuration("$pam_file",'auth','','pam_faillock.so', option ) | indent(8) }}}
+    done
 else
-    AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
     for pam_file in "${AUTH_FILES[@]}"
     do
         if ! grep -qE '^\s*auth.*pam_faillock.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
@@ -1947,10 +1953,10 @@ fi
 #}}
 {{%- macro bash_remove_pam_module_option(pam_file, group, control, module, option) -%}}
 {{%- if control == '' %}}
-if grep -qP '^\s*{{{ group }}}\s.*\b{{{ module }}}\s.*\b{{{ option }}}[=\s$]' "{{{ pam_file }}}"; then
+if grep -qP '^\s*{{{ group }}}\s.*\b{{{ module }}}\s.*\b{{{ option }}}\b' "{{{ pam_file }}}"; then
     sed -i -E --follow-symlinks 's/(.*{{{ group }}}.*{{{ module }}}.*)\b{{{ option }}}\b=?[[:alnum:]]*(.*)/\1\2/g' "{{{ pam_file }}}"
 {{%- else %}}
-if grep -qP '^\s*{{{ group }}}\s+'"{{{ control }}}"'\s+{{{ module }}}\s.*\b{{{ option }}}[=\s$]' "{{{ pam_file }}}"; then
+if grep -qP '^\s*{{{ group }}}\s+'"{{{ control }}}"'\s+{{{ module }}}\s.*\b{{{ option }}}\b' "{{{ pam_file }}}"; then
     sed -i -E --follow-symlinks 's/(.*{{{ group }}}.*'"{{{ control }}}"'.*{{{ module }}}.*)\s{{{ option }}}=?[[:alnum:]]*(.*)/\1\2/g' "{{{ pam_file }}}"
 {{%- endif %}}
 fi


### PR DESCRIPTION
#### Description:
- Make faillock related macros manage the edge cases:
  - When the user had set options in pam files, but faillock.conf was available
  - When the option is not a number
  - Remove pam option when the option doesn't have a value associated

#### Rationale:

- As stated in `pam_faillock` man page, modifying pam_faillock options from pam files is still possible but not recommended.
- This prepares for the `dir` option which isn't a number
- Doing this it was found that when a pam option didn't have a value associated, the macro `bash_remove_pam_module_option_configuration` wasn't working
