### PR TITLE
Double quote sysctl values in test scenarios

### DIFF
--- a/shared/templates/sysctl/tests/symlink_different_option.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_different_option.pass.sh
@@ -19,4 +19,4 @@ echo "net.ipv4.conf.default.accept_source_route = 0" >> /etc/sysctl.d/90-test.co
 # Add a symlink
 ln -s /etc/sysctl.d/90-test.conf /etc/sysctl.d/99-sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/symlink_repeated_sysctl_conf.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_repeated_sysctl_conf.pass.sh
@@ -11,4 +11,4 @@ echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf
 
 ln -s /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/symlink_root_duplicate.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_duplicate.fail.sh
@@ -15,4 +15,4 @@ echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /root/root-sysctl.con
 # Add a symlink
 ln -s /root/root-sysctl.conf /etc/sysctl.d/90-root.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
@@ -15,4 +15,4 @@ echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /root/root-sysctl.conf
 # Add a symlink
 ln -s /root/root-sysctl.conf /etc/sysctl.d/90-root.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/symlink_same_option.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_same_option.fail.sh
@@ -15,4 +15,4 @@ echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/90-test
 # and add a symlink
 ln -s /etc/sysctl.d/90-test.conf /etc/sysctl.d/99-sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/symlinks_to_same_file.pass.sh
+++ b/shared/templates/sysctl/tests/symlinks_to_same_file.pass.sh
@@ -13,5 +13,5 @@ echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf
 ln -s /etc/sysctl.conf /etc/sysctl.d/90-sysctl.conf
 ln -s /etc/sysctl.conf /etc/sysctl.d/99-sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_d.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_d.fail.sh
@@ -11,4 +11,4 @@ sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/first.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/duplicate.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file.pass.sh
@@ -11,4 +11,4 @@ sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file_name.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file_name.fail.sh
@@ -11,4 +11,4 @@ sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.d/sysctl.conf
 
-sysctl -w {{{ SYSCTLVAR }}}={{{ SYSCTL_CORRECT_VALUE }}}
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"


### PR DESCRIPTION
Some rules, for example sysctl_kernel_core_pattern, contain
a pipe in the value, for example `sysctlval: '|/bin/false'`.
If the value isn't double quoted, it causes the test
scenario to crash, because the pipe is interpreted as a pipe.

Addressing:
```
[jcerny@thinkpad scap-security-guide{master}]$ python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 sysctl_kernel_core_pattern
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/jcerny/work/git/scap-security-guide/logs/rule-custom-2022-07-29-1003/test_suite.log
INFO - xccdf_org.ssgproject.content_rule_sysctl_kernel_core_pattern
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'symlink_repeated_sysctl_conf.pass.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
INFO - Script line_not_there.fail.sh using profile (all) OK
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'symlink_same_option.fail.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'symlinks_to_same_file.pass.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'two_sysctls_on_same_file.pass.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'symlink_root_incompliant.fail.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'two_sysctls_on_d.fail.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'two_sysctls_on_same_file_name.fail.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
INFO - Script wrong_value.fail.sh using profile (all) OK
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'symlink_root_duplicate.fail.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
ERROR - Rule 'sysctl_kernel_core_pattern' test setup script 'symlink_different_option.pass.sh' failed with exit code 1
ERROR - Environment failed to prepare, skipping test
INFO - Script wrong_value_d_directory.fail.sh using profile (all) OK
INFO - Script one_sysctl_conf_one_sysctl_d.fail.sh using profile (all) OK
INFO - Script comment.fail.sh using profile (all) OK
INFO - Script correct_value.pass.sh using profile (all) OK
INFO - Script wrong_runtime.fail.sh using profile (all) OK
```

This has been discovered during a review of:
https://github.com/ComplianceAsCode/content/pull/9147

This is similar to: https://github.com/ComplianceAsCode/content/pull/4875
