### PR TITLE
Don't select the variable selector 'default'

### DIFF
--- a/controls/srg_gpos/SRG-OS-000046-GPOS-00022.yml
+++ b/controls/srg_gpos/SRG-OS-000046-GPOS-00022.yml
@@ -7,7 +7,7 @@ controls:
         rules:
             - postfix_client_configure_mail_alias
             - postfix_client_configure_mail_alias_postmaster
-            - var_postfix_root_mail_alias=default
+            - var_postfix_root_mail_alias=mil_sysadmin
             - audit_rules_system_shutdown
             - auditd_data_retention_action_mail_acct
             - var_auditd_action_mail_acct=root

--- a/linux_os/guide/services/mail/postfix_client/var_postfix_root_mail_alias.var
+++ b/linux_os/guide/services/mail/postfix_client/var_postfix_root_mail_alias.var
@@ -12,3 +12,4 @@ interactive: true
 
 options:
     default: system.administrator@mail.mil
+    mil_sysadmin: system.administrator@mail.mil


### PR DESCRIPTION


#### Description:

- Don't select the variable selector 'default'

#### Rationale:

- It is a special keyword that is not explicitly selectable. 
- Fixes Packit test "/Sanity/machine-hardening/stig" for RHEL9 STIG
