### PR TITLE
Add to SLE ANSSI profile various sysctl rules

### DIFF
--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -560,7 +560,9 @@ controls:
       It is recommended to load the Yama security module at startup (by example
       passing the security = yama argument to the kernel) and configure the
       sysctl kernel.yama.ptrace_scope to a value of at least 1.
-    # rules: TBD
+    status: automated
+    rules:
+    - sysctl_kernel_yama_ptrace_scope
 
   - id: R26
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -532,7 +532,9 @@ controls:
       sysctl kernel.modules_disabledconf:
       Prohibition of loading modules (except those already loaded to this point)
       kernel.modules_disabled = 1
-    # rules: TBD
+    status: automated # without remediation
+    rules:
+    - sysctl_kernel_modules_disabled
 
   - id: R25
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -520,6 +520,10 @@ controls:
     - sysctl_fs_protected_symlinks
     - sysctl_fs_protected_hardlinks
 
+    # Prohibit mapping of memory in low addresses (0)
+    # vm.mmap_min_addr = 65536
+    - sysctl_vm_mmap_min_addr
+
     # Larger choice space for PID values
     # kernel.pid_max = 65536
     - sysctl_kernel_pid_max

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -520,6 +520,10 @@ controls:
     - sysctl_fs_protected_symlinks
     - sysctl_fs_protected_hardlinks
 
+    # Larger choice space for PID values
+    # kernel.pid_max = 65536
+    - sysctl_kernel_pid_max
+
     # Access restriction to the dmesg buffer
     - sysctl_kernel_dmesg_restrict
 

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -520,6 +520,8 @@ controls:
     - sysctl_fs_protected_symlinks
     - sysctl_fs_protected_hardlinks
 
+    # Access restriction to the dmesg buffer
+    - sysctl_kernel_dmesg_restrict
   
   - id: R24
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -501,7 +501,20 @@ controls:
     levels:
     - intermediary
     title: Setting up system sysctl
-    # rules: TBD
+    status: automated
+    rules:
+    # Disabling SysReq
+    # kernel.sysrq = 0
+    # - sysctl_kernel_sysrq
+
+    # No core dump of executable setuid
+    # - sysctl_fs_suid_dumpable
+
+    # Prohibit links to find links to files
+    # the current user is not the owner
+    # Can prevent some programs from working properly
+    - sysctl_fs_protected_symlinks
+    - sysctl_fs_protected_hardlinks
 
   
   - id: R24

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -522,6 +522,18 @@ controls:
 
     # Access restriction to the dmesg buffer
     - sysctl_kernel_dmesg_restrict
+
+    # Disallow kernel profiling by unprivileged users
+    - sysctl_kernel_perf_event_paranoid
+
+    # Restricts the use of the perf system
+    # kernel.perf_event_paranoid = 2
+    # kernel.perf_event_max_sample_rate = 1
+    # kernel.perf_cpu_time_max_percent = 1
+    - sysctl_kernel_perf_event_paranoid
+    - sysctl_kernel_perf_event_max_sample_rate
+    - sysctl_kernel_perf_cpu_time_max_percent
+
   
   - id: R24
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -509,7 +509,7 @@ controls:
     rules:
     # Disabling SysReq
     # kernel.sysrq = 0
-    # - sysctl_kernel_sysrq
+    - sysctl_kernel_sysrq
 
     # No core dump of executable setuid
     - sysctl_fs_suid_dumpable

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -508,7 +508,7 @@ controls:
     # - sysctl_kernel_sysrq
 
     # No core dump of executable setuid
-    # - sysctl_fs_suid_dumpable
+    - sysctl_fs_suid_dumpable
 
     # Prohibit links to find links to files
     # the current user is not the owner

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -160,7 +160,11 @@ controls:
       Configurations recommended for this requirement are to be performed at the BIOS level.
       The content automation cannot really configure the BIOS, but can in some cases,
       check settings that are visible to the OS. Like for example the NX/DX setting.
-    # rules: TBD
+    status: partial
+    rules:
+    - sysctl_kernel_exec_shield
+    - bios_enable_execution_restrictions
+    - install_PAE_kernel_on_x86-32
 
   - id: R10
     levels:

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
@@ -17,6 +17,8 @@ identifiers:
     cce@rhel7: CCE-81026-7
     cce@rhel8: CCE-81027-5
     cce@rhel9: CCE-84110-6
