### PR TITLE
Introduce new sebool description and ocil macros

### DIFF
--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
@@ -2,12 +2,12 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
-title: 'Enable the deny_execmem SELinux Boolean'
+title: 'Configure the deny_execmem SELinux Boolean'
 
 description: |-
     By default, the SELinux boolean <tt>deny_execmem</tt> is disabled.
-    If this setting is disabled, it should be enabled.
-    {{{ describe_sebool_disable(sebool="deny_execmem") }}}
+    This setting should be configured to {{{ xccdf_value("var_deny_execmem") }}}.
+    <br/>{{{ describe_sebool_var(sebool="deny_execmem") }}}
 
 rationale: |-
     Allowing user domain applications to map a memory region as both writable and
@@ -23,14 +23,15 @@ identifiers:
 references:
     anssi: BP28(R67)
 
-{{{ complete_ocil_entry_sebool_enabled(sebool="deny_execmem") }}}
+{{{ complete_ocil_entry_sebool_var(sebool="deny_execmem") }}}
 
 warnings:
     - general: |-
         This rule doesn't come with a remediation, as enabling this SELinux boolean can cause
         applications to malfunction, for example Graphical login managers and Firefox.
     - functionality: |-
-        Proper function and stability should be assessed before applying enabling the SELinux boolean in production systems.
+        Proper function and stability should be assessed before applying enabling the SELinux
+        boolean in production systems.
 
 template:
     name: sebool

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polyinstantiation_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polyinstantiation_enabled/rule.yml
@@ -2,12 +2,12 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
 
-title: 'Disable the polyinstantiation_enabled SELinux Boolean'
+title: 'Configure the polyinstantiation_enabled SELinux Boolean'
 
 description: |-
     By default, the SELinux boolean <tt>polyinstantiation_enabled</tt> is disabled.
-    If this setting is enabled, it should be disabled.
-    {{{ describe_sebool_disable(sebool="polyinstantiation_enabled") }}}
+    This setting should be configured to {{{ xccdf_value("var_polyinstantiation_enabled") }}}.
+    <br/>{{{ describe_sebool_var(sebool="polyinstantiation_enabled") }}}
 
 rationale: ""
 
@@ -22,7 +22,7 @@ identifiers:
 references:
     anssi: BP28(R39)
 
-{{{ complete_ocil_entry_sebool_disabled(sebool="polyinstantiation_enabled") }}}
+{{{ complete_ocil_entry_sebool_var(sebool="polyinstantiation_enabled") }}}
 
 template:
     name: sebool

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/rule.yml
@@ -2,12 +2,12 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
 
-title: 'Disable the secure_mode_insmod SELinux Boolean'
+title: 'Configure the secure_mode_insmod SELinux Boolean'
 
 description: |-
     By default, the SELinux boolean <tt>secure_mode_insmod</tt> is disabled.
-    If this setting is enabled, it should be disabled.
-    {{{ describe_sebool_disable(sebool="secure_mode_insmod") }}}
+    This setting should be configured to {{{ xccdf_value("var_secure_mode_insmod") }}}.
+    <br/>{{{ describe_sebool_var(sebool="secure_mode_insmod") }}}
 
 rationale: ""
 
@@ -21,7 +21,7 @@ identifiers:
     cce@rhel8: CCE-83310-3
     cce@rhel9: CCE-84087-6
 
-{{{ complete_ocil_entry_sebool_disabled(sebool="secure_mode_insmod") }}}
+{{{ complete_ocil_entry_sebool_var(sebool="secure_mode_insmod") }}}
 
 template:
     name: sebool

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -489,6 +489,19 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 
 
 {{#
+    Describe how to set an SELinux boolean depending on a variable.
+
+:param sebool: The SELinux boolean to disable
+:type sebool: str
+
+#}}
+{{%- macro describe_sebool_var(sebool) %}}
+    To set the <code>{{{ sebool }}}</code> SELinux boolean, run the following command:
+    <pre>$ sudo setsebool -P {{{ sebool }}} {{{ xccdf_value("var_" + sebool) }}}</pre>
+{{%- endmacro %}}
+
+
+{{#
     Describe how to disable an SELinux boolean.
 
 :param sebool: The SELinux boolean to disable

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -782,6 +782,38 @@ ocil_clause: "no line is returned"
 {{# SELinux boolean macros #}}
 
 {{#
+    OCIL and OCIL clause for how to check if given SELinux boolean is set depending on a variable.
+
+:param sebool: The SELinux boolean to check
+:type sebool: str
+
+#}}
+{{%- macro complete_ocil_entry_sebool_var(sebool) %}}
+ocil: |-
+    {{{ describe_sebool_check_var(sebool) }}}
+
+ocil_clause: "{{{ sebool }}} is not set as expected"
+{{%- endmacro %}}
+
+{{#
+    Describe how to check if given SELinux boolean is set depending on a variable.
+
+:param sebool: The SELinux boolean to check
+:type sebool: str
+
+#}}
+{{%- macro describe_sebool_check_var(sebool) %}}
+    Run the following command to get the current configured value for <code>{{{ sebool }}}</code>
+    SELinux boolean:
+    <pre>$ getsebool {{{ sebool }}}</pre>
+    The expected cofiguration is {{{ xccdf_value("var_" + sebool) }}}.
+    "on" means true, and "off" means false
+{{%- endmacro %}}
+
+
+{{# SELinux boolean macros #}}
+
+{{#
     Describe how to check if given SELinux boolean is disabled.
 
 :param sebool: The SELinux boolean to check


### PR DESCRIPTION
#### Description:

- Create jinja macros for ocil and description of rules that use variables to set se booleans
- Re write `sebool_secure_mode_insmod`, `sebool_deny_execmem` and `sebool_polyinstantiation_enabled` to use these macros

#### Rationale:

- Ocil clause and description were misleading in these three rules for some products/profiles
