### PR TITLE
[Stabilization] System commands dir root or system account

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/shared.xml
@@ -2,27 +2,27 @@
   <definition class="compliance" id="file_groupownership_system_commands_dirs" version="1">
     {{{ oval_metadata("
         Checks that system commands in /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin 
-        are owned by root group.
+        are owned by root group or a system account.
       ") }}}
     <criteria >
       <criterion test_ref="test_groupownership_system_commands_dirs" />
     </criteria>
   </definition>
 
-  <unix:file_test  check="all" check_existence="none_exist" comment="system commands are owned by root" id="test_groupownership_system_commands_dirs" version="1">
+  <unix:file_test  check="all" check_existence="none_exist" comment="system commands are owned by root or a system account" id="test_groupownership_system_commands_dirs" version="1">
     <unix:object object_ref="object_groupownership_system_commands_dirs" />
   </unix:file_test>
 
   <unix:file_object comment="system commands files" id="object_groupownership_system_commands_dirs" version="1">
     <!-- Check that system commands within directories /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin 
-         belong to group with gid 0 (root) -->
+         belong to group with gid 0 (root) or gid < 1000 (system account)-->
     <unix:path operation="pattern match">^\/s?bin|^\/usr\/s?bin|^\/usr\/local\/s?bin</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
-   <filter action="include">state_groupowner_system_commands_dirs_not_root</filter>
+   <filter action="include">state_groupowner_system_commands_dirs_not_root_or_system_account</filter>
   </unix:file_object>
 
-  <unix:file_state id="state_groupowner_system_commands_dirs_not_root" version="1">
-    <unix:group_id datatype="int" operation="not equal">0</unix:group_id>
+  <unix:file_state id="state_groupowner_system_commands_dirs_not_root_or_system_account" version="1">
+    <unix:group_id datatype="int" operation="greater than or equal">1000</unix:group_id>
   </unix:file_state>
 
 </def-group>

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: fedora,ol8,rhel8,rhel9,sle12,sle15,ubuntu2004
 
-title: 'Verify that system commands files are group owned by root'
+title: 'Verify that system commands files are group owned by root or a system account'
 
 description: |-
     System commands files are stored in the following directories by default:
@@ -13,9 +13,11 @@ description: |-
     /usr/local/bin
     /usr/local/sbin
     </pre>
-    All files in these directories should be owned by the <tt>root</tt> group.
+    All files in these directories should be owned by the <tt>root</tt> group,
+    or a system account.
     If the directory, or any file in these directories, is found to be owned
-    by a group other than root correct its ownership with the following command:
+    by a group other than root or a a system account correct its ownership
+    with the following command:
     <pre>$ sudo chgrp root <i>FILE</i></pre>
 
 rationale: |-
@@ -63,4 +65,4 @@ fixtext: |-
     $ sudo chgrp root [FILE]
 
 srg_requirement:
-    {{{ full_name }}} system commands must be group-owned by root.
+    {{{ full_name }}} system commands must be group-owned by root or a system account.

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/tests/system_account_groupownership.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# gid of sshd group is 74
+test_group="sshd"
+
+for TESTFILE in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
+do
+   if [[ ! -f $TESTFILE ]]
+   then
+     touch $TESTFILE
+   fi
+   chgrp "$test_group" $TESTFILE
+done


### PR DESCRIPTION
#### Description:

- Update OVAL check to fail if a file with GIDs greater than or equal to 1000 is found.
  - System accounts can group own files in /bin, /sbin, /usr/bin, /usr/sbin, /usr/local/bin and /usr/local/sbin.

#### Rationale:

- Better align with [RHEL-08-010320](https://stigs.mab879.com/products/rhel8/v1r7/RHEL-08-010320/)

- Fixes #9249
- Port of #9258 to stabilization