+    cce@sle12: CCE-91559-5
+    cce@sle15: CCE-91252-7
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
@@ -19,6 +19,8 @@ identifiers:
     cce@rhel7: CCE-81029-1
     cce@rhel8: CCE-81030-9
     cce@rhel9: CCE-83900-1
+    cce@sle12: CCE-91560-3
+    cce@sle15: CCE-91253-5
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/sysctl_fs_suid_dumpable/rule.yml
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-26900-1
     cce@rhel8: CCE-80912-9
     cce@rhel9: CCE-83981-1
+    cce@sle12: CCE-91561-1
     cce@sle15: CCE-91447-3
 
 references:

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Enable ExecShield via sysctl'
 
@@ -32,6 +32,7 @@ identifiers:
     cce@rhel7: CCE-27211-2
     cce@rhel8: CCE-80914-5
     cce@rhel9: CCE-83970-4
+    cce@sle12: CCE-91562-9
     cce@sle15: CCE-91417-6
 
 references:

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/rule.yml
@@ -20,6 +20,8 @@ identifiers:
     cce@rhel7: CCE-27099-1
     cce@rhel8: CCE-83918-3
     cce@rhel9: CCE-88577-2
+    cce@sle12: CCE-91563-7
+    cce@sle15: CCE-91254-3
 
 references:
     anssi: BP28(R9)

--- a/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/install_PAE_kernel_on_x86-32/rule.yml
@@ -25,6 +25,8 @@ severity: unknown
 identifiers:
     cce@rhel7: CCE-27116-3
     cce@rhel8: CCE-83919-1
+    cce@sle12: CCE-91564-5
+    cce@sle15: CCE-91255-0
 
 references:
     anssi: BP28(R9)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Restrict Access to Kernel Message Buffer'
 
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-27050-4
     cce@rhel8: CCE-80913-7
     cce@rhel9: CCE-83952-2
+    cce@sle12: CCE-91565-2
     cce@sle15: CCE-91448-1
 
 references:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_modules_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disable loading and unloading of kernel modules'
 
@@ -19,6 +19,8 @@ identifiers:
     cce@rhel7: CCE-83392-1
     cce@rhel8: CCE-83397-0
     cce@rhel9: CCE-83967-0
+    cce@sle12: CCE-91566-0
+    cce@sle15: CCE-91256-8
 
 references:
     anssi: BP28(R24)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_cpu_time_max_percent/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Limit CPU consumption of the Perf system'
 
@@ -17,6 +17,8 @@ identifiers:
     cce@rhel7: CCE-83369-9
     cce@rhel8: CCE-83373-1
     cce@rhel9: CCE-83969-6
+    cce@sle12: CCE-91567-8
+    cce@sle15: CCE-91257-6
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_max_sample_rate/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Limit sampling frequency of the Perf system'
 
@@ -18,6 +18,8 @@ identifiers:
     cce@rhel7: CCE-83367-3
     cce@rhel8: CCE-83368-1
     cce@rhel9: CCE-83962-1
+    cce@sle12: CCE-91569-4
+    cce@sle15: CCE-91259-2
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disallow kernel profiling by unprivileged users'
 
@@ -16,6 +16,8 @@ identifiers:
     cce@rhel7: CCE-81053-1
     cce@rhel8: CCE-81054-9
     cce@rhel9: CCE-83959-7
+    cce@sle12: CCE-91568-6
+    cce@sle15: CCE-91258-4
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_pid_max/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Configure maximum number of process identifiers'
 
@@ -18,6 +18,8 @@ identifiers:
     cce@rhel7: CCE-83365-7
     cce@rhel8: CCE-83366-5
     cce@rhel9: CCE-83960-5
+    cce@sle12: CCE-91570-2
+    cce@sle15: CCE-91260-0
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_sysrq/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_sysrq/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Disallow magic SysRq key'
 
@@ -18,6 +18,8 @@ identifiers:
     cce@rhel7: CCE-83353-3
     cce@rhel8: CCE-83355-8
     cce@rhel9: CCE-83968-8
+    cce@sle12: CCE-91571-0
+    cce@sle15: CCE-91261-8
 
 references:
     anssi: BP28(R23)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Restrict usage of ptrace to descendant processes'
 
