### PR TITLE
Install ansible for the extra modules

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
       image: fedora:latest
     steps:
       - name: Install Deps
-        run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible-lint expat libxslt
+        run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible ansible-lint expat libxslt
       - name: Checkout
         uses: actions/checkout@v2
       - name: Configure


### PR DESCRIPTION

#### Description:

- Add ansbible dependency so that modules ini_file and sysctl are recognized.

#### Rationale:

- Fixes Ansible modules not being recognized during `ansible-playbook-syntax-check`
