### PR TITLE
Fix rule sudo_custom_logfile

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
@@ -29,7 +29,7 @@ ocil_clause: 'logfile is not enabled in sudo'
 
 ocil: |-
     To determine if <tt>logfile</tt> has been configured for sudo, run the following command:
-    <pre>$ sudo grep -ri "^[\s]*Defaults.*\blogfile\b.*" /etc/sudoers /etc/sudoers.d/</pre>
+    <pre>$ sudo grep -ri "^[\s]*Defaults\s*\blogfile\b.*" /etc/sudoers /etc/sudoers.d/</pre>
     The command should return a matching output.
 
 template:

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/broken_defaults.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/broken_defaults.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo "Defaultsabc logfile=/var/log/sudo.log" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/wrong_logfile.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/wrong_logfile.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+echo "Defaults logfile=/var/log/othersudologfile.log" >> /etc/sudoers

--- a/shared/templates/sudo_defaults_option/ansible.template
+++ b/shared/templates/sudo_defaults_option/ansible.template
@@ -8,7 +8,7 @@
 - name: Ensure {{{ OPTION }}} is enabled with the appropriate value in /etc/sudoers
   lineinfile:
     path: /etc/sudoers
-    regexp: '^[\s]*Defaults\s(.*)\b{{{ OPTION }}}=[-]?\w+\b(.*)$'
+    regexp: '^[\s]*Defaults\s(.*)\b{{{ OPTION }}}=[-]?.+\b(.*)$'
     line: 'Defaults \1{{{ OPTION }}}={{ {{{ VARIABLE_NAME }}} }}\2'
     validate: /usr/sbin/visudo -cf %s
     backrefs: yes

--- a/shared/templates/sudo_defaults_option/bash.template
+++ b/shared/templates/sudo_defaults_option/bash.template
@@ -9,7 +9,7 @@
 {{% endif %}}
 if /usr/sbin/visudo -qcf /etc/sudoers; then
     cp /etc/sudoers /etc/sudoers.bak
-    if ! grep -P '^[\s]*Defaults.*\b{{{ OPTION_REGEX }}}\b.*$' /etc/sudoers; then
+    if ! grep -P '^[\s]*Defaults[\s]*\b{{{ OPTION_REGEX }}}\b.*$' /etc/sudoers; then
         # sudoers file doesn't define Option {{{ OPTION }}}
         echo "Defaults {{{ OPTION_VALUE }}}" >> /etc/sudoers
     {{%- if not VARIABLE_NAME %}}
@@ -21,7 +21,8 @@ if /usr/sbin/visudo -qcf /etc/sudoers; then
             {{% if '/' in OPTION %}}
             {{{ raise("OPTION (" + OPTION + ") uses sed path separator (/) in " + rule_id) }}}
             {{% endif %}}
-            sed -Ei "s/(^[\s]*Defaults.*\b{{{ OPTION }}}=)[-]?\w+(\b.*$)/\1{{{ '${' ~ VARIABLE_NAME ~ '}' }}}\2/" /etc/sudoers
+            escaped_variable={{{ "${" ~ VARIABLE_NAME ~ "//$'/'/$'\/'}" }}}
+            sed -Ei "s/(^[\s]*Defaults.*\b{{{ OPTION }}}=)[-]?.+(\b.*$)/\1$escaped_variable\2/" /etc/sudoers
         fi
     fi
     {{% endif %}}

--- a/shared/templates/sudo_defaults_option/oval.template
+++ b/shared/templates/sudo_defaults_option/oval.template
@@ -13,7 +13,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_{{{ OPTION }}}_sudoers" version="1">
     <ind:filepath operation="pattern match">^/etc/sudoers(|\.d/.*)$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*Defaults.*\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]*\b{{{ OPTION_REGEX }}}.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal" >1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
- Allow only white space after the Default keyword to avoid
  matching words that only start with Default.
- If the variable value contains slashes they need to be escaped
  because the sed command uses slashes as a separator, otherwise
  the sed doesn't replace the wrong line during a remediation.

Also adds 2 test scenarios.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=2083109