### PR TITLE
Improve remediation which enable pam_faillock.so by directly editing PAM files

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -834,7 +834,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: '{{ item }}'
         line: auth        required      pam_faillock.so authfail
-        insertafter: ^auth.*sufficient.*pam_unix.so.*
+        insertbefore: ^auth.*required.*pam_deny.so.*
         state: present
       loop:
         - /etc/pam.d/system-auth

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -998,7 +998,7 @@ for pam_file in "${AUTH_FILES[@]}"
 do
     if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+(preauth silent|authfail).*$' "$pam_file" ; then
         sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent' "$pam_file"
-        sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/a auth        required      pam_faillock.so authfail' "$pam_file"
+        sed -i --follow-symlinks '/^auth.*required.*pam_deny.so.*/i auth        required      pam_faillock.so authfail' "$pam_file"
         sed -i --follow-symlinks '/^account.*required.*pam_unix.so.*/i account     required      pam_faillock.so' "$pam_file"
     fi
     sed -Ei 's/(auth.*)(\[default=die\])(.*pam_faillock.so)/\1required     \3/g' "$pam_file"


### PR DESCRIPTION
#### Description:

When the `pam_faillock.so` module is enabled by directly editing PAM files, the two required lines in the `auth` group were inserted using the `pam_unix.so` line as reference. This approach causes problems when more authentication modules are present. The remediation was updated to properly insert the second `pam_faillock.so` (authfail) line in the `auth` group.

#### Rationale:

- Fixes #4925
