### PR TITLE
Add the AUID filters on RHEL7 audit kernel module rules

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
@@ -4,7 +4,7 @@
 # disruption = low
 # strategy = configure
 
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
-	{{% if product in ["ol8", "rhel8"] %}}
+	{{% if product in ["ol8"] or 'rhel' in product %}}
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	{{% else %}}
 	AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_delete_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -49,7 +49,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_delete_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -62,7 +62,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_delete_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_delete_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure auditd Collects Information on Kernel Module Unloading - delete_m
 description: |-
     To capture kernel module unloading events, use following line, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F key=modules</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
@@ -7,7 +7,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 echo "-a always,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
@@ -7,7 +7,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules\
-{{% if product not in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 echo "-a never,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a never,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
@@ -7,7 +7,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-{{% if product not in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 echo "-a always,exit -F arch=b32 -S delete -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S delete -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
@@ -4,7 +4,7 @@
 # disruption = low
 # strategy = configure
 
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
-	{{% if product in ["ol8", "rhel8"] %}}
+	{{% if product in ["ol8"] or 'rhel' in product %}}
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	{{% else %}}
 	AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_finit_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -49,7 +49,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_finit_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -62,7 +62,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_finit_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_finit_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -9,7 +9,7 @@ description: |-
     to read audit rules during daemon startup (the default), add the following lines to a file
     with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt> to capture kernel module
     loading and unloading events, setting ARCH to either b32 or b64 as appropriate for your system:
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F key=modules</pre>
@@ -17,7 +17,7 @@ description: |-
     rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
     in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
     b64 as appropriate for your system:
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F key=modules</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
@@ -5,7 +5,7 @@
 # packages = audit
 {{% endif %}}
 
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 echo "-a always,exit -F arch=b32 -S finit_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S finit_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
@@ -4,7 +4,7 @@
 # disruption = low
 # strategy = configure
 
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
 	ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
 	OTHER_FILTERS=""
-	{{% if product in ["ol8", "rhel8"] %}}
+	{{% if product in ["ol8"] or 'rhel' in product %}}
 	AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
 	{{% else %}}
 	AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_init_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -49,7 +49,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_init_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -62,7 +62,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_init_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
@@ -75,7 +75,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_init_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure auditd Collects Information on Kernel Module Loading - init_modul
 description: |-
     To capture kernel module loading events, use following line, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
-    {{% if product in ["ol8", "rhel8"] %}}
+    {{% if product in ["ol8"] or 'rhel' in product %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F key=modules</pre>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
@@ -5,7 +5,7 @@
 # packages = audit
 {{% endif %}}
 
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 echo "-a always,exit -F arch=b32 -S init_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S init_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}


### PR DESCRIPTION


#### Description:

- Align RHEL7 and RHEL8 content by checking and remediating the audit rules for kernel module syscalls with AUID filters.
  - Before the STIG required RHEL7 rule was:
  `-a always,exit -F arch=b32 -S delete_module -k module-change`
  and it changed to:
  `-a always,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=unset -k module-change`

#### Rationale:

- Align these rule with latest RHEL7 STIG
