### PR TITLE
Disable `wrong_runtime.fail.sh` test scenario for sysctl_kernel_unprivileged_bpf_disabled`

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/tests/test_config.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+  - wrong_runtime.fail.sh


### PR DESCRIPTION
#### Description:
Disable not working test scenario.

#### Rationale:
Change of `kernel.unprivileged_bpf_disabled` is not permitted.
```
+ sysctl -w kernel.unprivileged_bpf_disabled=11
sysctl: setting key "kernel.unprivileged_bpf_disabled": Invalid argument
```
I've also tried valid argument `0`:
```
+ sysctl -w kernel.unprivileged_bpf_disabled=0
sysctl: setting key "kernel.unprivileged_bpf_disabled": Operation not permitted
```