### PR TITLE
Test missing references in a data stream

### DIFF
--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -38,10 +38,9 @@ def parse_args():
                         help="Show statistics for this XCCDF Profile only. If "
                         "not provided the script will show stats for all "
                         "available profiles.")
-    parser_stats.add_argument("--benchmark", "-b", required=True,
-                        action="store",
-                        help="Specify XCCDF file or a SCAP source data "
-                        "stream file to act on.")
+    parser_stats.add_argument(
+        "--benchmark", "-b", required=True, action="store",
+        help="Specify XCCDF file or a SCAP source data stream file to act on.")
     parser_stats.add_argument("--implemented-ovals", default=False,
                         action="store_true", dest="implemented_ovals",
                         help="Show IDs of implemented OVAL checks.")

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -220,12 +220,7 @@ def main():
     if args.profile:
         ret.append(benchmark.show_profile_stats(args.profile, args))
     else:
-        all_profile_elems = benchmark.tree.findall("./{%s}Profile" % (ssg.constants.XCCDF11_NS))
-        ret = []
-        for elem in all_profile_elems:
-            profile = elem.get('id')
-            if profile is not None:
-                ret.append(benchmark.show_profile_stats(profile, args))
+        ret.extend(benchmark.show_all_profile_stats(args))
 
     if args.format == "json":
         print(json.dumps(ret, indent=4))

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -40,8 +40,8 @@ def parse_args():
                         "available profiles.")
     parser_stats.add_argument("--benchmark", "-b", required=True,
                         action="store",
-                        help="Specify XCCDF file to act on. Must be a plain "
-                        "XCCDF file, doesn't work on source datastreams yet!")
+                        help="Specify XCCDF file or a SCAP source data "
+                        "stream file to act on.")
     parser_stats.add_argument("--implemented-ovals", default=False,
                         action="store_true", dest="implemented_ovals",
                         help="Show IDs of implemented OVAL checks.")

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -395,18 +395,6 @@ macro(ssg_build_xccdf_final PRODUCT)
         generate-ssg-${PRODUCT}-xccdf.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
-    if("${PRODUCT}" MATCHES "rhel")
-        if("${PRODUCT}" MATCHES "rhel7")
-            set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_nt28_high hipaa")
-        elseif("${PRODUCT}" MATCHES "rhel8")
-            set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_bp28_high hipaa")
-        endif()
-        add_test(
-                NAME "missing-references-ssg-${PRODUCT}-xccdf.xml"
-                COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${CMAKE_SOURCE_DIR}/tests/missing_refs.sh" "${PYTHON_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" ${REFERENCES_CHECK_PROFILE_LIST}
-        )
-        set_tests_properties("missing-references-ssg-${PRODUCT}-xccdf.xml" PROPERTIES LABELS quick)
-    endif()
 
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
@@ -554,6 +542,18 @@ macro(ssg_build_sds PRODUCT)
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/verify_references.py" --rules-with-invalid-checks --base-dir "${CMAKE_BINARY_DIR}" --ovaldefs-unused "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
     )
     set_tests_properties("verify-references-ssg-${PRODUCT}-ds.xml" PROPERTIES LABELS quick)
+    if("${PRODUCT}" MATCHES "rhel")
+        if("${PRODUCT}" MATCHES "rhel7")
+            set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_nt28_high hipaa")
+        elseif("${PRODUCT}" MATCHES "rhel8")
+            set(REFERENCES_CHECK_PROFILE_LIST "cis anssi_bp28_high hipaa")
+        endif()
+        add_test(
+                NAME "missing-references-ssg-${PRODUCT}-ds.xml"
+                COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${CMAKE_SOURCE_DIR}/tests/missing_refs.sh" "${PYTHON_EXECUTABLE}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" ${REFERENCES_CHECK_PROFILE_LIST}
+        )
+        set_tests_properties("missing-references-ssg-${PRODUCT}-ds.xml" PROPERTIES LABELS quick)
+    endif()
 endmacro()
 
 # Build per-product HTML guides to see the status of various profiles and

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -774,6 +774,16 @@ class XCCDFBenchmark(object):
 
             return profile_stats
 
