### PR TITLE
change way of disabling coredumps in RHEL9 OSPP

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/rule.yml
@@ -30,9 +30,6 @@ conflicts:
 identifiers:
     cce@rhel9: CCE-86005-6
 
-references:
-    ospp: FMT_SMF_EXT.1
-
 ocil_clause: |-
     the returned line does not have a value of ''.
 

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -110,7 +110,7 @@ selections:
     - package_gnutls-utils_installed
 
     ### Login
-    - sysctl_kernel_core_pattern_empty_string
+    - sysctl_kernel_core_pattern
     - sysctl_kernel_core_uses_pid
     - service_systemd-coredump_disabled
     - var_authselect_profile=minimal


### PR DESCRIPTION
#### Description:

- switch sysctl_kernel_core_pattern_empty_string for sysctl_kernel_core_pattern in RHEL9 OSPP
- remove OSPP reference from sysctl_kernel_core_pattern_empty_string

#### Rationale:

the rule sysctl_kernel_core_pattern_empty_string does not behave as expected.