### PR TITLE
Don't fail enable_fips_mode if /etc/grubenv is missing on s390x

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -7,9 +7,16 @@
       <extend_definition comment="Dracut FIPS module is enabled" definition_ref="enable_dracut_fips_module" />
       <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
       <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
-      {{% if product in ["ol8","rhel8"] %}}
+      {{% if product in ["ol8"] %}}
       <criterion comment="check if the kernel boot parameter is configured for FIPS mode"
       test_ref="test_grubenv_fips_mode" />
+      {{% elif product in ["rhel8"] %}}
+      <criteria operator="OR">
+        <extend_definition comment="Generic test for s390x architecture"
+        definition_ref="system_info_architecture_s390_64" />
+        <criterion comment="check if the kernel boot parameter is configured for FIPS mode"
+        test_ref="test_grubenv_fips_mode" />
+      </criteria>
       {{% endif %}}
     </criteria>
   </definition>


### PR DESCRIPTION

#### Description:

- Check that `/boot/grub2/grubenv` has `fips=1` or that the system arch is  s390x.

#### Rationale:

- There is no need to check  /etc/grubenv for fips=1 on s390x systems zIPL is used and it doesn't have `/boot/grub2/grubenv` file.

- Fixes #9304

Edit: fixed the linked issue
