### PR TITLE
Prefer xccdf_value

### DIFF
--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/rule.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/rule.yml
@@ -9,7 +9,7 @@ description: |-
     to change its root directory at startup. To do so, ensure
     <tt>/etc/xinetd.d/tftp</tt> includes <tt>-s</tt> as a command line argument, as shown in
     the following example:
-    <pre>server_args = -s {{{ sub_var_value("var_tftpd_secure_directory") }}}</pre>
+    <pre>server_args = -s {{{ xccdf_value("var_tftpd_secure_directory") }}}</pre>
 
 rationale: |-
     Using the <tt>-s</tt> option causes the TFTP service to only serve files from the
@@ -54,11 +54,11 @@ ocil: |-
     Verify <tt>tftp</tt> is configured by with the <tt>-s</tt> option by
     running the following command:
     <pre>grep "server_args" /etc/xinetd.d/tftp</pre>
-    <pre>server_args = -s {{{ sub_var_value("var_tftpd_secure_directory") }}}</pre>
+    <pre>server_args = -s {{{ xccdf_value("var_tftpd_secure_directory") }}}</pre>
 
 fixtext: |-
     Configure the TFTP daemon to operate in secure mode by adding the following line to "/etc/xinetd.d/tftp" (or modify the line to have the required value):
 
-    server_args = -s {{{ sub_var_value("var_tftpd_secure_directory") }}}
+    server_args = -s {{{ xccdf_value("var_tftpd_secure_directory") }}}
 
 srg_requirement: 'If the Trivial File Transfer Protocol (TFTP) server is required, the {{{ full_name }}} TFTP daemon must be configured to operate in secure mode.'

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure Default SNMP Password Is Not Used'
 description: |-
     Edit <tt>/etc/snmp/snmpd.conf</tt>, remove or change the default community strings of
     <tt>public</tt> and <tt>private</tt>.
-    This profile configures new read-only community string to <tt>{{{ sub_var_value("var_snmpd_ro_string") }}}</tt> and read-write community string to <tt>{{{ sub_var_value("var_snmpd_rw_string") }}}</tt>.
+    This profile configures new read-only community string to <tt>{{{ xccdf_value("var_snmpd_ro_string") }}}</tt> and read-write community string to <tt>{{{ sub_var_value("var_snmpd_rw_string") }}}</tt>.
     Once the default community strings have been changed, restart the SNMP service:
     <pre>$ sudo service snmpd restart</pre>
 

--- a/linux_os/guide/system/software/sudo/sudo_add_umask/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_umask/rule.yml
@@ -10,7 +10,7 @@ description: |-
 {{%- if product in ["rhel7", "rhel8"] %}}
     On {{{ full_name }}}, the default <tt>umask</tt> value is 0022.
 {{% endif %}}
-    The umask should be configured by making sure that the <tt>umask=sub_var_value("var_sudo_umask")</tt> tag exists in
+    The umask should be configured by making sure that the <tt>umask={{{ xccdf_value("var_sudo_umask") }}}</tt> tag exists in
     <tt>/etc/sudoers</tt> configuration file or any sudo configuration snippets
     in <tt>/etc/sudoers.d/</tt>.
 
@@ -35,7 +35,7 @@ ocil_clause: 'umask is not set with the appropriate value for sudo'
 ocil: |-
     To determine if <tt>umask</tt> has been configured for sudo with the appropriate value,
     run the following command:
-    <pre>$ sudo grep -ri '^Defaults.*umask=sub_var_value("var_sudo_umask")' /etc/sudoers /etc/sudoers.d/</pre>
+    <pre>$ sudo grep -ri '^Defaults.*umask={{{ xccdf_value("var_sudo_umask") }}}' /etc/sudoers /etc/sudoers.d/</pre>
     The command should return a matching output.
 
 template:

--- a/linux_os/guide/system/software/sudo/sudo_dedicated_group/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_dedicated_group/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure a dedicated group owns sudo'
 
 description: |-
     Restrict the execution of privilege escalated commands to a dedicated group of users.
-    Ensure the group owner of /usr/bin/sudo is {{{ sub_var_value("var_sudo_dedicated_group") }}}.
+    Ensure the group owner of /usr/bin/sudo is {{{ xccdf_value("var_sudo_dedicated_group") }}}.
 
 rationale: |-
     Restricting the set of users able to execute commands as privileged user reduces the attack surface.
@@ -30,7 +30,7 @@ identifiers:
 references:
   anssi: BP28(R57)
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="/usr/bin/sudo", group=sub_var_value("var_sudo_dedicated_group")) }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file="/usr/bin/sudo", group=xccdf_value("var_sudo_dedicated_group")) }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="/usr/bin/sudo", group=sub_var_value("var_sudo_dedicated_group")) }}}
+    {{{ ocil_file_group_owner(file="/usr/bin/sudo", group=xccdf_value("var_sudo_dedicated_group")) }}}

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -103,7 +103,8 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
 
 
 {{#
-    Calls :code:`xccdf_value` macro under the hood
+    Calls :code:`xccdf_value` macro under the hood. Deprecated: Use
+    :code:`xccdf_value`.
 
 :param varname: The name of the variable to reference
 :type varname: str

--- a/tests/test_xccdf_values_in_ds.sh
+++ b/tests/test_xccdf_values_in_ds.sh
@@ -9,3 +9,7 @@ if grep -iq "xccdf_value" "$DS" ; then
     printf "Found obtrusive xccdf_value in %s, ensure correct usage of the xccdf_value Jinja macro!" "$DS" >&2
     exit 1
 fi
+if grep -iq "sub_var_value" "$DS" ; then
+    printf "Found obtrusive sub_var_value in %s, rename as xccdf_value and ensure correct usage of the xccdf_value Jinja macro!" "$DS" >&2
+    exit 1
+fi


### PR DESCRIPTION
#### Description:

xccdf_value is more common than sub_var_value

#### Rationale:

As far as sub_var_value exists, it needs to be checked.

Related test expansion and bugfix.