### PR TITLE
Remove yp-related rules from RHEL9

### DIFF
--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,alinux3,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
 
 title: 'Remove NIS Client'
 

--- a/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
 
 title: 'Uninstall ypserv Package'
 


### PR DESCRIPTION
#### Description

The PR removes rules not RHEL9-relevant from RHEL9.

#### Rationale:

The package is not supported on that system: https://access.redhat.com/solutions/5991271

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2096602