### PR TITLE
Improve regex to match retry parameter in pwquality.conf

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/oval/shared.xml
@@ -88,7 +88,7 @@
 
   <ind:textfilecontent54_object id="obj_password_pam_pwquality_retry_pwquality_conf" version="1">
     <ind:filepath>/etc/security/pwquality.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^retry[\s]*=[\s]*(\d+)(?:[\s]|$)</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*retry[\s]*=[\s]*(\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/common.sh
@@ -1,13 +1,13 @@
 {{% if 'ubuntu' in product %}}
 configuration_files=("common-password")
-{{% elif product in ['ol8','ol9','rhel8', 'rhel9'] %}}
+{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
 configuration_files=("password-auth" "system-auth")
 {{% else %}}
 configuration_files=("system-auth")
 {{% endif %}}
 
 
-{{% if product in ['ol8','ol9','rhel8', 'rhel9'] %}}
+{{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
 authselect create-profile testingProfile --base-on minimal 
 
 for file in ${configuration_files[@]}; do

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/correct_value.pass.sh
@@ -9,7 +9,7 @@ for file in ${configuration_files[@]}; do
                                    'password',
 								   'required',
 								   'pam_pwquality.so',
-								   "retry",
-								   "3",
-								   "3") }}}
+								   'retry',
+								   '3',
+								   '^\s*account') }}}
 done

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct_with_space.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_correct_with_space.pass.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# packages = authselect
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# variables = var_password_pam_retry=3
+
+source common.sh
+
+CONF_FILE="/etc/security/pwquality.conf"
+
+retry_cnt=3
+if grep -q "^.*retry\s*=" "$CONF_FILE"; then
+	sed -i "s/^.*retry\s*=.*/ retry = $retry_cnt/" "$CONF_FILE"
+else
+	echo " retry = $retry_cnt" >> "$CONF_FILE"
+fi
+
+for file in ${configuration_files[@]}; do
+	echo "password required pam_pwquality.so" >> \
+		"/etc/authselect/custom/testingProfile/$file"
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_overriden.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_overriden.fail.sh
@@ -12,9 +12,9 @@ for file in ${configuration_files[@]}; do
                                    'password',
 								   'required',
 								   'pam_pwquality.so',
-								   "retry",
-								   "4",
-								   "4") }}}
+								   'retry',
+								   '4',
+								   '^\s*account') }}}
 done
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/wrong_value.fail.sh
@@ -9,7 +9,7 @@ for file in ${configuration_files[@]}; do
                                    'password',
 								   'required',
 								   'pam_pwquality.so',
-								   "retry",
-								   "7",
-								   "7") }}}
+								   'retry',
+								   '7',
+								   '^\s*account') }}}
 done


### PR DESCRIPTION
#### Description:

It is possible that the retry parameter in `pwquality.conf` is preceded by space.

#### Rationale:

It is a corner case I identified during some tests and the fix is pretty simple.
