### PR TITLE
Remove `auditd_data_retention_max_log_file_action` STIG specific test scenario

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/max_log_file_action_stig.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# packages = audit
-# profiles = xccdf_org.ssgproject.content_profile_stig
-# platform = Red Hat Enterprise Linux 8, Red Hat Enterprise Linux 9, multi_platform_fedora
-
-. $SHARED/auditd_utils.sh
-prepare_auditd_test_enviroment
-set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "syslog"


### PR DESCRIPTION
#### Description:
`auditd_data_retention_max_log_file_action` is not in STIG profile anymore. Remove its test scenario.

#### Rationale:
```
ERROR - Script max_log_file_action_stig.pass.sh using profile xccdf_org.ssgproject.content_profile_stig found issue:
ERROR - Rule xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action has not been evaluated! Wrong profile selected in test scenario?
ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_auditd_data_retention_max_log_file_action'.
```