### PR TITLE
Make iptables firewall "opt in" in RHEL8 CIS

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1238,7 +1238,7 @@ controls:
       - l1_server
       - l1_workstation
     status: automated
-    rules:
+    related_rules:
       - package_iptables_installed
       - package_iptables-services_installed
 
@@ -1289,7 +1289,7 @@ controls:
       - l1_server
       - l1_workstation
     status: automated
-    rules:
+    related_rules:
       - set_iptables_default_rule
 
   # NEEDS RULE
@@ -1306,10 +1306,9 @@ controls:
       - l1_server
       - l1_workstation
     status: automated
-    rules:
-      - service_iptables_enabled
     related_rules:
       - package_iptables-services_installed
+      - service_iptables_enabled
 
   # NEEDS RULE
   # https://github.com/ComplianceAsCode/content/issues/5258

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1307,7 +1307,6 @@ controls:
       - l1_workstation
     status: automated
     related_rules:
-      - package_iptables-services_installed
       - service_iptables_enabled
 
   # NEEDS RULE


### PR DESCRIPTION
#### Description:

- Move iptables rules to `related_rules` section.

#### Rationale:

- In RHEL we favor the use of firewalld, so lets move the iptables rules to related_rules. This will unselect them from the profile while keeping them discoverable via control files.

- Fixes #9190 