### PR TITLE
Add per profile filter of missing_cce test

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -527,7 +527,7 @@ macro(ssg_build_sds PRODUCT)
         )
     endif()
 
-    if("${PRODUCT}" MATCHES "rhel(7|8|9)")
+    if("${PRODUCT}" MATCHES "rhel(7|8|9)|sle(12|15)")
         add_test(
             NAME "missing-cces-${PRODUCT}"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -528,10 +528,17 @@ macro(ssg_build_sds PRODUCT)
     endif()
 
     if("${PRODUCT}" MATCHES "rhel(7|8|9)|sle(12|15)")
-        add_test(
-            NAME "missing-cces-${PRODUCT}"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-        )
+        if("${PRODUCT}" MATCHES "sle(12|15)")
+            add_test(
+                NAME "missing-cces-${PRODUCT}"
+                COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "-p anssi,hipaa,pci,stig"
+                )
+        else()
+            add_test(
+                NAME "missing-cces-${PRODUCT}"
+                COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/missing_cces.py" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+                )
+        endif()
         set_tests_properties("missing-cces-${PRODUCT}" PROPERTIES LABELS quick)
     endif()
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004
 
 title: 'Limit Password Reuse'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Digit Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Length'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Special Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Uppercase Characters'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/rule.yml
@@ -29,6 +29,7 @@ severity: medium
 identifiers:
     cce@rhel9: CCE-88570-7
     cce@sle12: CCE-83219-6
+    cce@sle15: CCE-91250-1
 
 references:
     disa: CCI-000130,CCI-000169,CCI-000172,CCI-002884

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -41,6 +41,7 @@ identifiers:
     cce@rhel7: CCE-27437-3
     cce@rhel8: CCE-80724-8
     cce@rhel9: CCE-83759-1
+    cce@sle15: CCE-91251-9
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/rule.yml
@@ -14,6 +14,7 @@ identifiers:
     cce@rhel7: CCE-82195-9
     cce@rhel8: CCE-80802-2
     cce@rhel9: CCE-83924-1
+    cce@sle12: CCE-91557-9
     cce@sle15: CCE-91230-3
 
 references:

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/rule.yml
@@ -23,6 +23,7 @@ identifiers:
     cce@rhel7: CCE-82192-6
     cce@rhel8: CCE-80811-3
     cce@rhel9: CCE-83921-7
+    cce@sle12: CCE-91558-7
     cce@sle15: CCE-91231-1
 
 references:

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -272,8 +272,8 @@ class OCILFileLinker(FileLinker):
         self.tree = self.translator.translate(self.tree, store_defname=True)
 
 
-def _find_identcce(rule):
-    for ident in rule.findall("./{%s}ident" % XCCDF11_NS):
+def _find_identcce(rule, namespace=XCCDF11_NS):
+    for ident in rule.findall("./{%s}ident" % namespace):
         if ident.get("system") == cce_uri:
             return ident
     return None

--- a/tests/missing_cces.py
+++ b/tests/missing_cces.py
@@ -6,6 +6,7 @@ import sys
 import itertools
 
 import ssg.xml
+from ssg.build_renumber import _find_identcce
 from ssg.constants import cce_uri, OSCAP_RULE, XCCDF12_NS
 
 
@@ -19,7 +20,8 @@ def match_profile(needle, haystack):
 def good_profile(profile_id, filter_profiles):
     if len(filter_profiles) == 0:
         return True
-    if len(list(filter(lambda x: match_profile(x, profile_id), filter_profiles))) == 0:
+    if len(list(filter(lambda x: match_profile(x, profile_id),
+                       filter_profiles))) == 0:
         return False
     return True
 
@@ -44,13 +46,6 @@ def get_selected_rules(benchmark, filter_profiles):
     return rules
 
 
-def match_rule_by_ident(rule):
-    for ident in rule.findall("{%s}ident" % (XCCDF12_NS)):
-        if ident.get("system") == cce_uri:
-            return True
-    return False
-
-
 def check_all_rules(root, filter_profiles):
     rules_missing_cce = []
     root = ssg.xml.parse_file(args.datastream_path)
@@ -60,8 +55,8 @@ def check_all_rules(root, filter_profiles):
             rule_id = rule.get("id")
             if rule_id not in selected_rules:
                 continue
-            match = match_rule_by_ident(rule)
-            if not match:
+            match = _find_identcce(rule, XCCDF12_NS)
+            if match is None:
                 rules_missing_cce.append(rule_id)
     return rules_missing_cce
 

--- a/tests/missing_cces.py
+++ b/tests/missing_cces.py
@@ -20,8 +20,7 @@ def match_profile(needle, haystack):
 def good_profile(profile_id, filter_profiles):
     if len(filter_profiles) == 0:
         return True
-    if len(list(filter(lambda x: match_profile(x, profile_id),
-                       filter_profiles))) == 0:
+    if len(list(filter(lambda x: match_profile(x, profile_id), filter_profiles))) == 0:
         return False
     return True
 
@@ -72,7 +71,6 @@ if __name__ == "__main__":
         "-p", "--profiles", help="Comma-separated list to check for missing CCEs",
         default='', required=False)
     args = parser.parse_args()
-    print(args)
     root = ssg.xml.parse_file(args.datastream_path)
     rules_missing_cce = check_all_rules(root, args.profiles.split(","))
     ds = os.path.basename(args.datastream_path)

--- a/tests/missing_cces.py
+++ b/tests/missing_cces.py
@@ -58,16 +58,17 @@ def check_all_rules(root, filter_profiles):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Checks the all rules that are part of at least one "
-        "profile have a CCE assigned."
-        "Optionally with -p provide comma-separated profile list to check against.")
+        "profile have a CCE assigned. "
+        "Optionally with -p/--profiles provide comma-separated profile list to check against.")
     parser.add_argument(
         "datastream_path", help="Path to a SCAP source datastream")
     parser.add_argument(
-        "-p", help="Comma-separated list to check for missing CCEs",
+        "-p", "--profiles", help="Comma-separated list to check for missing CCEs",
         default='', required=False)
     args = parser.parse_args()
