### PR TITLE
Store intermediate OVAL check files

### DIFF
--- a/build-scripts/combine_ovals.py
+++ b/build-scripts/combine_ovals.py
@@ -28,6 +28,10 @@ def parse_args():
         help="YAML file with information about the product we are building. "
         "e.g.: ~/scap-security-guide/rhel7/product.yml"
     )
+    p.add_argument(
+        "--build-ovals-dir", required=True, dest="build_ovals_dir",
+        help="Directory to store intermediate built OVAL files."
+    )
     p.add_argument("--output", type=argparse.FileType("wb"), required=True)
     p.add_argument("ovaldirs", metavar="OVAL_DIR", nargs="+",
                    help="Shared directory(ies) from which we will collect "
@@ -57,7 +61,8 @@ def main():
         env_yaml,
         args.product_yaml,
         ssg.utils.required_key(env_yaml, "target_oval_version_str"),
-        args.ovaldirs)
+        args.ovaldirs,
+        args.build_ovals_dir)
 
     # parse new file(string) as an ssg.xml.ElementTree, so we can reorder elements
     # appropriately

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -107,7 +107,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
         add_custom_command(
             OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/profiles"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/profiles"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_all.py" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --controls-dir "${CMAKE_SOURCE_DIR}/controls" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --sce-metadata "${CMAKE_CURRENT_BINARY_DIR}/checks/sce/metadata.json"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_all.py" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --controls-dir "${CMAKE_SOURCE_DIR}/controls" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --sce-metadata "${CMAKE_CURRENT_BINARY_DIR}/checks_from_template/sce/metadata.json"
             DEPENDS generate-internal-${PRODUCT}-sce-metadata.json
             COMMENT "[${PRODUCT}-content] compiling everything"
         )
@@ -115,7 +115,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
         add_custom_command(
             OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/profiles"
             COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/profiles"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_all.py" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --controls-dir "${CMAKE_SOURCE_DIR}/controls" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --sce-metadata "${CMAKE_CURRENT_BINARY_DIR}/checks/sce/metadata.json" --stig-references "${STIG_REFERENCE_FILE}"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_all.py" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --controls-dir "${CMAKE_SOURCE_DIR}/controls" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --sce-metadata "${CMAKE_CURRENT_BINARY_DIR}/checks_from_template/sce/metadata.json" --stig-references "${STIG_REFERENCE_FILE}"
             DEPENDS generate-internal-${PRODUCT}-sce-metadata.json
             COMMENT "[${PRODUCT}-content] compiling everything"
         )
@@ -145,7 +145,7 @@ endmacro()
 # Build all templated content using the YAML "template" key in this product's
 # rules. This includes OVAL, Bash, Ansible, and the like.
 macro(ssg_build_templated_content PRODUCT)
-    set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks")
+    set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks_from_template")
     set(BUILD_REMEDIATIONS_DIR "${CMAKE_CURRENT_BINARY_DIR}/fixes_from_templates")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/templated-content-${PRODUCT}"
@@ -264,11 +264,11 @@ macro(ssg_build_remediations PRODUCT)
 endmacro()
 
 macro(ssg_build_oval_unlinked PRODUCT)
-    set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks")
+    set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks_from_template")
     set(OVAL_COMBINE_PATHS "${BUILD_CHECKS_DIR}/shared/oval" "${SSG_SHARED}/checks/oval" "${BUILD_CHECKS_DIR}/oval" "${CMAKE_CURRENT_SOURCE_DIR}/checks/oval")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks_custom/oval" ${OVAL_COMBINE_PATHS}
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" ${OVAL_COMBINE_PATHS}
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT}
         COMMENT "[${PRODUCT}-content] generating oval-unlinked.xml"
@@ -284,7 +284,7 @@ endmacro()
 # (without needing a separate XML or XSLT linking step) and also place
 # <complex-check /> elements as necessary.
 macro(ssg_build_sce PRODUCT)
-    set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks")
+    set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks_from_template")
     # Unlike build_oval_unlinked, here we're ignoring the existing checks from
     # templates and other places and we're merely appending/templating the
     # content from the rules directories. That's why we ignore BUILD_CHECKS_DIR
@@ -317,7 +317,7 @@ macro(ssg_build_sce PRODUCT)
     endif()
     add_custom_target(
         generate-internal-${PRODUCT}-sce-metadata.json
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/checks/sce/metadata.json"
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/checks_from_template/sce/metadata.json"
     )
 endmacro()
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -268,7 +268,7 @@ macro(ssg_build_oval_unlinked PRODUCT)
     set(OVAL_COMBINE_PATHS "${BUILD_CHECKS_DIR}/shared/oval" "${SSG_SHARED}/checks/oval" "${BUILD_CHECKS_DIR}/oval" "${CMAKE_CURRENT_SOURCE_DIR}/checks/oval")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" ${OVAL_COMBINE_PATHS}
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks_custom/oval" ${OVAL_COMBINE_PATHS}
         COMMAND "${XMLLINT_EXECUTABLE}" --format --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         DEPENDS generate-internal-templated-content-${PRODUCT}
         COMMENT "[${PRODUCT}-content] generating oval-unlinked.xml"

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -260,7 +260,7 @@ def _check_rule_id(oval_file_tree, rule_id):
     return False
 
 
-def checks(env_yaml, yaml_path, oval_version, oval_dirs):
+def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
     """
     Concatenate all XML files in the oval directory, to create the document
     body. Then concatenates this with all XML files in the guide directories,
@@ -285,6 +285,11 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
     additional_content_directories = env_yaml.get("additional_content_directories", [])
     add_content_dirs = [os.path.abspath(os.path.join(product_dir, rd)) for rd in additional_content_directories]
 
+    if build_ovals_dir:
+        # Create output directory if it doesn't yet exist.
+        if not os.path.exists(build_ovals_dir):
+            os.makedirs(build_ovals_dir)
+
     for _dir_path in find_rule_dirs_in_paths([guide_dir] + add_content_dirs):
         rule_id = get_rule_dir_id(_dir_path)
 
@@ -307,6 +312,13 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs):
             filename = "%s.xml" % rule_id
 
             xml_content = process_file_with_macros(_path, local_env_yaml)
+
+            if build_ovals_dir:
+                # store intermediate files
+                output_file_name = rule_id + ".xml"
+                output_filepath = os.path.join(build_ovals_dir, output_file_name)
+                with open(output_filepath, "w") as f:
+                    f.write(xml_content)
 
             if not _check_is_applicable_for_product(xml_content, product):
                 continue

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -313,6 +313,9 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
 
             xml_content = process_file_with_macros(_path, local_env_yaml)
 
+            if not _check_is_applicable_for_product(xml_content, product):
+                continue
+
             if build_ovals_dir:
                 # store intermediate files
                 output_file_name = rule_id + ".xml"
@@ -320,8 +323,6 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
                 with open(output_filepath, "w") as f:
                     f.write(xml_content)
 
-            if not _check_is_applicable_for_product(xml_content, product):
-                continue
             if _check_is_loaded(already_loaded, filename, oval_version):
                 continue
             oval_file_tree = _create_oval_tree_from_string(xml_content)


### PR DESCRIPTION
#### Description:

- While building the content, store intermediate OVAL check files.
- Rename the old `checks` folder to `checks_from_template` which was essentially what those files were. OVAL checks generated from templates.

#### Rationale:

- Rendered OVAL checks can be easily inspected.
- Often the checks make usage of macros that can make difficult to know what the end result of a check is.
