### PR TITLE
Gitpod: move ssh keys into workspace dir so it's persisted if environment is stopped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ ocp4/profiles/test.profile
 
 # Ignore the build profiling files
 .build_profiling/*
+
+# Ignore .ssh folder that is used by gitpod integration to store
+# keys used for automatus backends
+.ssh

--- a/.gitpod.launch.json
+++ b/.gitpod.launch.json
@@ -66,7 +66,10 @@
           "--add-platform",
           "&&CPE&&",
           "${command:content-navigator.getRuleId}"
-      ]
+      ],
+      "env": {
+        "SSH_ADDITIONAL_OPTIONS": "-o IdentityFile=${workspaceFolder}/&&PRIVATE_KEY_FILEPATH&&"
+      }
     },
     {
       "name": "Run Automatus using Docker backend (test_rule_in_container.sh)",
@@ -85,7 +88,8 @@
           "${command:content-navigator.getRuleId}"
       ],
       "env": {
-        "ADDITIONAL_SSGTS_OPTIONS": "--debug --duplicate-templates --add-product-to-fips-certified fedora"
+        "ADDITIONAL_SSGTS_OPTIONS": "--debug --duplicate-templates --add-product-to-fips-certified fedora",
+        "SSH_ADDITIONAL_OPTIONS": "-o IdentityFile=${workspaceFolder}/&&PRIVATE_KEY_FILEPATH&&"
       }
     }
   ]

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -29,6 +29,10 @@ tasks:
       sed -i "s/&&CONTAINER_NAME&&/$CONTAINER_NAME/g" .vscode/launch.json
       sed -i "s/&&DEFAULT_PRODUCT&&/$PRODUCT/g" .vscode/launch.json
       sed -i "s,&&CPE&&,$CPE,g" .vscode/launch.json
-      ssh-keygen -N '' -f ~/.ssh/id_rsa
-      docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat ~/.ssh/id_rsa.pub)" -t $CONTAINER_NAME --build-arg IMAGE=$CONTAINER_VERSION -f Dockerfiles/test_suite-$CONTAINER .
+      PRIVATE_KEY_FOLDER=.ssh
+      PRIVATE_KEY_FILEPATH=$PRIVATE_KEY_FOLDER/id_rsa
+      sed -i "s,&&PRIVATE_KEY_FILEPATH&&,$PRIVATE_KEY_FILEPATH,g" .vscode/launch.json
+      mkdir -p $PRIVATE_KEY_FOLDER
+      ssh-keygen -N '' -f $PRIVATE_KEY_FILEPATH
+      docker build --build-arg "CLIENT_PUBLIC_KEY=$(cat $PRIVATE_KEY_FILEPATH.pub)" -t $CONTAINER_NAME --build-arg IMAGE=$CONTAINER_VERSION -f Dockerfiles/test_suite-$CONTAINER .
       ./build_product $PRODUCT --datastream-only


### PR DESCRIPTION
#### Description:

- Make the ssh keys used by automatus persistent.

#### Rationale:

- The environment can be stopped and restarted and the testing environment should keep working.
