### PR TITLE
OCP: Fix rule kubelet_configure_event_creation

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_event_creation/kubernetes/shared.yml
+++ b/applications/openshift/kubelet/kubelet_configure_event_creation/kubernetes/shared.yml
@@ -1,3 +1,3 @@
 ---
 # platform = multi_platform_ocp
-{{{ kubelet_config_fixed(path='kubeletConfig',parameter='eventRecordQPS', value='10') }}}
+{{{ kubelet_config_fixed(path='kubeletConfig',parameter='eventRecordQPS', value='{{.var_event_record_qps}}') }}}


### PR DESCRIPTION
Fix remediation for rule `kubelet_configure_event_creation`, to use var `var_event_record_qps` in the remediation instead of a fixed value. 

Related BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2082416
