### PR TITLE
Add OVAL to fapolicy_default_deny

### DIFF
--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/oval/shared.xml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/oval/shared.xml
@@ -1,0 +1,39 @@
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+        {{{
+        oval_metadata("Configure Fapolicy Module to Employ a Deny-all, Permit-by-exception Policy")
+        }}}
+        <criteria>
+        <criterion comment="fapolicyd employs a deny-all policy"
+        test_ref="test_fapolicy_default_deny_policy" />
+        <criterion comment="fapolicyd is in enforcement mode"
+        test_ref="test_fapolicy_default_deny_enforcement" />
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_test check_existence="only_one_exists" check="all"
+    comment="fapolicyd employs a deny-all policy"
+    id="test_fapolicy_default_deny_policy" version="1">
+        <ind:object object_ref="obj_fapolicy_default_deny_policy" />
+    </ind:textfilecontent54_test>
+    <ind:textfilecontent54_object id="obj_fapolicy_default_deny_policy" version="1">
+        <ind:behaviors multiline="false" />
+        <ind:filepath>/etc/fapolicyd/fapolicyd.rules</ind:filepath>
+        <ind:pattern operation="pattern match">(^|\n)\s*deny\s*perm=any\s*all\s*:\s*all\s*$</ind:pattern>
+        <ind:instance datatype="int">1</ind:instance>
+    </ind:textfilecontent54_object>
+    <ind:textfilecontent54_test check_existence="all_exist" check="all"
+    comment="fapolicyd is in enforcement mode"
+    id="test_fapolicy_default_deny_enforcement" version="1">
+        <ind:object object_ref="obj_fapolicy_default_deny_enforcement" />
+        <ind:state state_ref="state_fapolicy_default_deny_enforcement" />
+    </ind:textfilecontent54_test>
+    <ind:textfilecontent54_object id="obj_fapolicy_default_deny_enforcement" version="1">
+        <ind:filepath>/etc/fapolicyd/fapolicyd.conf</ind:filepath>
+        <ind:pattern operation="pattern match">^\s*permissive\s*=\s*(\d+)</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+    <ind:textfilecontent54_state id="state_fapolicy_default_deny_enforcement" version="1" comment="root email alias">
+    <ind:subexpression operation="equals" datatype="int">0</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/rule.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,ol9,rhel8,rhel9
 
 title: 'Configure Fapolicy Module to Employ a Deny-all, Permit-by-exception Policy to Allow the Execution of Authorized Software Programs.'
 
@@ -25,6 +25,7 @@ references:
   disa:  CCI-001764
   nist: CM-7 (2),CM-7 (5) (b),CM-6 b
   srg: SRG-OS-000368-GPOS-00154,SRG-OS-000370-GPOS-00155,SRG-OS-000480-GPOS-00232
+  stigid@ol8: OL08-00-040137
   stigid@rhel8: RHEL-08-040137
 
 ocil_clause: 'fapolicyd is not running in enforcement mode with a deny-all, permit-by-exception policy'

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/commented_value.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/commented_value.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = fapolicyd
+# remediation = none
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","1") }}}
+
+truncate -s 0 /etc/fapolicyd/fapolicyd.rules
+
+echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" > /etc/fapolicyd/fapolicyd.rules
+echo "# deny perm=any all : all" > /etc/fapolicyd/fapolicyd.rules
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","0") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/correct_value.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = fapolicyd
+# remediation = none
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","1") }}}
+
+truncate -s 0 /etc/fapolicyd/fapolicyd.rules
+
+echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" > /etc/fapolicyd/fapolicyd.rules
+echo "deny perm=any all : all" > /etc/fapolicyd/fapolicyd.rules
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","0") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_not_last.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/deny_not_last.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = fapolicyd
+# remediation = none
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","1") }}}
+
+truncate -s 0 /etc/fapolicyd/fapolicyd.rules
+
+echo "deny perm=any all : all" >> /etc/fapolicyd/fapolicyd.rules
+echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" > /etc/fapolicyd/fapolicyd.rules
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","0") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/fapolicy_permissive.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/fapolicy_permissive.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = fapolicyd
+# remediation = none
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","0") }}}

--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/tests/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = fapolicyd
+# remediation = none
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","1") }}}
+
+truncate -s 0 /etc/fapolicyd/fapolicyd.rules
+
+echo "allow exe=/usr/bin/python3.7 : ftype=text/x-python" > /etc/fapolicyd/fapolicyd.rules
+
+{{{ bash_shell_file_set("/etc/fapolicyd/fapolicyd.conf","permissive","0") }}}

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -1069,6 +1069,7 @@ selections:
     - service_fapolicyd_enabled
 
     # OL08-00-040137
+    - fapolicy_default_deny
 
     # OL08-00-040139
     - package_usbguard_installed


### PR DESCRIPTION
#### Description:

- Add the rule `fapolicy_default_deny` to OL8 STIG profile
- Add OVAL and tests to this rule

#### Rationale:

- This rule covers DISA STIG ID `OL08-00-040137`
- OVAL and tests add automation capability of this rule
