### PR TITLE
Introduce the rule accounts_passwords_pam_faillock_dir

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
@@ -1,0 +1,4 @@
+# platform = multi_platform_all
+
+{{{ ansible_pam_faillock_enable() }}}
+{{{ ansible_pam_faillock_parameter_value("dir", "var_accounts_passwords_pam_faillock_dir") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/ansible/shared.yml
@@ -1,4 +1,8 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
 
 {{{ ansible_pam_faillock_enable() }}}
 {{{ ansible_pam_faillock_parameter_value("dir", "var_accounts_passwords_pam_faillock_dir") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
@@ -1,4 +1,8 @@
 # platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
 
 {{{ bash_pam_faillock_enable() }}}
  

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/bash/shared.sh
@@ -1,0 +1,5 @@
+# platform = multi_platform_all
+
+{{{ bash_pam_faillock_enable() }}}
+ 
+{{{ bash_pam_faillock_parameter_value("dir","/var/log/faillock") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/oval/shared.xml
@@ -1,0 +1,200 @@
+{{% set default_dir = "/var/run/faillock" %}}
+<def-group>
+      <definition class="compliance" id="{{{ rule_id }}}" version="5">
+            {{{ oval_metadata(" Persist lockout account after reboot") }}}
+            <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+                  possible. But due to backwards compatibility, they are also allowed in pam files
+                  directly. In case they are defined in both places, pam files have precedence and this
+                  may confuse the assessment. The following tests ensure only one option is used. Note
+                  that if faillock.conf is available, authselect tool only manage parameters on it -->
+            <criteria operator="OR"
+            comment="Check expected value for pam_faillock.so dir parameter">
+                  <criteria operator="AND"
+                  comment="Check expected pam_faillock.so dir parameter in pam files">
+                        <criterion
+                        test_ref="test_pam_faillock_dir_parameter_system_auth"
+                        comment="Check the dir parameter in auth section of system-auth file"/>
+                        <criterion
+                        test_ref="test_pam_faillock_dir_parameter_password_auth"
+                        comment="Check the dir parameter in auth section of password-auth file"/>
+                        <criterion
+                        test_ref="test_pam_faillock_dir_parameter_no_faillock_conf"
+                        comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
+                  </criteria>
+                  <criteria operator="AND"
+                  comment="Check expected pam_faillock.so dir parameter in faillock.conf">
+                        <criterion
+                        test_ref="test_pam_faillock_dir_parameter_no_pamd_system"
+                        comment="Check the dir parameter is not present system-auth file"/>
+                        <criterion
+                        test_ref="test_pam_faillock_dir_parameter_no_pamd_password"
+                        comment="Check the dir parameter is not present password-auth file"/>
+                        <criterion
+                        test_ref="test_pam_faillock_dir_parameter_faillock_conf"
+                        comment="Ensure the dir parameter is present in /etc/security/faillock.conf"/>
+                  </criteria>
+            </criteria>
+      </definition>
+
+      <constant_variable id="var_faillock_dir_parameter_regex" datatype="string" version="1"
+      comment="common regex to identify dir entry">
+            <value>dir\s*=\s*(\S+|"[^"]+)</value>
+      </constant_variable>
+
+      <local_variable id="var_pam_faillock_dir_parameter_regex" version="1" datatype="string"
+      comment="regex to identify dir parameter in pam files">
+            <concat>
+                  <literal_component>^[\s]*auth[\s]+(?:required|requisite)</literal_component>
+                  <literal_component>[\s]+pam_faillock.so[^\n#]*</literal_component>
+                  <variable_component var_ref="var_faillock_dir_parameter_regex"/>
+            </concat>
+      </local_variable>
+
+      <local_variable id="var_faillock_conf_dir_parameter_regex" version="1" datatype="string"
+      comment="regex to identify dir parameter in faillock.conf file">
+            <concat>
+                  <literal_component>^[\s]*</literal_component>
+                  <variable_component var_ref="var_faillock_dir_parameter_regex"/>
+            </concat>
+      </local_variable>
+
+      <local_variable id="var_faillock_dir_set_both_preauth_authfail_system_auth" version="1"
+      comment="Counts the unique occurrences of preauth and authfail so if it is two, it
+      demonstrates both are present, this takes the results from system-auth file" datatype="int">
+            <count>
+                  <unique>
+                        <regex_capture pattern="(authfail|preauth)">
+                              <object_component
+                              item_field="text"
+                              object_ref="obj_all_pam_faillock_dir_parameter_system_auth" />
+                        </regex_capture>
+                  </unique>
+            </count>
+      </local_variable>
+
+      <local_variable id="var_faillock_dir_set_both_preauth_authfail_password_auth" version="1"
+      comment="Counts the unique occurrences of preauth and authfail so if it is two, it
+      demonstrates both are present, this takes the results from password-auth file"
+      datatype="int">
+            <count>
+                  <unique>
+                        <regex_capture pattern="(authfail|preauth)">
+                              <object_component
+                              item_field="text"
+                              object_ref="obj_all_pam_faillock_dir_parameter_password_auth" />
+                        </regex_capture>
+                  </unique>
+            </count>
+      </local_variable>
+
+      <ind:textfilecontent54_state version="1"
+      id="state_pam_faillock_dir_parameter_not_default_value">
+            <ind:subexpression datatype="string" operation="not equal">{{{
+            default_dir }}}</ind:subexpression>
+      </ind:textfilecontent54_state>
+
+      <ind:textfilecontent54_object id="obj_all_pam_faillock_dir_parameter_system_auth"
+      comment="Get the pam_faillock.so preauth dir parameter from system-auth file" version="1">
+            <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
+            <ind:pattern operation="pattern match"
+            var_ref="var_pam_faillock_dir_parameter_regex" />
+            <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+            <filter action="include"
+            >state_pam_faillock_dir_parameter_not_default_value</filter>
+      </ind:textfilecontent54_object>
+
+      <ind:textfilecontent54_object id="obj_all_pam_faillock_dir_parameter_password_auth"
+      comment="Get the pam_faillock.so preauth dir parameter from system-auth file" version="1">
+            <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
+            <ind:pattern operation="pattern match"
+            var_ref="var_pam_faillock_dir_parameter_regex" />
+            <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+            <filter action="include">state_pam_faillock_dir_parameter_not_default_value</filter>
+      </ind:textfilecontent54_object>
+
+      <ind:textfilecontent54_object version="1"
+      id="obj_pam_faillock_authfail_dir_parameter_system_auth"
+      comment="Get the pam_faillock.so authfail dir parameter from system-auth file">
+            <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
+            <ind:pattern operation="pattern match"
+            var_ref="var_pam_faillock_dir_parameter_regex"/>
+            <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+      </ind:textfilecontent54_object>
+
+      <!-- Check the pam_faillock.so dir parameter in system-auth -->
+      <ind:variable_state id="state_pam_faillock_dir_parameter_system_auth" version="1">
+            <ind:value>2</ind:value>
+      </ind:variable_state>
+
+      <ind:variable_object id="obj_pam_faillock_dir_parameter_system_auth"
+      version="1">
+            <ind:var_ref>var_faillock_dir_set_both_preauth_authfail_system_auth</ind:var_ref>
+      </ind:variable_object>
+
+      <ind:variable_test id="test_pam_faillock_dir_parameter_system_auth"
+      check="all" check_existence="all_exist" version="1"
+      comment="Check that the expected dir value in system-auth is present both with preauth and
+      authfail">
+            <ind:object
+            object_ref="obj_pam_faillock_dir_parameter_system_auth" />
+            <ind:state
+            state_ref="state_pam_faillock_dir_parameter_system_auth" />
+      </ind:variable_test>
+
+      <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+      id="test_pam_faillock_dir_parameter_no_pamd_system"
+      comment="Check the absence of dir parameter in system-auth">
+            <ind:object
+            object_ref="obj_all_pam_faillock_dir_parameter_system_auth"/>
+      </ind:textfilecontent54_test>
+
+      <!-- Check the pam_faillock.so dir parameter in password-auth -->
+      <ind:variable_state id="state_pam_faillock_dir_parameter_password_auth" version="1">
+            <ind:value>2</ind:value>
+      </ind:variable_state>
+
+      <ind:variable_object id="obj_pam_faillock_dir_parameter_password_auth"
+      version="1">
+            <ind:var_ref>var_faillock_dir_set_both_preauth_authfail_password_auth</ind:var_ref>
+      </ind:variable_object>
+
+      <ind:variable_test id="test_pam_faillock_dir_parameter_password_auth"
+      check="all" check_existence="all_exist" version="1"
+      comment="Check that the expected dir value in password-auth is present both with preauth and
+      authfail">
+            <ind:object
+            object_ref="obj_pam_faillock_dir_parameter_password_auth" />
+            <ind:state
+            state_ref="state_pam_faillock_dir_parameter_password_auth" />
+      </ind:variable_test>
+
+      <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+      id="test_pam_faillock_dir_parameter_no_pamd_password"
+      comment="Check the absence of dir parameter in password-auth">
+            <ind:object
+            object_ref="obj_all_pam_faillock_dir_parameter_password_auth"/>
+      </ind:textfilecontent54_test>
+
+      <!-- Check pam_faillock.so dir parameter in /etc/security/faillock.conf -->
+      <ind:textfilecontent54_object version="1"
+      id="object_pam_faillock_dir_parameter_faillock_conf"
+      comment="Check the expected pam_faillock.so dir parameter in /etc/security/faillock.conf">
+            <ind:filepath>/etc/security/faillock.conf</ind:filepath>
+            <ind:pattern operation="pattern match"
+            var_ref="var_faillock_conf_dir_parameter_regex"/>
+            <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+      </ind:textfilecontent54_object>
+
+      <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+      id="test_pam_faillock_dir_parameter_faillock_conf"
+      comment="Check the expected dir value in in /etc/security/faillock.conf">
+            <ind:object object_ref="object_pam_faillock_dir_parameter_faillock_conf"/>
+            <ind:state state_ref="state_pam_faillock_dir_parameter_not_default_value"/>
+      </ind:textfilecontent54_test>
+
+      <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+      id="test_pam_faillock_dir_parameter_no_faillock_conf"
+      comment="Check the absence of dir parameter in /etc/security/faillock.conf">
+            <ind:object object_ref="object_pam_faillock_dir_parameter_faillock_conf"/>
+      </ind:textfilecontent54_test>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/rule.yml
@@ -1,0 +1,59 @@
+documentation_complete: true
+
+prodtype: ol8,ol9,rhel8,rhel9
+
+title: 'Lock Accounts Must Persist'
+
+description: |-
+    This rule ensures that the system lock out accounts using <tt>pam_faillock.so</tt> persist
+    after system reboot. From "Pam_Faillock" man pages:
+    <pre>Note that the default directory that "pam_faillock" uses is usually cleared on system
+    boot so the access will be reenabled after system reboot. If that is undesirable, a different
+    tally directory must be set with the "dir" option.</pre>
+
+    pam_faillock.so module requires multiple entries in pam files. These entries must be carefully
+    defined to work as expected. In order to avoid errors when manually editing these files, it is
+    recommended to use the appropriate tools, such as <tt>authselect</tt> or <tt>authconfig</tt>,
+    depending on the OS version.
+
+rationale: |-
+    Locking out user accounts after a number of incorrect attempts prevents direct password
+    guessing attacks. In combination with the <tt>silent</tt> option, user enumeration attacks
+    are also mitigated.
+
+severity: medium
+
+references:
+    disa: CCI-000044,CCI-002238
+    nist: AC-7(b),AC-7(a),AC-7.1(ii)
+    srg: SRG-OS-000021-GPOS-00005,SRG-OS-000329-GPOS-00128
+    stigid@ol8: OL08-00-020016
+    stigid@rhel8: RHEL-08-020016
+
+ocil_clause: 'dir is not set or is set to /var/run/faillock'
+
+ocil: |-
+    To ensure the tally directory is configured correctly, run the following command:
+    <pre>$ grep 'dir =' /etc/security/faillock.conf</pre>
+    The output should show that dir is set to something different to "/var/run/faillock"
+
+fixtext: |-
+    To configure {{{ full_name }}} to persist locked out accounts after reboot using
+    <tt>pam_faillock.so</tt>, first enable the feature using the following command:
+    $ sudo authselect enable-feature with-faillock
+
+    Then edit the <tt>/etc/security/faillock.conf</tt> file as follows:
+    add, uncomment or edit the following line:
+    <pre>dir = /var/log/faillock</pre>
+
+platform: pam
+
+warnings:
+    - general: |-
+        If the system relies on <tt>authselect</tt> tool to manage PAM settings, the remediation
+        will also use <tt>authselect</tt> tool. However, if any manual modification was made in
+        PAM files, the <tt>authselect</tt> integrity check will fail and the remediation will be
+        aborted in order to preserve intentional changes. In this case, an informative message will
+        be shown in the remediation report.
+        If the system supports the <tt>/etc/security/faillock.conf</tt> file, the pam_faillock
+        parameters should be defined in <tt>faillock.conf</tt> file.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/common.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+pam_files=("password-auth" "system-auth")
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
+
+for file in ${pam_files[@]}; do
+	if grep -q "pam_faillock\.so.*dir=" "$CUSTOM_PROFILE_DIR/$file" ; then
+		sed -i --follow-symlinks "/pam_faillock\.so/d" "$CUSTOM_PROFILE_DIR/$file"
+	fi
+done
+
+authselect select --force custom/testingProfile
+
+truncate -s 0 /etc/security/pam_faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/conflicting_settings_authselect.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+source common.sh
+
+echo "dir = /var/log/faillock" > /etc/security/pam_faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+
+for file in ${pam_files[@]}; do
+    if grep -q "pam_faillock\.so.*dir=" "$CUSTOM_PROFILE_DIR/$file" ; then
+        echo "auth required pam_faillock.so preauth dir=/var/log/faillock" >> \
+        "$CUSTOM_PROFILE_DIR/$file"
+    fi
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/expected_faillock_conf.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/expected_faillock_conf.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+source common.sh
+
+echo "dir = /var/log/faillock" >> /etc/security/faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/expected_pam_files.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh
+
+for file in ${pam_files[@]}; do
+    echo "auth required pam_faillock.so preauth  dir=/var/log/faillock" >> "$CUSTOM_PROFILE_DIR/$file"
+    echo "auth required pam_faillock.so authfail dir=/var/log/faillock" >> "$CUSTOM_PROFILE_DIR/$file"
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/missing_dir_in_authfail.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/missing_dir_in_authfail.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh
+
+for file in ${pam_files[@]}; do
+    echo "auth required pam_faillock.so preauth  dir=/var/log/faillock" >> "$CUSTOM_PROFILE_DIR/$file"
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/missing_dir_in_preauth.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/missing_dir_in_preauth.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh
+
+for file in ${pam_files[@]}; do
+    echo "auth required pam_faillock.so authfail  dir=/var/log/faillock" >> "$CUSTOM_PROFILE_DIR/$file"
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/wrong_faillock_conf.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/wrong_faillock_conf.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+source common.sh
+
+echo "dir = /var/run/faillock" >> /etc/security/faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/wrong_pam_files.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_dir/tests/wrong_pam_files.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh
+
+
+for file in ${pam_files[@]}; do
+    echo "auth required pam_faillock.so preauth  dir=/var/run/faillock" >> "$CUSTOM_PROFILE_DIR/$file"
+    echo "auth required pam_faillock.so authfail dir=/var/run/faillock" >> "$CUSTOM_PROFILE_DIR/$file"
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_dir.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_accounts_passwords_pam_faillock_dir.var
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: faillock directory
+
+description: 'The directory where the user files with the failure records are kept'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    ol8: "/var/log/faillock"
+    default: "/var/log/faillock"

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -44,6 +44,7 @@ selections:
     - sshd_idle_timeout_value=10_minutes
     - var_accounts_authorized_local_users_regex=ol8
     - var_accounts_passwords_pam_faillock_deny=3
+    - var_accounts_passwords_pam_faillock_dir=ol8
     - var_accounts_passwords_pam_faillock_fail_interval=900
     - var_accounts_passwords_pam_faillock_unlock_time=never
     - var_ssh_client_rekey_limit_size=1G
@@ -496,9 +497,8 @@ selections:
     # OL08-00-020014, OL08-00-020015
     - accounts_passwords_pam_faillock_unlock_time
 
-    # OL08-00-020016
-
-    # OL08-00-020017
+    # OL08-00-020016, OL08-00-020017
+    - accounts_passwords_pam_faillock_dir
 
     # OL08-00-020018
 


### PR DESCRIPTION
#### Description:

- Create rule `accounts_passwords_pam_faillock_dir`
- Add ansible, bash, OVAL and tests
- Add rule to OL8 STIG 

#### Rationale:

- This covers DISA STIG IDs `OL08-00-020016` & `OL08-00-020017`
