### PR TITLE
Add more sysctl rules to intermediary profile

### DIFF
--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -33,3 +33,7 @@ selections:
   - sysctl_kernel_randomize_va_space
   - sysctl_net_ipv4_conf_default_accept_redirects
   - sysctl_net_ipv4_conf_default_rp_filter
+  - sysctl_net_ipv4_tcp_syncookies
+  - sysctl_net_ipv4_conf_all_send_redirects
+  - sysctl_net_ipv4_conf_default_send_redirects
+  - sysctl_net_ipv4_ip_forward


### PR DESCRIPTION
#### Description:

- Add following rules to ANSSI Intermediary:
  - sysctl_net_ipv4_tcp_syncookies
  - sysctl_net_ipv4_conf_all_send_redirects
  - sysctl_net_ipv4_conf_default_send_redirects
  - sysctl_net_ipv4_ip_forward