### PR TITLE
smartcard_auth: Ensure check and remediation work on RHEL7 regardless of authconfig runs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -38,8 +38,7 @@ pam_pkcs11.so nodebug"
 # Define smartcard-auth config location
 SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
 # Define 'pam_pkcs11.so' auth section to be appended past $PAM_ENV_SO into $SMARTCARD_AUTH_CONF
-SMARTCARD_AUTH_SECTION="\
-auth        [success=done ignore=ignore default=die] pam_pkcs11.so nodebug wait_for_card"
+SMARTCARD_AUTH_SECTION="auth        [success=done ignore=ignore default=die] pam_pkcs11.so nodebug wait_for_card"
 # Define expected 'pam_permit.so' row in $SMARTCARD_AUTH_CONF
 PAM_PERMIT_SO="account.*required.*pam_permit.so"
 # Define 'pam_pkcs11.so' password section
@@ -63,10 +62,17 @@ then
 fi
 
 # Then also correct the SMARTCARD_AUTH_CONF
-if ! grep -q 'pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+if ! grep -q 'auth.*pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
 then
 	# Append (expected) SMARTCARD_AUTH_SECTION row past the pam_env.so into SMARTCARD_AUTH_CONF file
-	sed -i --follow-symlinks -e '/^'"$PAM_ENV_SO"'/a '"$SMARTCARD_AUTH_SECTION" "$SMARTCARD_AUTH_CONF"
+	sed -i --follow-symlinks -e '/^'"$PAM_ENV_SO"'/a \
+        '"$SMARTCARD_AUTH_SECTION" "$SMARTCARD_AUTH_CONF"
+else
+    if ! grep -q 'auth.*pam_pkcs11.so.*no_debug.*wait_for_card' "$SMARTCARD_AUTH_CONF"
+    then
+        sed -i --follow-symlinks -e 's/^auth.*pam_pkcs11.so.*/'"$SMARTCARD_AUTH_SECTION"'/' "$SMARTCARD_AUTH_CONF"
+    fi
+fi
 	# Append (expected) SMARTCARD_PASSWORD_SECTION row past the pam_permit.so into SMARTCARD_AUTH_CONF file
 	sed -i --follow-symlinks -e '/^'"$PAM_PERMIT_SO"'/a '"$SMARTCARD_PASSWORD_SECTION" "$SMARTCARD_AUTH_CONF"
 fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -42,8 +42,7 @@ SMARTCARD_AUTH_SECTION="auth        [success=done ignore=ignore default=die] pam
 # Define expected 'pam_permit.so' row in $SMARTCARD_AUTH_CONF
 PAM_PERMIT_SO="account.*required.*pam_permit.so"
 # Define 'pam_pkcs11.so' password section
-SMARTCARD_PASSWORD_SECTION="\
-password    required      pam_pkcs11.so"
+SMARTCARD_PASSWORD_SECTION="password    required      pam_pkcs11.so"
 
 # First Correct the SYSTEM_AUTH_CONF configuration
 if ! grep -q 'pam_pkcs11.so' "$SYSTEM_AUTH_CONF"
@@ -73,8 +72,16 @@ else
         sed -i --follow-symlinks -e 's/^auth.*pam_pkcs11.so.*/'"$SMARTCARD_AUTH_SECTION"'/' "$SMARTCARD_AUTH_CONF"
     fi
 fi
+if ! grep -q 'password.*pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+then
 	# Append (expected) SMARTCARD_PASSWORD_SECTION row past the pam_permit.so into SMARTCARD_AUTH_CONF file
-	sed -i --follow-symlinks -e '/^'"$PAM_PERMIT_SO"'/a '"$SMARTCARD_PASSWORD_SECTION" "$SMARTCARD_AUTH_CONF"
+	sed -i --follow-symlinks -e '/^'"$PAM_PERMIT_SO"'/a \
+        '"$SMARTCARD_PASSWORD_SECTION" "$SMARTCARD_AUTH_CONF"
+else
+    if ! grep -q 'password.*required.*pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+    then
+        sed -i --follow-symlinks -e 's/password.*pam_pkcs11.so.*/'"$SMARTCARD_PASSWORD_SECTION"'/' "$SMARTCARD_AUTH_CONF"
+    fi
 fi
 
 # Perform /etc/pam_pkcs11/pam_pkcs11.conf settings below

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/oval/shared.xml
@@ -46,6 +46,7 @@
   comment="Regular expression to check if smartcard authentication is enabled in /etc/pam.d/system-auth" version="1">
     <concat>
       <literal_component>\nauth[\s]+required[\s]+pam_env.so</literal_component>
