### PR TITLE
Add mount_option rules to ANSSI SLE intermediary profile

### DIFF
--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -192,34 +192,58 @@ controls:
     title: Partitioning type
     status: partial
     rules:
+    # this covers nodev options
+    - mount_option_nodev_nonroot_local_partitions
     # The recommended partitioning type is as follows:
     # / <without option> Root partition, contains the rest of the tree
     # /boot nosuid, nodev, noexec (optional noauto) Contains the kernel and the bootloader. No access required once the boot finished (except update)
     - partition_for_boot
+    - mount_option_boot_nosuid
+    - mount_option_boot_noexec
+    # The noauto option rule breaks checking of the other mount options
+    # Commented until rules for /boot mount_option handles this use case
+    # - mount_option_boot_noauto
 
     # /opt nosuid, nodev (optional ro) Additional packages to the system.  Read-only editing if not used
     - partition_for_opt
+    - mount_option_opt_nosuid
 
     # /tmp nosuid, nodev, noexec Temporary files. Must contain only non-executable elements. Cleaned after reboot
     - partition_for_tmp
+    - mount_option_tmp_nosuid
+    - mount_option_tmp_noexec
 
     # /srv nosuid, nodev (noexec, optional ro) Contains files served by a service type web, ftp, etc
     - partition_for_srv
+    - mount_option_srv_nosuid
 
     # /home nosuid, nodev, noexec Contains the HOME users.  Read-only editing if not in use
     - partition_for_home
+    - mount_option_home_nosuid
+    - mount_option_home_noexec
 
     # /usr nodev Contains the majority of utilities and system files
     - partition_for_usr
 
     # /var nosuid, nodev, noexec Partition containing variable files during the life of the system (mails, PID files, databases of a service)
     - partition_for_var
+    - mount_option_var_nosuid
+    - mount_option_var_noexec
 
     # /var/log nosuid, nodev, noexec Contains system logs
     - partition_for_var_log
+    - mount_option_var_log_noexec
+    - mount_option_var_log_nosuid
 
     # /var/tmp nosuid, nodev, noexec Temporary files kept after extinction
     - partition_for_var_tmp
+    - mount_option_var_tmp_nosuid
+    - mount_option_var_tmp_noexec
+
+    related_rules:
+    # /proc hidepid = 2 Contains process information and the system
+    - mount_option_proc_hidepid
+    - var_mount_option_proc_hidepid=2
 
   - id: R13
     levels:

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Add noexec Option to /boot'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Add nosuid Option to /boot'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Add noexec Option to /home'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle15
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Add nodev Option to Non-Root Local Partitions'
 
@@ -31,6 +31,7 @@ identifiers:
     cce@rhel7: CCE-80145-6
     cce@rhel8: CCE-82069-6
     cce@rhel9: CCE-83873-0
+    cce@sle12: CCE-91544-7
     cce@sle15: CCE-91237-8
 
 references:

--- a/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Add nosuid Option to /opt'
 
@@ -23,6 +23,8 @@ identifiers:
     cce@rhel7: CCE-83317-8
     cce@rhel8: CCE-83319-4
     cce@rhel9: CCE-83880-5
+    cce@sle12: CCE-91584-3
+    cce@sle15: CCE-91270-9
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Add nosuid Option to /srv'
 
@@ -23,6 +23,8 @@ identifiers:
     cce@rhel7: CCE-83320-2
     cce@rhel8: CCE-83322-8
     cce@rhel9: CCE-83862-3
+    cce@sle12: CCE-91585-0
+    cce@sle15: CCE-91271-7
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -22,6 +22,8 @@ identifiers:
     cce@rhel7: CCE-80150-6
     cce@rhel8: CCE-82139-7
     cce@rhel9: CCE-83885-4
+    cce@sle12: CCE-91586-8
+    cce@sle15: CCE-91272-5
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -22,6 +22,8 @@ identifiers:
     cce@rhel7: CCE-80151-4
     cce@rhel8: CCE-82140-5
     cce@rhel9: CCE-83872-2
+    cce@sle12: CCE-91587-6
+    cce@sle15: CCE-91273-3
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Add noexec Option to /var/log'
 
@@ -22,6 +22,8 @@ identifiers:
     cce@rhel7: CCE-82142-1
     cce@rhel8: CCE-82008-4
     cce@rhel9: CCE-83887-0
+    cce@sle12: CCE-91588-4
+    cce@sle15: CCE-91274-1
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Add nosuid Option to /var/log'
 
@@ -23,6 +23,8 @@ identifiers:
     cce@rhel7: CCE-82144-7
     cce@rhel8: CCE-82065-4
     cce@rhel9: CCE-83870-6
+    cce@sle12: CCE-91589-2
+    cce@sle15: CCE-91275-8
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4
+prodtype: alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Add noexec Option to /var'
 
@@ -21,6 +21,8 @@ identifiers:
     cce@rhel7: CCE-83329-3
     cce@rhel8: CCE-83330-1
     cce@rhel9: CCE-83865-6
+    cce@sle12: CCE-91590-0
+    cce@sle15: CCE-91276-6
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux3,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9
+prodtype: alinux3,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Add nosuid Option to /var'
 
@@ -17,6 +17,8 @@ identifiers:
     cce@rhel7: CCE-83378-0
     cce@rhel8: CCE-83383-0
     cce@rhel9: CCE-83867-2
+    cce@sle12: CCE-91591-8
+    cce@sle15: CCE-91277-4
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -23,6 +23,8 @@ identifiers:
     cce@rhel7: CCE-82150-4
     cce@rhel8: CCE-82151-2
     cce@rhel9: CCE-83866-4
+    cce@sle12: CCE-91592-6
+    cce@sle15: CCE-91278-2
 
 references:
     anssi: BP28(R12)

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -23,6 +23,8 @@ identifiers:
     cce@rhel7: CCE-82153-8
     cce@rhel8: CCE-82154-6
     cce@rhel9: CCE-83863-1
+    cce@sle12: CCE-91593-4
+    cce@sle15: CCE-91279-0
 
 references:
     anssi: BP28(R12)


### PR DESCRIPTION
#### Description:

- Enable SLE12,SLE15 platforms for mount_option_opt_nosuid/noexec,mount_option_var_log_nosuid/noexec,mount_option_var_noexec/nosuid rules
- Enable SLE12 platform for mount_option_boot_nosuid,mount_option_home_noexec,mount_option_nodev_nonroot_local_partitions,mount_option_boot_noexec
- Add SLES CCE ids for mount_option_tmp and mount_option_var_tm
