### PR TITLE
Introduced rules to disable accounts because of inactivity

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/bash/shared.sh
@@ -1,0 +1,29 @@
+# platform = multi_platform_ol
+
+PAM_FILE_PATH="/etc/pam.d/password-auth"
+if [ -f /usr/bin/authselect ]; then
+    {{{ bash_check_authselect_integrity() | indent(4) }}}
+    {{{ bash_ensure_authselect_custom_profile() | indent(4) }}}
+    PAM_FILE_NAME=$(basename "$PAM_FILE_PATH")
+    PAM_FILE_PATH="/etc/authselect/$CURRENT_PROFILE/$PAM_FILE_NAME"
+    authselect apply-changes -b --backup=before-hardening-pam_lastlog.so-inactive.backup
+fi
+{{{ bash_ensure_pam_module_option("$PAM_FILE_PATH",
+                                  'auth',
+                                  'required',
+                                  'pam_lastlog.so',
+                                  'inactive', '35') }}}
+{{{ bash_ensure_pam_module_line("$PAM_FILE_PATH",
+                                'auth',
+                                'sufficient', 
+                                'pam_unix.so') }}}
+# Ensure pam_unix.so is configured after pam_lastlog.so
+if ! grep -Pz \
+    "auth\s*required\s*pam_lastlog\.so[^#]*inactive=35[\s\S]*\n\s*auth\s*sufficient\s*pam_unix\.so"\
+    "$PAM_FILE_PATH"  ; then
+    PAM_LASTLOG_LINE="$(grep -oP '^\s*auth.*pam_lastlog\.so.*' $PAM_FILE_PATH)"
+    sed -i "0,/^\s*auth.*pam_unix\.so.*/i$PAM_LASTLOG_LINE" "$PAM_FILE_PATH"
+fi
+if [ -f /usr/bin/authselect ]; then
+    authselect apply-changes -b --backup=after-hardening-pam_lastlog.so-inactive.backup
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The accounts should be configured to expire automatically following"
+    ~ " password expiration.") }}}
+    <criteria
+    comment="the value for the inactive parameter should be set appropriately in /etc/pam.d/password-auth">
+      <criterion test_ref="test_password_auth_inactive" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" id="test_password_auth_inactive" version="1"
+  comment="the value for the inactive parameter should be set appropriately in /etc/pam.d/password-auth">
+    <ind:object object_ref="obj_password_auth_inactive" />
+    <ind:state state_ref="state_password_auth_inactive" />
+    <ind:state state_ref="state_password_auth_inactive_positive" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_password_auth_inactive" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^auth\s*(?:required|requisite)\s*pam_lastlog\.so[^#]*inactive=(\d+)[\s\S]*^\s*auth\s*sufficient\s*pam_unix\.so</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_password_auth_inactive" version="1">
+    <ind:subexpression operation="less than or equal" var_ref="var_account_disable_post_pw_expiration"
+    datatype="int" />
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_password_auth_inactive_positive" version="1">
+    <ind:subexpression operation="greater than" datatype="int">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="inactive days expiration" datatype="int" id="var_account_disable_post_pw_expiration" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/rule.yml
@@ -8,10 +8,12 @@ description: |-
     Verify the account identifiers (individuals, groups, roles, and devices) are disabled after
     {{{ xccdf_value("var_account_disable_inactivity") }}} or less days of inactivity by
     checking the account inactivity value with the following command:
-    <pre>grep 'inactive\|pam_unix' /etc/pam.d/password-auth | grep -w auth</pre>
+    <pre>grep 'inactive\|pam_unix' /etc/pam.d/password-auth | grep -w auth
+    
+    auth required pam_lastlog.so inactive=35
+    auth sufficient pam_unix.so</pre>
     The line with the inactive parameter should be placed before <tt>pam_unix.so</tt> module as in
