### PR TITLE
Introduce rule accounts_passwords_pam_faillock_audit

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/ansible/shared.yml
@@ -1,0 +1,53 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_pam_faillock_enable() }}}
+
+- name: {{{ rule_title }}} - Check the presence of /etc/security/faillock.conf file
+  ansible.builtin.stat:
+    path: /etc/security/faillock.conf
+  register: result_faillock_conf_check
+
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so audit parameter in /etc/security/faillock.conf
+  ansible.builtin.lineinfile:
+    path: /etc/security/faillock.conf
+    regexp: ^\s*audit
+    line: audit
+    state: present
+  when:
+    - result_faillock_conf_check.stat.exists
+
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so audit parameter not in PAM files
+  block:
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
+    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
+  when:
+    - result_faillock_conf_check.stat.exists
+
+- name: {{{ rule_title }}} - Ensure the pam_faillock.so audit parameter in PAM files
+  block:
+    - name: {{{ rule_title }}} - Check if pam_faillock.so audit parameter is already enabled in pam files
+      ansible.builtin.lineinfile:
+        path: /etc/pam.d/system-auth
+        regexp: .*auth.*pam_faillock.so.*preauth.*audit
+        state: absent
+      check_mode: yes
+      changed_when: false
+      register: result_pam_faillock_audit_parameter_is_present
+
+    - name: {{{ rule_title }}} - Ensure the inclusion of pam_faillock.so preauth audit parameter in auth section
+      ansible.builtin.lineinfile:
+        path: "{{ item }}"
+        backrefs: true
+        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)
+        line: \1required\3 audit
+        state: present
+      loop:
+        - /etc/pam.d/system-auth
+        - /etc/pam.d/password-auth
+      when:
+        - result_pam_faillock_audit_parameter_is_present.found == 0
+  when:
+    - not result_faillock_conf_check.stat.exists

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/ansible/shared.yml
@@ -3,51 +3,6 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+
 {{{ ansible_pam_faillock_enable() }}}
