### PR TITLE
Include warning about the pam_securetty.so PAM module

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/ansible/shared.yml
@@ -1,9 +1,8 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
-
 
 - name: "Direct root Logins Not Allowed"
   copy:

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/bash/shared.sh
@@ -1,2 +1,3 @@
 # platform = multi_platform_all
+
 echo > /etc/securetty

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/oval/shared.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="no_direct_root_logins" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Preventing direct root logins help ensure accountability for actions
       taken on the system using the root account.") }}}
     <criteria operator="AND">
@@ -8,19 +8,25 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="/etc/securetty file exists" id="test_etc_securetty_exists" version="1">
+  <ind:textfilecontent54_test id="test_etc_securetty_exists" version="1"
+      check="all" check_existence="all_exist" comment="/etc/securetty file exists">
     <ind:object object_ref="object_etc_securetty_exists" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="/etc/securetty file exists" id="object_etc_securetty_exists" version="1">
+
+  <ind:textfilecontent54_object id="object_etc_securetty_exists" version="1"
+      comment="/etc/securetty file exists">
     <ind:filepath>/etc/securetty</ind:filepath>
     <ind:pattern operation="pattern match">^.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="no entries in /etc/securetty" id="test_no_direct_root_logins" version="1">
+  <ind:textfilecontent54_test id="test_no_direct_root_logins" version="1"
+      check="all" check_existence="all_exist" comment="no entries in /etc/securetty">
     <ind:object object_ref="object_no_direct_root_logins" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="no entries /etc/securetty" id="object_no_direct_root_logins" version="1">
+
+  <ind:textfilecontent54_object id="object_no_direct_root_logins" version="1"
+      comment="no entries /etc/securetty">
     <ind:filepath>/etc/securetty</ind:filepath>
     <ind:pattern operation="pattern match">^$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_direct_root_logins/rule.yml
@@ -59,3 +59,9 @@ ocil: |-
     If any output is returned, this is a finding.
 
 platform: machine
+
+warnings:
+    - general: |-
+       This rule only checks the <tt>/etc/securetty</tt> file existence and its content.
+       If you need to restrict user access using the <tt>/etc/securetty</tt> file, make sure
+       the <tt>pam_securetty.so</tt> PAM module is properly enabled in relevant PAM files.


### PR DESCRIPTION
#### Description:

The `no_direct_root_logins` rule checks and remediate the `/etc/securetty` file, which is used by the `pam_securetty.so` module. Currently, this module is no longer enabled by default in many distros. It was included a warning message to make the user aware of this, since the `/etc/securetty` file is useless without the `pam_securetty.so` module properly enabled.

#### Rationale:

Increase awareness for the users
