### PR TITLE
Update rule no_empty_passwords to check password-auth

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -15,7 +15,7 @@
 {{% if product in ['sle12', 'sle15'] %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
 {{% else %}}
-    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:filepath operation="pattern match">/etc/pam.d/(system|password)-auth</ind:filepath>
 {{% endif %}}
     <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/rule.yml
@@ -10,7 +10,8 @@ description: |-
     {{% if product in ["sle12", "sle15"] %}}
     password authentication configurations in <tt>/etc/pam.d/</tt>
     {{% else %}}
-    <tt>/etc/pam.d/system-auth</tt>
+    <tt>/etc/pam.d/system-auth</tt> and
+    <tt>/etc/pam.d/password-auth</tt>
     {{% endif %}}
     to prevent logins with empty passwords.
 
@@ -61,20 +62,24 @@ ocil: |-
     {{% if product in ["sle12", "sle15"] %}}
     <pre>$ grep pam_unix.so /etc/pam.d/* | grep nullok</pre>
     {{% else %}}
-    <pre>$ grep nullok /etc/pam.d/system-auth</pre>
+    <pre>$ grep nullok /etc/pam.d/system-auth /etc/pam.d/password-auth</pre>
     {{% endif %}}
     If this produces any output, it may be possible to log into accounts
     with empty passwords. Remove any instances of the <tt>nullok</tt> option to
     prevent logins with empty passwords.
 
 fixtext: |-
-    Configure {{{ full_name }}} in the system-auth file to not allow null passwords.
+    Configure {{{ full_name }}} in the system-auth and password-auth files to not allow null
+    passwords.
 
-    Remove any instances of the "nullok" option in the "/etc/pam.d/system-auth" file to prevent logons with empty passwords.
+    Remove any instances of the "nullok" option in the "/etc/pam.d/system-auth" and
+    "/etc/pam.d/password-auth" files to prevent logons with empty passwords.
 
     Note: Manual changes to the listed file may be overwritten by the "authselect" program.
 
-srg_requirement: '{{{ full_name }}} must not allow blank or null passwords in the system-auth file.'
+srg_requirement: |-
+    '{{{ full_name }}} must not allow blank or null passwords in the system-auth file nor
+    password-auth.'
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = none
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_absent.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_present.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/no_nullok.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 sed -i --follow-symlinks '/nullok/d' /etc/pam.d/system-auth
+sed -i --follow-symlinks '/nullok/d' /etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
+PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
 
 sed -i '/nullok/d' $SYSTEM_AUTH_FILE
+sed -i '/nullok/d' $PASSWORD_AUTH_FILE
 echo "# auth  sufficient  pam_unix.so try_first_pass nullok" >> $SYSTEM_AUTH_FILE
+echo "# auth  sufficient  pam_unix.so try_first_pass nullok" >> $PASSWORD_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present_password_auth.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present_password_auth.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+
+PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
+
+if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $PASSWORD_AUTH_FILE); then
+    sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $PASSWORD_AUTH_FILE
+fi

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -668,10 +668,8 @@ selections:
     # OL08-00-020330
     - sshd_disable_empty_passwords
 
-    # OL08-00-020331
+    # OL08-00-020331, OL08-00-020332
     - no_empty_passwords
-
-    # OL08-00-020332
 
     # OL08-00-020340
     - display_login_attempts


### PR DESCRIPTION
#### Description:

- Include the `password-auth` file in OVAL check and rule wording

#### Rationale:

- Remediations were already managing this file
- This covers DISA STIG `OL08-00-020332`
