### PR TITLE
Put smartcard rules with pam_pkcs11 out of s390x

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -37,6 +37,8 @@ rationale: |-
 
 severity: medium
 
+platform: not_s390x_arch
+
 identifiers:
     cce@rhel7: CCE-80519-2
     cce@rhel8: CCE-84029-8

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -28,7 +28,8 @@ rationale: |-
 
 severity: medium
 
-platform: machine  # The check uses service_... extended definition, which doesnt support offline mode
+platforms:
+    - not_s390x_arch
 
 identifiers:
     cce@rhel7: CCE-80207-4

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
@@ -24,6 +24,9 @@ rationale: |-
 
 severity: medium
 
+platforms:
+    - not_s390x_arch
+
 identifiers:
     cce@rhel7: CCE-80520-0
     cce@rhel8: CCE-82475-5


### PR DESCRIPTION


#### Description:

- Package `pam_pkcs11` is not available for RHEL on s390x.

#### Rationale:

- Fixes `error` result of these rules on RHEL-7 on s390x
