### PR TITLE
Don't fail rule if /etc/grubenv missing on s390x

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/shared.xml
@@ -10,7 +10,7 @@
       {{% if product in ["ol8"] %}}
       <criterion comment="check if the kernel boot parameter is configured for FIPS mode"
       test_ref="test_grubenv_fips_mode" />
-      {{% elif product in ["rhel8"] %}}
+      {{% elif "rhel" in product %}}
       <criteria operator="OR">
         <extend_definition comment="Generic test for s390x architecture"
         definition_ref="system_info_architecture_s390_64" />
@@ -35,7 +35,7 @@
     <ind:value operation="pattern match" datatype="string">^FIPS(:(OSPP|NO-SHA1|NO-CAMELLIA))?$</ind:value>
   {{%- endif %}}
   </ind:variable_state>
-  {{% if product in ["ol8","rhel8"] %}}
+  {{% if product in ["ol8"] or "rhel" in product %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" id="test_grubenv_fips_mode"
   comment="Fips mode selected in running kernel opts" version="1">
     <ind:object object_ref="obj_grubenv_fips_mode" />


### PR DESCRIPTION


#### Description:

- Skip check for `fips=1` on `/boot/grub2/grubenv` on more products that run on s390x.

#### Rationale:

- Follow up from #9355