+    print(args)
     root = ssg.xml.parse_file(args.datastream_path)
-    rules_missing_cce = check_all_rules(root, args.p.split(","))
+    rules_missing_cce = check_all_rules(root, args.profiles.split(","))
     ds = os.path.basename(args.datastream_path)
     if len(rules_missing_cce) > 0:
         print("The following rules in %s are missing CCEs:" % (ds))

--- a/tests/missing_cces.py
+++ b/tests/missing_cces.py
@@ -8,9 +8,26 @@ import ssg.xml
 from ssg.constants import cce_uri, OSCAP_RULE, XCCDF12_NS
 
 
-def get_selected_rules(benchmark):
+def match_profile(needle, haystack):
+    start_string = "xccdf_org.ssgproject.content_profile_%s" % needle
+    if haystack.startswith(start_string):
+        return True
+    return False
+
+
+def good_profile(profile_id, filter_profiles):
+    if len(filter_profiles) == 0:
+        return True
+    if len(list(filter(lambda x: match_profile(x, profile_id), filter_profiles))) == 0:
+        return False
+    return True
+
+
+def get_selected_rules(benchmark, filter_profiles):
     rules = set()
     for profile in benchmark.findall(".//{%s}Profile" % (XCCDF12_NS)):
+        if not good_profile(profile.get('id'), filter_profiles):
+            continue
         for selection in profile.findall(".//{%s}select" % (XCCDF12_NS)):
             idref = selection.get("idref")
             selected = selection.get("selected")
@@ -19,11 +36,11 @@ def get_selected_rules(benchmark):
     return rules
 
 
-def check_all_rules(root):
+def check_all_rules(root, filter_profiles):
     rules_missing_cce = []
     root = ssg.xml.parse_file(args.datastream_path)
     for benchmark in root.findall(".//{%s}Benchmark" % (XCCDF12_NS)):
-        selected_rules = get_selected_rules(benchmark)
+        selected_rules = get_selected_rules(benchmark, filter_profiles)
         for rule in benchmark.findall(".//{%s}Rule" % (XCCDF12_NS)):
             rule_id = rule.get("id")
             if rule_id not in selected_rules:
@@ -41,12 +58,16 @@ def check_all_rules(root):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Checks the all rules that are part of at least one "
-        "profile have a CCE assigned.")
+        "profile have a CCE assigned."
+        "Optionally with -p provide comma-separated profile list to check against.")
     parser.add_argument(
         "datastream_path", help="Path to a SCAP source datastream")
+    parser.add_argument(
+        "-p", help="Comma-separated list to check for missing CCEs",
+        default='', required=False)
     args = parser.parse_args()
     root = ssg.xml.parse_file(args.datastream_path)
-    rules_missing_cce = check_all_rules(root)
+    rules_missing_cce = check_all_rules(root, args.p.split(","))
     ds = os.path.basename(args.datastream_path)
     if len(rules_missing_cce) > 0:
         print("The following rules in %s are missing CCEs:" % (ds))


### PR DESCRIPTION
#### Description:

- Add ability to filter missing cces by profile list

#### Rationale:

- Add missing cce test for SLE platforms
- Add ability to missing_cces.py test to filter checks by optional parameter of comma-separated profile names
- In case no list of profile names provided legacy behaviour is preserved, checking all available profiles
- Make sure that for SLE platforms missing CCEs check is run only for profiles anssi,hipaa,pci,stig
- Add missing CCES for couple of rules for SLE15

The change was started after short [discussion](https://github.com/ComplianceAsCode/content/pull/8770#issuecomment-1136388810) in context of https://github.com/ComplianceAsCode/content/pull/8770
