### PR TITLE
Fix bash remediation in rsyslog_remote_access_monitoring rule

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_remote_access_monitoring/bash/shared.sh
@@ -19,7 +19,7 @@ do
 			# Add selector to file
 			sed -r -i "0,/^(\S+\s+\/var\/log\/secure$)/s//\1\n${K} \/var\/log\/secure/" /etc/rsyslog.conf
 		else
-			echo "${K} \/var\/log\/secure/" >> /etc/rsyslog.conf
+			echo "${K} /var/log/secure" >> /etc/rsyslog.conf
 		fi
 	fi
 done


### PR DESCRIPTION
#### Description:

In cases where a reference line is not found, a new line was included with invalid syntax.
Removed the escape characters only necessary in the `sed` command used by this remediation.

#### Rationale:

- Fixes #8204 
