### PR TITLE
feature: ssg parsing: add sometimes external_variable related asserts

### DIFF
--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -411,6 +411,9 @@ def check_and_correct_xccdf_to_oval_data_export_matching_constraints(xccdftree, 
 
         # This is the required XCCDF 'type' for <xccdf:Value> derived
         # from OVAL variable 'datatype' and mapping above
+        assert ovalvartype in OVAL_TO_XCCDF_DATATYPE_CONSTRAINTS, \
+            ('datatype not known: "%s" "%s known types "%s"' %
+             (ovalvarid, ovalvartype, OVAL_TO_XCCDF_DATATYPE_CONSTRAINTS))
         reqxccdftype = OVAL_TO_XCCDF_DATATYPE_CONSTRAINTS[ovalvartype]
         # Compare the actual value of 'type' of <xccdf:Value> with the requirement
         if xccdfvartype != reqxccdftype:

--- a/ssg/parse_oval.py
+++ b/ssg/parse_oval.py
@@ -55,6 +55,9 @@ class ElementFinder(object):
             if _attr_group is not None:
                 ref_attribute_name, entity_id = _attr_group
                 reference_target = REFERENCE_TO_GROUP[ref_attribute_name]
+                assert entity_id in self.oval_groups[reference_target], \
+                    ('Missing definition: "%s" in "%s" "%s"' %
+                     (entity_id, reference_target, element))
                 new_root = self.oval_groups[reference_target][entity_id]
 
         if new_root is not None:


### PR DESCRIPTION
#### Description:

Add two assertions to help when editing OVAL files.

#### Rationale:

Provide some info what might be wrong. It helps to write files faster.

I hit those when external_variable definitions were not right. I decided
to leave them as asserts. I guess these points can be hit via other cases
and so stacktrace is nice to have then too.

You can hit those at least:
- datatype is not known, for example ""
- external_variable is missing
- external_variable id is wrong
- test id is wrong