### PR TITLE
Fix account_password_selinux_faillock_dir rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -5,7 +5,7 @@ FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam
 
 for dir in $(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
             | sed -r 's/.*=\s*(\S+)/\1/'); do
-    if ! `semanage fcontext -a -t faillog_t "$dir(/.*)?"`; then
+    if ! semanage fcontext -a -t faillog_t "$dir(/.*)?"; then
         semanage fcontext -m -t faillog_t "$dir(/.*)?"
     fi
     if [ ! -e $dir ]; then

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -1,14 +1,15 @@
 #!/bin/bash
 # platform = multi_platform_all
 
-FAILLOCK_DIR=$(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" \
-                    /etc/security/faillock.conf \
-                    /etc/pam.d/system-auth \
-                    /etc/pam.d/password-auth \
-                    | sed -r 's/.*=\s*(\S+)/\1/')
+FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam.d/password-auth"
 
-mkdir -p $FAILLOCK_DIR
-
-semanage fcontext -a -t faillog_t "$FAILLOCK_DIR(/.*)?"
-
-restorecon -R -v "$FAILLOCK_DIR"
+for dir in $(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
+            | sed -r 's/.*=\s*(\S+)/\1/'); do
+    if ! `semanage fcontext -a -t faillog_t "$dir(/.*)?"`; then
+        semanage fcontext -m -t faillog_t "$dir(/.*)?"
+    fi
+    if [ ! -e $dir ]; then
+        mkdir -p $dir
+    fi
+    restorecon -R -v $dir
+done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -2,37 +2,41 @@
                           "/etc/pam.d/system-auth",
                           "/etc/security/faillock.conf"] %}}
 <def-group>
