### PR TITLE
change: mount_option rules should not require existence of extra filesystems

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/rule.yml
@@ -42,6 +42,6 @@ ocil: |-
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
         mountoption: sec=krb5:krb5i:krb5p
         mountpoint: remote_filesystems

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nodev_remote_filesystems/rule.yml
@@ -46,6 +46,6 @@ srg_requirement: '{{{ full_name }}} must prevent special devices on file systems
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
         mountoption: nodev
         mountpoint: remote_filesystems

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/rule.yml
@@ -54,6 +54,6 @@ srg_requirement: '{{{ full_name }}} must prevent code from being executed on fil
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
         mountoption: noexec
         mountpoint: remote_filesystems

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_nosuid_remote_filesystems/rule.yml
@@ -52,6 +52,6 @@ srg_requirement: '{{{ full_name }}} must prevent files with the setuid and setgi
 template:
     name: mount_option_remote_filesystems
     vars:
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
         mountoption: nosuid
         mountpoint: remote_filesystems

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noauto/rule.yml
@@ -33,7 +33,7 @@ template:
     vars:
         mountpoint: /boot
         mountoption: noauto
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/rule.yml
@@ -38,7 +38,7 @@ template:
     vars:
         mountpoint: /boot
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/boot", "nodev") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_noexec/rule.yml
@@ -35,4 +35,4 @@ template:
     vars:
         mountpoint: /boot
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nosuid/rule.yml
@@ -42,7 +42,7 @@ template:
     vars:
         mountpoint: /boot
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/boot", "nosuid") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nodev/rule.yml
@@ -44,7 +44,7 @@ template:
     vars:
         mountpoint: /home
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/home", "nodev") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_noexec/rule.yml
@@ -44,4 +44,4 @@ template:
     vars:
         mountpoint: /home
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'

--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -58,5 +58,5 @@ template:
     vars:
         mountpoint: /home
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_opt_nosuid/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         mountpoint: /opt
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'

--- a/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_srv_nosuid/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         mountpoint: /srv
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nodev/rule.yml
@@ -52,7 +52,7 @@ template:
     vars:
         mountpoint: /tmp
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 # Note that /tmp on RHEL systems is not tmpfs
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_noexec/rule.yml
@@ -51,7 +51,7 @@ template:
     vars:
         mountpoint: /tmp
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 # Note that /tmp on RHEL systems is not tmpfs
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_tmp_nosuid/rule.yml
@@ -52,7 +52,7 @@ template:
     vars:
         mountpoint: /tmp
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 # Note that /tmp on RHEL systems is not tmpfs
 
 fixtext: |-

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nodev/rule.yml
@@ -42,7 +42,7 @@ template:
     vars:
         mountpoint: /var/log/audit
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/log/audit", "nodev") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_noexec/rule.yml
@@ -40,7 +40,7 @@ template:
     vars:
         mountpoint: /var/log/audit
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/log/audit", "noexec") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_audit_nosuid/rule.yml
@@ -41,7 +41,7 @@ template:
     vars:
         mountpoint: /var/log/audit
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/log/audit", "nosuid") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nodev/rule.yml
@@ -42,7 +42,7 @@ template:
     vars:
         mountpoint: /var/log
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/log", "nodev") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_noexec/rule.yml
@@ -41,7 +41,7 @@ template:
     vars:
         mountpoint: /var/log
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/log", "noexec") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_log_nosuid/rule.yml
@@ -42,7 +42,7 @@ template:
     vars:
         mountpoint: /var/log
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/log", "nosuid") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nodev/rule.yml
@@ -39,7 +39,7 @@ template:
     vars:
         mountpoint: /var
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var", "nodev") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_noexec/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         mountpoint: /var
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_nosuid/rule.yml
@@ -34,4 +34,4 @@ template:
     vars:
         mountpoint: /var
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nodev/rule.yml
@@ -46,7 +46,7 @@ template:
     vars:
         mountpoint: /var/tmp
         mountoption: nodev
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/tmp", "nodev") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_noexec/rule.yml
@@ -45,7 +45,7 @@ template:
     vars:
         mountpoint: /var/tmp
         mountoption: noexec
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/tmp", "noexec") }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_nosuid/rule.yml
@@ -45,7 +45,7 @@ template:
     vars:
         mountpoint: /var/tmp
         mountoption: nosuid
-        mount_has_to_exist: 'yes'
+        mount_has_to_exist: 'no'
 
 fixtext: |-
     {{{ fixtext_mount_option("/var/tmp", "nosuid") }}}


### PR DESCRIPTION
#### Description:

Do not require filesystem to exist when checking mount flags.

#### Rationale:

If rule requires existence of extra filesystems, then it is not possible
to enable these provisionally.

If mount_has_to_exist=yes these test both filesystem and flag.

There is following rules to enable if policy requires specific
partition:

partition_for_boot
partition_for_home
partition_for_opt
partition_for_srv
partition_for_tmp
partition_for_usr
partition_for_var
partition_for_var_log
partition_for_var_log_audit
partition_for_var_tmp

With this patch, when a mount point is missing, test result is:

	notapplicable

As I'd expect.