### PR TITLE
remove sshd_enable_strictmodes from RHEL9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -58,7 +58,6 @@ selections:
     # sshd
     - sshd_use_directory_configuration
     - sshd_disable_root_login
-    - sshd_enable_strictmodes
     - disable_host_auth
     - sshd_disable_empty_passwords
     - sshd_disable_kerb_auth


### PR DESCRIPTION
#### Description:

- remove the rule from RHEL9 profile

#### Rationale:

The configuration option is compiled in in RHEL9.