### PR TITLE
Update SLE15 DISA STIG from v1r6

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_commonauth/rule.yml
@@ -39,7 +39,6 @@ references:
     disa: CCI-000803
     nist: IA-7,IA-7.1
     srg: SRG-OS-000120-GPOS-00061
-    stigid@sle15: SLES-15-010250
     vmmsrg: SRG-OS-000480-VMM-002000
 
 ocil_clause: 'it does not'

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
@@ -37,7 +37,7 @@ references:
     stigid@ol8: OL08-00-010130
     stigid@rhel8: RHEL-08-010130
     stigid@sle12: SLES-12-010240
-    stigid@sle15: SLES-15-020180
+    stigid@sle15: SLES-15-020190
 
 ocil_clause: 'it does not'
 

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -242,7 +242,6 @@ selections:
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_systemauth
     - set_password_hashing_min_rounds_logindefs
-    - set_password_hashing_algorithm_commonauth
     - smartcard_configure_ca
     - smartcard_configure_cert_checking
     - smartcard_pam_enabled


### PR DESCRIPTION
#### Description:

-  Update SLE15 DISA profile

#### Rationale:

- Drop removed rule from STIG
- Fix wrong STIG ID of set_password_hashing_min_rounds_logindefs rule