@@ -19,6 +19,8 @@ identifiers:
     cce@rhel7: CCE-81058-0
     cce@rhel8: CCE-80953-3
     cce@rhel9: CCE-83965-4
+    cce@sle12: CCE-91572-8
+    cce@sle15: CCE-91262-6
 
 references:
     anssi: BP28(R25)

--- a/linux_os/guide/system/permissions/restrictions/sysctl_vm_mmap_min_addr/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_vm_mmap_min_addr/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Prevent applications from mapping low portion of virtual memory'
 
@@ -18,6 +18,8 @@ identifiers:
     cce@rhel7: CCE-83358-2
     cce@rhel8: CCE-83363-2
     cce@rhel9: CCE-83958-9
+    cce@sle12: CCE-91573-6
+    cce@sle15: CCE-91263-4
 
 references:
     anssi: BP28(R23)

--- a/products/sle12/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle12/profiles/anssi_bp28_enhanced.profile
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+metadata:
+    SMEs:
+        - abergmann
+
+title: 'ANSSI-BP-028 (enhanced)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the enhanced hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    Only the components strictly necessary to the service provided by the system should be installed.
+    Those whose presence can not be justified should be disabled, removed or deleted.
+    Performing a minimal install is a good starting point, but doesn't provide any assurance
+    over any package installed later.
+    Manual review is required to assess if the installed services are minimal.
+
+selections:
+  - anssi_sle:all:enhanced

--- a/products/sle12/profiles/anssi_bp28_high.profile
+++ b/products/sle12/profiles/anssi_bp28_high.profile
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+metadata:
+    SMEs:
+        - abergmann
+
+title: 'ANSSI-BP-028 (high)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the high hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    Only the components strictly necessary to the service provided by the system should be installed.
+    Those whose presence can not be justified should be disabled, removed or deleted.
+    Performing a minimal install is a good starting point, but doesn't provide any assurance
+    over any package installed later.
+    Manual review is required to assess if the installed services are minimal.
+
+selections:
+  - anssi_sle:all:high

--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+metadata:
+    SMEs:
+        - abergmann
+
+title: 'ANSSI-BP-028 (enhanced)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the enhanced hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    Only the components strictly necessary to the service provided by the system should be installed.
+    Those whose presence can not be justified should be disabled, removed or deleted.
+    Performing a minimal install is a good starting point, but doesn't provide any assurance
+    over any package installed later.
+    Manual review is required to assess if the installed services are minimal.
+
+selections:
+  - anssi_sle:all:enhanced

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+metadata:
+    SMEs:
+        - abergmann
+
+title: 'ANSSI-BP-028 (high)'
+
+description: |-
+    This profile contains configurations that align to ANSSI-BP-028 v1.2 at the high hardening level.
+
+    ANSSI is the French National Information Security Agency, and stands for Agence nationale de la sécurité des systèmes d'information.
+    ANSSI-BP-028 is a configuration recommendation for GNU/Linux systems.
+
+    A copy of the ANSSI-BP-028 can be found at the ANSSI website:
+    https://www.ssi.gouv.fr/administration/guide/recommandations-de-securite-relatives-a-un-systeme-gnulinux/
+
+    Only the components strictly necessary to the service provided by the system should be installed.
+    Those whose presence can not be justified should be disabled, removed or deleted.
+    Performing a minimal install is a good starting point, but doesn't provide any assurance
+    over any package installed later.
+    Manual review is required to assess if the installed services are minimal.
+
+selections:
+  - anssi_sle:all:high


### PR DESCRIPTION
#### Description:

- Add to SLE ANSSI profile various sysctl rules.

#### Rationale:

- Add to SLE12 and SLE15 ANSSI profile rules
  - sysctl_vm_mmap_min_addr
  - sysctl_kernel_yama_ptrace_scope
  - sysctl_kernel_sysrq
  - sysctl_kernel_pid_max
  - sysctl_kernel_modules_disabled
  - sysctl_kernel_dmesg_restrict
  - sysctl_fs_suid_dumpable
  - sysctl_fs_protected_symlinks and sysctl_fs_protected_hardlinks
  - sysctl_kernel_perf_event_max_sample_rate
  - sysctl_kernel_perf_cpu_time_max_percent
  - sysctl_kernel_perf_event_paranoid

- Add definitions for the SLE platforms for enhanced and high ANSSI profiles