### PR TITLE
tests/install_vm.py: improve condition checking if VM is running

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -119,7 +119,7 @@ def wait_vm_not_running(domain):
     try:
         while True:
             time.sleep(5)
-            if subprocess.getoutput("virsh domstate {0}".format(domain)).rstrip() != "running":
+            if "running" not in subprocess.getoutput("virsh domstate {0}".format(domain)).rstrip():
                 return
             if time.time() >= end_time:
                 print("Timeout reached: {0} VM failed to shutdown, cancelling wait."


### PR DESCRIPTION
On some systems `virsh domstate` might return strings like
`'shut off\n'` and in such cases the previous condition didn't
work properly.