### PR TITLE
Add automation content to kernel_module_uvcvideo_disabled

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
@@ -19,6 +19,7 @@ references:
     disa: CCI-000381
     nist: CM-7 (a),CM-7 (5) (b)
     srg: SRG-OS-000095-GPOS-00049,SRG-OS-000370-GPOS-00155
+    stigid@l8: OL08-00-040020
     stigid@rhel8: RHEL-08-040020
 
 platform: machine
@@ -55,3 +56,8 @@ fixtext: |-
     Reboot the system for the settings to take effect.
 
 srg_requirement: '{{{ full_name }}} must cover or disable the built-in or attached camera when not in use.'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: uvcvideo

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -979,6 +979,7 @@ selections:
     - package_rsh-server_removed
 
     # OL08-00-040020
+    - kernel_module_uvcvideo_disabled
 
     # OL08-00-040021
     - kernel_module_atm_disabled

--- a/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform Oracle Linux 7, Oracle Linux 8, Red Hat Enterprise Linux 7, Red Hat Enterprise Linux 8
+
+echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf


### PR DESCRIPTION
#### Description:

- Add the rule kernel_module_uvcvideo_disabled to OL8 STIG profile
- Assign the template kernel_module_disabled to this rule

#### Rationale:

- This rule was manual and this introduces propper automation
