### PR TITLE
Fix typo in audit_access_success_aarch64 rule title

### DIFF
--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success_aarch64/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: rhel9
 
-title: 'Configure auditing of successful file accesses (AArch64'
+title: 'Configure auditing of successful file accesses (AArch64)'
 
 {{% set file_contents_audit_access_success =
 "## Successful file access (any other opens) This has to go last.


### PR DESCRIPTION
#### Description:

- Fix typo in audit_access_success_aarch64 rule title.

