### PR TITLE
Fix man-page header for lexgrog

### DIFF
--- a/docs/man_page_template.jinja
+++ b/docs/man_page_template.jinja
@@ -1,7 +1,7 @@
 .TH scap-security-guide 8 "26 Jan 2013" "version 1"
 
 .SH NAME
-SCAP Security Guide - Delivers security guidance, baselines, and
+SCAP-Security-Guide \- Delivers security guidance, baselines, and
 associated validation mechanisms utilizing the Security Content
 Automation Protocol (SCAP).
 


### PR DESCRIPTION
#### Description:

Update the NAME entry, which was not correctly formatted.

#### Rationale:

lexgrog can't parse the NAME entry.

Test with:
`lexgrog ./<path_to>/scap-security-guide.8`