### PR TITLE
Use XCCDF 1.2 to generate STIG HTML table

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1137,7 +1137,7 @@ macro(ssg_build_html_stig_tables PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-stig.xslt" "${DISA_STIG_REF}"
+        COMMAND "${XSLTPROC_EXECUTABLE}" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-stig-manual.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-stig-manual.xslt" "${DISA_STIG_REF}"
         DEPENDS "${DISA_STIG_REF}"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-stig.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML MANUAL STIG table"
@@ -1152,9 +1152,9 @@ macro(ssg_build_html_stig_tables PRODUCT)
     )
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/unlinked-stig-xccdf.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam overlay "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml" --stringparam ocil-document "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ocil-linked.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/unlinked-stig-xccdf.xml" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf-apply-overlay-stig.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam overlay "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml" --stringparam ocil-document "${CMAKE_CURRENT_BINARY_DIR_NO_SPACES}/ocil-linked.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/unlinked-stig-xccdf.xml" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf-apply-overlay-stig.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf-apply-overlay-stig.xslt"
         DEPENDS "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
         COMMENT "[${PRODUCT}-tables] generating unlinked STIG XCCDF XML file"

--- a/products/alinux2/transforms/xccdf2table-stig-manual.xslt
+++ b/products/alinux2/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/alinux3/transforms/xccdf2table-stig-manual.xslt
+++ b/products/alinux3/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/chromium/transforms/xccdf2table-stig-manual.xslt
+++ b/products/chromium/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/debian10/transforms/xccdf2table-stig-manual.xslt
+++ b/products/debian10/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/debian11/transforms/xccdf2table-stig-manual.xslt
+++ b/products/debian11/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/debian9/transforms/xccdf2table-stig-manual.xslt
+++ b/products/debian9/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/firefox/transforms/xccdf2table-stig-manual.xslt
+++ b/products/firefox/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/fuse6/transforms/xccdf2table-stig-manual.xslt
+++ b/products/fuse6/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/jre/transforms/xccdf2table-stig-manual.xslt
+++ b/products/jre/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/macos1015/transforms/xccdf2table-stig-manual.xslt
+++ b/products/macos1015/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/ol7/transforms/xccdf2table-stig-manual.xslt
+++ b/products/ol7/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/ol8/transforms/xccdf2table-stig-manual.xslt
+++ b/products/ol8/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/rhcos4/transforms/xccdf2table-stig-manual.xslt
+++ b/products/rhcos4/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/rhel7/transforms/xccdf2table-stig-manual.xslt
+++ b/products/rhel7/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/rhel8/transforms/xccdf2table-stig-manual.xslt
+++ b/products/rhel8/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/rhel9/transforms/xccdf2table-stig-manual.xslt
+++ b/products/rhel9/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/rhv4/transforms/xccdf2table-stig-manual.xslt
+++ b/products/rhv4/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/sle12/transforms/xccdf2table-stig-manual.xslt
+++ b/products/sle12/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/sle15/transforms/xccdf2table-stig-manual.xslt
+++ b/products/sle15/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/ubuntu1604/transforms/xccdf2table-stig-manual.xslt
+++ b/products/ubuntu1604/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/ubuntu1804/transforms/xccdf2table-stig-manual.xslt
+++ b/products/ubuntu1804/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/ubuntu2004/transforms/xccdf2table-stig-manual.xslt
+++ b/products/ubuntu2004/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/uos20/transforms/xccdf2table-stig-manual.xslt
+++ b/products/uos20/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/products/vsel/transforms/xccdf2table-stig-manual.xslt
+++ b/products/vsel/transforms/xccdf2table-stig-manual.xslt
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+
+<xsl:import href="../../../shared/transforms/shared_xccdf2table-stig-manual.xslt"/>
+
+<xsl:include href="constants.xslt"/>
+<xsl:include href="table-style.xslt"/>
+
+</xsl:stylesheet>

--- a/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
+++ b/shared/transforms/shared_xccdf-apply-overlay-stig.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:xccdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ocil2="http://scap.nist.gov/schema/ocil/2.0" exclude-result-prefixes="xccdf">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns="http://checklists.nist.gov/xccdf/1.2" xmlns:xccdf-1.1="http://checklists.nist.gov/xccdf/1.1"  xmlns:xccdf-1.2="http://checklists.nist.gov/xccdf/1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ocil2="http://scap.nist.gov/schema/ocil/2.0" exclude-result-prefixes="xccdf-1.2">
 
 <xsl:output method="xml" indent="yes"/>
 
@@ -10,7 +10,7 @@
   <xsl:param name="ocil-document" select="''"/>
   <xsl:variable name="ocil" select="document($ocil-document)/ocil2:ocil"/>
 