-    <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("An SELinux Context must be configued for the Faillock directory.") }}}
-        <criteria operator="AND">
-            <criterion comment="the faillock directory should have faillog_t as context"
-            test_ref="test_selinux_faillock_dir" />
-        </criteria>
-    </definition>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+  {{{ oval_metadata("An SELinux Context must be configued for the Faillock directory.") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_account_password_selinux_faillock_dir"
+                 comment="the faillock directory should have faillog_t as context"/>
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_object id="object_account_password_selinux_faillock_dir_collector" version="1">
+    <ind:filepath operation="pattern match">{{{ faillock_files | join("|")}}}</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
 
-    <ind:textfilecontent54_object id="obj_faillock_dir_collector" version="1">
-        <ind:filepath operation="pattern match">{{{ faillock_files | join("|")}}}</ind:filepath>
-        <ind:pattern operation="pattern match">^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)</ind:pattern>
-        <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-    </ind:textfilecontent54_object>
+  <local_variable id="var_account_password_selinux_faillock_dir_collector" version="1"
+    datatype="string" comment="List of directories defined in pam_faillock.so dir parameters">
+    <object_component item_field="subexpression"
+                      object_ref="object_account_password_selinux_faillock_dir_collector"/>
+  </local_variable>
 
-    <local_variable id="var_faillock_dir_collector" datatype="string" version="1" comment="File hash for etcd CA">
-      <object_component item_field="subexpression" object_ref="obj_faillock_dir_collector" />
-    </local_variable>
+  <linux:selinuxsecuritycontext_test id="test_account_password_selinux_faillock_dir" version="2"
+    check="all" check_existence="all_exist"
+    comment="faillog_t context is set in pam_faillock.so tally directories">
+    <linux:object object_ref="object_account_password_selinux_faillock_dir"/>
+    <linux:state state_ref="state_account_password_selinux_faillock_dir"/>
+  </linux:selinuxsecuritycontext_test>
 
-    <linux:selinuxsecuritycontext_test check="all" check_existence="all_exist" comment="device_t in /dev"
-    id="test_selinux_faillock_dir" version="1">
-        <linux:object object_ref="obj_selinux_faillock_dir" />
-        <linux:state state_ref="state_selinux_faillock_dir" />
-    </linux:selinuxsecuritycontext_test>
-    
-    <linux:selinuxsecuritycontext_object comment="device_t in /dev" 
-    id="obj_selinux_faillock_dir" version="1">
-        <linux:path operation="equals" var_ref="var_faillock_dir_collector"  var_check="all"/>
-        <linux:filename xsi:nil="true" />
-    </linux:selinuxsecuritycontext_object>
-    <linux:selinuxsecuritycontext_state comment="device_t label" id="state_selinux_faillock_dir" version="1">
-        <linux:type datatype="string" operation="equals">faillog_t</linux:type>
-    </linux:selinuxsecuritycontext_state>
+  <linux:selinuxsecuritycontext_object id="object_account_password_selinux_faillock_dir"
+    comment="SELinux context information from pam_faillock.so tally directories" version="1">
+    <linux:path operation="equals" var_check="all"
+                var_ref="var_account_password_selinux_faillock_dir_collector"/>
+    <linux:filename xsi:nil="true"/>
+  </linux:selinuxsecuritycontext_object>
 
+  <linux:selinuxsecuritycontext_state id="state_account_password_selinux_faillock_dir" version="1"
+    comment="faillog_t context is set">
+    <linux:type datatype="string" operation="equals">faillog_t</linux:type>
+  </linux:selinuxsecuritycontext_state>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -2,14 +2,15 @@ documentation_complete: true
 
 prodtype: ol8,ol9,rhel8,rhel9
 
-title: 'An SELinux Context must be configued for the Faillock directory'
+title: 'An SELinux Context must be configured for the pam_faillock.so records directory'
 
 description: |-
-    The <tt>dir</tt> configuration option in PAM faillock defines where the lockout data is stored.
-    The configured directory must have the correct the SELinux context.
+    The <tt>dir</tt> configuration option in PAM pam_faillock.so module defines where the lockout
+    records is stored. The configured directory must have the correct SELinux context.
 
 rationale: |-
-    Not having the correct SELinux context on the faillock directory may lead to unauthorized access to the directory.
+    Not having the correct SELinux context on the pam_faillock.so records directory may lead to
+    unauthorized access to the directory.
 
 severity: medium
 
@@ -29,7 +30,7 @@ platform: machine
 ocil_clause: 'the security context type of the non-default tally directory is not "faillog_t"'
 
 ocil: |-
-    If the system does not have SELinux enabled and enforcing a targeted policy, or if the pam_faillock module is not configured for use, this requirement is not applicable.
+    If the system does not have SELinux enabled and enforcing a targeted policy, or if the pam_faillock.so module is not configured for use, this requirement is not applicable.
 
     Verify the location of the non-default tally directory for the pam_faillock module with the following command:
 
@@ -44,18 +45,18 @@ ocil: |-
     unconfined_u:object_r:faillog_t:s0 /var/log/faillock
 
 fixtext: |-
-    Configure {{{ full_name }}} to allow the use of a non-default faillock tally directory while SELinux enforces a targeted policy.
+    Configure {{{ full_name }}} to allow the use of a non-default pam_faillock.so tally directory while SELinux enforces a targeted policy.
 
-    Create a non-default faillock tally directory (if it does not already exist) with the following example:
+    Create a non-default pam_faillock.so tally directory (if it does not already exist) with the following example:
 
     $ sudo mkdir /var/log/faillock
 
-    Update the /etc/selinux/targeted/contexts/files/file_contexts.local with "faillog_t" context type for the non-default faillock tally directory with the following command:
+    Update the /etc/selinux/targeted/contexts/files/file_contexts.local with "faillog_t" context type for the non-default pam_faillock.so tally directory with the following command:
 
     $ sudo semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
 
-    Next, update the context type of the non-default faillock directory/subdirectories and files with the following command:
+    Next, update the context type of the non-default pam_faillock.so directory/subdirectories and files with the following command:
 
     $ sudo restorecon -R -v /var/log/faillock
 
-srg_requirement: '{{{ full_name }}} must configure SELinux context type to allow the use of a non-default faillock tally directory.'
+srg_requirement: '{{{ full_name }}} must configure SELinux context type to allow the use of a non-default pam_faillock.so tally directory.'

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value.pass.sh
@@ -3,10 +3,8 @@
 # platform = multi_platform_all
 
 truncate -s 0 /etc/security/faillock.conf
-echo "dir=/var/log/faillock" >  /etc/security/faillock.conf
+echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 
 mkdir /var/log/faillock
-
 semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
-
 restorecon -R -v "/var/log/faillock"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value_multiple_dirs.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value_multiple_dirs.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = policycoreutils-python-utils
+# platform = multi_platform_all
+
+truncate -s 0 /etc/security/faillock.conf
+echo "dir=/var/log/faillock" > /etc/security/faillock.conf
+echo "auth  required pam_faillock.so dir=/var/log/faillock_admins"
+
+mkdir /var/log/faillock /var/log/faillock_admins
+semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
+semanage fcontext -a -t faillog_t "/var/log/faillock_admins(/.*)?"
+restorecon -R -v "/var/log/faillock"
+restorecon -R -v "/var/log/faillock_admins"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/missing_dir.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/missing_dir.fail.sh
@@ -3,6 +3,5 @@
 # platform = multi_platform_all
 
 truncate -s 0 /etc/security/faillock.conf
-echo "dir=/var/log/faillock" >  /etc/security/faillock.conf
-
+echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 rm -rf /var/log/faillock

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh
@@ -3,12 +3,8 @@
 # platform = multi_platform_all
 
 truncate -s 0 /etc/security/faillock.conf
-echo "dir=/var/log/faillock" >  /etc/security/faillock.conf
+echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 
 mkdir /var/log/faillock
-
-semanage fcontext -a -t dummy_t "/var/log/faillock(/.*)?"
-
+semanage fcontext -a -t tmp_t "/var/log/faillock(/.*)?"
 restorecon -R -v "/var/log/faillock"
-
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value_multiple_dirs.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value_multiple_dirs.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = policycoreutils-python-utils
+# platform = multi_platform_all
+
+truncate -s 0 /etc/security/faillock.conf
+echo "dir=/var/log/faillock" > /etc/security/faillock.conf
+echo "auth  required pam_faillock.so dir=/var/log/faillock_admins"
+
+mkdir /var/log/faillock /var/log/faillock_admins
+semanage fcontext -a -t tmp_t "/var/log/faillock(/.*)?"
+semanage fcontext -a -t faillog_t "/var/log/faillock_admins(/.*)?"
+restorecon -R -v "/var/log/faillock"
+restorecon -R -v "/var/log/faillock_admins"


### PR DESCRIPTION
#### Description:

Many issues were fixed in this rule:
- The description was aligned with other similar rules when referring PAM modules
- The OVAL was aligned to the style guide
- Eliminated copy-and-paste issues from the OVAL and ensured proper `comments`
- Fix bash remediation which could fail in many cases
- Included test scenarios for multiple dirs
- Fixed test scenario using invalid `fcontext` with semanage

#### Rationale:

Makes the rule more robust
Possibly fix an issue with `packit` test in CS9:
`xccdf_org.ssgproject.content_rule_account_password_selinux_faillock_dir:error`

Reference: https://artifacts.dev.testing-farm.io/de16abc5-0a45-4a80-8768-f8d6c85df4cc/
