### PR TITLE
[Stabilization] remove accounts_max_concurrent_login_sessions from RHEL9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -161,8 +161,6 @@ selections:
     - coredump_disable_storage
     - coredump_disable_backtraces
     - service_systemd-coredump_disabled
-    - var_accounts_max_concurrent_login_sessions=10
-    - accounts_max_concurrent_login_sessions
     - securetty_root_login_console_only
     - var_authselect_profile=sssd
     - enable_authselect


### PR DESCRIPTION
The same content as https://github.com/ComplianceAsCode/content/pull/9218 but against stabilization branch.