### PR TITLE
Assign shell_lineinfile template to firewalld-backend rule

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,ol9,rhel8,rhel9
 
 title: 'Configure Firewalld to Use the Nftables Backend'
 
@@ -21,6 +21,7 @@ references:
     disa: CCI-002385
     nist: SC-5
     srg: SRG-OS-000420-GPOS-00186
+    stigid@ol8: OL08-00-040150
     stigid@rhel8: RHEL-08-040150
 
 ocil_clause: 'the "nftables" is not set as the "firewallbackend"'
@@ -43,3 +44,10 @@ fixtext: |-
     Establish rate-limiting rules based on organization-defined types of DoS attacks on impacted network interfaces.
 
 srg_requirement: 'A firewall must be able to protect against or limit the effects of Denial of Service (DoS) attacks by ensuring {{{ full_name }}} can implement rate-limiting measures on impacted network interfaces.'
+
+template:
+    name: shell_lineinfile
+    vars:
+        path: /etc/firewalld/firewalld.conf
+        parameter: FirewallBackend
+        value: nftables

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -1084,6 +1084,7 @@ selections:
     - service_usbguard_enabled
 
     # OL08-00-040150
+    - firewalld-backend
 
     # OL08-00-040159
     - package_openssh-server_installed


### PR DESCRIPTION
#### Description:

- Add the rule `firewalld-backend` to OL8 STIG profile
- Add the template `shell_lineinfile` to `firewalld-backend` rule yaml

#### Rationale:

- This covers DISA STIG ID `OL08-00-040150`
- This rule didn't have automation content
