### PR TITLE
Accept sudoers files without includes as compliant

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/oval/shared.xml
@@ -8,8 +8,8 @@
       </criteria>
       <criteria operator="AND">
         <criterion comment="Check /etc/sudoers for #includedir" test_ref="test_sudoers_default_includedir" />
-        <criterion comment="Check /etc/sudoers for #include" test_ref="test_sudoers_without_include" />
-        <criterion comment="Check /etc/sudoers.d for includes" test_ref="test_sudoersd_without_includes" />
+        <criterion comment="Check /etc/sudoers doesn't have any #include" test_ref="test_sudoers_without_include" />
+        <criterion comment="Check /etc/sudoers.d doesn't have any #include or #includedir" test_ref="test_sudoersd_without_includes" />
       </criteria>
     </criteria>
   </definition>

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/oval/shared.xml
@@ -1,10 +1,16 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Check if sudo includes only the default includedir") }}}
-    <criteria operator="AND">
-      <criterion comment="Check /etc/sudoers for #includedir" test_ref="test_sudoers_default_includedir" />
-      <criterion comment="Check /etc/sudoers for #include" test_ref="test_sudoers_without_include" />
-      <criterion comment="Check /etc/sudoers.d for includes" test_ref="test_sudoersd_without_includes" />
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <criterion comment="Check /etc/sudoers doesn't have any #include" test_ref="test_sudoers_without_include" />
+        <criterion comment="Check /etc/sudoers doesn't have any #includedir" test_ref="test_sudoers_without_includedir" />
+      </criteria>
+      <criteria operator="AND">
+        <criterion comment="Check /etc/sudoers for #includedir" test_ref="test_sudoers_default_includedir" />
+        <criterion comment="Check /etc/sudoers for #include" test_ref="test_sudoers_without_include" />
+        <criterion comment="Check /etc/sudoers.d for includes" test_ref="test_sudoersd_without_includes" />
+      </criteria>
     </criteria>
   </definition>
 
@@ -29,6 +35,16 @@
   <ind:textfilecontent54_object id="object_sudoers_without_include" version="1">
     <ind:filepath>/etc/sudoers</ind:filepath>
     <ind:pattern operation="pattern match">^#include[\s]+.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+      comment="audit augenrules rmmod" id="test_sudoers_without_includedir" version="1">
+    <ind:object object_ref="object_sudoers_without_includedir" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_sudoers_without_includedir" version="1">
+    <ind:filepath>/etc/sudoers</ind:filepath>
+    <ind:pattern operation="pattern match">^#includedir[\s]+.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
@@ -8,9 +8,11 @@ description: |-
     Administrators can configure authorized <tt>sudo</tt> users via drop-in files, and it is possible to include
     other directories and configuration files from the file currently being parsed.
   
-    Make sure that <tt>/etc/sudoers</tt> only includes drop-in configuration files from <tt>/etc/sudoers.d</tt>.
-    The <tt>/etc/sudoers</tt> should contain only one <tt>#includedir</tt> directive pointing to
-    <tt>/etc/sudoers.d</tt>, and no file in <tt>/etc/sudoers.d/</tt> should include other files or directories.
+    Make sure that <tt>/etc/sudoers</tt> only includes drop-in configuration files from <tt>/etc/sudoers.d</tt>,
+    or that no drop-in file is included.
+    Either the <tt>/etc/sudoers</tt> should contain only one <tt>#includedir</tt> directive pointing to
+    <tt>/etc/sudoers.d</tt>, and no file in <tt>/etc/sudoers.d/</tt> should include other files or directories;
+    Or the <tt>/etc/sudoers</tt> should not contain any <tt>#include</tt> or <tt>#includedir</tt> directives.
     Note that the '#' character doesn't denote a comment in the configuration file.
 
 rationale: |-

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/no_includedir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/no_includedir.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_all
 
-sed -i "/#includedir.*/d" /etc/sudoers
+sed -i "/#include(dir)?.*/d" /etc/sudoers


### PR DESCRIPTION


#### Description:

- Update rule sudoers_default_includedir to accept as compliant `/etc/sudoers` files that don't have any `#include` or `#includedir` directive

#### Rationale:

- Better align the rule with RHEL-08-010379
