### PR TITLE
SUSE update chronyd max poll to support chrony.d

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -48,7 +48,7 @@
     path: "{{ item }}"
     regexp: '^((?:server|pool|peer).*maxpoll)[ ]+[0-9]+(.*)$'
     replace: '\1 {{ var_time_service_set_maxpoll }}\2'
-  loop: "{{update_chrony_files.stdout_lines|list|flatten|unique}}"
+  loop: "{{ update_chrony_files.stdout_lines|list|flatten|unique }}"
   when: chrony_conf_exist_result.stat.exists
 
 - name: Set the maxpoll values in {{{ chrony_conf_path }}}
@@ -56,5 +56,5 @@
     path: "{{ item }}"
     regexp: '(^(?:server|pool|peer)\s+((?!maxpoll).)*)$'
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
-  loop: "{{update_chrony_files.stdout_lines|list|flatten|unique}}"
+  loop: "{{ update_chrony_files.stdout_lines|list|flatten|unique} }"
   when: chrony_conf_exist_result.stat.exists

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -56,5 +56,5 @@
     path: "{{ item }}"
     regexp: '(^(?:server|pool|peer)\s+((?!maxpoll).)*)$'
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
-  loop: "{{ update_chrony_files.stdout_lines|list|flatten|unique} }"
+  loop: "{{ update_chrony_files.stdout_lines|list|flatten|unique }}"
   when: chrony_conf_exist_result.stat.exists

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -11,24 +11,12 @@
     path: /etc/ntp.conf
   register: ntp_conf_exist_result
 
-- name: Check that {{{ chrony_conf_path }}} exist
-  stat:
-    path: {{{ chrony_conf_path }}}
-  register: chrony_conf_exist_result
-
 - name: Update the maxpoll values in /etc/ntp.conf
   replace:
     path: /etc/ntp.conf
     regexp: '^(server.*maxpoll)[ ]+[0-9]+(.*)$'
     replace: '\1 {{ var_time_service_set_maxpoll }}\2'
   when: ntp_conf_exist_result.stat.exists
-
-- name: Update the maxpoll values in {{{ chrony_conf_path }}}
-  replace:
-    path: {{{ chrony_conf_path }}}
-    regexp: '^((?:server|pool|peer).*maxpoll)[ ]+[0-9]+(.*)$'
-    replace: '\1 {{ var_time_service_set_maxpoll }}\2'
-  when: chrony_conf_exist_result.stat.exists
 
 - name: Set the maxpoll values in /etc/ntp.conf
   replace:
@@ -37,9 +25,36 @@
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
   when: ntp_conf_exist_result.stat.exists
 
+# Chrony, need to hand chrony.conf and any file in chrony.d
+# since chrony_conf_path is the full path to chrony.conf
+# and includes chrony.conf, that must be handled as well
+
+- name: Check that {{{ chrony_conf_path }}} exist
+  stat:
+    path: {{{ chrony_conf_path }}}
+  register: chrony_conf_exist_result
+
+- name: Get get conf files from {{{ chrony_conf_path }}}
+  shell: |
+    set -o pipefail
+    CHRONY_NAME={{{ chrony_conf_path }}}
+    CHRONY_PATH=${CHRONY_NAME%%.*}
+    find ${CHRONY_PATH}.* -type f -name '*.conf'
+  register: update_chrony_files
+  when: chrony_conf_exist_result.stat.exists
+
+- name: Update the maxpoll values in {{{ chrony_conf_path }}}
+  replace:
+    path: "{{ item }}"
+    regexp: '^((?:server|pool|peer).*maxpoll)[ ]+[0-9]+(.*)$'
+    replace: '\1 {{ var_time_service_set_maxpoll }}\2'
+  loop: "{{update_chrony_files.stdout_lines|list|flatten|unique}}"
+  when: chrony_conf_exist_result.stat.exists
+
 - name: Set the maxpoll values in {{{ chrony_conf_path }}}
   replace:
-    path: {{{ chrony_conf_path }}}
+    path: "{{ item }}"
     regexp: '(^(?:server|pool|peer)\s+((?!maxpoll).)*)$'
     replace: '\1 maxpoll {{ var_time_service_set_maxpoll }}\n'
+  loop: "{{update_chrony_files.stdout_lines|list|flatten|unique}}"
   when: chrony_conf_exist_result.stat.exists

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/ansible/shared.yml
@@ -42,6 +42,7 @@
     find ${CHRONY_PATH}.* -type f -name '*.conf'
   register: update_chrony_files
   when: chrony_conf_exist_result.stat.exists
+  changed_when: False
 
 - name: Update the maxpoll values in {{{ chrony_conf_path }}}
   replace:

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -3,20 +3,32 @@
 {{{ bash_instantiate_variables("var_time_service_set_maxpoll") }}}
 
 
-{{% if 'ubuntu' not in product %}}
-pof="/usr/sbin/pidof"
-{{% else %}}
+{{% if 'sle' in product or 'ubuntu' in product %}}
 pof="/bin/pidof"
+{{% else %}}
+pof="/usr/sbin/pidof"
 {{% endif %}}
 
-config_file="/etc/ntp.conf"
-$pof ntpd || config_file="{{{ chrony_conf_path }}}"
+CONFIG_FILES="/etc/ntp.conf"
+$pof ntpd || {
+    CHRONY_NAME={{{ chrony_conf_path }}}
+    CHRONY_PATH=${CHRONY_NAME%%.*}
+    CONFIG_FILES=$(find ${CHRONY_PATH}.* -type f -name '*.conf')
+}
+
+# get list of ntp files
+
+for config_file in $CONFIG_FILES; do
+    # Set maxpoll values to var_time_service_set_maxpoll
+    sed -i "s/^\(\(server\|pool\|peer\).*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \3/" "$config_file"
+done
 
 
-# Set maxpoll values to var_time_service_set_maxpoll
-sed -i "s/^\(\(server\|pool\|peer\).*maxpoll\) [0-9][0-9]*\(.*\)$/\1 $var_time_service_set_maxpoll \3/" "$config_file"
 
-# Add maxpoll to server, pool or peer entries without maxpoll
-grep "^\(server\|pool\|peer\)" "$config_file" | grep -v maxpoll | while read -r line ; do
+
+for config_file in $CONFIG_FILES; do
+    # Add maxpoll to server, pool or peer entries without maxpoll
+    grep "^\(server\|pool\|peer\)" "$config_file" | grep -v maxpoll | while read -r line ; do
         sed -i "s/$line/& maxpoll $var_time_service_set_maxpoll/" "$config_file"
+    done
 done


### PR DESCRIPTION
For chrony ntp servers may be listed in either chrony.conf or
in conf files in the chrony.d directory.
This is correctly handled in the oval, but the ansible
and bash remediation will only handles chrony.conf

To fix, find all chrony conf file and loop over those.

#### Description:

- extend ansible and bash remediation to handle conf files under chrony.d/ 
- on sle systems pidof is /bin/pidof so, we work the logic around that.

#### Rationale:

- chrony allow for servers to be specified in files under ./chrony.d. This is supported in the oval test code, but was not being handled by the remediation

