### PR TITLE
Generate per profile testinfo tables from XCCDF 1.2

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1188,9 +1188,9 @@ macro(ssg_build_html_stig_tables_per_profile PRODUCT STIG_PROFILE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${STIG_PROFILE}" -stringparam testinfo "y" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${STIG_PROFILE}" -stringparam testinfo "y" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML STIG test info document for ${STIG_PROFILE}"
     )

--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -1,27 +1,29 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.2" xmlns:xccdf-1.1="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
 
 <!-- this style sheet expects parameter $profile, which is the id of the Profile to be shown -->
 
 <xsl:variable name="cci_list" select="document('../references/disa-cci-list.xml')/cci:cci_list" />
-<xsl:variable name="os_srg" select="document('../references/disa-os-srg-v2r3.xml')/cdf:Benchmark" />
+<xsl:variable name="os_srg" select="document('../references/disa-os-srg-v2r3.xml')/xccdf-1.1:Benchmark" />
 
 <xsl:param name="profile" select="''"/>
 <xsl:param name="testinfo" select="''" />
 
+<xsl:variable name="profile_id" select="concat('xccdf_org.ssgproject.content_profile_', $profile)" />
+
 	<xsl:template match="/">
-		<xsl:if test="not(/cdf:Benchmark/cdf:Profile[@id=$profile])">
-			<xsl:message terminate="yes">Profile '<xsl:value-of select="$profile"/>' not found.</xsl:message>
+		<xsl:if test="not(/cdf:Benchmark/cdf:Profile[@id=$profile_id])">
+			<xsl:message terminate="yes">Profile '<xsl:value-of select="$profile_id"/>' not found.</xsl:message>
 		</xsl:if>
 		<html>
 		<head>
-			<title><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:title" /></title>
+			<title><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile_id]/cdf:title" /></title>
 		</head>
 		<body>
 			<br/>
 			<br/>
-			<div style="text-align: center; font-size: x-large; font-weight:bold"><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:title" /></div>
-			<div style="text-align: center; font-size: normal "><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:description" /></div>
+			<div style="text-align: center; font-size: x-large; font-weight:bold"><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile_id]/cdf:title" /></div>
+			<div style="text-align: center; font-size: normal "><xsl:value-of select="/cdf:Benchmark/cdf:Profile[@id=$profile_id]/cdf:description" /></div>
 			<br/>
 			<br/>
 			<xsl:apply-templates select="/cdf:Benchmark"/>
@@ -46,7 +48,7 @@
 				<td>800-53 Refs</td>
 			</thead>
 
-		<xsl:for-each select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:select">
+		<xsl:for-each select="/cdf:Benchmark/cdf:Profile[@id=$profile_id]/cdf:select">
 			<xsl:variable name="idrefer" select="@idref" />
 			<xsl:variable name="enabletest" select="@selected" />
 			<xsl:for-each select="//cdf:Rule">
@@ -83,9 +85,9 @@
 			<xsl:for-each select="cdf:reference[@href=$disa-cciuri]">
             	<xsl:variable name="cci_formatted" select='self::node()[text()]' />
 				<xsl:variable name="cci_expanded" select="$cci_formatted"  />
-				<xsl:for-each select="$os_srg/cdf:Group/cdf:Rule" >
-					<xsl:if test="cdf:ident=$cci_expanded">
-						<xsl:value-of select="cdf:version"/>
+				<xsl:for-each select="$os_srg/xccdf-1.1:Group/xccdf-1.1:Rule" >
+					<xsl:if test="xccdf-1.1:ident=$cci_expanded">
+						<xsl:value-of select="xccdf-1.1:version"/>
 						<br/>
 					</xsl:if>
 				</xsl:for-each>


### PR DESCRIPTION
#### Description:
This commit changes the `table-${PRODUCT}-${STIG_PROFILE}-testinfo.html`
files generator to use the `ssg-${PRODUCT}-xccdf-1.2.xml` instead of
`ssg-${PRODUCT}-xccdf.xml` as an input.


#### Rationale:
This reduces our dependency on XCCDF 1.1 so it will help us to remove the XCCDF 1.1 format in future.

