### PR TITLE
no_empty_passwords test scenarios preserving symlinks

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/oval/shared.xml
@@ -15,7 +15,7 @@
 {{% if product in ['sle12', 'sle15'] %}}
     <ind:filepath operation="pattern match">^/etc/pam.d/.*$</ind:filepath>
 {{% else %}}
-    <ind:filepath operation="pattern match">/etc/pam.d/(system|password)-auth</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/pam.d/(system|password)-auth$</ind:filepath>
 {{% endif %}}
     <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_commented.pass.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
-SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
-PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
-
-sed -i '/nullok/d' $SYSTEM_AUTH_FILE
-sed -i '/nullok/d' $PASSWORD_AUTH_FILE
-echo "# auth  sufficient  pam_unix.so try_first_pass nullok" >> $SYSTEM_AUTH_FILE
-echo "# auth  sufficient  pam_unix.so try_first_pass nullok" >> $PASSWORD_AUTH_FILE
+for pam_file in /etc/pam.d/system-auth /etc/pam.d/password-auth; do
+    sed -i --follow-symlinks '/nullok/d' $pam_file
+    echo "# auth  sufficient  pam_unix.so try_first_pass nullok" >> $pam_file
+done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -4,5 +4,5 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
-    sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
+    sed -i --follow-symlinks 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present_password_auth.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present_password_auth.fail.sh
@@ -4,5 +4,5 @@
 PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
 
 if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $PASSWORD_AUTH_FILE); then
-    sed -i 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $PASSWORD_AUTH_FILE
+    sed -i --follow-symlinks 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $PASSWORD_AUTH_FILE
 fi


### PR DESCRIPTION
#### Description:

In RHEL7 the `system-auth` and `password-auth` are symlinks to `system-auth-ac` and `password-auth-ac` respectively.
Some scripts were using `sed` command without the `--follow-symlinks` option, removing the symlinks and breaking the tests.

#### Rationale:

- Fixes #9313
- Fixes #9315 