### PR TITLE
Fix OCP rule `kubelet_enable_client_cert_rotation`

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_client_cert_rotation/rule.yml
@@ -34,7 +34,7 @@ ocil_clause: 'the kubelet cannot rotate client certificate'
 ocil: |-
     Run the following command on the kubelet node(s):
     <pre>$ sudo grep RotateKubeletClientCertificate {{{ kubeletconf_path }}}</pre>
-    The output should return <tt>true</tt>.
+    The output should return nothing or <tt>true</tt>.
 
 identifiers:
     cce@ocp4: CCE-83352-5


### PR DESCRIPTION
Fix the instruction for rule `kubelet_enable_client_cert_rotation`, related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2105153
