### PR TITLE
[Stabilization]  remove securetty_root_login_console_only from RHEL9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -144,7 +144,6 @@ selections:
     - coredump_disable_storage
     - coredump_disable_backtraces
     - service_systemd-coredump_disabled
-    - securetty_root_login_console_only
     - var_authselect_profile=sssd
     - enable_authselect
     - use_pam_wheel_for_su


### PR DESCRIPTION
https://github.com/ComplianceAsCode/content/pull/9234 against stabilization branch