### PR TITLE
Use XCCDF 1.2 to create STIG overlay

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1152,8 +1152,8 @@ macro(ssg_build_html_stig_tables PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/create-stig-overlay.py" --quiet --disa-xccdf="${DISA_STIG_REF}" --ssg-xccdf="${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/create-stig-overlay.py" --quiet --disa-xccdf="${DISA_STIG_REF}" --ssg-xccdf="${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml" -o "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
         DEPENDS "${DISA_STIG_REF}"
         COMMENT "[${PRODUCT}-tables] generating STIG XML overlay"
     )

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import re
 import sys
 import argparse
 import os

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -141,7 +141,7 @@ def parse_args():
     parser.add_argument("-o", "--output", default=outfile,
                         action="store", dest="output_file",
                         help="STIG overlay XML content file \
-                             [default: %default]")
+                             [default: %s]" % outfile)
     parser.add_argument("-q", "--quiet", dest="quiet", default=False,
                       action="store_true", help="Do not print anything and assume yes for everything")
 

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -155,7 +155,7 @@ def parse_args():
     parser.add_argument("-o", "--output", default=outfile,
                         action="store", dest="output_file",
                         help="STIG overlay XML content file \
-                             [default: %s]" % outfile)
+                            [default: %s]" % outfile)
     parser.add_argument("-q", "--quiet", dest="quiet", default=False,
                       action="store_true", help="Do not print anything and assume yes for everything")
 

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -9,6 +9,8 @@ import ssg
 import ssg.xml
 import xml.dom.minidom
 
+from ssg.constants import XCCDF11_NS, XCCDF12_NS, OSCAP_RULE
+
 ET = ssg.xml.ElementTree
 
 
@@ -17,7 +19,6 @@ stig_ns = ["https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-
            "https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os",
            "https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security%2Capplication-servers",
            "https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=app-security%2Capp-security-dev"]
-xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
 dc_ns = "http://purl.org/dc/elements/1.1/"
 outfile = "stig_overlay.xml"
 
@@ -35,15 +36,26 @@ def yes_no_prompt():
 
 
 def element_value(element, element_obj):
-    for elem in element_obj.findall("./{%s}%s" % (xccdf_ns, element)):
+    for elem in element_obj.findall("./{%s}%s" % (XCCDF11_NS, element)):
         elem = elem.text
     try:
         return elem
     except UnboundLocalError as e:
         return ""
 
+def determine_xccdf_tree_namespace(tree):
+    root = tree.getroot()
+    if root.tag == "{%s}Benchmark" % XCCDF11_NS:
+        xccdf_ns = XCCDF11_NS
+    elif root.tag == "{%s}Benchmark" % XCCDF12_NS:
+        xccdf_ns = XCCDF12_NS
+    else:
+        raise ValueError("Unknown root element '%s'" % root.tag)
+    return xccdf_ns
+
 
 def ssg_xccdf_stigid_mapping(ssgtree):
+    xccdf_ns = determine_xccdf_tree_namespace(ssgtree)
     xccdftostig_idmapping = {}
 
     for rule in ssgtree.findall(".//{%s}Rule" % xccdf_ns):
@@ -51,6 +63,8 @@ def ssg_xccdf_stigid_mapping(ssgtree):
         rhid = ""
 
         xccdfid = rule.get("id")
+        if xccdf_ns == XCCDF12_NS:
+            xccdfid = xccdfid.replace(OSCAP_RULE, "")
         if xccdfid is not None:
             for references in stig_ns:
                 stig = [ids for ids in rule.findall(".//{%s}reference[@href='%s']" % (xccdf_ns, references))]
@@ -74,12 +88,12 @@ def new_stig_overlay(xccdftree, ssgtree, outfile, quiet):
     else:
         ssg_mapping = ssg_xccdf_stigid_mapping(ssgtree)
 
-    new_stig_overlay = ET.Element("overlays", xmlns=xccdf_ns)
-    for group in xccdftree.findall("./{%s}Group" % xccdf_ns):
+    new_stig_overlay = ET.Element("overlays", xmlns=XCCDF11_NS)
+    for group in xccdftree.findall("./{%s}Group" % XCCDF11_NS):
         vkey = group.get("id").strip('V-')
-        for title in group.findall("./{%s}title" % xccdf_ns):
+        for title in group.findall("./{%s}title" % XCCDF11_NS):
             srg = title.text
-        for rule in group.findall("./{%s}Rule" % xccdf_ns):
+        for rule in group.findall("./{%s}Rule" % XCCDF11_NS):
             svkey_raw = rule.get("id")
             svkey = svkey_raw.strip()[3:9]
             severity = rule.get("severity")
@@ -135,7 +149,7 @@ def parse_args():
                               For example: disa-stig-rhel8-v1r12-xccdf-manual.xml")
     parser.add_argument("--ssg-xccdf", default=None,
                         action="store", dest="ssg_xccdf_filename",
-                        help="A SSG generated XCCDF file. \
+                        help="A SSG generated XCCDF file. Can be XCCDF 1.1 or XCCDF 1.2 \
                               For example: ssg-rhel8-xccdf.xml")
     parser.add_argument("-o", "--output", default=outfile,
                         action="store", dest="output_file",

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -43,6 +43,7 @@ def element_value(element, element_obj):
     except UnboundLocalError as e:
         return ""
 
+
 def determine_xccdf_tree_namespace(tree):
     root = tree.getroot()
     if root.tag == "{%s}Benchmark" % XCCDF11_NS:


### PR DESCRIPTION
#### Description:
Use XCCDF 1.2 to create STIG overlay. The script create-stig-overlay.py has been updated to accept XCCDF 1.2. The format of the overlay file doesn't change.

For more details, please read commit messages of every commit.

#### Rationale:
This change will help us to remove XCCDF 1.1 in future.
