### PR TITLE
Introduce and apply the "partition exists" platform

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -38,7 +38,8 @@ references:
     stigid@ol8: OL08-00-040132
     stigid@rhel8: RHEL-08-040132
 
-platform: machine
+platforms:
+  - machine and partition-var-tmp
 
 template:
     name: mount_option

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/notapplicable.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/tests/notapplicable.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+. $SHARED/partition.sh
+
+clean_up_partition /var/tmp  # Remove the partition from the system, and unmount it

--- a/shared/applicability/general.yml
+++ b/shared/applicability/general.yml
@@ -77,6 +77,20 @@ cpes:
       bash_conditional: {{{ bash_pkg_conditional("pam") }}}
       ansible_conditional: {{{ ansible_pkg_conditional("pam") }}}
 
+  - partition-var-tmp:
+      name: "cpe:/a:partition-var-tmp"
+      title: "There is a /var/tmp partition"
+      check_id: installed_env_mounts_var_tmp
+      bash_conditional: {{{ bash_partition_conditional("/var/tmp") }}}
+      ansible_conditional: {{{ ansible_partition_conditional("/var/tmp") }}}
+
+  - partition-tmp:
+      name: "cpe:/a:partition-tmp"
+      title: "There is a /tmp partition"
+      check_id: installed_env_mounts_tmp
+      bash_conditional: {{{ bash_partition_conditional("/tmp") }}}
+      ansible_conditional: {{{ ansible_partition_conditional("/tmp") }}}
+
   - polkit:
       name: "cpe:/a:polkit"
       title: "Package polkit is installed"

--- a/shared/checks/oval/installed_env_mounts_tmp.xml
+++ b/shared/checks/oval/installed_env_mounts_tmp.xml
@@ -6,5 +6,5 @@
     </criteria>
   </definition>
 
-  {{{ partition_exists_tos("/tmp") }}}
+  {{{ partition_exists_test_object("/tmp") }}}
 </def-group>

--- a/shared/checks/oval/installed_env_mounts_tmp.xml
+++ b/shared/checks/oval/installed_env_mounts_tmp.xml
@@ -1,0 +1,10 @@
+<def-group>
+  <definition class="inventory" id="installed_env_mounts_tmp" version="1">
+    {{{ oval_metadata("", title="Partition /tmp exists", affected_platforms=[full_name]) }}}
+    <criteria>
+       {{{ partition_exists_criterion("/tmp") }}}
+    </criteria>
+  </definition>
+
+  {{{ partition_exists_tos("/tmp") }}}
+</def-group>

--- a/shared/checks/oval/installed_env_mounts_var_tmp.xml
+++ b/shared/checks/oval/installed_env_mounts_var_tmp.xml
@@ -6,5 +6,5 @@
     </criteria>
   </definition>
 
-  {{{ partition_exists_tos("/var/tmp") }}}
+  {{{ partition_exists_test_object("/var/tmp") }}}
 </def-group>

--- a/shared/checks/oval/installed_env_mounts_var_tmp.xml
+++ b/shared/checks/oval/installed_env_mounts_var_tmp.xml
@@ -1,0 +1,10 @@
+<def-group>
+  <definition class="inventory" id="installed_env_mounts_var_tmp" version="1">
+    {{{ oval_metadata("", title="Partition /var/tmp exists", affected_platforms=[full_name]) }}}
+    <criteria>
+       {{{ partition_exists_criterion("/var/tmp") }}}
+    </criteria>
+  </definition>
+
+  {{{ partition_exists_tos("/var/tmp") }}}
+</def-group>

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1439,3 +1439,8 @@ Part of the grub2_bootloader_argument_absent template.
   when:
     - result_pam_file_present.stat.exists
 {{%- endmacro -%}}
+
+
+{{%- macro ansible_partition_conditional(path) -%}}
+"ansible_facts.ansible_mounts | json_query(\"[?mount=='{{{ path }}}'].mount\") | length == 1"
+{{%- endmacro -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2085,3 +2085,8 @@ else
     echo "{{{ pam_file }}} was not found" >&2
 fi
 {{%- endmacro -%}}
+
+
+{{%- macro bash_partition_conditional(path) -%}}
+'findmnt --mountpoint "{{{ path }}}" > /dev/null'
+{{%- endmacro -%}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -926,3 +926,24 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 {{%- else %}}
   {{%- set user_list="nobody" %}}
 {{%- endif %}}
+
+
+{{%- macro partition_exists_criterion(path) %}}
+{{%- set escaped_path = path | replace("/", "_") %}}
+      <criterion comment="The path {{{ path }}} is a partition's mount point" test_ref="test_partition_{{{ escaped_path  }}}_exists" />
+{{%- endmacro %}}
+
+{{%- macro partition_exists_tos(path) %}}
+{{%- set escaped_path = path | replace("/", "_") %}}
+  <linux:partition_test check="all" check_existence="all_exist"
+      comment="Partition {{{ path }}} exists"
+      id="test_partition_{{{ escaped_path }}}_exists"
+  version="1">
+    <linux:object object_ref="object_partition_{{{ escaped_path }}}_exists" />
+    {{#- <linux:partition_state state_ref="" /> #}}
+  </linux:partition_test>
+
+  <linux:partition_object id="object_partition_{{{ escaped_path }}}_exists" version="1">
+    <linux:mount_point>{{{ path }}}</linux:mount_point>
+  </linux:partition_object>
+{{%- endmacro %}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -929,18 +929,17 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 
 
 {{%- macro partition_exists_criterion(path) %}}
-{{%- set escaped_path = path | replace("/", "_") %}}
+{{%- set escaped_path = path | escape_id %}}
       <criterion comment="The path {{{ path }}} is a partition's mount point" test_ref="test_partition_{{{ escaped_path  }}}_exists" />
 {{%- endmacro %}}
 
-{{%- macro partition_exists_tos(path) %}}
-{{%- set escaped_path = path | replace("/", "_") %}}
+{{%- macro partition_exists_test_object(path) %}}
+{{%- set escaped_path = path | escape_id %}}
   <linux:partition_test check="all" check_existence="all_exist"
       comment="Partition {{{ path }}} exists"
       id="test_partition_{{{ escaped_path }}}_exists"
   version="1">
     <linux:object object_ref="object_partition_{{{ escaped_path }}}_exists" />
-    {{#- <linux:partition_state state_ref="" /> #}}
   </linux:partition_test>
 
   <linux:partition_object id="object_partition_{{{ escaped_path }}}_exists" version="1">


### PR DESCRIPTION
#### Description:

This PR introduces platforms related to existence of partitions that can be used to extend applicability behaviors.
The new functionality is heavily macro-based, and instantiated for `/tmp` and `/var/tmp` partitions.

TODO:

- [ ] Verify the Ansible conditional
- [ ] Apply to all appropriate rules

#### Rationale:

If a profile doesn't require separate partitions, but it prescribes mount options if they exist, the applicability approach is the right one.

- Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2032403
