### PR TITLE
Relax chrony check and remediations

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
@@ -19,7 +19,7 @@
 - name: "Remove any previous configuration of user used to run chronyd process"
   replace:
     path: /etc/sysconfig/chronyd
-    regexp: '\s*-u\s+\w+\s*'
+    regexp: '\s*-u\s*\w+\s*'
     replace: ' '
   when: chronyd_file is defined and chronyd_file.matched > 0
 

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/ansible/shared.yml
@@ -4,6 +4,11 @@
 # complexity = low
 # disruption = low
 
+{{%- set ok_by_default = false %}}
+{{%- if product in ["rhel7", "ol7", "rhel8", "ol8", "rhel9", "ol9", "fedora"] %}}
+{{%- set ok_by_default = true %}}
+{{%- endif %}}
+
 - name: "Detect if file /etc/sysconfig/chronyd is not empty or missing"
   find:
     path: /etc/sysconfig/
@@ -18,6 +23,7 @@
     replace: ' '
   when: chronyd_file is defined and chronyd_file.matched > 0
 
+{{%- if not ok_by_default %}}
 - name: "Correct existing line in /etc/sysconfig/chronyd to run chronyd as chrony user"
   lineinfile:
     path: /etc/sysconfig/chronyd
@@ -34,3 +40,4 @@
     state: present
     create: True
   when: chronyd_file is defined and chronyd_file.matched == 0
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/shared.sh
@@ -8,14 +8,14 @@
 if grep -q 'OPTIONS=.*' /etc/sysconfig/chronyd; then
 	# trying to solve cases where the parameter after OPTIONS
 	#may or may not be enclosed in quotes
-	sed -i -E -e 's/\s*-u\s+\w+\s*/ /' -e 's/^([\s]*OPTIONS=["]?[^"]*)("?)/\1\2/' /etc/sysconfig/chronyd
+	sed -i -E -e 's/\s*-u\s*\w+\s*/ /' -e 's/^([\s]*OPTIONS=["]?[^"]*)("?)/\1\2/' /etc/sysconfig/chronyd
 fi
 {{% else -%}}
 {{%- endif %}}
 if grep -q 'OPTIONS=.*' /etc/sysconfig/chronyd; then
 	# trying to solve cases where the parameter after OPTIONS
 	#may or may not be enclosed in quotes
-	sed -i -E -e 's/\s*-u\s+\w+\s*/ /' -e 's/^([\s]*OPTIONS=["]?[^"]*)("?)/\1 -u chrony\2/' /etc/sysconfig/chronyd
+	sed -i -E -e 's/\s*-u\s*\w+\s*/ /' -e 's/^([\s]*OPTIONS=["]?[^"]*)("?)/\1 -u chrony\2/' /etc/sysconfig/chronyd
 else
 	echo 'OPTIONS="-u chrony"' >> /etc/sysconfig/chronyd
 fi

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/shared.sh
@@ -1,5 +1,17 @@
 # platform = multi_platform_all
+{{%- set ok_by_default = false %}}
+{{%- if product in ["rhel7", "ol7", "rhel8", "ol8", "rhel9", "ol9", "fedora"] %}}
+{{%- set ok_by_default = true %}}
+{{%- endif %}}
 
+{{% if ok_by_default -%}}
+if grep -q 'OPTIONS=.*' /etc/sysconfig/chronyd; then
+	# trying to solve cases where the parameter after OPTIONS
+	#may or may not be enclosed in quotes
+	sed -i -E -e 's/\s*-u\s+\w+\s*/ /' -e 's/^([\s]*OPTIONS=["]?[^"]*)("?)/\1\2/' /etc/sysconfig/chronyd
+fi
+{{% else -%}}
+{{%- endif %}}
 if grep -q 'OPTIONS=.*' /etc/sysconfig/chronyd; then
 	# trying to solve cases where the parameter after OPTIONS
 	#may or may not be enclosed in quotes

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
@@ -30,5 +30,5 @@
 
 </def-group>
 {{%- else -%}}
