### PR TITLE
Condition run of newaliases to its availability

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/ansible/shared.yml
@@ -13,6 +13,13 @@
     create: true
     state: present
 
+- name: 'Check if newaliases command is available'
+  ansible.builtin.stat:
+    path: /usr/bin/newaliases
+  register: result_newaliases_present
+
 - name: Update postfix aliases
   ansible.builtin.command:
     cmd: newaliases
+  when:
+    - result_newaliases_present.stat.exists

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
@@ -4,4 +4,6 @@
 
 {{{ bash_replace_or_append('/etc/aliases', '^root', "$var_postfix_root_mail_alias", '%s: %s') }}}
 
-newaliases
+if [ -f /usr/bin/newaliases ]; then
+    newaliases
+fi

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/ansible/shared.yml
@@ -11,7 +11,14 @@
                             value='root',
                             create='yes') }}}
 
+- name: 'Check if newaliases command is available'
+  ansible.builtin.stat:
+    path: /usr/bin/newaliases
+  register: result_newaliases_present
+
 - name: Update postfix aliases
   ansible.builtin.command:
     cmd: newaliases
+  when:
+    - result_newaliases_present.stat.exists
 

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/bash/shared.sh
@@ -11,4 +11,6 @@
                     separator=": ",
                     separator_regex="\s*:\s*") }}}
 
-newaliases
+if [ -f /usr/bin/newaliases ]; then
+    newaliases
+fi


### PR DESCRIPTION


#### Description:

-  Condition execution  of `newaliases` to its availability.

#### Rationale:

- Not every MTA needs to rebuild the aliases database.
- Fixes #9230