### PR TITLE
remove securetty_root_login_console_only from RHEL9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -150,7 +150,6 @@ selections:
     - coredump_disable_storage
     - coredump_disable_backtraces
     - service_systemd-coredump_disabled
-    - securetty_root_login_console_only
     - var_authselect_profile=sssd
     - enable_authselect
     - use_pam_wheel_for_su


### PR DESCRIPTION
#### Description:

- remove rule securetty_root_login_console_only from RHEL9 OSPP profile

#### Rationale:

https://bugzilla.redhat.com/show_bug.cgi?id=2109994