+
+    def show_all_profile_stats(self, options):
+        all_profile_elems = self.tree.findall("./{%s}Profile" % (xccdf_ns))
+        ret = []
+        for elem in all_profile_elems:
+            profile = elem.get('id')
+            if profile is not None:
+                ret.append(self.show_profile_stats(profile, options))
+        return ret
+
     def console_print(self, content, width):
         """Prints the 'content' array left aligned, each time 45 characters
            long, each row 'width' characters wide"""

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -6,7 +6,7 @@ import sys
 
 from .build_yaml import ProfileWithInlinePolicies
 from .xml import ElementTree
-from .constants import XCCDF11_NS as xccdf_ns
+from .constants import XCCDF11_NS, XCCDF12_NS
 from .constants import oval_namespace as oval_ns
 from .constants import SCE_SYSTEM as sce_ns
 from .constants import bash_system as bash_rem_system
@@ -103,7 +103,12 @@ class XCCDFBenchmark(object):
                 file_string = xccdf_file.read()
                 tree = ElementTree.fromstring(file_string)
                 self.tree = tree
-                self.xccdf_ns = xccdf_ns
+                if tree.tag == "{%s}Benchmark" % XCCDF11_NS:
+                    self.xccdf_ns = XCCDF11_NS
+                elif tree.tag == "{%s}Benchmark" % XCCDF12_NS:
+                    self.xccdf_ns = XCCDF12_NS
+                else:
+                    raise ValueError("Unknown root element '%s'" % tree.tag)
         except IOError as ioerr:
             print("%s" % ioerr)
             sys.exit(1)

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -6,7 +6,7 @@ import sys
 
 from .build_yaml import ProfileWithInlinePolicies
 from .xml import ElementTree
-from .constants import XCCDF11_NS, XCCDF12_NS
+from .constants import XCCDF11_NS, XCCDF12_NS, datastream_namespace
 from .constants import oval_namespace as oval_ns
 from .constants import SCE_SYSTEM as sce_ns
 from .constants import bash_system as bash_rem_system
@@ -102,10 +102,15 @@ class XCCDFBenchmark(object):
             with open(filepath, 'r') as xccdf_file:
                 file_string = xccdf_file.read()
                 tree = ElementTree.fromstring(file_string)
-                self.tree = tree
                 if tree.tag == "{%s}Benchmark" % XCCDF11_NS:
+                    self.tree = tree
                     self.xccdf_ns = XCCDF11_NS
                 elif tree.tag == "{%s}Benchmark" % XCCDF12_NS:
+                    self.tree = tree
+                    self.xccdf_ns = XCCDF12_NS
+                elif tree.tag == "{%s}data-stream-collection" % datastream_namespace:
+                    benchmark_tree = tree.find(".//{%s}Benchmark" % XCCDF12_NS)
+                    self.tree = benchmark_tree
                     self.xccdf_ns = XCCDF12_NS
                 else:
                     raise ValueError("Unknown root element '%s'" % tree.tag)

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -244,7 +244,7 @@ class XCCDFBenchmark(object):
                 ansible_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
                                         (self.xccdf_ns, ansible_rem_system))
                 ignition_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                        (self.xccdf_ns, ignition_rem_system))
+                                         (self.xccdf_ns, ignition_rem_system))
                 kubernetes_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
                                            (self.xccdf_ns, kubernetes_rem_system))
                 puppet_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
@@ -258,9 +258,9 @@ class XCCDFBenchmark(object):
                 cis_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
                                     (self.xccdf_ns, self.cis_ns))
                 hipaa_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (self.xccdf_ns, hipaa_ns))
+                                      (self.xccdf_ns, hipaa_ns))
                 anssi_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (self.xccdf_ns, anssi_ns))
+                                      (self.xccdf_ns, anssi_ns))
                 ospp_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
                                      (self.xccdf_ns, ospp_ns))
                 cui_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
@@ -785,7 +785,6 @@ class XCCDFBenchmark(object):
             del profile_stats['rules']
 
             return profile_stats