-    the line:
-    <pre>auth sufficient pam_unix.so</pre>
+    the example output.
 
 rationale: |-
     Inactive identifiers pose a risk to systems and applications because attackers may exploit an

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/rule.yml
@@ -1,0 +1,62 @@
+documentation_complete: true
+
+prodtype: ol8,ol9
+
+title: 'Set Account Expiration Following Inactivity in password-auth'
+
+description: |-
+    Verify the account identifiers (individuals, groups, roles, and devices) are disabled after
+    {{{ xccdf_value("var_account_disable_inactivity") }}} or less days of inactivity by
+    checking the account inactivity value with the following command:
+    <pre>grep 'inactive\|pam_unix' /etc/pam.d/password-auth | grep -w auth</pre>
+    The line with the inactive parameter should be placed before <tt>pam_unix.so</tt> module as in
+    the line:
+    <pre>auth sufficient pam_unix.so</pre>
+
+rationale: |-
+    Inactive identifiers pose a risk to systems and applications because attackers may exploit an
+    inactive identifier and potentially obtain undetected access to the system. Owners of inactive
+    accounts will not notice if unauthorized access to their user account has been obtained.
+
+severity: medium
+
+references:
+    disa: CCI-000795
+    nist: IA-4(e)
+    srg: SRG-OS-000118-GPOS-00060
+    stigid@ol8: OL08-00-020261
+
+platform: pam
+
+ocil_clause: 'the value of inactive is incorrect or is not set before pam_unix.so'
+
+ocil: |-
+    To verify the <tt>inactive</tt> setting, run the following command:
+    <pre>$ grep 'inactive\|pam_unix' /etc/pam.d/password-auth | grep -w auth</pre>
+    The output should indicate the <tt>inactive</tt> configuration option is set
+    to an appropriate integer between 1 and
+    {{{ xccdf_value("var_account_disable_inactivity") }}}; and should appear
+    before the <tt>pam_unix.so</tt> module as shown in the example below:
+    <pre>$ grep 'inactive\|pam_unix' /etc/pam.d/password-auth | grep -w auth
+    auth required pam_lastlog.so inactive={{{
+    xccdf_value("var_account_disable_inactivity") }}}
+    auth sufficient pam_unix.so</pre>
+
+fixtext: |-
+    Configure {{{ full_name }}} to disable account identifiers after
+    {{{ xccdf_value("var_account_disable_inactivity") }}} days of inactivity. 
+    Add or correct the following line in <tt>/etc/pam.d/password-auth</tt>:
+    <pre>auth required pam_lastlog.so inactive=<i>{{{
+    xccdf_value("var_account_disable_inactivity") }}}</i></pre>
+    This line should be placed before <tt>pam_unix.so</tt> module as in the line:
+    <pre>auth sufficient pam_unix.so</pre>
+    A recommendation is {{{ xccdf_value("var_account_disable_inactivity") }}} days, but a
+    lower value is acceptable.
+
+warnings:
+    - general: |-
+       If the system relies on <tt>authselect</tt> tool to manage PAM settings, the remediation
+       will also use <tt>authselect</tt> tool. However, if any manual modification was made in
+       PAM files, the <tt>authselect</tt> integrity check will fail and the remediation will be
+       aborted in order to preserve intentional changes. In this case, an informative message will
+       be shown in the remediation report.

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/common.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PAM_FILE="/etc/authselect/custom/testingProfile/password-auth"
+
+
+if grep -q "pam_lastlog\.so.*" "$CUSTOM_PAM_FILE" ; then
+    sed -i --follow-symlinks "/pam_lastlog\.so/d" "$CUSTOM_PAM_FILE"
+fi
+{{{ bash_ensure_pam_module_line("$CUSTOM_PAM_FILE",
+                                "auth",
+                                "sufficient",
+                                "pam_unix.so") }}}
+
+authselect select --force custom/testingProfile

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/line_not_there.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/stricter_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/stricter_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=34' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_order.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_order.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/a auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=36' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/bash/shared.sh
@@ -1,0 +1,29 @@
+# platform = multi_platform_ol
+
+PAM_FILE_PATH="/etc/pam.d/system-auth"
+if [ -f /usr/bin/authselect ]; then
+    {{{ bash_check_authselect_integrity() | indent(4) }}}
+    {{{ bash_ensure_authselect_custom_profile() | indent(4) }}}
+    PAM_FILE_NAME=$(basename "$PAM_FILE_PATH")
+    PAM_FILE_PATH="/etc/authselect/$CURRENT_PROFILE/$PAM_FILE_NAME"
+    authselect apply-changes -b --backup=before-hardening-pam_lastlog.so-inactive.backup
+fi
+{{{ bash_ensure_pam_module_option("$PAM_FILE_PATH",
+                                  'auth',
+                                  'required',
+                                  'pam_lastlog.so',
+                                  'inactive', '35') }}}
+{{{ bash_ensure_pam_module_line("$PAM_FILE_PATH",
+                                'auth',
+                                'sufficient',
+                                'pam_unix.so') }}}
+# Ensure pam_unix.so is configured after pam_lastlog.so
+if ! grep -Pz \
+    "auth\s*required\s*pam_lastlog\.so[^#]*inactive=35[\s\S]*\n\s*auth\s*sufficient\s*pam_unix\.so"\
+    "$PAM_FILE_PATH"  ; then
+    PAM_LASTLOG_LINE="$(grep -oP '^\s*auth.*pam_lastlog\.so.*' $PAM_FILE_PATH)"
+    sed -i "0,/^\s*auth.*pam_unix\.so.*/i$PAM_LASTLOG_LINE" "$PAM_FILE_PATH"
+fi
+if [ -f /usr/bin/authselect ]; then
+    authselect apply-changes -b --backup=after-hardening-pam_lastlog.so-inactive.backup
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/oval/shared.xml
@@ -1,0 +1,35 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("The accounts should be configured to expire automatically following"
+    ~ " password expiration.") }}}
+    <criteria
+    comment="the value for the inactive parameter should be set appropriately in /etc/pam.d/system-auth">
+      <criterion test_ref="test_system_auth_inactive" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" id="test_system_auth_inactive" version="1"
+  comment="the value for the inactive parameter should be set appropriately in /etc/pam.d/system-auth">
+    <ind:object object_ref="obj_system_auth_inactive" />
+    <ind:state state_ref="state_system_auth_inactive" />
+    <ind:state state_ref="state_system_auth_inactive_positive" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_system_auth_inactive" version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern operation="pattern match">^auth\s*(?:required|requisite)\s*pam_lastlog\.so[^#]*inactive=(\d+)[\s\S]*^\s*auth\s*sufficient\s*pam_unix\.so</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_system_auth_inactive" version="1">
+    <ind:subexpression operation="less than or equal" var_ref="var_account_disable_post_pw_expiration"
+    datatype="int" />
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_state id="state_system_auth_inactive_positive" version="1">
+    <ind:subexpression operation="greater than" datatype="int">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="inactive days expiration" datatype="int" id="var_account_disable_post_pw_expiration" version="1" />
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/rule.yml
@@ -8,10 +8,12 @@ description: |-
     Verify the account identifiers (individuals, groups, roles, and devices) are disabled after
     {{{ xccdf_value("var_account_disable_inactivity") }}} or less days of inactivity by
     checking the account inactivity value with the following command:
