### PR TITLE
Mask sensitive objects

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -1,15 +1,18 @@
-# platform = multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low
 # disruption = low
-- name: Collect users with not correct maximum time period between password changes  
-  command: >
-    awk -F: '$5 > 60 || $5 == "" {print $1}' /etc/shadow
+{{{ ansible_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
+
+- name: Collect users with not correct maximum time period between password changes
+  ansible.builtin.command: >
+    awk -F: '$5 > {{ var_accounts_maximum_age_login_defs }} || $5 == "" {print $1}' /etc/shadow
   register: user_names
-  
-- name: Change the maximum time period between password changes 
-  command: >
-    chage -M 60 {{ item }}
-  with_items: "{{ user_names.stdout_lines }}"
+
+- name: Change the maximum time period between password changes
+  ansible.builtin.user:
+    user: '{{ item }}'
+    password_expire_max: '{{ var_accounts_maximum_age_login_defs }}'
+  with_items: '{{ user_names.stdout_lines }}'
   when: user_names.stdout_lines | length > 0

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -7,5 +7,5 @@
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
 {{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_maximum_age_login_defs\" -F: '$5 > var || $5 == \"\" {print $1}' /etc/shadow") -%}}
-passwd -x $var_accounts_maximum_age_login_defs $i
+chage -M $var_accounts_maximum_age_login_defs $i
 {{%- endcall %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/oval/shared.xml
@@ -33,12 +33,14 @@
 
   <unix:shadow_state id="min_max_password_change_interval" version="1"
     comment="change passwords every minimum interval or more">
+    <unix:password operation="pattern match" mask="true">.*</unix:password>
     <unix:chg_req operation="greater than or equal" datatype="int"
       var_ref="var_accounts_minimum_age_login_defs"/>
   </unix:shadow_state>
 
   <unix:shadow_state id="max_password_change_interval" version="1"
     comment="change passwords at the recommended interval or less">
+    <unix:password operation="pattern match" mask="true">.*</unix:password>
     <unix:chg_req operation="less than or equal" datatype="int"
       var_ref="var_accounts_maximum_age_login_defs"/>
   </unix:shadow_state>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/oval/shared.xml
@@ -1,25 +1,28 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_set_max_life_existing" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
       {{{ oval_metadata("Set Existing Passwords Maximum Age") }}}
     <criteria operator="AND">
-        <criterion comment="Passwords must be restricted to the appropriate maximum age for existing accounts." test_ref="test_password_max_life_existing" />
-        <criterion comment="Passwords must have a maximum lifetime greater than or equal minimum password age." test_ref="test_password_max_life_existing_minimum" />
+        <criterion test_ref="test_password_max_life_existing"
+          comment="Passwords must be restricted to the appropriate maximum age for existing accounts."/>
+        <criterion test_ref="test_password_max_life_existing_minimum"
+          comment="Passwords must have a maximum lifetime greater than or equal minimum password age."/>
     </criteria>
   </definition>
 
-  <!-- Define a test for the shadow file for non-system accounts to look for the maximum password change interval. -->
-  <unix:shadow_test
-      id="test_password_max_life_existing" 
-      check="all"
-      check_existence="at_least_one_exists"
-      version="1" 
-      comment="Password maximum lifetime for existing accounts is at least the minimum.">
+  <!-- Define a test for the shadow file for non-system accounts to look for the maximum
+       password change interval. -->
+  <unix:shadow_test id="test_password_max_life_existing" version="1"
+    check="all" check_existence="at_least_one_exists"
+    comment="Password maximum lifetime for existing accounts is at least the minimum.">
     <unix:object object_ref="object_shadow_password_users_max_life_existing"/>
     <unix:state state_ref="max_password_change_interval"/>
   </unix:shadow_test>
 
-  <!-- Define a second test to ensure the maximum password life is at least the defined minimum (usually 1). -->
-  <unix:shadow_test id="test_password_max_life_existing_minimum"  check="all" check_existence="at_least_one_exists" version="1" comment="Password maximum life entry is at least a defined minimum">
+  <!-- Define a second test to ensure the maximum password life is at least the defined
+       minimum (usually 1). -->
+  <unix:shadow_test id="test_password_max_life_existing_minimum" version="1"
+    check="all" check_existence="at_least_one_exists"
+    comment="Password maximum life entry is at least a defined minimum">
     <unix:object object_ref="object_shadow_password_users_max_life_existing"/>
     <unix:state state_ref="min_max_password_change_interval"/>
   </unix:shadow_test>
@@ -28,31 +31,22 @@
     <unix:username operation="pattern match">.*</unix:username>
   </unix:shadow_object>
 
-  <unix:shadow_state id="min_max_password_change_interval" version="1" comment="change passwords every minimum interval or more">
-    <unix:chg_req
-      operation="greater than or equal"
-      datatype="int"
+  <unix:shadow_state id="min_max_password_change_interval" version="1"
+    comment="change passwords every minimum interval or more">
+    <unix:chg_req operation="greater than or equal" datatype="int"
       var_ref="var_accounts_minimum_age_login_defs"/>
   </unix:shadow_state>
 
-  <unix:shadow_state id="max_password_change_interval" version="1" comment="change passwords at at the recommended interval or less">
-    <unix:chg_req
-      operation="less than or equal"
-      datatype="int"
+  <unix:shadow_state id="max_password_change_interval" version="1"
+    comment="change passwords at the recommended interval or less">
+    <unix:chg_req operation="less than or equal" datatype="int"
       var_ref="var_accounts_maximum_age_login_defs"/>
   </unix:shadow_state>
 
-  <!-- these external variables are defined at the group level, reusing the account-level definitions. -->
-  <external_variable
-      comment="Maximum password age"
-      datatype="int"
-      id="var_accounts_maximum_age_login_defs"
-      version="1" />
-
-  <external_variable
-      comment="Minimum password age"
-      datatype="int"
-      id="var_accounts_minimum_age_login_defs"
-      version="1" />
-
+  <!-- these external variables are defined at the group level,
+       reusing the account-level definitions. -->
+  <external_variable id="var_accounts_maximum_age_login_defs" datatype="int" version="1"
+                     comment="Maximum password age"/>
+  <external_variable id="var_accounts_minimum_age_login_defs" datatype="int" version="1"
+                     comment="Minimum password age"/>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -52,7 +52,7 @@ ocil: |-
 fixtext: |-
     Configure non-compliant accounts to enforce a 60-day maximum password lifetime restriction.
 
-    passwd -x {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}} [user]
+    chage -M {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}} [user]
 
 srg_requirement: |-
     {{{ full_name }}} user account passwords must have a 60-day maximum password lifetime restriction.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/tests/incorrect_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/tests/incorrect_stig.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# variables = var_accounts_minimum_age_login_defs=1,var_accounts_maximum_age_login_defs=60
 # make existing entries pass
 for acct in $(awk -F: '{print $1}' /etc/shadow ); do
     chage -M 60 -d $(date +%Y-%m-%d) $acct

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/tests/incorrect_stig_blank.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/tests/incorrect_stig_blank.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# variables = var_accounts_minimum_age_login_defs=1,var_accounts_maximum_age_login_defs=60
 # make existing entries pass
 for acct in $(awk -F: '{print $1}' /etc/shadow ); do
     chage -M 60 -d $(date +%Y-%m-%d) $acct

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/oval/shared.xml
@@ -1,11 +1,13 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_all_shadowed" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("All password hashes should be shadowed.") }}}
     <criteria>
-      <criterion comment="password hashes are shadowed" test_ref="test_accounts_password_all_shadowed" />
+      <criterion test_ref="test_accounts_password_all_shadowed"
+                 comment="password hashes are shadowed"/>
     </criteria>
   </definition>
-  <unix:password_test check="all" comment="password hashes are shadowed" id="test_accounts_password_all_shadowed" version="1">
+  <unix:password_test check="all" id="test_accounts_password_all_shadowed" version="1"
+                      comment="password hashes are shadowed">
     <unix:object object_ref="object_accounts_password_all_shadowed" />
     <unix:state state_ref="state_accounts_password_all_shadowed" />
   </unix:password_test>
@@ -13,6 +15,6 @@
     <unix:username operation="pattern match">.*</unix:username>
   </unix:password_object>
   <unix:password_state id="state_accounts_password_all_shadowed" version="1">
-    <unix:password operation="pattern match">^[x*]$</unix:password>
+    <unix:password operation="pattern match" mask="true">^[x*]$</unix:password>
   </unix:password_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/hash.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/hash.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 echo "testuser:0fcf3792f5fffc4fcd1801fab37e0470c66d46cb0f01:8000:8000:testuser:/home/testuser:/bin/bash" >> /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_hash.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_hash.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 echo "testuser:x0fcf3792f5fffc4fcd1801fab37e0470c66d46cb0f01:8000:8000:testuser:/home/testuser:/bin/bash" >> /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_username.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed/tests/x_in_username.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 echo "xtestuser:0fcf3792f5fffc4fcd1801fab37e0470c66d46cb0f01:8000:8000:testuser:/home/testuser:/bin/bash" >> /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -18,7 +18,7 @@
     <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
   </unix:shadow_object>
   <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
-      <unix:password operation="pattern match">^(!|!!|\*)$</unix:password>
+      <unix:password operation="pattern match">^(!|!!|\*|!locked)$</unix:password>
   </unix:shadow_state>
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
       <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -1,12 +1,16 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_all_shadowed_sha512" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("All password hashes should be shadowed.") }}}
     <criteria>
-      <criterion comment="password hashes are shadowed using sha512" test_ref="test_accounts_password_all_shadowed_sha512" />
+      <criterion comment="password hashes are shadowed using sha512"
+                 test_ref="test_accounts_password_all_shadowed_sha512" negate="true"/>
     </criteria>
   </definition>
-  <unix:shadow_test check="all" check_existence="none_exist" comment="password hashes are shadowed using sha512" id="test_accounts_password_all_shadowed_sha512" version="1">
-    <unix:object object_ref="object_accounts_password_all_shadowed_sha512" />
+  <unix:shadow_test check="all" check_existence="at_least_one_exists" version="1"
+                    id="test_accounts_password_all_shadowed_sha512"
+                    comment="password hashes are shadowed using sha512">
+    <unix:object object_ref="object_accounts_password_all_shadowed_sha512"/>
+    <unix:state state_ref="state_accounts_password_all_shadowed_sha512_hidepass"/>
   </unix:shadow_test>
   <unix:shadow_object id="object_accounts_password_all_shadowed_sha512" version="1">
     <unix:username operation="pattern match">.*</unix:username>
@@ -18,5 +22,8 @@
   </unix:shadow_state>
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
       <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>
+  </unix:shadow_state>
+  <unix:shadow_state id="state_accounts_password_all_shadowed_sha512_hidepass" version="1">
+      <unix:password operation="pattern match" mask="true">.*</unix:password>
   </unix:shadow_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/md5_password.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/md5_password.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 echo 'test1:$1$i7b0anAK$5uDHbPSrnl4b.e4aXQSe80:18793:0:99999:7:::' >> /etc/shadow

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha256_password.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha256_password.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# remediation = none
 
 echo 'test1:$5$pGYg89QLDc2XwqyE$VCajsVQgNxxGcVpRFh6OMA64YumUg82XF.JnWkBJcI.:18793:0:99999:7:::' >> /etc/shadow

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo 'test1:$6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/:18793:0:99999:7:::' >> /etc/shadow


### PR DESCRIPTION
#### Description:

In some rules, sensitive information might be shown in reports, even when they are not necessary.
It was included the `mask` parameter to hidden sensitive information from reports.

#### Rationale:

- Fixes #8902
