### PR TITLE
Packit: change Fedora test target to be the latest released Fedora

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -19,6 +19,6 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-latest
+    - fedora-latest-stable
     - centos-stream-8
     - centos-stream-9


### PR DESCRIPTION
#### Description:

- atm `fedora-latest` is running on unreleased Fedora 37 which might be unstable (cause fails in our CI job), let's change to the `fedora-latest-stable` which should be the latest released stable version (36)