### PR TITLE
Add trim_trailing_whitespace to editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,7 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [{*.py, *.yml, *.yaml, *.jinja}]
 indent_style = space


### PR DESCRIPTION


#### Description:
Add `trim_trailing_whitespace` to `.editorconfig`.
#### Rationale:
To better follow the style guide.
