### PR TITLE
Add sebool rules for execheap insmod and ssh login to ANSSI SLE profile

### DIFF
--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -693,13 +693,13 @@ controls:
       Each user or service account must have its own temporary directory
       and dispose of it exclusively.
     notes: The approach of the selected rules is to use and configure pam_namespace module.
-    status: partial
+    status: automated
     rules:
     - enable_pam_namespace
     - accounts_polyinstantiated_tmp
     - accounts_polyinstantiated_var_tmp
     - var_polyinstantiation_enabled=on
-    #- sebool_polyinstantiation_enabled
+    - sebool_polyinstantiation_enabled
 
   - id: R40
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -577,7 +577,13 @@ controls:
       The semantics of "ClientAliveCountMax 0" has changed from "disconnect on first timeout" to
       "don't disconnect network inactive sessions". The server either probes for the client liveness
       or keeps inactive sessions connected.
-    # rules: TBD
+    status: automated
+    rules:
+    - accounts_tmout
+    - var_accounts_tmout=10_min
+    - sshd_set_idle_timeout
+    - sshd_idle_timeout_value=10_minutes
+    - sshd_set_keepalive
 
   - id: R30
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -1014,7 +1014,11 @@ controls:
     description: >-
       SELinux policy manipulation and debugging tools should not be installed
       on a machine in production.
-    # rules: TBD
+    status: automated
+    rules:
+    - package_setroubleshoot_removed
+    - package_setroubleshoot-server_removed
+    - package_setroubleshoot-plugins_removed
 
   - id: R69
     levels:

--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -995,7 +995,17 @@ controls:
       In RHEL, the SELinux boolean allow_execheap is renamed to selinuxuser_execheap, and the
       boolean allow_execstack is renamed to selinuxuser_execstack. And allow_execmem is not
       available, deny_execmem provides the same functionality.
-    # rules: TBD
+    status: automated
+    rules:
+    - var_selinuxuser_execheap=off
+    - sebool_selinuxuser_execheap
+    - var_deny_execmem=on
+    - sebool_deny_execmem
+    - var_selinuxuser_execstack=off
+    - sebool_selinuxuser_execstack
+    - var_secure_mode_insmod=on
+    - sebool_secure_mode_insmod
+    - sebool_ssh_sysadm_login
 
   - id: R68
     levels:

--- a/linux_os/guide/system/selinux/package_setroubleshoot-plugins_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_setroubleshoot-plugins_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Uninstall setroubleshoot-plugins Package'
 
@@ -20,6 +20,8 @@ identifiers:
     cce@rhel7: CCE-84249-2
     cce@rhel8: CCE-84250-0
     cce@rhel9: CCE-84251-8
+    cce@sle12: CCE-91582-7
+    cce@sle15: CCE-91269-1
 
 references:
     anssi: BP28(R68)

--- a/linux_os/guide/system/selinux/package_setroubleshoot-server_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_setroubleshoot-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Uninstall setroubleshoot-server Package'
 
@@ -21,6 +21,8 @@ identifiers:
     cce@rhel7: CCE-83488-7
     cce@rhel8: CCE-83490-3
     cce@rhel9: CCE-84252-6
+    cce@sle12: CCE-91580-1
+    cce@sle15: CCE-91267-5
 
 references:
     anssi: BP28(R68)

--- a/linux_os/guide/system/selinux/package_setroubleshoot_removed/rule.yml
+++ b/linux_os/guide/system/selinux/package_setroubleshoot_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,fedora,ol7,ol8,rhel7,rhel8,rhel9,sle15
+prodtype: alinux2,alinux3,fedora,ol7,ol8,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Uninstall setroubleshoot Package'
 
@@ -21,6 +21,8 @@ identifiers:
     cce@rhel7: CCE-80444-3
     cce@rhel8: CCE-82755-0
     cce@rhel9: CCE-84073-6
+    cce@sle12: CCE-91581-9
+    cce@sle15: CCE-91268-3
 
 references:
     anssi: BP28(R68)

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_deny_execmem/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Configure the deny_execmem SELinux Boolean'
 
@@ -19,6 +19,8 @@ identifiers:
     cce@rhel7: CCE-82290-8
     cce@rhel8: CCE-83307-9
     cce@rhel9: CCE-84082-7
+    cce@sle12: CCE-91575-1
+    cce@sle15: CCE-91265-9
 
 references:
     anssi: BP28(R67)

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_polyinstantiation_enabled/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_polyinstantiation_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Configure the polyinstantiation_enabled SELinux Boolean'
 
@@ -17,6 +17,7 @@ identifiers:
     cce@rhel7: CCE-82305-4
     cce@rhel8: CCE-84230-2
     cce@rhel9: CCE-84083-5
+    cce@sle12: CCE-91579-3
     cce@sle15: CCE-91238-6
 
 references:

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_insmod/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Configure the secure_mode_insmod SELinux Boolean'
 
@@ -20,6 +20,8 @@ identifiers:
     cce@rhel7: CCE-82308-8
     cce@rhel8: CCE-83310-3
     cce@rhel9: CCE-84087-6
+    cce@sle12: CCE-91576-9
+    cce@sle15: CCE-91266-7
 
 {{{ complete_ocil_entry_sebool_var(sebool="secure_mode_insmod") }}}
 

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execheap/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Disable the selinuxuser_execheap SELinux Boolean'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-82312-0
     cce@rhel8: CCE-80949-1
     cce@rhel9: CCE-84084-3
+    cce@sle12: CCE-91577-7
     cce@sle15: CCE-91424-2
 
 references:

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_selinuxuser_execstack/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'disable the selinuxuser_execstack SELinux Boolean'
 
@@ -19,6 +19,7 @@ identifiers:
     cce@rhel7: CCE-82314-6
     cce@rhel8: CCE-80951-7
     cce@rhel9: CCE-84089-2
+    cce@sle12: CCE-91578-5
     cce@sle15: CCE-91422-6
 
 references:

--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_sysadm_login/rule.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_ssh_sysadm_login/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Disable the ssh_sysadm_login SELinux Boolean'
 
@@ -34,6 +34,8 @@ identifiers:
     cce@rhel7: CCE-82327-8
     cce@rhel8: CCE-83311-1
     cce@rhel9: CCE-84081-9
+    cce@sle12: CCE-91574-4
+    cce@sle15: CCE-91264-2
 
 {{{ complete_ocil_entry_sebool_disabled(sebool="ssh_sysadm_login") }}}
 


### PR DESCRIPTION
#### Description:

- Add selinux related rules to ANSSI profile for SLE platforms

#### Rationale:

- Add rules:
  - sebool_ssh_sysadm_login
  - sebool_selinuxuser_execstack
  - sebool_selinuxuser_execheap
  - sebool_secure_mode_insmod
  - sebool_deny_execmem
  - sebool_polyinstantiation_enabled
  - package_setroubleshoot-plugins_removed
  - package_setroubleshoot-server_removed
  - package_setroubleshoot_removed

- Also add user timeout rules to ANSSI enhanced profile for SLE platforms
