### PR TITLE
Add oval,bash and ansible for auditd_audispd_network_failure_action rule

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/ansible/shared.yml
@@ -1,0 +1,15 @@
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("var_audispd_network_failure_action") }}}
+{{% set audisp_config_file_path = audisp_conf_path + "/audisp-remote.conf" %}}
+
+- name: Make sure that network failure action is configured for Audispd
+  lineinfile:
+    path: "{{{ audisp_config_file_path }}}"
+    line: "network_failure_action = {{ var_audispd_network_failure_action }}"
+    regexp: '^\s*network_failure_action\s*=.*$'
+    create: true
+    state: present

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+
+{{{ bash_instantiate_variables("var_audispd_network_failure_action") }}}
+
+AUDITCONFIG={{{ audisp_conf_path }}}/audisp-remote.conf
+
+{{{ bash_replace_or_append("$AUDITCONFIG", '^network_failure_action', "$var_audispd_network_failure_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/oval/shared.xml
@@ -1,0 +1,26 @@
+{{% set audisp_config_file_path = audisp_conf_path + "/audisp-remote.conf" %}}
+<def-group>
+  <definition class="compliance" id="auditd_audispd_network_failure_action" version="1">
+    {{{ oval_metadata("remote_server setting in " + audisp_config_file_path + " is set to a certain IP address or hostname") }}}
+    <criteria>
+        <criterion comment="remote_server setting in audisp-remote.conf" test_ref="test_auditd_audispd_network_failure_action" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="the action the operating system takes if there is an error sending audit records to a remote system" id="test_auditd_audispd_network_failure_action" version="1">
+    <ind:object object_ref="object_auditd_audispd_network_failure_action" />
+    <ind:state state_ref="state_auditd_audispd_network_failure_action" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_auditd_audispd_network_failure_action" version="1">
+    <ind:filepath>{{{ audisp_config_file_path }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^[ ]*network_failure_action[ ]+=[ ]+(\S+)[ ]*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_auditd_audispd_network_failure_action" version="1">
+    <ind:subexpression operation="equals" var_ref="var_audispd_network_failure_action" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="audispd network failure action" datatype="string" id="var_audispd_network_failure_action" version="1" />
+</def-group>

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_absent.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_absent.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+delete_parameter {{{ audisp_conf_path }}}/audisp-remote.conf "network_failure_action"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_set.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/tests/audisp_network_failure_action_set.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value {{{ audisp_conf_path }}}/audisp-remote.conf "network_failure_action" "single"


### PR DESCRIPTION

#### Description:

- Add OVAL check definition, and BASH and Ansible remediation scripts for auditd_audispd_network_failure_action rule

#### Rationale:

- Used auditd_audispd_configure_remote_server and auditd_audispd_syslog_plugin_activated rules as example

