### PR TITLE
Fix broken XCCDF values

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -527,6 +527,12 @@ macro(ssg_build_sds PRODUCT)
         )
     endif()
 
+    add_test(
+        NAME "xccdf-values-${PRODUCT}"
+        COMMAND "${CMAKE_SOURCE_DIR}/tests/test_xccdf_values_in_ds.sh" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+    )
+    set_tests_properties("xccdf-values-${PRODUCT}" PROPERTIES LABELS "quick")
+
     if("${PRODUCT}" MATCHES "rhel(7|8|9)|sle(12|15)")
         if("${PRODUCT}" MATCHES "sle(12|15)")
             add_test(

--- a/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_l1tf_argument/rule.yml
@@ -8,9 +8,9 @@ description: |-
     the page table entry isn't present.
 
     Select the appropriate mitigation by adding the argument
-    <tt>l1tf={{{ xccdf_value(var_l1tf_options) }}}</tt> to the default
+    <tt>l1tf={{{ xccdf_value("var_l1tf_options") }}}</tt> to the default
     GRUB 2 command line for the Linux operating system.
-    {{{ describe_grub2_argument("l1tf=xccdf_value(var_l1tf_options)") | indent(4) }}}
+    {{{ describe_grub2_argument("l1tf=" + xccdf_value("var_l1tf_options")) | indent(4) }}}
 
     Since Linux Kernel 4.19 you can check the L1TF vulnerability state with the
     following command:
@@ -33,7 +33,7 @@ identifiers:
 ocil_clause: 'l1tf mitigations are not configured appropriately'
 
 ocil: |-
-    {{{ ocil_grub2_argument("l1tf=xccdf_value(var_l1tf_options)") | indent(4) }}}
+    {{{ ocil_grub2_argument("l1tf=" + xccdf_value("var_l1tf_options")) | indent(4) }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_mds_argument/rule.yml
@@ -17,9 +17,9 @@ description: |-
     via a cache side channel attack.
 
     Select the appropriate mitigation by adding the argument
-    <tt>mds={{{ xccdf_value(var_mds_options) }}}</tt> to the default
+    <tt>mds={{{ xccdf_value("var_mds_options") }}}</tt> to the default
     GRUB 2 command line for the Linux operating system.
-    {{{ describe_grub2_argument("mds=xccdf_value(var_mds_options)") | indent(4) }}}
+    {{{ describe_grub2_argument("mds=" + xccdf_value("var_mds_options")) | indent(4) }}}
 
     Not all processors are affected by all variants of MDS, but the mitigation mechanism is
     identical for all of them.
@@ -45,7 +45,7 @@ identifiers:
 ocil_clause: 'MDS mitigations are not configured appropriately'
 
 ocil: |-
-    {{{ ocil_grub2_argument("mds=xccdf_value(var_mds_options)") | indent(4) }}}
+    {{{ ocil_grub2_argument("mds=" + xccdf_value(var_mds_options)) | indent(4) }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_rng_core_default_quality_argument/rule.yml
@@ -17,9 +17,9 @@ description: |-
     on all hardware random number generators.
 
     Select the appropriate confidence by adding the argument
-    <tt>rng_core.default_quality={{{ xccdf_value(var_rng_core_default_quality_options) }}}</tt> to the default
+    <tt>rng_core.default_quality={{{ xccdf_value("var_rng_core_default_quality") }}}</tt> to the default
     GRUB 2 command line for the Linux operating system.
-    {{{ describe_grub2_argument("rng_core.default_quality=xccdf_value(var_rng_core_default_quality)") | indent(4) }}}
+    {{{ describe_grub2_argument("rng_core.default_quality=" + xccdf_value("var_rng_core_default_quality")) | indent(4) }}}
 
 rationale: |-
     A system may struggle to initialize its entropy pool and end up starving. Crediting entropy
@@ -34,7 +34,7 @@ identifiers:
 ocil_clause: 'trust on hardware random number generator is not configured appropriately'
 
 ocil: |-
-    {{{ ocil_grub2_argument("rng_core.default_quality=xccdf_value(var_rng_core_default_quality)") | indent(4) }}}
+    {{{ ocil_grub2_argument("rng_core.default_quality=" + xccdf_value("var_rng_core_default_quality")) | indent(4) }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_spec_store_bypass_disable_argument/rule.yml
@@ -15,9 +15,9 @@ description: |-
     <tt>cat /sys/devices/system/cpu/vulnerabilities/spec_store_bypass</tt>
 
     Select the appropriate SSB state by adding the argument
-    <tt>spec_store_bypass_disable={{{ xccdf_value(var_spec_store_bypass_disable_options) }}}</tt> to the default
+    <tt>spec_store_bypass_disable={{{ xccdf_value("var_spec_store_bypass_disable_options") }}}</tt> to the default
     GRUB 2 command line for the Linux operating system.
-    {{{ describe_grub2_argument("spec_store_bypass_disable=xccdf_value(var_spec_store_bypass_disable_options)") | indent(4) }}}
+    {{{ describe_grub2_argument("spec_store_bypass_disable=" + xccdf_value("var_spec_store_bypass_disable_options")) | indent(4) }}}
 
 rationale: |-
     In vulnerable processsors, the speculatively forwarded store can be used in a cache side channel
@@ -36,7 +36,7 @@ identifiers:
 ocil_clause: 'SSB is not configured appropriately'
 
 ocil: |-
-    {{{ ocil_grub2_argument("spec_store_bypass_disable=xccdf_value(var_spec_store_bypass_disable_options)") | indent(4) }}}
+    {{{ ocil_grub2_argument("spec_store_bypass_disable=" + xccdf_value("var_spec_store_bypass_disable_options")) | indent(4) }}}
 
 platform: machine
 

--- a/products/chromium/guide/chromium/chromium_default_search_provider_name/rule.yml
+++ b/products/chromium/guide/chromium/chromium_default_search_provider_name/rule.yml
@@ -2,7 +2,8 @@ documentation_complete: true
 
 title: 'Set the Default Search Provider''s URL'
 
-description: "Specifies the URL of the default search provider that is to be used. To set the \nURL of the default search provider, set <tt>DefaultSearchProviderName</tt> to \n<tt><sub idref=\"var_default_search_provider\" /></tt> in the Chromium policy file."
+description: |-
+    Specifies the URL of the default search provider that is to be used. To set the URL of the default search provider, set <tt>DefaultSearchProviderName</tt> to <tt>{{{ xccdf_value("var_default_search_provider_name") }}}</tt> in the Chromium policy file.
 
 rationale: |-
     When doing internet searches, it is important to set an organizationally approved search
@@ -19,4 +20,4 @@ ocil: |-
     To verify that a default search provider is set, run the following command:
     <pre>$ grep DefaultSearchProviderName /etc/chromium/policies/managed/*.json</pre>
     The output should contain:
-    <pre>"DefaultSearchProviderName": "<sub idref="var_default_search_provider" />",</pre>
+    <pre>"DefaultSearchProviderName": "{{{ xccdf_value("var_default_search_provider_name") }}}",</pre>

--- a/products/chromium/guide/chromium/chromium_http_authentication/rule.yml
+++ b/products/chromium/guide/chromium/chromium_http_authentication/rule.yml
@@ -2,7 +2,8 @@ documentation_complete: true
 
 title: 'Set Chromium''s HTTP Authentication Scheme'
 
-description: "To set the default Chromium's HTTP Authentication Scheme, set \n<tt>AuthSchemes</tt> to <tt><sub idref=\"var_auth_schemes\" /></tt> in the \nChromium policy file."
+description: |-
+    To set the default Chromium's HTTP Authentication Scheme, set <tt>AuthSchemes</tt> to <tt>{{{ xccdf_value("var_auth_schema") }}}</tt> in the Chromium policy file.
 
 rationale: 'Specifies which HTTP Authentication schemes are supported by Google Chromium.'
 
@@ -17,4 +18,4 @@ ocil: |-
     To verify that the HTTP Authentication Scheme is set, run the following command:
     <pre>$ grep AuthSchemes /etc/chromium/policies/managed/*.json</pre>
     The output should contain:
-    <pre>"AuthSchemes": "<sub idref="var_auth_schemes" />",</pre>
+    <pre>"AuthSchemes": "{{{ xccdf_value("var_auth_schema") }}}",</pre>

--- a/tests/test_xccdf_values_in_ds.sh
+++ b/tests/test_xccdf_values_in_ds.sh
@@ -2,10 +2,10 @@
 
 DS="$1"
 if grep -iq "dangling reference to" "$DS" ; then
-    printf "Found dangling reference in $DS, ensure correct usage of the xccdf_value Jinja macro!" >&2
+    printf "Found dangling reference in %s, ensure correct usage of the xccdf_value Jinja macro!" "$DS" >&2
     exit 1
 fi
 if grep -iq "xccdf_value" "$DS" ; then
-    printf "Found obtrusive xccdf_value in $DS, ensure correct usage of the xccdf_value Jinja macro!" >&2
+    printf "Found obtrusive xccdf_value in %s, ensure correct usage of the xccdf_value Jinja macro!" "$DS" >&2
     exit 1
 fi

--- a/tests/test_xccdf_values_in_ds.sh
+++ b/tests/test_xccdf_values_in_ds.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DS="$1"
+if grep -iq "dangling reference to" "$DS" ; then
+    printf "Found dangling reference in $DS, ensure correct usage of the xccdf_value Jinja macro!" >&2
+    exit 1
+fi
+if grep -iq "xccdf_value" "$DS" ; then
+    printf "Found obtrusive xccdf_value in $DS, ensure correct usage of the xccdf_value Jinja macro!" >&2
+    exit 1
+fi


### PR DESCRIPTION
#### Description:
Fix usage of quotes and add a test for ctest.

#### Rationale:

Bad usage of quotes causes that the built data stream contains the following words that shouldn't be there:
- dangling reference to
- xccdf_value