-  <xsl:template match="xccdf:Benchmark">
+  <xsl:template match="xccdf-1.2:Benchmark">
     <xsl:copy>
       <xsl:attribute name="id">
         <xsl:value-of select="@id"/>
@@ -18,15 +18,15 @@
 
     <title>DISA STIG for <xsl:value-of select="$product_long_name" /></title>
 
-	<xsl:variable name="rules" select="//xccdf:Rule"/>
+	<xsl:variable name="rules" select="//xccdf-1.2:Rule"/>
 
-    <xsl:for-each select="$overlays/xccdf:overlay">  <!-- make sure overlays file namespace is XCCDF (hack) -->
-      <xsl:variable name="overlay_id" select="xccdf:VMSinfo/@VKey"/>
+    <xsl:for-each select="$overlays/xccdf-1.1:overlay">  <!-- make sure overlays file namespace is XCCDF (hack) -->
+      <xsl:variable name="overlay_id" select="xccdf-1.1:VMSinfo/@VKey"/>
       <xsl:variable name="overlay_version" select="@ownerid"/>
       <xsl:variable name="overlay_rule" select="@ruleid"/>
       <xsl:variable name="overlay_severity" select="@severity"/>
       <xsl:variable name="overlay_ref" select="@disa"/>
-      <xsl:variable name="overlay_title" select="xccdf:title/@text"/>
+      <xsl:variable name="overlay_title" select="xccdf-1.1:title/@text"/>
 
       <xsl:choose>
         <xsl:when test="$overlay_rule='XXXX'">
@@ -48,21 +48,21 @@
         </xsl:when>
         <xsl:otherwise>
           <xsl:for-each select="$rules">
-            <xsl:if test="@id=$overlay_rule">
+            <xsl:if test="@id = concat('xccdf_org.ssgproject.content_rule_', $overlay_rule)">
           <Group id="V-{$overlay_id}">
             <title>SRG-OS-ID</title>
             <description></description>
                 <Rule id="{$overlay_rule}" severity="{$overlay_severity}" >
           <version><xsl:value-of select="$overlay_version"/></version>
                 <title><xsl:value-of select="$overlay_title"/></title>
-                <description><xsl:copy-of select="xccdf:rationale/node()" /></description>
+                <description><xsl:copy-of select="xccdf-1.2:rationale/node()" /></description>
                 <check system="C-{$overlay_id}_chk">
                   <check-content>
-                    <xsl:apply-templates select="xccdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/>
+                    <xsl:apply-templates select="xccdf-1.2:check[@system='http://scap.nist.gov/schema/ocil/2']"/>
                   </check-content>
                 </check>
             <ident system="https://public.cyber.mil/stigs/cci"><xsl:value-of select="$overlay_ref" /></ident>
-                <fixtext><xsl:copy-of select="xccdf:description/node()" /></fixtext>
+                <fixtext><xsl:copy-of select="xccdf-1.2:description/node()" /></fixtext>
               </Rule>
               </Group>
             </xsl:if>
@@ -74,8 +74,8 @@
     </xsl:copy>
   </xsl:template>
 
-	<xsl:template match="xccdf:check[@system='http://scap.nist.gov/schema/ocil/2']">
-		<xsl:variable name="questionaireId" select="xccdf:check-content-ref/@name"/>
+	<xsl:template match="xccdf-1.2:check[@system='http://scap.nist.gov/schema/ocil/2']">
+		<xsl:variable name="questionaireId" select="xccdf-1.2:check-content-ref/@name"/>
 		<xsl:variable name="questionaire" select="$ocil/ocil2:questionnaires/ocil2:questionnaire[@id=$questionaireId]"/>
 		<xsl:variable name="testActionRef" select="$questionaire/ocil2:actions/ocil2:test_action_ref/text()"/>
 		<xsl:variable name="questionRef" select="$ocil/ocil2:test_actions/*[@id=$testActionRef]/@question_ref"/>

--- a/shared/transforms/shared_xccdf2table-stig-manual.xslt
+++ b/shared/transforms/shared_xccdf2table-stig-manual.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.2" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 
 <!-- setting the external variable $notes identifies a file from which to add notes,
 	 but set to nothing by default -->


### PR DESCRIPTION

#### Description:
We will use `ssg-${PRODUCT}-xccdf-1.2.xml` to generate
`table-${PRODUCT}-stig.html`. Note that the `stig_overlay.xml` file
remains in the XCCDF 1.1 namespace, but the temporary internal file
`unlinked-stig-xccdf.xml` will now be in XCCDF 1.2 namespace.

#### Rationale:
This reduces our dependency on XCCDF 1.1 so it will help us to remove the XCCDF 1.1 format in future.
