### PR TITLE
Add rsyslogd to the list of tools checked by aide

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/ansible/shared.yml
@@ -22,6 +22,7 @@
       - /usr/sbin/aureport
       - /usr/sbin/ausearch
       - /usr/sbin/autrace
+      {{% if product == 'ol8' or 'rhel' in product %}}- /usr/sbin/rsyslogd{{% endif %}}
 
 - name: Ensure existing AIDE configuration for audit tools are correct
   lineinfile:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/bash/shared.sh
@@ -18,12 +18,11 @@
 {{% set auditfiles = auditfiles + ["/usr/sbin/audispd"] %}}
 {{% endif %}}
 
-{{% if product == 'ol8' %}}
+{{% if product == 'ol8' or 'rhel' in product %}}
 {{% set auditfiles = auditfiles + ["/usr/sbin/rsyslogd"] %}}
 {{% endif %}}
 
 {{% for file in auditfiles %}}
-
 if grep -i '^.*{{{file}}}.*$' {{{ aide_conf_path }}}; then
 sed -i "s#.*{{{file}}}.*#{{{file}}} {{{ aide_string() }}}#" {{{ aide_conf_path }}}
 else

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -11,7 +11,7 @@
       {{% if 'rhel' not in product and product != 'ol8' %}}
       <criterion comment="audispd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_audispd" />
       {{% endif %}}
-      {{% if product == 'ol8' %}}
+      {{% if product == 'ol8' or 'rhel' in product %}}
       <criterion comment="rsyslogd is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_rsyslogd" />
       {{% endif %}}
       <criterion comment="augenrules is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_augenrules" />

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
@@ -7,7 +7,7 @@ aide --init
 
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
 
 for theFile in "${bins[@]}"
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
@@ -4,7 +4,7 @@
 yum -y install aide
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
 
 for theFile in "${bins[@]}"
 do

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
@@ -6,7 +6,7 @@ yum -y install aide
 aide --init
 
 declare -a bins
-bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace')
+bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
 
 for theFile in "${bins[@]}"
 do


### PR DESCRIPTION


#### Description:

- Add rsyslogd to the list of tools check by aide in rule `aide_check_audit_tools`

#### Rationale:

- RHEL products should also check for integrity of /usr/sbin/rsyslogd.
- Better align RHEL-8 with STIG V1R7.