-{{{ oval_check_config_file(path='/etc/sysconfig/chronyd', prefix_regex='^[ \\t]*', parameter='OPTIONS', separator_regex='=', value='["]?.*-u chrony.*["]?', missing_parameter_pass=ok_by_default, missing_config_file_fail=true) }}}
+{{{ oval_check_config_file(path='/etc/sysconfig/chronyd', prefix_regex='^[ \\t]*', parameter='OPTIONS', separator_regex='=', value='["]?.*-u[\s]*chrony.*["]?', missing_parameter_pass=ok_by_default, missing_config_file_fail=true) }}}
 {{%- endif %}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/oval/shared.xml
@@ -1,1 +1,34 @@
-{{{ oval_check_config_file(path='/etc/sysconfig/chronyd', prefix_regex='^[ \\t]*', parameter='OPTIONS', separator_regex='=', value='["]?.*-u chrony.*["]?', missing_parameter_pass=false, missing_config_file_fail=true) }}}
+{{%- set ok_by_default = false %}}
+{{%- if product in ["rhel7", "ol7", "rhel8", "ol8", "rhel9", "ol9", "fedora"] %}}
+{{%- set ok_by_default = true %}}
+{{%- endif %}}
+
+
+{{%- if ok_by_default %}}
+<def-group oval_version="5.11">
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure that no other user than chrony is configured to run the chrony service") }}}
+
+      <criteria comment="chronyd enabled and multiple remote servers specified" operator="AND">
+        <criterion comment="The default chrony user hasn't been overriden" test_ref="test_no_user_override" />
+      </criteria>
+
+  </definition>
+
+  <ind:textfilecontent54_test id="test_no_user_override"
+    comment="The default chrony user hasn't been overriden"
+    check_existence="none_exist" check="all" version="1">
+    <ind:object object_ref="obj_user_override" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_user_override" version="1">
+    <ind:behaviors singleline="true" />
+    <ind:filepath>/etc/sysconfig/chronyd</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*OPTIONS=.*[\s'"]-u(?!\s*chrony\b).*</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">0</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>
+{{%- else -%}}
+{{{ oval_check_config_file(path='/etc/sysconfig/chronyd', prefix_regex='^[ \\t]*', parameter='OPTIONS', separator_regex='=', value='["]?.*-u chrony.*["]?', missing_parameter_pass=ok_by_default, missing_config_file_fail=true) }}}
+{{%- endif %}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
@@ -4,15 +4,26 @@ prodtype: alinux2,alinux3,fedora,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Ensure that chronyd is running under chrony user account'
 
+{{%- set ok_by_default = false %}}
+{{%- if product in ["rhel7", "ol7", "rhel8", "ol8", "rhel9", "ol9", "fedora"] %}}
+{{%- set ok_by_default = true %}}
+{{%- endif %}}
+
 description: |-
     chrony is a daemon which implements the Network Time Protocol (NTP). It is designed to
     synchronize system clocks across a variety of systems and use a source that is highly
     accurate. More information on chrony can be found at
     {{{ weblink(link="http://chrony.tuxfamily.org/") }}}.
     Chrony can be configured to be a client and/or a server.
-    To ensure that chronyd is running under chrony user account, Add or edit the
+    To ensure that chronyd is running under chrony user account,
+    {{% if not ok_by_default -%}}
+    add or edit the
     <tt>OPTIONS</tt> variable in <tt>/etc/sysconfig/chronyd</tt> to include <tt>-u chrony</tt>:
     <pre>OPTIONS="-u chrony"</pre>
+    {{% else -%}}
+    remove any <tt>-u ...</tt> option from <tt>OPTIONS</tt> other than <tt>-u chrony</tt>,
+    as chrony is run under its own user by default.
+    {{%- endif %}}
     This recommendation only applies if chrony is in use on the system.
 
 rationale: |-
@@ -40,6 +51,11 @@ identifiers:
 ocil_clause: 'chronyd is not running under chrony user account'
 
 ocil: |-
-    Run the following command and verify that <tt>-u chrony</tt> is included in <tt>OPTIONS</tt>:
+    {{% if not ok_by_default -%}}
+    Run the following command and verify that <tt>OPTIONS</tt> are configured correctly:
     <pre># grep "^OPTIONS" /etc/sysconfig/chronyd
     OPTIONS="-u chrony"</pre>
+    {{% else -%}}
+    <pre># grep "^OPTIONS.*-u" /etc/sysconfig/chronyd | grep -v -e '-u\s*chrony\b'</pre>
+    returns no output
+    {{%- endif %}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/correct_multiple_options.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/correct_multiple_options.pass.sh
@@ -2,4 +2,4 @@
 # packages = chrony
 
 
-echo 'OPTIONS="-g -u chrony"' > /etc/sysconfig/chronyd
+echo 'OPTIONS="-g -uchrony"' > /etc/sysconfig/chronyd

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
 # packages = chrony
 
 

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty_options.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/empty_options.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_rhel,multi_platform_fedora
 # packages = chrony
 
 

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/file_missing.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
 # packages = chrony
 
 

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/wrong_line_2.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/tests/wrong_line_2.fail.sh
@@ -2,4 +2,4 @@
 # packages = chrony
 
 
-echo 'OPTIONS="-g"' > /etc/sysconfig/chronyd
+echo 'OPTIONS="-g -uroot"' > /etc/sysconfig/chronyd


### PR DESCRIPTION
#### Description:

I have verified that the '-u chrony' in OPTIONS is not needed on RHEL7-9, nor on Fedora.
The chrony user is the one that is used to run the service.
As a result, I have updated the check, remediations and description.

I have also updated existing check + remediation content wrt POSIX CLI standards.

#### Rationale:

Having correct configuration labelled as incompliant just adds noise.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2077531
