### PR TITLE
Specify output file names

### DIFF
--- a/build-scripts/relabel_ids.py
+++ b/build-scripts/relabel_ids.py
@@ -23,16 +23,18 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="This script finds check-content files (currently, "
         "OVAL and OCIL) referenced from XCCDF and synchronizes all IDs.")
-    parser.add_argument("xccdf_file")
-    parser.add_argument("new_xccdf_file")
-    parser.add_argument("id_name", help="ID naming scheme")
+    parser.add_argument("--input-xccdf", help="Input XCCDF file")
+    parser.add_argument("--output-xccdf", help="Output XCCDF file")
+    parser.add_argument("--output-oval", help="Output OVAL file")
+    parser.add_argument("--output-ocil", help="Output OCIL file")
+    parser.add_argument("--id-name", help="ID naming scheme")
 
     return parser.parse_args()
 
 
 def main():
     args = parse_args()
-    xccdffile = args.xccdf_file
+    xccdffile = args.input_xccdf
     idname = args.id_name
 
     # Step over xccdf file, and find referenced check files
@@ -45,19 +47,19 @@ def main():
 
     translator = ssg.id_translate.IDTranslator(idname)
 
-    oval_linker = ssg.build_renumber.OVALFileLinker(translator, xccdftree,
-                                                    checks)
+    oval_linker = ssg.build_renumber.OVALFileLinker(
+        translator, xccdftree, checks, args.output_oval)
     oval_linker.link()
     oval_linker.save_linked_tree()
     oval_linker.link_xccdf()
 
-    ocil_linker = ssg.build_renumber.OCILFileLinker(translator, xccdftree,
-                                                    checks)
+    ocil_linker = ssg.build_renumber.OCILFileLinker(
+        translator, xccdftree, checks, args.output_ocil)
     ocil_linker.link()
     ocil_linker.save_linked_tree()
     ocil_linker.link_xccdf()
 
-    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.new_xccdf_file)
+    ssg.xml.ElementTree.ElementTree(xccdftree).write(args.output_xccdf)
     sys.exit(0)
 
 

--- a/build-scripts/relabel_ids.py
+++ b/build-scripts/relabel_ids.py
@@ -23,11 +23,15 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="This script finds check-content files (currently, "
         "OVAL and OCIL) referenced from XCCDF and synchronizes all IDs.")
-    parser.add_argument("--input-xccdf", help="Input XCCDF file")
-    parser.add_argument("--output-xccdf", help="Output XCCDF file")
-    parser.add_argument("--output-oval", help="Output OVAL file")
-    parser.add_argument("--output-ocil", help="Output OCIL file")
-    parser.add_argument("--id-name", help="ID naming scheme")
+    parser.add_argument(
+        "--input-xccdf", required=True, help="Input XCCDF file")
+    parser.add_argument(
+        "--output-xccdf", required=True, help="Output XCCDF file")
+    parser.add_argument(
+        "--output-oval", required=True, help="Output OVAL file")
+    parser.add_argument(
+        "--output-ocil", required=True, help="Output OCIL file")
+    parser.add_argument("--id-name", required=True, help="ID naming scheme")
 
     return parser.parse_args()
 

--- a/build-scripts/relabel_ids.py
+++ b/build-scripts/relabel_ids.py
@@ -12,8 +12,7 @@ import ssg.id_translate
 import ssg.xml
 
 
-# This script requires two arguments: an "unlinked" XCCDF file and an ID name
-# scheme. This script is designed to convert and synchronize check IDs
+# This script is designed to convert and synchronize check IDs
 # referenced from the XCCDF document for the supported checksystems, which are
 # currently OVAL and OCIL.  The IDs are to be converted from strings to
 # meaningless numbers.

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -366,7 +366,7 @@ macro(ssg_build_link_xccdf_oval_ocil PRODUCT)
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked.xml"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-linked.xml"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ocil-linked.xml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/relabel_ids.py" "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked.xml" ssg
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/relabel_ids.py" --input-xccdf "${CMAKE_CURRENT_BINARY_DIR}/shorthand.xml" --output-xccdf "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked.xml" --output-oval "${CMAKE_CURRENT_BINARY_DIR}/oval-linked.xml" --output-ocil "${CMAKE_CURRENT_BINARY_DIR}/ocil-linked.xml" --id-name "ssg"
         DEPENDS generate-internal-${PRODUCT}-oval-unlinked.xml
         DEPENDS ${PRODUCT}-shorthand.xml-ocil-unlinked.xml
         COMMENT "[${PRODUCT}-content] linking IDs, generating xccdf-linked.xml, oval-linked.xml, ocil-linked.xml"

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import sys
 import collections
+import os
 
 
 from .constants import oval_namespace, XCCDF11_NS, cce_uri, ocil_cs, ocil_namespace
@@ -26,12 +27,13 @@ class FileLinker(object):
     CHECK_SYSTEM = None
     CHECK_NAMESPACE = None
 
-    def __init__(self, translator, xccdftree, checks):
+    def __init__(self, translator, xccdftree, checks, output_file_name):
         self.translator = translator
         self.checks_related_to_us = self._get_related_checks(checks)
         self.fname = self._get_input_fname()
         self.tree = None
-        self.linked_fname = self.fname.replace("unlinked", "linked")
+        self.linked_fname = output_file_name
+        self.linked_fname_basename = os.path.basename(self.linked_fname)
         self.xccdftree = xccdftree
 
     def _get_related_checks(self, checks):
@@ -100,7 +102,7 @@ class FileLinker(object):
         checkid = self.translator.generate_id(
             self._get_checkid_string(), checkcontentref.get("name"))
         checkcontentref.set("name", checkid)
-        checkcontentref.set("href", self.linked_fname)
+        checkcontentref.set("href", self.linked_fname_basename)
 
         variable_str = "{%s}variable" % self.CHECK_NAMESPACE
         for checkexport in checkexports:
@@ -113,8 +115,9 @@ class OVALFileLinker(FileLinker):
     CHECK_SYSTEM = oval_cs
     CHECK_NAMESPACE = oval_ns
 
-    def __init__(self, translator, xccdftree, checks):
-        super(OVALFileLinker, self).__init__(translator, xccdftree, checks)
+    def __init__(self, translator, xccdftree, checks, output_file_name):
+        super(OVALFileLinker, self).__init__(
+            translator, xccdftree, checks, output_file_name)
         self.oval_groups = None
 
     def _get_checkid_string(self):


### PR DESCRIPTION
This change enables us to explicitly specify output file names of the
relabel_ids.py script. Instead of inferring the output file names by the
script the output file names will be specified on command line. This way
the usage and outputs of relabel_ids.py will be more understandable.
This change will be used in the CMake command that calls relabel_ids.py.