### PR TITLE
Add Enable Auth Select to RHEL8/9 STIG

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/rule.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/rule.yml
@@ -31,8 +31,10 @@ identifiers:
 references:
     anssi: BP28(R5)
     cis@rhel8: 1.2.3
+    disa: CCI-000213
     hipaa: 164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)  # taken from require_singleuser_auth
-
+    nist: AC-3
+    srg: SRG-OS-000480-GPOS-00227
 
 ocil: |-
     Verify that <tt>authselect</tt> is enabled by running

--- a/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig-ks.cfg
@@ -61,11 +61,6 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
-# Set up the authentication options for the system (required)
-# sssd profile sets sha512 to hash passwords
-# passwords are shadowed by default
-# See the manual page for authselect-profile for a complete list of possible options.
-authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-stig_gui-ks.cfg
@@ -61,12 +61,6 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
-# Set up the authentication options for the system (required)
-# sssd profile sets sha512 to hash passwords
-# passwords are shadowed by default
-# See the manual page for authselect-profile for a complete list of possible options.
-authselect select sssd
-
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing
 selinux --enforcing

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -82,6 +82,9 @@ selections:
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
 
+    # Other needed rules
+    - enable_authselect
+
     ### Rules:
     # RHEL-08-010000
     - installed_OS_is_vendor_supported

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -72,6 +72,7 @@ selections:
     - var_auditd_disk_full_action=rhel8
     - var_sssd_certificate_verification_digest_function=sha1
     - login_banner_text=dod_banners
+    - var_authselect_profile=sssd
 
     ### Enable / Configure FIPS
     - enable_fips_mode

--- a/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig-ks.cfg
@@ -61,12 +61,6 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
-# Set up the authentication options for the system (required)
-# sssd profile sets sha512 to hash passwords
-# passwords are shadowed by default
-# See the manual page for authselect-profile for a complete list of possible options.
-authselect select sssd
-
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing
 selinux --enforcing

--- a/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
+++ b/products/rhel9/kickstart/ssg-rhel9-stig_gui-ks.cfg
@@ -61,11 +61,6 @@ user --name=admin --groups=wheel --password=$6$Ga6ZnIlytrWpuCzO$q0LqT1USHpahzUaf
 # --ssh		allow sshd service through the firewall
 firewall --enabled --ssh
 
-# Set up the authentication options for the system (required)
-# sssd profile sets sha512 to hash passwords
-# passwords are shadowed by default
-# See the manual page for authselect-profile for a complete list of possible options.
-authselect select sssd
 
 # State of SELinux on the installed system (optional)
 # Defaults to enforcing

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -83,6 +83,9 @@ selections:
     - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
 
+    # Other needed rules
+    - enable_authselect
+
     ### Rules:
     # RHEL-08-010000
     - installed_OS_is_vendor_supported

--- a/products/rhel9/profiles/stig.profile
+++ b/products/rhel9/profiles/stig.profile
@@ -73,6 +73,7 @@ selections:
     - var_auditd_disk_full_action=halt
     - var_sssd_certificate_verification_digest_function=sha1
     - login_banner_text=dod_banners
+    - var_authselect_profile=sssd
 
     ### Enable / Configure FIPS
     - enable_fips_mode

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -199,6 +199,7 @@ selections:
 - disable_ctrlaltdel_reboot
 - disable_users_coredumps
 - display_login_attempts
+- enable_authselect
 - enable_dracut_fips_module
 - enable_fips_mode
 - encrypt_partitions
@@ -457,6 +458,7 @@ selections:
 - var_auditd_disk_full_action=rhel8
 - var_sssd_certificate_verification_digest_function=sha1
 - login_banner_text=dod_banners
+- var_authselect_profile=sssd
 - var_system_crypto_policy=fips
 - var_sudo_timestamp_timeout=always_prompt
 - var_slub_debug_options=P

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -210,6 +210,7 @@ selections:
 - disable_ctrlaltdel_reboot
 - disable_users_coredumps
 - display_login_attempts
+- enable_authselect
 - enable_dracut_fips_module
 - enable_fips_mode
 - encrypt_partitions
@@ -465,6 +466,7 @@ selections:
 - var_auditd_disk_full_action=rhel8
 - var_sssd_certificate_verification_digest_function=sha1
 - login_banner_text=dod_banners
+- var_authselect_profile=sssd
 - var_system_crypto_policy=fips
 - var_sudo_timestamp_timeout=always_prompt
 - var_slub_debug_options=P


### PR DESCRIPTION
#### Description:

* Add the rule enable_authselect to the RHEL8 and RHEL9 STIG profiles
* Add references for enable_authselect

#### Rationale:

Fixes #9142

cc @mildas 