### PR TITLE
Improve bash_ensure_pam_module_line macro

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1094,7 +1094,7 @@ Part of the grub2_bootloader_argument_absent template.
     If the line was already present, but with a different control, the control will be updated.
     Note: If there are multiple lines matching the "group" + "module", no lines will be updated.
     Instead, a new line will be included after the regex informed in "after_match" or at the
-    end of file if "after_match" parameter is empty.
+    end of file if "after_match" parameter is empty or there is no match.
     This is a conservative safeguard for improper use of this macro in rare cases of modules
     configured by multiple lines, like pam_sss.so, pam_faillock.so and pam_lastlog.so. In some
     situations, these special modules may have similar lines sharing the same "group" and "module".

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1876,7 +1876,7 @@ fi
     If the line was already present, but with a different control, the control will be updated.
     Note: If there are multiple lines matching the "group" + "module", no lines will be updated.
     Instead, a new line will be included after the regex informed in "after_match" or at the
-    end of file if "after_match" parameter is empty.
+    end of file if "after_match" parameter is empty or there is no match.
     This is a conservative safeguard for improper use of this macro in rare cases of modules
     configured by multiple lines, like pam_sss.so, pam_faillock.so and pam_lastlog.so. In some
     situations, these special modules may have similar lines sharing the same "group" and "module".
@@ -1904,7 +1904,11 @@ if ! grep -qP '^\s*{{{ group }}}\s+'"{{{ control }}}"'\s+{{{ module }}}\s*.*' "{
         sed -i --follow-symlinks '1i {{{ group }}}     '"{{{ control }}}"'    {{{ module }}}' "{{{ pam_file }}}"
         {{%- else %}}
         LAST_MATCH_LINE=$(grep -nP "{{{ after_match }}}" "{{{ pam_file }}}" | tail -n 1 | cut -d: -f 1)
-        sed -i --follow-symlinks $LAST_MATCH_LINE' a {{{ group }}}     '"{{{ control }}}"'    {{{ module }}}' "{{{ pam_file }}}"
+        if [ ! -z $LAST_MATCH_LINE ]; then
+            sed -i --follow-symlinks $LAST_MATCH_LINE' a {{{ group }}}     '"{{{ control }}}"'    {{{ module }}}' "{{{ pam_file }}}"
+        else
+            echo '{{{ group }}}    '"{{{ control }}}"'    {{{ module }}}' >> "{{{ pam_file }}}"
+        fi
         {{%- endif %}}
     fi
 fi


### PR DESCRIPTION
#### Description:

This macro was previously updated to align to the Ansible equivalent in cases where multiple matches were found, in order to only include a line after the last match. However, in cases where the informed regex have no match, many lines would be included. This patch ensures the same behavior of the Ansible equivalent when there is no match.

#### Rationale:

Makes the macro more robust and better aligned to the equivalent in Ansible.
