### PR TITLE
Support commas in variables

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/correct_variable.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/tests/correct_variable.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# variables = sshd_approved_ciphers=ijkl158,sits,wwq-98,kl24
+
+if grep -q "^Ciphers" /etc/ssh/sshd_config; then
+	sed -i "s/^Ciphers.*/Ciphers ijkl158,sits,wwq-98,kl24/" /etc/ssh/sshd_config
+else
+	echo 'Ciphers ijkl158,sits,wwq-98,kl24' >> /etc/ssh/sshd_config
+fi

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -583,8 +583,18 @@ class Scenario():
                 self.contents, re.MULTILINE)
             if found is None:
                 continue
-            splitted = found.group(1).split(',')
-            params[parameter] = [value.strip() for value in splitted]
+            if parameter == "variables":
+                variables = []
+                for token in found.group(1).split(','):
+                    token = token.strip()
+                    if '=' in token:
+                        variables.append(token)
+                    else:
+                        variables[-1] += "," + token
+                params["variables"] = variables
+            else:
+                splitted = found.group(1).split(',')
+                params[parameter] = [value.strip() for value in splitted]
 
         if not params["profiles"]:
             params["profiles"].append(OSCAP_PROFILE_ALL_ID)


### PR DESCRIPTION
This adds support for commas in variable values in the test
scenarios metadata in the `variables` key. For example:
`# variables = sshd_approved_ciphers=ijkl158,sits,wwq-98,kl24`

Fixes: #7553
