### PR TITLE
Reintroduce back the sshd timeout rules in RHEL8 STIG profile

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_idle_timeout/rule.yml
@@ -57,6 +57,7 @@ references:
     stigid@ol7: OL07-00-040320
     stigid@ol8: OL08-00-010201
     stigid@rhel7: RHEL-07-040320
+    stigid@rhel8: RHEL-08-010201
     stigid@sle12: SLES-12-030190
     stigid@sle15: SLES-15-010280
     stigid@ubuntu2004: UBTU-20-010037

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
@@ -53,6 +53,7 @@ references:
     stigid@ol7: OL07-00-040340
     stigid@ol8: OL08-00-010200
     stigid@rhel7: RHEL-07-040340
+    stigid@rhel8: RHEL-08-010200
     stigid@sle12: SLES-12-030191
     stigid@sle15: SLES-15-010320
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -170,13 +170,13 @@ selections:
     # RHEL-08-010190
     - dir_perms_world_writable_sticky_bits
 
-    # These two items don't behave as they used to in RHEL8.6 and RHEL9
-    # anymore. They will be disabled for now until an alternative
-    # solution is found.
-    # # RHEL-08-010200
-    # - sshd_set_keepalive_0
-    # # RHEL-08-010201
-    # - sshd_set_idle_timeout
+    # Although these rules have a different behavior in RHEL>=8.6
+    # they still need to be selected so it follows exactly what STIG
+    # states.
+    # RHEL-08-010200
+    - sshd_set_keepalive_0
+    # RHEL-08-010201
+    - sshd_set_idle_timeout
 
     # RHEL-08-010210
     - file_permissions_var_log_messages

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -369,6 +369,8 @@ selections:
 - sshd_enable_warning_banner
 - sshd_print_last_log
 - sshd_rekey_limit
+- sshd_set_idle_timeout
+- sshd_set_keepalive_0
 - sshd_use_strong_rng
 - sshd_x11_use_localhost
 - sssd_certificate_verification

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -379,6 +379,8 @@ selections:
 - sshd_enable_warning_banner
 - sshd_print_last_log
 - sshd_rekey_limit
+- sshd_set_idle_timeout
+- sshd_set_keepalive_0
 - sshd_use_strong_rng
 - sshd_x11_use_localhost
 - sssd_certificate_verification


### PR DESCRIPTION
#### Description:

- Reintroduce back the sshd timeout rules in RHEL8 STIG profile.

#### Rationale:

- The profile should stick to the letter in terms of STIG profile implementation.
