### PR TITLE
add 4 rules back to RHEL9 datastream

### DIFF
--- a/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
+++ b/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Remove the Kerberos Server Package'
 

--- a/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypbind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: alinux2,alinux3,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Remove NIS Client'
 

--- a/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/nis/package_ypserv_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Uninstall ypserv Package'
 

--- a/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9
 
 title: 'Uninstall krb5-workstation Package'
 


### PR DESCRIPTION
#### Description:

Add following rules back to RHEL9 datastream by adding rhel9 prodtype:
 - package_ypserv_removed
 - package_ypbind_removed
 - package_krb5-server_removed
 - package_krb5-workstation_removed

#### Rationale:

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2117669