### PR TITLE
Use data stream to verify profile titles and descriptions

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -407,25 +407,7 @@ macro(ssg_build_xccdf_final PRODUCT)
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/verify_references.py" --rules-with-invalid-checks --base-dir "${CMAKE_BINARY_DIR}" --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
     set_tests_properties("verify-references-ssg-${PRODUCT}-xccdf.xml" PROPERTIES LABELS quick)
-    add_test(
-        NAME "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-titles"
-        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"title\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-    )
-    set_tests_properties("verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-titles" PROPERTIES LABELS quick)
-    add_test(
-        NAME "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-descriptions"
-        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"description\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-    )
-    set_tests_properties("verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-descriptions" PROPERTIES LABELS quick)
-    # Sets WILL_FAIL property for all '*-override-true-all-profile-*' tests to
-    # true as it is expected that XPath of a passing test will be empty (and
-    # non-zero exit code is returned in such case).
-    set_tests_properties(
-        "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-titles"
-        "verify-ssg-${PRODUCT}-xccdf.xml-override-true-all-profile-descriptions"
-        PROPERTIES
-        WILL_FAIL true
-    )
+
     if("${PRODUCT}" MATCHES "rhel")
         if("${PRODUCT}" MATCHES "rhel7")
             set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_nt28_high hipaa")
@@ -555,6 +537,25 @@ macro(ssg_build_sds PRODUCT)
             )
         endif()
     endif()
+    add_test(
+        NAME "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-titles"
+        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"title\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+    )
+    set_tests_properties("verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-titles" PROPERTIES LABELS quick)
+    add_test(
+        NAME "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-descriptions"
+        COMMAND "${XMLLINT_EXECUTABLE}" --xpath "//*[local-name()=\"Profile\"]/*[local-name()=\"description\"][not(@override=\"true\")]" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+    )
+    set_tests_properties("verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-descriptions" PROPERTIES LABELS quick)
+    # Sets WILL_FAIL property for all '*-override-true-all-profile-*' tests to
+    # true as it is expected that XPath of a passing test will be empty (and
+    # non-zero exit code is returned in such case).
+    set_tests_properties(
+        "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-titles"
+        "verify-ssg-${PRODUCT}-ds.xml-override-true-all-profile-descriptions"
+        PROPERTIES
+        WILL_FAIL true
+    )
 endmacro()
 
 # Build per-product HTML guides to see the status of various profiles and


### PR DESCRIPTION
We will use SCAP source data stream instead of XCCDF 1.1 in the tests
that verify whether all profile titles and descriptions have
override attribute set to true.