### PR TITLE
Make OSPP profiles use minimal Authselect profile

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/rule.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/rule.yml
@@ -34,6 +34,7 @@ references:
     disa: CCI-000213
     hipaa: 164.308(a)(1)(ii)(B),164.308(a)(7)(i),164.308(a)(7)(ii)(A),164.310(a)(1),164.310(a)(2)(i),164.310(a)(2)(ii),164.310(a)(2)(iii),164.310(b),164.310(c),164.310(d)(1),164.310(d)(2)(iii)  # taken from require_singleuser_auth
     nist: AC-3
+    ospp: FIA_UAU.1,FIA_AFL.1
     srg: SRG-OS-000480-GPOS-00227
 
 ocil: |-

--- a/products/rhel8/profiles/ospp.profile
+++ b/products/rhel8/profiles/ospp.profile
@@ -220,7 +220,7 @@ selections:
     - var_accounts_max_concurrent_login_sessions=10
     - accounts_max_concurrent_login_sessions
     - securetty_root_login_console_only
-    - var_authselect_profile=sssd
+    - var_authselect_profile=minimal
     - enable_authselect
     - var_password_pam_unix_remember=5
     - accounts_password_pam_unix_remember

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -115,7 +115,7 @@ selections:
     - coredump_disable_storage
     - coredump_disable_backtraces
     - service_systemd-coredump_disabled
-    - var_authselect_profile=sssd
+    - var_authselect_profile=minimal
     - enable_authselect
     - use_pam_wheel_for_su
 

--- a/tests/data/profile_stability/rhel8/ospp.profile
+++ b/tests/data/profile_stability/rhel8/ospp.profile
@@ -242,7 +242,7 @@ selections:
 - var_slub_debug_options=P
 - var_auditd_flush=incremental_async
 - var_accounts_max_concurrent_login_sessions=10
-- var_authselect_profile=sssd
+- var_authselect_profile=minimal
 - var_password_pam_unix_remember=5
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted


### PR DESCRIPTION
#### Description:

- change variable in RHEL9 and RHEL8 OSPP profiles to use minimal Autselect profile instead of SSSD
- add OSPP references to enable_authselect rule

#### Rationale:

https://bugzilla.redhat.com/show_bug.cgi?id=2114979
