### PR TITLE
Command 'chown', change from '.' to ':' separator

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/bash/shared.sh
@@ -3,13 +3,13 @@
 if LC_ALL=C grep -m 1 -q ^log_group /etc/audit/auditd.conf; then
   GROUP=$(awk -F "=" '/log_group/ {print $2}' /etc/audit/auditd.conf | tr -d ' ')
   if ! [ "${GROUP}" == 'root' ] ; then
-    chown root.${GROUP} /var/log/audit
-    chown root.${GROUP} /var/log/audit/audit.log*
+    chown root:${GROUP} /var/log/audit
+    chown root:${GROUP} /var/log/audit/audit.log*
   else
-    chown root.root /var/log/audit
-    chown root.root /var/log/audit/audit.log*
+    chown root:root /var/log/audit
+    chown root:root /var/log/audit/audit.log*
   fi
 else
-  chown root.root /var/log/audit
-  chown root.root /var/log/audit/audit.log*
+  chown root:root /var/log/audit
+  chown root:root /var/log/audit/audit.log*
 fi


### PR DESCRIPTION
#### Description:

Command `chown`, change user, group separator from `.` to `:`.

#### Rationale:

According to GNU documentation:
> New scripts should avoid the use of '.' because it is not portable, and
> because it has undesirable results if the entire owner'.'group happens
> to identify a user whose name contains '.'.

This also makes the command more consistent, with the rest of the
commands, located in the repository.