-
 
     def show_all_profile_stats(self, options):
         all_profile_elems = self.tree.findall("./{%s}Profile" % (self.xccdf_ns))

--- a/ssg/build_profile.py
+++ b/ssg/build_profile.py
@@ -103,12 +103,13 @@ class XCCDFBenchmark(object):
                 file_string = xccdf_file.read()
                 tree = ElementTree.fromstring(file_string)
                 self.tree = tree
+                self.xccdf_ns = xccdf_ns
         except IOError as ioerr:
             print("%s" % ioerr)
             sys.exit(1)
 
         self.indexed_rules = {}
-        for rule in self.tree.findall(".//{%s}Rule" % (xccdf_ns)):
+        for rule in self.tree.findall(".//{%s}Rule" % (self.xccdf_ns)):
             rule_id = rule.get("id")
             if rule_id is None:
                 raise RuntimeError("Can't index a rule with no id attribute!")
@@ -189,7 +190,7 @@ class XCCDFBenchmark(object):
 
         rule_stats = []
         ssg_version_elem = self.tree.find("./{%s}version[@update=\"%s\"]" %
-                                          (xccdf_ns, ssg_version_uri))
+                                          (self.xccdf_ns, ssg_version_uri))
 
         rules = []
 
@@ -198,12 +199,13 @@ class XCCDFBenchmark(object):
             rules = self.indexed_rules.values()
         else:
             xccdf_profile = self.tree.find("./{%s}Profile[@id=\"%s\"]" %
-                                           (xccdf_ns, profile))
+                                           (self.xccdf_ns, profile))
             if xccdf_profile is None:
                 print("No such profile \"%s\" found in the benchmark!"
                       % profile)
                 print("* Available profiles:")
-                profiles_avail = self.tree.findall("./{%s}Profile" % (xccdf_ns))
+                profiles_avail = self.tree.findall(
+                    "./{%s}Profile" % (self.xccdf_ns))
                 for _profile in profiles_avail:
                     print("** %s" % _profile.get('id'))
                 sys.exit(1)
@@ -212,7 +214,7 @@ class XCCDFBenchmark(object):
             # selected rule. If you want to reuse this for custom content, you
             # need to change this to look into Rule/@selected
             selects = xccdf_profile.findall("./{%s}select[@selected=\"true\"]" %
-                                            xccdf_ns)
+                                            self.xccdf_ns)
 
             for select in selects:
                 rule_id = select.get('idref')
@@ -224,35 +226,35 @@ class XCCDFBenchmark(object):
         for rule in rules:
             if rule is not None:
                 oval = rule.find("./{%s}check[@system=\"%s\"]" %
-                                 (xccdf_ns, oval_ns))
+                                 (self.xccdf_ns, oval_ns))
                 sce = rule.find("./{%s}check[@system=\"%s\"]" %
-                                (xccdf_ns, sce_ns))
+                                (self.xccdf_ns, sce_ns))
                 bash_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                     (xccdf_ns, bash_rem_system))
+                                     (self.xccdf_ns, bash_rem_system))
                 ansible_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                        (xccdf_ns, ansible_rem_system))
+                                        (self.xccdf_ns, ansible_rem_system))
                 ignition_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                        (xccdf_ns, ignition_rem_system))
+                                        (self.xccdf_ns, ignition_rem_system))
                 kubernetes_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                           (xccdf_ns, kubernetes_rem_system))
+                                           (self.xccdf_ns, kubernetes_rem_system))
                 puppet_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                       (xccdf_ns, puppet_rem_system))
+                                       (self.xccdf_ns, puppet_rem_system))
                 anaconda_fix = rule.find("./{%s}fix[@system=\"%s\"]" %
-                                         (xccdf_ns, anaconda_rem_system))
+                                         (self.xccdf_ns, anaconda_rem_system))
                 cce = rule.find("./{%s}ident[@system=\"%s\"]" %
-                                (xccdf_ns, cce_uri))
+                                (self.xccdf_ns, cce_uri))
                 stig_id = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, self.stig_ns))
+                                    (self.xccdf_ns, self.stig_ns))
                 cis_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, self.cis_ns))