-    <pre>grep 'inactive\|pam_unix' /etc/pam.d/system-auth | grep -w auth</pre>
+    <pre>grep 'inactive\|pam_unix' /etc/pam.d/password-auth | grep -w auth
+    
+    auth required pam_lastlog.so inactive=35
+    auth sufficient pam_unix.so</pre>
     The line with the inactive parameter should be placed before <tt>pam_unix.so</tt> module as in
-    the line:
-    <pre>auth sufficient pam_unix.so</pre>
+    the example output.
 
 rationale: |-
     Inactive identifiers pose a risk to systems and applications because attackers may exploit an

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/rule.yml
@@ -1,0 +1,62 @@
+documentation_complete: true
+
+prodtype: ol8,ol9
+
+title: 'Set Account Expiration Following Inactivity in system-auth'
+
+description: |-
+    Verify the account identifiers (individuals, groups, roles, and devices) are disabled after
+    {{{ xccdf_value("var_account_disable_inactivity") }}} or less days of inactivity by
+    checking the account inactivity value with the following command:
+    <pre>grep 'inactive\|pam_unix' /etc/pam.d/system-auth | grep -w auth</pre>
+    The line with the inactive parameter should be placed before <tt>pam_unix.so</tt> module as in
+    the line:
+    <pre>auth sufficient pam_unix.so</pre>
+
+rationale: |-
+    Inactive identifiers pose a risk to systems and applications because attackers may exploit an
+    inactive identifier and potentially obtain undetected access to the system. Owners of inactive
+    accounts will not notice if unauthorized access to their user account has been obtained.
+
+severity: medium
+
+references:
+    disa: CCI-000795
+    nist: IA-4(e)
+    srg: SRG-OS-000118-GPOS-00060
+    stigid@ol8: OL08-00-020260
+
+platform: pam
+
+ocil_clause: 'the value of inactive is incorrect or is not set before pam_unix.so'
+
+ocil: |-
+    To verify the <tt>inactive</tt> setting, run the following command:
+    <pre>$ grep 'inactive\|pam_unix' /etc/pam.d/system-auth | grep -w auth</pre>
+    The output should indicate the <tt>inactive</tt> configuration option is set
+    to an appropriate integer between 1 and
+    {{{ xccdf_value("var_account_disable_inactivity") }}}; and should appear
+    before the <tt>pam_unix.so</tt> module as shown in the example below:
+    <pre>$ grep 'inactive\|pam_unix' /etc/pam.d/system-auth | grep -w auth
+    auth required pam_lastlog.so inactive={{{
+    xccdf_value("var_account_disable_inactivity") }}}
+    auth sufficient pam_unix.so</pre>
+
+fixtext: |-
+    Configure {{{ full_name }}} to disable account identifiers after
+    {{{ xccdf_value("var_account_disable_inactivity") }}} days of inactivity.
+    Add or correct the following line in <tt>/etc/pam.d/system-auth</tt>:
+    <pre>auth required pam_lastlog.so inactive=<i>{{{
+    xccdf_value("var_account_disable_inactivity") }}}</i></pre>
+    This line should be placed before <tt>pam_unix.so</tt> module as in the line:
+    <pre>auth sufficient pam_unix.so</pre>
+    A recommendation is {{{ xccdf_value("var_account_disable_inactivity") }}} days, but a
+    lower value is acceptable.
+
+warnings:
+    - general: |-
+       If the system relies on <tt>authselect</tt> tool to manage PAM settings, the remediation
+       will also use <tt>authselect</tt> tool. However, if any manual modification was made in
+       PAM files, the <tt>authselect</tt> integrity check will fail and the remediation will be
+       aborted in order to preserve intentional changes. In this case, an informative message will
+       be shown in the remediation report.

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/common.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PAM_FILE="/etc/authselect/custom/testingProfile/system-auth"
+
+
+if grep -q "pam_lastlog\.so.*" "$CUSTOM_PAM_FILE" ; then
+    sed -i --follow-symlinks "/pam_lastlog\.so/d" "$CUSTOM_PAM_FILE"
+fi
+{{{ bash_ensure_pam_module_line("$CUSTOM_PAM_FILE",
+                                "auth",
+                                "sufficient",
+                                "pam_unix.so") }}}
+
+authselect select --force custom/testingProfile

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/line_not_there.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/stricter_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/stricter_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=34' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_order.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_order.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/a auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = authselect,pam
+# variables = var_account_disable_inactivity=35
+
+source common.sh
+
+sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=36' $CUSTOM_PAM_FILE
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/var_account_disable_inactivity.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/var_account_disable_inactivity.var
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'number of days after the last login of the user when the user will be locked out'
+
+description: |-
+    'This option is specific for the auth or account phase. It specifies the number of days after
+    the last login of the user when the user will be locked out by the pam_lastlog module.'
+
+type: number
+
+interactive: false
+
+options:
+    "0": "0"
+    180: 180
+    30: 30
+    35: 35
+    40: 40
+    60: 60
+    90: 90
+    default: 35

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -637,6 +637,7 @@ selections:
     - account_disable_inactivity_system_auth
 
     # OL08-00-020261
+    - account_disable_inactivity_password_auth
 
     # OL08-00-020262
     - file_permissions_lastlog

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -51,6 +51,7 @@ selections:
     - var_ssh_client_rekey_limit_time=1hour
     - var_accounts_fail_delay=4
     - var_account_disable_post_pw_expiration=35
+    - var_account_disable_inactivity=35
     - var_auditd_action_mail_acct=root
     - var_time_service_set_maxpoll=18_hours
     - var_accounts_maximum_age_login_defs=60
@@ -633,6 +634,7 @@ selections:
 
     # OL08-00-020260
     - account_disable_post_pw_expiration
+    - account_disable_inactivity_system_auth
 
     # OL08-00-020261
 


### PR DESCRIPTION
#### Description:

- Introduce rules `account_disable_inactivity_system_auth` & `account_disable_inactivity_password_auth`
-  Add automation content to them

#### Rationale:

- These rules cover DISA STIG IDs: `OL08-00-020260` & `OL08-00-020261`
