### PR TITLE
Never add OCIL for security_patches_up_to_date

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1640,8 +1640,8 @@ class Rule(XCCDFEntity):
             check_content_ref.set("href", "oval-unlinked.xml")
             check_content_ref.set("name", self.id_)
 
-        oval_content_only = self.oval_external_content is not None
-        if (self.ocil or self.ocil_clause) and not oval_content_only:
+        patches_up_to_date = (self.id_ == "security_patches_up_to_date")
+        if (self.ocil or self.ocil_clause) and not patches_up_to_date:
             ocil_check = ET.SubElement(check_parent, "check")
             ocil_check.set("system", ocil_cs)
             ocil_check_ref = ET.SubElement(ocil_check, "check-content-ref")


### PR DESCRIPTION


#### Description:

- Prevent security_patches_up_to_date from having an OCIL clause, regardless of whether the rule has an external OVAL content or not.

#### Rationale:

- Follow up from https://github.com/ComplianceAsCode/content/pull/9027
- The products that did not define an `oval_feed` ended up with a `security_patches_up_to_date` with an OCIL check. 
- Fixes SCAPVAL validations for fedora, rhv4, uos20, eks, alinux2, alinux3.