### PR TITLE
Fix ansible partition conditionals

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1442,5 +1442,5 @@ Part of the grub2_bootloader_argument_absent template.
 
 
 {{%- macro ansible_partition_conditional(path) -%}}
-"ansible_facts.ansible_mounts | json_query(\"[?mount=='{{{ path }}}'].mount\") | length == 1"
+"ansible_mounts | json_query(\"[?mount=='{{{ path }}}'].mount\") | length == 1"
 {{%- endmacro -%}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1442,5 +1442,5 @@ Part of the grub2_bootloader_argument_absent template.
 
 
 {{%- macro ansible_partition_conditional(path) -%}}
-"ansible_mounts | json_query(\"[?mount=='{{{ path }}}'].mount\") | length == 1"
+'"{{{ path }}}" in ansible_mounts | map(attribute="mount") | list'
 {{%- endmacro -%}}


### PR DESCRIPTION
#### Description:

- Use `ansible_mounts` instead of `ansible_facts.ansible_mounts`, the latter doesn't work.
- Avoid use of `json_query`, it will require another dependency (`jmespath`) that is not always available for the same python version used by Ansible.

#### Rationale:

- Fixes missing `jmespath` pakage:
```
TASK [Add nodev Option to /tmp: Check information associated to mountpoint] ****
fatal: [192.168.122.102]: FAILED! => {"msg": "The conditional check '( ansible_virtualization_type not in [\"docker\", \"lxc\",
 \"openvz\", \"podman\", \"container\"] and ansible_facts.ansible_mounts | json_query(\"[?mount=='/tmp'].mount\") | length 
== 1 )' failed. The error was: You need to install \"jmespath\" prior to running json_query filter\n\nThe error appears to be 
in '/usr/share/scap-security-guide/ansible/rhel8-playbook-cis_workstation_l1.yml': line 8188, column 7, but may\nbe 
elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: 'Add 
nodev Option to /tmp: Check information associated to mountpoint'\n      ^ here\nThis one looks easy to fix. It seems that 
there is a value started\nwith a quote, and the YAML parser is expecting to see the line ended\nwith the same kind of 
quote. For instance:\n\n    when: \"ok\" in result.stdout\n\nCould be written as:\n\n   when: '\"ok\" in result.stdout'\n\nOr 
equivalently:\n\n   when: \"'ok' in result.stdout\"\n"}
```
- Fixes `ansible_facts.ansible_mounts` evaluating to `None`:
```
TASK [Add nodev Option to /var/tmp: Check information associated to mountpoint] **********************************************************************************************************************************************************************************************************************************************
Monday 15 August 2022  12:00:30 +0200 (0:00:00.103)       0:00:01.483 *********                                                                                                                                                                                                                                               
fatal: [rhel86part]: FAILED! => {"msg": "The conditional check '( ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"] and ansible_facts.ansible_mounts | json_query(\"[?mount=='/var/tmp'].mount\") | length == 1 )' failed. The error was: Unexpected templating type error occur
red on ({% if ( ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"] and ansible_facts.ansible_mounts | json_query(\"[?mount=='/var/tmp'].mount\") | length == 1 ) %} True {% else %} False {% endif %}): object of type 'NoneType' has no len()\n\nThe error appears to be in '/ho
me/wsato/git/content/build/ansible/rhel8-playbook-cis.yml': line 26217, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: 'Add nodev Option to /var/tmp: Check information associated to mountpoint'\n      ^ here\nThis one looks easy
 to fix. It seems that there is a value started\nwith a quote, and the YAML parser is expecting to see the line ended\nwith the same kind of quote. For instance:\n\n    when: \"ok\" in result.stdout\n\nCould be written as:\n\n   when: '\"ok\" in result.stdout'\n\nOr equivalently:\n\n   when: \"'ok' in result.stdout\"
\n"}           
```
