### PR TITLE
add warning to the rsyslog_remote_loghost rule about configuring queues

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -94,7 +94,7 @@ srg_requirement: 'The {{{ full_name }}} audit records must be off-loaded onto a 
 warnings:
     - functionality: |-
         It is important to configure queues in case the client is sending log
-        messages to a remote server. If queues are not configured, there is a
+        messages to a remote server. If queues are not configured,
         the system will stop functioning when the connection
         to the remote server is not available. Please consult Rsyslog
         documentation for more information about configuration of queues. The

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -95,14 +95,14 @@ warnings:
     - functionality: |-
         It is important to configure queues in case the client is sending log
         messages to a remote server. If queues are not configured, there is a
-        danger that the system will stop functioning in case that the connection
+        the system will stop functioning when the connection
         to the remote server is not available. Please consult Rsyslog
         documentation for more information about configuration of queues. The
         example configuration which should go into <tt>/etc/rsyslog.conf</tt>
         can look like the following lines:
         <pre>
         $ActionQueueType LinkedList
-        $ActionQueueFileName somenameforprefix
+        $ActionQueueFileName queuefilename
         $ActionQueueMaxDiskSpace 1g
         $ActionQueueSaveOnShutdown on
         $ActionResumeRetryCount -1

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -90,3 +90,20 @@ fixtext: |-
     *.* @@[remoteloggingserver]:[port]"
 
 srg_requirement: 'The {{{ full_name }}} audit records must be off-loaded onto a different system or storage media from the system being audited.'
+
+warnings:
+    - functionality: |-
+        It is important to configure queues in case the client is sending log
+        messages to a remote server. If queues are not configured, there is a
+        danger that the system will stop functioning in case that the connection
+        to the remote server is not available. Please consult Rsyslog
+        documentation for more information about configuration of queues. The
+        example configuration which should go into <tt>/etc/rsyslog.conf</tt>
+        can look like the following lines:
+        <pre>
+        $ActionQueueType LinkedList
+        $ActionQueueFileName somenameforprefix
+        $ActionQueueMaxDiskSpace 1g
+        $ActionQueueSaveOnShutdown on
+        $ActionResumeRetryCount -1
+        </pre>


### PR DESCRIPTION
#### Description:

- add functionality warning describing how to configure queues which are needed when doing remote logging

#### Rationale:

https://bugzilla.redhat.com/show_bug.cgi?id=2078974