### PR TITLE
[stabilization] Remove rules for package removal from RHEL 9 OSPP

### DIFF
--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -132,12 +132,6 @@ selections:
     - package_chrony_installed
     - package_gnutls-utils_installed
 
-    ### Remove Prohibited Packages
-    - package_sendmail_removed
-    - package_iprutils_removed
-    - package_gssproxy_removed
-    - package_nfs-utils_removed
-
     ### Login
     - disable_users_coredumps
     - sysctl_kernel_core_pattern


### PR DESCRIPTION
Remove rules package_sendmail_removed, package_iprutils_removed,
package_gssproxy_removed, package_nfs-utils_removed from RHEL 9 OSPP
profile.  None of the packages would get installed on RHEL CC
configuration by default (they are not in the @core group). Their
potential presence is not in conflict with any SFR claimed for RHEL
Common Criteria certification.  The rule
package_krb5-workstation_removed has already been removed by
https://github.com/ComplianceAsCode/content/pull/9003

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2108226

This PR is a copy of https://github.com/ComplianceAsCode/content/pull/9233 for the stabilization branch in order to push the change to release version 0.1.63.
