### PR TITLE
Ensure order of zipl boot argument rules

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1124,10 +1124,14 @@ class Group(XCCDFEntity):
                  r'(service_.*_(enabled|disabled))|' +
                  r'install_smartcard_packages|' +
                  r'sshd_set_keepalive(_0)?|' +
-                 r'sshd_set_idle_timeout$')
+                 r'sshd_set_idle_timeout|' +
+                 r'zipl_.*_argument.*|'
+                 r'zipl_enable_selinux|'
+                 r'zipl_bootmap_is_up_to_date$')
         priority_order = ["enable_authselect", "installed", "install_smartcard_packages", "removed",
                           "enabled", "disabled", "sshd_set_keepalive_0",
-                          "sshd_set_keepalive", "sshd_set_idle_timeout"]
+                          "sshd_set_keepalive", "sshd_set_idle_timeout",
+                          "_argument", "zipl_enable_selinux", "zipl_bootmap_is_up_to_date"]
         rules_in_group = reorder_according_to_ordering(rules_in_group, priority_order, regex)
 
         # Add rules in priority order, first all packages installed, then removed,


### PR DESCRIPTION

#### Description:

- Rule `zipl_bootmap_is_up_to_date` needs to be the last one to be scanned
and remediated because it takes the boot configuration done in other zipl
argument rules and updates the bootmap that will be used by zIPL.

#### Rationale:

- If the bootmap is updated before all the configurations are in place the
bootmap will be out dated.
- Fixes #9312
