### PR TITLE
Add OVAL, bash and tests to account_password_selinux_faillock_dir

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+FAILLOCK_DIR=$(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" \
+                    /etc/security/faillock.conf \
+                    /etc/pam.d/system-auth \
+                    /etc/pam.d/password-auth \
+                    | sed -r 's/.*=\s*(\S+)/\1/')
+
+mkdir -p $FAILLOCK_DIR
+
+semanage fcontext -a -t faillog_t "$FAILLOCK_DIR(/.*)?"
+
+restorecon -R -v "$FAILLOCK_DIR"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -1,0 +1,38 @@
+{{% set faillock_files = ["/etc/pam.d/password-auth",
+                          "/etc/pam.d/system-auth",
+                          "/etc/security/faillock.conf"] %}}
+<def-group>
+    <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("An SELinux Context must be configued for the Faillock directory.") }}}
+        <criteria operator="AND">
+            <criterion comment="the faillock directory should have faillog_t as context"
+            test_ref="test_selinux_faillock_dir" />
+        </criteria>
+    </definition>
+
+    <ind:textfilecontent54_object id="obj_faillock_dir_collector" version="1">
+        <ind:filepath operation="pattern match">{{{ faillock_files | join("|")}}}</ind:filepath>
+        <ind:pattern operation="pattern match">^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)</ind:pattern>
+        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    </ind:textfilecontent54_object>
+
+    <local_variable id="var_faillock_dir_collector" datatype="string" version="1" comment="File hash for etcd CA">
+      <object_component item_field="subexpression" object_ref="obj_faillock_dir_collector" />
+    </local_variable>
+
+    <linux:selinuxsecuritycontext_test check="all" check_existence="all_exist" comment="device_t in /dev"
+    id="test_selinux_faillock_dir" version="1">
+        <linux:object object_ref="obj_selinux_faillock_dir" />
+        <linux:state state_ref="state_selinux_faillock_dir" />
+    </linux:selinuxsecuritycontext_test>
+    
+    <linux:selinuxsecuritycontext_object comment="device_t in /dev" 
+    id="obj_selinux_faillock_dir" version="1">
+        <linux:path operation="equals" var_ref="var_faillock_dir_collector"  var_check="all"/>
+        <linux:filename xsi:nil="true" />
+    </linux:selinuxsecuritycontext_object>
+    <linux:selinuxsecuritycontext_state comment="device_t label" id="state_selinux_faillock_dir" version="1">
+        <linux:type datatype="string" operation="equals">faillog_t</linux:type>
+    </linux:selinuxsecuritycontext_state>
+
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: ol8,ol9,rhel8,rhel9
 
 title: 'An SELinux Context must be configued for the Faillock directory'
 
@@ -21,6 +21,7 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
+    stigid@ol8: OL08-00-020027
     stigid@rhel8: RHEL-08-020027
 
 platform: machine

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = policycoreutils-python-utils
+# platform = multi_platform_all
+
+truncate -s 0 /etc/security/faillock.conf
+echo "dir=/var/log/faillock" >  /etc/security/faillock.conf
+
+mkdir /var/log/faillock
+
+semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
+
+restorecon -R -v "/var/log/faillock"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/missing_dir.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/missing_dir.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = policycoreutils-python-utils
+# platform = multi_platform_all
+
+truncate -s 0 /etc/security/faillock.conf
+echo "dir=/var/log/faillock" >  /etc/security/faillock.conf
+
+rm -rf /var/log/faillock

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = policycoreutils-python-utils
+# platform = multi_platform_all
+
+truncate -s 0 /etc/security/faillock.conf
+echo "dir=/var/log/faillock" >  /etc/security/faillock.conf
+
+mkdir /var/log/faillock
+
+semanage fcontext -a -t dummy_t "/var/log/faillock(/.*)?"
+
+restorecon -R -v "/var/log/faillock"
+
+

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -514,9 +514,8 @@ selections:
     # OL08-00-020024
     - accounts_max_concurrent_login_sessions
 
-    # OL08-00-020027
-
-    # OL08-00-020028
+    # OL08-00-020027, OL08-00-020028
+    - account_password_selinux_faillock_dir
 
     # OL08-00-020030, OL08-00-020082
     - dconf_gnome_screensaver_lock_enabled


### PR DESCRIPTION
#### Description:

- Add `account_password_selinux_faillock_dir` to OL8 STIG profile
- Add bash, OVAL and tests to `account_password_selinux_faillock_dir`

#### Rationale:

- This rule covers DISA STIG IDs `OL08-00-020027` & `OL08-00-020028`
