### PR TITLE
Update CIS L2 test for configure_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/cis_l2.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/tests/cis_l2.pass.sh
@@ -3,4 +3,4 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis,xccdf_org.ssgproject.content_profile_cis_workstation_l2
 # packages = crypto-policies-scripts
 
-update-crypto-policies --set "FUTURE"
+update-crypto-policies --set "DEFAULT"


### PR DESCRIPTION


#### Description:

- Since CIS RHEL8 v2.0.0 the policy doesn't require FUTURE in L2 anymore.

#### Rationale:

- Fix failing test scenarios:
```
ERROR - Script policy_future_cis_l2.pass.sh using profile xccdf_org.ssgproject.content_profile_cis found issue:
ERROR - Rule evaluation resulted in fail, instead of expected pass during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_configure_crypto_policy'.
ERROR - Script policy_future_cis_l2.pass.sh using profile xccdf_org.ssgproject.content_profile_cis_workstation_l2 found issue:
ERROR - Rule evaluation resulted in fail, instead of expected pass during initial stage 
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_configure_crypto_policy'.
```
