### PR TITLE
add warning to audit_rules_for_ospp

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_rules_for_ospp/rule.yml
@@ -67,3 +67,12 @@ fixtext: |-
     Then, run the following command to load all audit rules:
 
     $ sudo augenrules --load
+
+warnings:
+    - performance:
+        It might happen that Audit buffer configured by this rule is not large
+        enough for certain use cases. If that is the case, the buffer size can
+        be overridden by placing <pre>-b larger_buffer_size</pre> into a file
+        within <tt>/etc/audit/rules.d</tt> directory, replacing
+        <tt>larger_file_size</tt> with the desired value. The file name should
+        start with a number higher than 10 and lower than 99.


### PR DESCRIPTION
#### Description:

- add warning to audit_rules_for_ospp
- the warning is the same as for audit_basic_configuration

#### Rationale:

The reason is that the rule audit_rules_for_ospp technicaly does the same thing as when audit_basic_configuration rule is being used. Audit rules_for_ospp does of course more, but the rule is included in its remediation and check.
