### PR TITLE
Remove rule dnf-automatic_security_updates_only from RHEL 9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -365,9 +365,6 @@ selections:
 
     ## Enable Automatic Software Updates
     ## SI-2 / FMT_MOF_EXT.1
-    # Configure dnf-automatic to Install Only Security Updates
-    - dnf-automatic_security_updates_only
-
     # Configure dnf-automatic to Install Available Updates Automatically
     - dnf-automatic_apply_updates
 


### PR DESCRIPTION
The dnf-automatic_security_updates_only rule fails on setups where
admins would prefer to have all updates applied automatically. There is
no reason to force one or other upgrade type as the need is
deployment-specific.



#### Rationale:

Resolves: RHBZ#2108158
