### PR TITLE
Remove a confusing sentence

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -8,8 +8,7 @@ title: 'Require Authentication for Single User Mode'
 description: |-
     Single-user mode is intended as a system recovery
     method, providing a single user root access to the system by
-    providing a boot option at startup. By default, no authentication
-    is performed if single-user mode is selected.
+    providing a boot option at startup.
     <br /><br />
     By default, single-user mode is protected by requiring a password and is set
     in <tt>/usr/lib/systemd/system/rescue.service</tt>.


### PR DESCRIPTION
In the rule description, there are 2 conflicting sentences, they
both start by "By default ...", but they negate each other.
In fact, the second of them is true, so the first one could be
removed.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2092799