### PR TITLE
Remove 3 package rules from RHEL 9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -132,12 +132,10 @@ selections:
     ### rpcbind
 
     ### Install Required Packages
-    - package_aide_installed
     - package_dnf-automatic_installed
     - package_subscription-manager_installed
     - package_firewalld_installed
     - package_openscap-scanner_installed
-    - package_policycoreutils_installed
     - package_sudo_installed
     - package_usbguard_installed
     - package_scap-security-guide_installed
@@ -145,7 +143,6 @@ selections:
     - package_crypto-policies_installed
     - package_openssh-server_installed
     - package_openssh-clients_installed
-    - package_policycoreutils-python-utils_installed
     - package_chrony_installed
     - package_gnutls-utils_installed
 


### PR DESCRIPTION
Remove rules package_aide_installed, package_policycoreutils_installed,
and package_policycoreutils-python-utils_installed from the RHEL 9 OSPP
profile because they are not related to any specific OSPP SFR and
also there is no reason to enforce their presence on the RHEL CC
Target of Evaluation.

Resolves: rhbz#2108224