+                                    (self.xccdf_ns, self.cis_ns))
                 hipaa_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, hipaa_ns))
+                                    (self.xccdf_ns, hipaa_ns))
                 anssi_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, anssi_ns))
+                                    (self.xccdf_ns, anssi_ns))
                 ospp_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                     (xccdf_ns, ospp_ns))
+                                     (self.xccdf_ns, ospp_ns))
                 cui_ref = rule.find("./{%s}reference[@href=\"%s\"]" %
-                                    (xccdf_ns, cui_ns))
+                                    (self.xccdf_ns, cui_ns))
 
                 rule_stats.append(
                     RuleStats(rule.get("id"), oval, sce,
@@ -776,7 +778,7 @@ class XCCDFBenchmark(object):
 
 
     def show_all_profile_stats(self, options):
-        all_profile_elems = self.tree.findall("./{%s}Profile" % (xccdf_ns))
+        all_profile_elems = self.tree.findall("./{%s}Profile" % (self.xccdf_ns))
         ret = []
         for elem in all_profile_elems:
             profile = elem.get('id')

--- a/tests/missing_refs.sh
+++ b/tests/missing_refs.sh
@@ -21,7 +21,8 @@ function check_missing_references() {
         refs_argument="--missing-$profile-refs"
     fi
 
-    profile_stats="$("$PYTHON_EXECUTABLE" "$PROJECT_ROOT/build-scripts/profile_tool.py" stats --benchmark "$BENCHMARK" --profile $profile $refs_argument --skip-stats)"
+    full_profile_id="xccdf_org.ssgproject.content_profile_$profile"
+    profile_stats="$("$PYTHON_EXECUTABLE" "$PROJECT_ROOT/build-scripts/profile_tool.py" stats --benchmark "$BENCHMARK" --profile $full_profile_id $refs_argument --skip-stats)"
 
     if [ ! -z "$profile_stats" ]; then
         printf '%s\n' "$profile_stats" >&2

--- a/tests/missing_refs.sh
+++ b/tests/missing_refs.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 PYTHON_EXECUTABLE="$1"
-BENCHMARK="$2"
+DATASTREAM="$2"
 shift 2
 PROFILES=()
 while test $# -gt 0; do
@@ -22,7 +22,7 @@ function check_missing_references() {
     fi
 
     full_profile_id="xccdf_org.ssgproject.content_profile_$profile"
-    profile_stats="$("$PYTHON_EXECUTABLE" "$PROJECT_ROOT/build-scripts/profile_tool.py" stats --benchmark "$BENCHMARK" --profile $full_profile_id $refs_argument --skip-stats)"
+    profile_stats="$("$PYTHON_EXECUTABLE" "$PROJECT_ROOT/build-scripts/profile_tool.py" stats --benchmark "$DATASTREAM" --profile $full_profile_id $refs_argument --skip-stats)"
 
     if [ ! -z "$profile_stats" ]; then
         printf '%s\n' "$profile_stats" >&2

--- a/tests/missing_refs.sh
+++ b/tests/missing_refs.sh
@@ -22,7 +22,7 @@ function check_missing_references() {
     fi
 
     full_profile_id="xccdf_org.ssgproject.content_profile_$profile"
-    profile_stats="$("$PYTHON_EXECUTABLE" "$PROJECT_ROOT/build-scripts/profile_tool.py" stats --benchmark "$DATASTREAM" --profile $full_profile_id $refs_argument --skip-stats)"
+    profile_stats="$("$PYTHON_EXECUTABLE" "$PROJECT_ROOT/build-scripts/profile_tool.py" stats --benchmark "$DATASTREAM" --profile "$full_profile_id" "$refs_argument" --skip-stats)"
 
     if [ ! -z "$profile_stats" ]; then
         printf '%s\n' "$profile_stats" >&2


### PR DESCRIPTION
#### Description:
Update `profile_tool.py` to support also SCAP source data streams and change upstream test `missing-references` to consume data stream.

For more details, please read commit message of every commit.

#### Rationale:
This makes one test independent from XCCDF 1.1 which will help us to remove XCCDF 1.1 in future.