+      <literal_component>(\nauth[\s]+required[\s]+pam_faildelay.so[\s]+delay=2000000)?</literal_component>
       <literal_component>\nauth[\s]+\[success=1[\s]default=ignore\][\s]pam_succeed_if.so[\s]service[\s]notin[\s]</literal_component>
       <literal_component>login:gdm:xdm:kdm:xscreensaver:gnome-screensaver:kscreensaver[\s]quiet[\s]use_uid</literal_component>
       <literal_component>\nauth[\s]+\[success=done[\s]authinfo_unavail=ignore[\s]ignore=ignore[\s]default=die\][\s]</literal_component>
@@ -70,6 +71,7 @@
   comment="Regular expressiion to check if smartcard authentication is required in /etc/pam.d/system-auth" version="1">
     <concat>
       <literal_component>\nauth[\s]+required[\s]+pam_env.so</literal_component>
+      <literal_component>(\nauth[\s]+required[\s]+pam_faildelay.so[\s]+delay=2000000)?</literal_component>
       <literal_component>\nauth[\s]+\[success=1[\s]default=ignore\][\s]pam_succeed_if.so[\s]service[\s]notin[\s]</literal_component>
       <literal_component>login:gdm:xdm:kdm:xscreensaver:gnome-screensaver:kscreensaver[\s]quiet[\s]use_uid</literal_component>
       <literal_component>\nauth[\s]+\[success=done[\s]ignore=ignore[\s]default=die\][\s]</literal_component>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_authconfig.fail.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
+
+systemctl enable pcscd.socket
+systemctl start pcscd.socket
+
+cat << EOF > "/etc/pam.d/system-auth"
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authconfig is run.
+auth        required      pam_env.so
+auth        required      pam_faildelay.so delay=2000000
+auth        sufficient    pam_unix.so nullok try_first_pass
+auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
+password    sufficient    pam_unix.so sha512 shadow nullok try_first_pass use_authtok
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so
+EOF
+
+cat << EOF > "/etc/pam.d/smartcard-auth"
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authconfig is run.
+auth        required      pam_env.so
+auth        [success=done ignore=ignore default=die] pam_pkcs11.so nodebug wait_for_card
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     required      pam_permit.so
+
+password    required      pam_pkcs11.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet use_uid
+session     required      pam_unix.so
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_pam_faildelay.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_pam_faildelay.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
+
+systemctl enable pcscd.socket
+systemctl start pcscd.socket
+
+. ./configure_pam_stack.sh
+
+# Add pam_faildelay line to system-auth
+PAM_ENV_SO="auth.*required.*pam_env.so"
+sed -i --follow-symlinks '/auth.*required.*pam_env.so/ a auth        required                                     pam_faildelay.so delay=2000000' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_without_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_without_authconfig.fail.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# packages = pcsc-lite pam_pkcs11 esc
+
+systemctl enable pcscd.socket
+systemctl start pcscd.socket
+
+cat << EOF > "/etc/pam.d/system-auth"
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authconfig is run.
+auth        required      pam_env.so
+auth        sufficient    pam_unix.so try_first_pass nullok
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+
+password    requisite     pam_pwquality.so try_first_pass local_users_only retry
+=3 authtok_type=
+password    sufficient    pam_unix.so try_first_pass use_authtok nullok sha512 s
+hadow
+password    required      pam_deny.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet 
+use_uid
+session     required      pam_unix.so
+EOF
+
+cat << EOF > "/etc/pam.d/smartcard-auth"
+#%PAM-1.0
+# This file is auto-generated.
+# User changes will be destroyed the next time authconfig is run.
+auth        required      pam_env.so
+auth        [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card
+auth        required      pam_deny.so
+
+account     required      pam_unix.so
+account     sufficient    pam_localuser.so
+account     sufficient    pam_succeed_if.so uid < 500 quiet
+account     required      pam_permit.so
+
+password    optional      pam_pkcs11.so
+
+session     optional      pam_keyinit.so revoke
+session     required      pam_limits.so
+-session     optional      pam_systemd.so
+session     [success=1 default=ignore] pam_succeed_if.so service in crond quiet 
+use_uid
+session     required      pam_unix.so
+EOF


### PR DESCRIPTION
#### Description:

- Rule `smartcard_auth` would error depending on how a RHEL7 system was installed.
  A system where `authconfig` was run during installation has a slightly different PAM stack than a system that did not run `authconfig` during installtion.
- This patch fixes:
  - The check so that it accept presence of `pam_faildelay.so` in `/etc/pam.d/system-auth`
  - The remediation so that it can correct lines with `pam_pkcs11.so` in `/etc/pam.d/smartcard-auth`.
  The remediation would only append new lines and not correct the existing ones.

#### Rationale:

- Fixes `error` status of `smartcard_auth` in some situations
