### PR TITLE
The FMT_MOF_EXT.1 only deals with restricting management functions to administrator

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -47,7 +47,7 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1
     pcidss: Req-8.2.3
     srg: SRG-OS-000071-GPOS-00039
     stigid@ol7: OL07-00-010140

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -48,7 +48,7 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1
     pcidss: Req-8.2.3
     srg: SRG-OS-000070-GPOS-00038
     stigid@ol7: OL07-00-010130

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -47,7 +47,7 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1
     pcidss: Req-8.2.3
     srg: SRG-OS-000078-GPOS-00046
     stigid@ol7: OL07-00-010280

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -49,7 +49,7 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000266-GPOS-00101
     stigid@ol7: OL07-00-010150
     stigid@ol8: OL08-00-020280

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -44,7 +44,7 @@ references:
     iso27001-2013: A.18.1.4,A.7.1.1,A.9.2.1,A.9.2.2,A.9.2.3,A.9.2.4,A.9.2.6,A.9.3.1,A.9.4.2,A.9.4.3
     nist: IA-5(c),IA-5(1)(a),CM-6(a),IA-5(4)
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
-    ospp: FMT_MOF_EXT.1
+    ospp: FMT_SMF_EXT.1
     pcidss: Req-8.2.3
     srg: SRG-OS-000069-GPOS-00037,SRG-OS-000070-GPOS-00038
     stigid@ol7: OL07-00-010120


### PR DESCRIPTION

#### Description:

- Use FMT_SMF_EXT.1 reference for rules directly related to the management functions.

#### Rationale:

- The FMT_MOF_EXT.1 only deals with restricting management functions to administrator, the functions themselves are listed in FMT_SMF_EXT.1.
- I am aware that the Configuration Annex (https://www.niap-ccevs.org/MMO/PP/-442ConfigAnnex-/) uses the FMT_MOF_EXT.1 reference, that is being challenged in https://github.com/commoncriteria/operatingsystem/issues/113.
