### PR TITLE
Remove 3 crypto rules from RHEL 9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -191,10 +191,7 @@ selections:
     - var_system_crypto_policy=fips_ospp
     - configure_crypto_policy
     - configure_ssh_crypto_policy
-    - configure_bind_crypto_policy
     - configure_openssl_crypto_policy
-    - configure_libreswan_crypto_policy
-    - configure_kerberos_crypto_policy
     - enable_dracut_fips_module
 
     #######################################################


### PR DESCRIPTION
Remove rules configure_bind_crypto_policy,
configure_libreswan_crypto_policy, and configure_kerberos_crypto_policy
from the RHEL 9 OSPP profile because they deal with components that are
not part of the RHEL CC Target of Evaluation.

Resolves: rhbz#2108167