-
-- name: {{{ rule_title }}} - Check the presence of /etc/security/faillock.conf file
-  ansible.builtin.stat:
-    path: /etc/security/faillock.conf
-  register: result_faillock_conf_check
-
-- name: {{{ rule_title }}} - Ensure the pam_faillock.so audit parameter in /etc/security/faillock.conf
-  ansible.builtin.lineinfile:
-    path: /etc/security/faillock.conf
-    regexp: ^\s*audit
-    line: audit
-    state: present
-  when:
-    - result_faillock_conf_check.stat.exists
-
-- name: {{{ rule_title }}} - Ensure the pam_faillock.so audit parameter not in PAM files
-  block:
-    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
-    {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/password-auth','auth','','pam_faillock.so',parameter) | indent(4) }}}
-  when:
-    - result_faillock_conf_check.stat.exists
-
-- name: {{{ rule_title }}} - Ensure the pam_faillock.so audit parameter in PAM files
-  block:
-    - name: {{{ rule_title }}} - Check if pam_faillock.so audit parameter is already enabled in pam files
-      ansible.builtin.lineinfile:
-        path: /etc/pam.d/system-auth
-        regexp: .*auth.*pam_faillock.so.*preauth.*audit
-        state: absent
-      check_mode: yes
-      changed_when: false
-      register: result_pam_faillock_audit_parameter_is_present
-
-    - name: {{{ rule_title }}} - Ensure the inclusion of pam_faillock.so preauth audit parameter in auth section
-      ansible.builtin.lineinfile:
-        path: "{{ item }}"
-        backrefs: true
-        regexp: (^\s*auth\s+)([\w\[].*\b)(\s+pam_faillock.so preauth.*)
-        line: \1required\3 audit
-        state: present
-      loop:
-        - /etc/pam.d/system-auth
-        - /etc/pam.d/password-auth
-      when:
-        - result_pam_faillock_audit_parameter_is_present.found == 0
-  when:
-    - not result_faillock_conf_check.stat.exists
+{{{ ansible_pam_faillock_parameter_value("audit", authfail=False)}}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/bash/shared.sh
@@ -1,0 +1,23 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+
+{{{ bash_pam_faillock_enable() }}}
+AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
+FAILLOCK_CONF="/etc/security/faillock.conf"
+if [ -f $FAILLOCK_CONF ]; then
+    regex="^\s*audit"
+    line="audit"
+    if ! grep -q $regex $FAILLOCK_CONF; then
+        echo $line >> $FAILLOCK_CONF
+    fi
+    for pam_file in "${AUTH_FILES[@]}"
+    do
+        {{{ bash_remove_pam_module_option_configuration("$pam_file",'auth','','pam_faillock.so', 'audit' ) | indent(8) }}}
+    done
+else
+    for pam_file in "${AUTH_FILES[@]}"
+    do
+        if ! grep -qE '^\s*auth.*pam_faillock.so preauth.*audit' "$pam_file"; then
+            sed -i --follow-symlinks 's/^\s*auth.*required.*pam_faillock.so.*preauth/ s/$/ audit/' "$pam_file"
+        fi
+    done
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/bash/shared.sh
@@ -1,23 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 {{{ bash_pam_faillock_enable() }}}
-AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
-FAILLOCK_CONF="/etc/security/faillock.conf"
-if [ -f $FAILLOCK_CONF ]; then
-    regex="^\s*audit"
-    line="audit"
-    if ! grep -q $regex $FAILLOCK_CONF; then
-        echo $line >> $FAILLOCK_CONF
-    fi
-    for pam_file in "${AUTH_FILES[@]}"
-    do
-        {{{ bash_remove_pam_module_option_configuration("$pam_file",'auth','','pam_faillock.so', 'audit' ) | indent(8) }}}
-    done
-else
-    for pam_file in "${AUTH_FILES[@]}"
-    do
-        if ! grep -qE '^\s*auth.*pam_faillock.so preauth.*audit' "$pam_file"; then
-            sed -i --follow-symlinks 's/^\s*auth.*required.*pam_faillock.so.*preauth/ s/$/ audit/' "$pam_file"
-        fi
-    done
-fi
+{{{ bash_pam_faillock_parameter_value("audit", authfail=False)}}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/oval/shared.xml
@@ -1,7 +1,7 @@
 <def-group>
     <definition class="compliance" id="{{{ rule_id }}}" version="5">
         {{{
-        oval_metadata("Prevent System Messages When Three Unsuccessful Logon Attempts Occur")
+        oval_metadata("Account Lockouts Must Be Logged")
         }}}
         <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
             possible. But due to backwards compatibility, they are also allowed in pam files

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/oval/shared.xml
@@ -1,0 +1,111 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="5">
+        {{{
+        oval_metadata("Prevent System Messages When Three Unsuccessful Logon Attempts Occur")
+        }}}
+        <!-- pam_faillock.so parameters should be defined in /etc/security/faillock.conf whenever
+            possible. But due to backwards compatibility, they are also allowed in pam files
+            directly. In case they are defined in both places, pam files have precedence and this
+            may confuse the assessment. The following tests ensure only one option is used. Note
+            that if faillock.conf is available, authselect tool only manage parameters on it -->
+        <criteria operator="OR"
+        comment="Check expected value for pam_faillock.so audit parameter">
+            <criteria operator="AND"
+            comment="Check expected pam_faillock.so audit parameter in pam files">
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_system_auth"
+                comment="Check the audit parameter in auth section of system-auth file"/>
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_password_auth"
+                comment="Check the audit parameter in auth section of password-auth file"/>
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_no_faillock_conf"
+                comment="Ensure /etc/security/faillock.conf is not used together with pam files"/>
+            </criteria>
+            <criteria operator="AND"
+            comment="Check expected pam_faillock.so audit parameter in faillock.conf">
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_no_pamd_system"
+                comment="Check the audit parameter is not present system-auth file"/>
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_no_pamd_password"
+                comment="Check the audit parameter is not present password-auth file"/>
+                <criterion
+                test_ref="test_pam_faillock_audit_parameter_faillock_conf"
+                comment="Ensure the audit parameter is present in /etc/security/faillock.conf"/>
+            </criteria>
+        </criteria>
+    </definition>
+
+    <constant_variable id="var_pam_faillock_audit_parameter_regex" version="1" datatype="string"
+    comment="regex to identify audit parameter in pam files">
+        <value>^[\s]*auth[\s]+(?:required|requisite)[\s]+pam_faillock.so[^\n#]preauth[^\n#]*audit</value>
+    </constant_variable>
+
+    <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_system_auth"
+    comment="Get the pam_faillock.so preauth audit parameter from system-auth file" version="1">
+        <ind:filepath >/etc/pam.d/system-auth</ind:filepath>
+        <ind:pattern operation="pattern match"
+        var_ref="var_pam_faillock_audit_parameter_regex" />
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_object id="obj_all_pam_faillock_audit_parameter_password_auth"
+    comment="Get the pam_faillock.so preauth audit parameter from system-auth file" version="1">
+        <ind:filepath >/etc/pam.d/password-auth</ind:filepath>
+        <ind:pattern operation="pattern match"
+        var_ref="var_pam_faillock_audit_parameter_regex" />
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <!-- Check the pam_faillock.so audit parameter in system-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
+    id="test_pam_faillock_audit_parameter_system_auth"
+    comment="Check the presence of audit parameter in system-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_system_auth"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+    id="test_pam_faillock_audit_parameter_no_pamd_system"
+    comment="Check the absence of audit parameter in system-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_system_auth"/>
+    </ind:textfilecontent54_test>
+
+    <!-- Check the pam_faillock.so audit parameter in password-auth -->
+    <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" version="1"
+    id="test_pam_faillock_audit_parameter_password_auth"
+    comment="Check the presence of audit parameter in password-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_password_auth"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+    id="test_pam_faillock_audit_parameter_no_pamd_password"
+    comment="Check the absence of audit parameter in password-auth">
+        <ind:object
+        object_ref="obj_all_pam_faillock_audit_parameter_password_auth"/>
+    </ind:textfilecontent54_test>
+
+    <!-- Check pam_faillock.so audit parameter in /etc/security/faillock.conf -->
+    <ind:textfilecontent54_object version="1"
+    id="object_pam_faillock_audit_parameter_faillock_conf"
+    comment="Check the expected pam_faillock.so audit parameter in /etc/security/faillock.conf">
+        <ind:filepath>/etc/security/faillock.conf</ind:filepath>
+        <ind:pattern operation="pattern match">^\s*audit</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <ind:textfilecontent54_test check="all" check_existence="all_exist" version="1"
+    id="test_pam_faillock_audit_parameter_faillock_conf"
+    comment="Check the expected audit value in in /etc/security/faillock.conf">
+        <ind:object object_ref="object_pam_faillock_audit_parameter_faillock_conf"/>
+    </ind:textfilecontent54_test>
+
+    <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1"
+    id="test_pam_faillock_audit_parameter_no_faillock_conf"
+    comment="Check the absence of audit parameter in /etc/security/faillock.conf">
+        <ind:object object_ref="object_pam_faillock_audit_parameter_faillock_conf"/>
+    </ind:textfilecontent54_test>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Account lockouts must be logged'
+title: 'Account Lockouts Must Be Logged'
 
 description: |-
     PAM faillock locks an account due to excessive password failures, this event must be logged.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
@@ -19,6 +19,7 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
+    stigid@ol8: OL08-00-020021
     stigid@rhel8: RHEL-08-020021
 
 ocil_clause: 'the "audit" option is not set, is missing or commented out'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/common.sh
@@ -1,0 +1,15 @@
+pam_files=("password-auth" "system-auth")
+
+authselect create-profile testingProfile --base-on minimal
+
+CUSTOM_PROFILE_DIR="/etc/authselect/custom/testingProfile"
+
+for file in ${pam_files[@]}; do
+	if grep -q "pam_faillock\.so.*audit" "$CUSTOM_PROFILE_DIR/$file" ; then
+		sed -i --follow-symlinks "/pam_faillock\.so.*audit/d" "$CUSTOM_PROFILE_DIR/$file"
+	fi
+done
+
+authselect select --force custom/testingProfile
+
+truncate -s 0 /etc/security/pam_faillock.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/conflicting_settings_authselect.fail.sh
@@ -1,0 +1,19 @@
+
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+source common.sh
+
+echo "audit" > /etc/security/pam_faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+
+for file in ${pam_files[@]}; do
+    if grep -q "pam_faillock\.so.*audit" "$CUSTOM_PROFILE_DIR/$file" ; then
+        echo "auth required pam_faillock.so preauth audit" >> \
+        "$CUSTOM_PROFILE_DIR/$file"
+    fi
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/expected_faillock_conf.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/expected_faillock_conf.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+# platform = Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+
+source common.sh
+
+echo "audit" >> /etc/security/faillock.conf
+
+{{{ bash_pam_faillock_enable() }}}
+

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/expected_pam_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/expected_pam_files.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh
+
+for file in ${pam_files[@]}; do
+    echo "auth required pam_faillock.so preauth  audit" >> "$CUSTOM_PROFILE_DIR/$file"
+done
+
+authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/missing_parameter.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/tests/missing_parameter.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# packages = authselect,pam
+
+source common.sh

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -504,9 +504,8 @@ selections:
 
     # OL08-00-020019
 
-    # OL08-00-020020
-
-    # OL08-00-020021
+    # OL08-00-020020, OL08-00-020021
+    - account_passwords_pam_faillock_audit
 
     # OL08-00-020022, OL08-00-020023
     - accounts_passwords_pam_faillock_deny_root

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -864,8 +864,10 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 
   :param parameter:         The pam_faillock.so parameter name.
   :param faillock_var_name: If the parameter expects a value from a variable, the variable name is informed here.
+  :param authfail: check the pam_faillock.so conf line with authfail
+
 #}}
-{{%- macro ansible_pam_faillock_parameter_value(parameter, faillock_var_name='') -%}}
+{{%- macro ansible_pam_faillock_parameter_value(parameter, faillock_var_name='', authfail=True) -%}}
 
 {{%- if faillock_var_name != '' %}}
 {{{ ansible_instantiate_variables( faillock_var_name ) }}}
@@ -926,6 +928,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found == 0
 
+    {{%- if authfail %}}
     - name: {{{ rule_title }}} - Ensure the inclusion of pam_faillock.so authfail {{{ parameter }}} parameter in auth section
       ansible.builtin.lineinfile:
         path: "{{ item }}"
@@ -942,6 +945,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         - /etc/pam.d/password-auth
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found == 0
+    {{%- endif %}}
 
     {{%- if faillock_var_name != '' %}}
     - name: {{{ rule_title }}} - Ensure the desired value for pam_faillock.so preauth {{{ parameter }}} parameter in auth section
@@ -957,6 +961,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found > 0
 
+    {{%- if authfail %}}
     - name: {{{ rule_title }}} - Ensure the desired value for pam_faillock.so authfail {{{ parameter }}} parameter in auth section
       ansible.builtin.lineinfile:
         path: "{{ item }}"
@@ -969,6 +974,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         - /etc/pam.d/password-auth
       when:
         - result_pam_faillock_{{{ parameter }}}_parameter_is_present.found > 0
+    {{%- endif %}}
     {{%- endif %}}
   when:
     - not result_faillock_conf_check.stat.exists

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1021,9 +1021,10 @@ fi
 
 :param option: faillock option eg. deny, unlock_time, fail_interval
 :param value: value of option
+:param authfail: check the pam_faillock.so conf line with authfail 
 
 #}}
-{{%- macro bash_pam_faillock_parameter_value(option, value='') -%}}
+{{%- macro bash_pam_faillock_parameter_value(option, value='', authfail=True) -%}}
 AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
 FAILLOCK_CONF="/etc/security/faillock.conf"
 if [ -f $FAILLOCK_CONF ]; then
@@ -1053,17 +1054,23 @@ else
         if ! grep -qE '^\s*auth.*pam_faillock.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
             {{%- if value == '' %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}/' "$pam_file"
+            {{%- if authfail %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}/' "$pam_file"
+            {{%- endif %}}
             {{%- else %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            {{%- if authfail %}}
             sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            {{%- endif %}}
             {{%- endif %}}
         {{%- if value == '' %}}
         fi
         {{%- else %}}
         else
             sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            {{%- if authfail %}}
             sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            {{%- endif %}}
         fi
         {{%- endif %}}
     done


### PR DESCRIPTION
#### Description:

- Introduce rule `accounts_passwords_pam_faillock_audit`
- Added OVAL, Bash, Ansible and tests  to rule 

#### Rationale:

- This covers DISA STIG Ids `OL08-00-020020` & `OL08-00-020021`
