### PR TITLE
Ensure the Ansible shell command doesn't fail

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/ansible/shared.yml
@@ -38,7 +38,7 @@
 - name: "Extract log files"
   shell: |
     set -o pipefail
-    grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item }}  |awk '{print $NF}'|sed -e 's/^-//'
+    grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item }}  |awk '{print $NF}'|sed -e 's/^-//' || true
   loop: "{{ rsyslog_config_files.results|map(attribute='stdout_lines')|list|flatten|unique + [ rsyslog_etc_config ] }}"
   register: log_files
   changed_when: False


### PR DESCRIPTION


#### Description:

- Ensure the shell commands return true.

#### Rationale:

- The grep command may not find any matching log file to configure, and that is fine.
- Follow up from #9123
- Fixes #9174
