### PR TITLE
include = sign in remediation of configure_openssl_crypto_policy

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/ansible/shared.yml
@@ -20,7 +20,7 @@
   lineinfile:
     create: yes
     insertafter: '^\s*\[\s*crypto_policy\s*]\s*'
-    line: ".include /etc/crypto-policies/back-ends/opensslcnf.config"
+    line: ".include = /etc/crypto-policies/back-ends/opensslcnf.config"
     path: {{{ openssl_cnf_path }}}
   when:
     - test_crypto_policy_group.stdout is defined
@@ -29,7 +29,7 @@
 - name: "Add crypto_policy group and set include opensslcnf.config"
   lineinfile:
     create: yes
-    line: "[crypto_policy]\n.include /etc/crypto-policies/back-ends/opensslcnf.config"
+    line: "[crypto_policy]\n.include = /etc/crypto-policies/back-ends/opensslcnf.config"
     path: {{{ openssl_cnf_path }}}
   when:
     - test_crypto_policy_group.stdout is defined

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/bash/shared.sh
@@ -2,8 +2,8 @@
 
 OPENSSL_CRYPTO_POLICY_SECTION='[ crypto_policy ]'
 OPENSSL_CRYPTO_POLICY_SECTION_REGEX='\[\s*crypto_policy\s*\]'
-OPENSSL_CRYPTO_POLICY_INCLUSION='.include /etc/crypto-policies/back-ends/opensslcnf.config'
-OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*/etc/crypto-policies/back-ends/opensslcnf.config$'
+OPENSSL_CRYPTO_POLICY_INCLUSION='.include = /etc/crypto-policies/back-ends/opensslcnf.config'
+OPENSSL_CRYPTO_POLICY_INCLUSION_REGEX='^\s*\.include\s*(?:=\s*)?/etc/crypto-policies/back-ends/opensslcnf.config$'
 
 {{% if 'sle' in product %}}
   {{% set openssl_cnf_path="/etc/ssl/openssl.cnf" %}}


### PR DESCRIPTION
#### Description:

- when remediating, use .include = instead of plain .include

#### Rationale:

Using the "=" sign after .include is more common in config files. The change will not break any OpenSSL. Additionally, OpenSSL versions without support for .include directive will not fail to parse the configuration if the "=" is used, they will just ignore the directive.
    https://www.openssl.org/docs/man1.1.1/man5/config.html
https://www.openssl.org/docs/man3.0/man5/config.html


Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2108569
