### PR TITLE
Update few sysctl rules to accept multiple compliant values

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -59,8 +59,10 @@ template:
     name: sysctl
     vars:
         sysctlvar: net.ipv4.conf.all.rp_filter
+        {{% if 'ol' in product or 'rhel' in product %}}
         sysctlval:
         - '1'
         - '2'
         wrong_sysctlval_for_testing: "0"
+        {{% endif %}}
         datatype: int

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -47,11 +47,36 @@ references:
     stigid@rhel7: RHEL-07-040611
     stigid@rhel8: RHEL-08-040285
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.conf.all.rp_filter", value="1") }}}
+ocil: |-
+    The runtime status of the <code>net.ipv4.conf.all.rp_filter</code> parameter can be queried
+    by running the following command:
+    <pre>$ sysctl net.ipv4.conf.all.rp_filter</pre>
+    The output of the command should indicate either:
+    <code>net.ipv4.conf.all.rp_filter = 1</code>
+    or:
+    <code>net.ipv4.conf.all.rp_filter = 2</code>
+    The output of the command should not indicate:
+    <code>net.ipv4.conf.all.rp_filter = 0</code>
+
+    The preferable way how to assure the runtime compliance is to have
+    correct persistent configuration, and rebooting the system.
+
+    The persistent sysctl parameter configuration is performed by specifying the appropriate
+    assignment in any file located in the <pre>/etc/sysctl.d</pre> directory.
+    Verify that there is not any existing incorrect configuration by executing the following command:
+    <pre>$ grep -r '^\s*net.ipv4.conf.all.rp_filter\s*=' /etc/sysctl.conf /etc/sysctl.d</pre>
+    The command should not find any assignments other than:
+    net.ipv4.conf.all.rp_filter = 1
+    or:
+    net.ipv4.conf.all.rp_filter = 2
+
+    Conflicting assignments are not allowed.
+
+ocil_clause: "the net.ipv4.conf.all.rp_filter is not set to 1 or 2 or is configured to be 0"
 
 fixtext: |-
     Configure {{{ full_name }}} to use reverse path filtering on all IPv4 interfaces.
-    {{{ fixtext_sysctl(sysctl="net.ipv4.conf.all.rp_filter", value="1") | indent(4) }}}
+    {{{ fixtext_sysctl(sysctl="net.ipv4.conf.all.rp_filter", value=xccdf_value("sysctl_net_ipv4_conf_all_rp_filter_value")) | indent(4) }}}
 
 srg_requirement: '{{{ full_name }}} must use reverse path filtering on all IPv4 interfaces.'
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/rule.yml
@@ -59,4 +59,8 @@ template:
     name: sysctl
     vars:
         sysctlvar: net.ipv4.conf.all.rp_filter
+        sysctlval:
+        - '1'
+        - '2'
+        wrong_sysctlval_for_testing: "0"
         datatype: int

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_1.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_1.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel
 
 # Clean sysctl config directories
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_1.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_1.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/net.ipv4.conf.all.rp_filter/d" /etc/sysctl.conf
+echo "net.ipv4.conf.all.rp_filter = 1" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w net.ipv4.conf.all.rp_filter="1"

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_2.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_2.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel
 
 # Clean sysctl config directories
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_2.pass.sh
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/tests/value_2.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/net.ipv4.conf.all.rp_filter/d" /etc/sysctl.conf
+echo "net.ipv4.conf.all.rp_filter = 2" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w net.ipv4.conf.all.rp_filter="2"

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter_value.var
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter_value.var
@@ -17,5 +17,5 @@ interactive: false
 
 options:
     default: 1
-    disabled: "0"
     enabled: 1
+    loose: 2

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -42,6 +42,10 @@ template:
     name: sysctl
     vars:
         sysctlvar: kernel.kptr_restrict
+        sysctlval:
+        - '1'
+        - '2'
+        wrong_sysctlval_for_testing: "0"
         datatype: int
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -42,10 +42,12 @@ template:
     name: sysctl
     vars:
         sysctlvar: kernel.kptr_restrict
+        {{% if 'ol' in product or 'rhel' in product %}}
         sysctlval:
         - '1'
         - '2'
         wrong_sysctlval_for_testing: "0"
+        {{% endif %}}
         datatype: int
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -34,6 +34,33 @@ references:
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.kptr_restrict", value="1") }}}
 
+ocil: |-
+    The runtime status of the <code>kernel.kptr_restrict</code> kernel parameter can be queried
+    by running the following command:
+    <pre>$ sysctl kernel.kptr_restrict</pre>
+    The output of the command should indicate either:
+    <code>kernel.kptr_restrict = 1</code>
+    or:
+    <code>kernel.kptr_restrict = 2</code>
+    The output of the command should not indicate:
+    <code>kernel.kptr_restrict = 0</code>
+
+    The preferable way how to assure the runtime compliance is to have
+    correct persistent configuration, and rebooting the system.
+
+    The persistent kernel parameter configuration is performed by specifying the appropriate
+    assignment in any file located in the <pre>/etc/sysctl.d</pre> directory.
+    Verify that there is not any existing incorrect configuration by executing the following command:
+    <pre>$ grep -r '^\s*kernel.kptr_restrict\s*=' /etc/sysctl.conf /etc/sysctl.d</pre>
+    The command should not find any assignments other than:
+    kernel.kptr_restrict = 1
+    or:
+    kernel.kptr_restrict = 2
+
+    Conflicting assignments are not allowed.
+
+ocil_clause: "the kernel.kptr_restrict is not set to 1 or 2 or is configured to be 0"
+
 srg_requirement: '{{{ full_name }}} must restrict exposed kernel pointer addresses access.'
 
 platform: machine
@@ -52,4 +79,4 @@ template:
 
 fixtext: |-
     Configure {{{ full_name }}} to restrict exposed kernel pointer addresses access.
-    {{{ fixtext_sysctl("kernel.kptr_restrict", "1") | indent(4) }}}
+    {{{ fixtext_sysctl("kernel.kptr_restrict", value=xccdf_value("sysctl_kernel_kptr_restrict_value")) | indent(4) }}}

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_1.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_1.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel
 
 # Clean sysctl config directories
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_1.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_1.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.kptr_restrict/d" /etc/sysctl.conf
+echo "kernel.kptr_restrict = 1" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.kptr_restrict="1"

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_2.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_2.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel
 
 # Clean sysctl config directories
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_2.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/tests/value_2.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.kptr_restrict/d" /etc/sysctl.conf
+echo "kernel.kptr_restrict = 2" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.kptr_restrict="2"

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict_value.var
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict_value.var
@@ -12,6 +12,5 @@ interactive: false
 
 options:
     default: 1
-    0: 0
     1: 1
     2: 2

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled_value.var
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled_value.var
@@ -13,6 +13,5 @@ interactive: false
 
 options:
     default: 2
-    0: "0"
     1: "1"
     2: "2"


### PR DESCRIPTION
#### Description:

- Update the rules listed below to accept multiple values as compliant.
  - `sysctl_net_ipv4_conf_all_rp_filter`
  - `sysctl_kernel_kptr_restrict`

#### Rationale:

- Better align the rules with the RHEL and OL STIGs.
