### PR TITLE
Add AUID filters on audit_rules_kernel_module_loading

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 {{% set auid_filters = "-F auid>=" ~ auid ~ " -F auid!=unset" %}}
 {{% else %}}
 {{% set auid_filters = "" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/bash/shared.sh
@@ -12,7 +12,7 @@ for ARCH in "${RULE_ARCHS[@]}"
 do
         ACTION_ARCH_FILTERS="-a always,exit -F arch=$ARCH"
         OTHER_FILTERS=""
-        {{% if product in ["ol8", "rhel8"] %}}
+        {{% if product in ["ol8"] or 'rhel' in product %}}
         AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
         {{% else %}}
         AUID_FILTERS=""

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -10,6 +10,6 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,8d' test_audit.rules > /etc/audit/audit.rules
 sed -i '4,7d' /etc/audit/audit.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -9,6 +9,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '1,12d' test_audit.rules > /etc/audit/audit.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -9,6 +9,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '8,15d' test_audit.rules > /etc/audit/audit.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
@@ -7,6 +7,6 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,8d' test_audit.rules > /etc/audit/rules.d/test.rules
 sed -i '4,7d' /etc/audit/rules.d/test.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
@@ -6,6 +6,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '1,12d' test_audit.rules > /etc/audit/rules.d/test.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
@@ -5,6 +5,6 @@ rm -f /etc/audit/rules.d/*
 
 # cut out irrelevant rules for this test
 sed '8,15d' test_audit.rules > /etc/audit/rules.d/test.rules
-{{% if product in ["ol8", "rhel8"] %}}
+{{% if product in ["ol8"] or 'rhel' in product %}}
 sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
 {{% endif %}}


### PR DESCRIPTION


#### Description:

- Add the AUID filters to `audit_rules_kernel_module_loading` rule so that it is aligned with RHEL8 too.
  - Some RHEL7 profiles use this rule, it combines multiple syscalls related to kernel module loading.
  - While the checks are shared with other rules for individual syscalls, the remediations are not.

#### Rationale:

- Follow up from #9290

