### PR TITLE
bugfix: sudoers_validate_passwd: handle @ includes too

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/ansible/shared.yml
@@ -5,17 +5,18 @@
 # disruption = low
 
 {{{ ansible_only_lineinfile(msg='Ensure sudo only has the default includedir', line_regex='^#includedir.*$', path='/etc/sudoers', new_line='#includedir /etc/sudoers.d') }}}
-{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t include other non-default file', regex='^#include[\s]+.*$', path='/etc/sudoers', state='absent') }}}
+{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t include other non-default file', regex='^[#@]include[\s]+.*$', path='/etc/sudoers', state='absent') }}}
+{{{ ansible_lineinfile(msg='Ensure sudoers doesn\'t have non-default includedir', regex='^@includedir[\s]+.*$', path='/etc/sudoers', state='absent') }}}
 - name: "Find out if /etc/sudoers.d/* files contain file or directory includes"
   find:
     path: "/etc/sudoers.d"
     patterns: "*"
-    contains: '^#include(dir)?\s.*$'
+    contains: '^[#@]include(dir)?\s.*$'
   register: sudoers_d_includes
 
 - name: "Remove found occurrences of file and directory includes from /etc/sudoers.d/* files"
   lineinfile:
     path: "{{ item.path }}"
-    regexp: '^#include(dir)?\s.*$'
+    regexp: '^[#@]include(dir)?\s.*$'
     state: absent
   with_items: "{{ sudoers_d_includes.files }}"

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/bash/shared.sh
@@ -16,6 +16,6 @@ fi
 
 sed -i "/^#include\s\+.*/d" "$sudoers_config_file"
 
-if grep -Pr "^#include(dir)? .*" "$sudoers_config_dir" ; then
-    sed -i "/^#include\(dir\)\?\s\+.*/d" "$sudoers_config_dir"/*
+if grep -Pr "^[#@]include(dir)?\s" "$sudoers_config_dir" ; then
+    sed -Ei "/^[#@]include(dir)?\s/d" "$sudoers_config_dir"/*
 fi

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/bash/shared.sh
@@ -4,7 +4,7 @@ sudoers_config_file="/etc/sudoers"
 sudoers_config_dir="/etc/sudoers.d"
 sudoers_includedir_count=$(grep -c "#includedir" "$sudoers_config_file")
 if [ "$sudoers_includedir_count" -gt 1 ]; then
-    sed -i "/#includedir.*/d" "$sudoers_config_file"
+    sed -i "/#includedir/d" "$sudoers_config_file"
     echo "#includedir /etc/sudoers.d" >> "$sudoers_config_file"
 elif [ "$sudoers_includedir_count" -eq 0 ]; then
     echo "#includedir /etc/sudoers.d" >> "$sudoers_config_file"
@@ -14,7 +14,7 @@ else
     fi
 fi
 
-sed -i "/^#include\s\+.*/d" "$sudoers_config_file"
+sed -Ei "/^#include\s/d; /^@includedir\s/d" "$sudoers_config_file"
 
 if grep -Pr "^[#@]include(dir)?\s" "$sudoers_config_dir" ; then
     sed -Ei "/^[#@]include(dir)?\s/d" "$sudoers_config_dir"/*

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/oval/shared.xml
@@ -3,19 +3,20 @@
     {{{ oval_metadata("Check if sudo includes only the default includedir") }}}
     <criteria operator="OR">
       <criteria operator="AND">
-        <criterion comment="Check /etc/sudoers doesn't have any #include" test_ref="test_sudoers_without_include" />
+        <criterion comment="Check /etc/sudoers doesn't have any #include or @include" test_ref="test_sudoers_without_include" />
         <criterion comment="Check /etc/sudoers doesn't have any #includedir" test_ref="test_sudoers_without_includedir" />
       </criteria>
       <criteria operator="AND">
         <criterion comment="Check /etc/sudoers for #includedir" test_ref="test_sudoers_default_includedir" />
         <criterion comment="Check /etc/sudoers doesn't have any #include" test_ref="test_sudoers_without_include" />
+        <criterion comment="Check /etc/sudoers doesn't have any @includedir" test_ref="test_sudoers_without_includedir_new" />
         <criterion comment="Check /etc/sudoers.d doesn't have any #include or #includedir" test_ref="test_sudoersd_without_includes" />
       </criteria>
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
-      comment="audit augenrules rmmod" id="test_sudoers_default_includedir" version="1">
+      comment="test only one sudoers #includedir" id="test_sudoers_default_includedir" version="1">
     <ind:object object_ref="object_sudoers_default_includedir" />
     <ind:state state_ref="state_sudoers_default_includedir" />
   </ind:textfilecontent54_test>
@@ -29,33 +30,43 @@
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
-      comment="audit augenrules rmmod" id="test_sudoers_without_include" version="1">
+      comment="test none sudoers #include or @include" id="test_sudoers_without_include" version="1">
     <ind:object object_ref="object_sudoers_without_include" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_sudoers_without_include" version="1">
     <ind:filepath>/etc/sudoers</ind:filepath>
-    <ind:pattern operation="pattern match">^#include[\s]+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[#@]include[\s]+.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
-      comment="audit augenrules rmmod" id="test_sudoers_without_includedir" version="1">
+      comment="test none sudoers @includedir" id="test_sudoers_without_includedir_new" version="1">
+    <ind:object object_ref="object_sudoers_without_include_new" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_sudoers_without_include_new" version="1">
+    <ind:filepath>/etc/sudoers</ind:filepath>
+    <ind:pattern operation="pattern match">^@includedir[\s]+.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+      comment="test none sudoers #includedir or @includdir" id="test_sudoers_without_includedir" version="1">
     <ind:object object_ref="object_sudoers_without_includedir" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_sudoers_without_includedir" version="1">
     <ind:filepath>/etc/sudoers</ind:filepath>
-    <ind:pattern operation="pattern match">^#includedir[\s]+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[#@]includedir[\s]+.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
-      comment="audit augenrules rmmod" id="test_sudoersd_without_includes" version="1">
+      comment="test none sudoers.d #include, @include, #includedir or @includedir" id="test_sudoersd_without_includes" version="1">
     <ind:object object_ref="object_sudoersd_without_includes" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_sudoersd_without_includes" version="1">
     <ind:path>/etc/sudoers.d/</ind:path>
     <ind:filename operation="pattern match">.*</ind:filename>
-    <ind:pattern operation="pattern match">^#include(dir)?[\s]+.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[#@]include(?:dir)?[\s]+.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/rule.yml
@@ -7,12 +7,13 @@ title: 'Ensure sudo only includes the default configuration directory'
 description: |-
     Administrators can configure authorized <tt>sudo</tt> users via drop-in files, and it is possible to include
     other directories and configuration files from the file currently being parsed.
-  
+
     Make sure that <tt>/etc/sudoers</tt> only includes drop-in configuration files from <tt>/etc/sudoers.d</tt>,
     or that no drop-in file is included.
     Either the <tt>/etc/sudoers</tt> should contain only one <tt>#includedir</tt> directive pointing to
     <tt>/etc/sudoers.d</tt>, and no file in <tt>/etc/sudoers.d/</tt> should include other files or directories;
-    Or the <tt>/etc/sudoers</tt> should not contain any <tt>#include</tt> or <tt>#includedir</tt> directives.
+    Or the <tt>/etc/sudoers</tt> should not contain any <tt>#include</tt>,
+    <tt>@include</tt>, <tt>#includedir</tt> or <tt>@includedir</tt> directives.
     Note that the '#' character doesn't denote a comment in the configuration file.
 
 rationale: |-
@@ -44,6 +45,6 @@ ocil_clause: "the /etc/sudoers doesn't include /etc/sudores.d or includes other 
 ocil: |-
     To determine whether <tt>sudo</tt> command includes configuration files from the appropriate directory,
     run the following command:
-    <pre>$ sudo grep -rP '^#include(dir)?' /etc/sudoers /etc/sudoers.d</pre>
+    <pre>$ sudo grep -rP '^[#@]include(dir)?' /etc/sudoers /etc/sudoers.d</pre>
     If only the line <tt>/etc/sudoers:#includedir /etc/sudoers.d</tt> is returned, then the drop-in include configuration is set correctly.
     Any other line returned is a finding.

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/no_includedir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/no_includedir.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_all
 
-sed -i "/#include(dir)?.*/d" /etc/sudoers
+sed -i "/#include(dir)?/d" /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/sudoers.d_with_include_new.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/sudoers.d_with_include_new.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+mkdir -p /etc/sudoers.d
+# Ensure default config is there
+if ! grep -q "#includedir /etc/sudoers.d" /etc/sudoers; then
+    echo "#includedir /etc/sudoers.d" >> /etc/sudoers
+fi
+
+touch /etc/my-sudoers
+echo "@include /etc/my-sudoers" > /etc/sudoers.d/my-sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/sudoers.d_with_includedir_new.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/sudoers.d_with_includedir_new.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+mkdir -p /etc/sudoers.d
+# Ensure default config is there
+if ! grep -q "#includedir /etc/sudoers.d" /etc/sudoers; then
+    echo "#includedir /etc/sudoers.d" >> /etc/sudoers
+fi
+
+mkdir -p /etc/my-sudoers.d
+echo "@includedir /etc/my-sudoers.d" > /etc/sudoers.d/my-sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/wrong_includedir.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/wrong_includedir.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
 
-sed -i "/#includedir.*/d" /etc/sudoers
+sed -i "/#includedir/d" /etc/sudoers
 echo "#includedir /opt/extra_config.d" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/wrong_includedir_new.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_default_includedir/tests/wrong_includedir_new.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_all
+
+sed -i "/#includedir/d" /etc/sudoers
+echo "@includedir /etc/sudoers.d" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/rule.yml
@@ -8,7 +8,12 @@ description: |-
     The sudoers security policy requires that users authenticate themselves before they can use sudo.
     When sudoers requires authentication, it validates the invoking user's credentials.
     The expected output for:
-    <pre>sudo egrep -i '(!rootpw|!targetpw|!runaspw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#'</pre>
+    <pre> sudo cvtsudoers -f sudoers /etc/sudoers | grep -E '^Defaults !?(rootpw|targetpw|runaspw)$' </pre>
+    <pre> Defaults !targetpw
+          Defaults !rootpw
+          Defaults !runaspw </pre>
+    or if cvtsudoers not supported:
+    <pre> sudo find /etc/sudoers /etc/sudoers.d \( \! -name '*~' -a \! -name '*.*' \) -exec grep -E --with-filename '^[[:blank:]]*Defaults[[:blank:]](.*[[:blank:]])?!?\b(rootpw|targetpw|runaspw)' -- {} \; </pre>
     <pre> /etc/sudoers:Defaults !targetpw
           /etc/sudoers:Defaults !rootpw
           /etc/sudoers:Defaults !runaspw </pre>
@@ -41,7 +46,9 @@ ocil_clause: 'invoke user passwd when using sudo'
 
 ocil: |-
     Run the following command to Verify that the sudoers security policy is configured to use the invoking user's password for privilege escalation:
-    <pre> sudo egrep -i '(!rootpw|!targetpw|!runaspw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#'</pre>
+    <pre> sudo cvtsudoers -f sudoers /etc/sudoers | grep -E '^Defaults !?(rootpw|targetpw|runaspw)' </pre>
+    or if cvtsudoers not supported:
+    <pre> sudo find /etc/sudoers /etc/sudoers.d \( \! -name '*~' -a \! -name '*.*' \) -exec grep -E --with-filename '^[[:blank:]]*Defaults[[:blank:]](.*[[:blank:]])?!?\b(rootpw|targetpw|runaspw)' -- {} \; </pre>
     If no results are returned, this is a finding.
     If conflicting results are returned, this is a finding.
     If "Defaults !targetpw" is not defined, this is a finding.

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_passwd_duplicates.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_passwd_duplicates.fail.sh
@@ -1,0 +1,8 @@
+# platform = SUSE Linux Enterprise 15,multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# packages = sudo
+
+echo 'Defaults !targetpw' >> /etc/sudoers
+echo 'Defaults !rootpw' >> /etc/sudoers
+echo 'Defaults !runaspw' >> /etc/sudoers
+# This wins
+echo 'Defaults runaspw' >> /etc/sudoers


### PR DESCRIPTION
Major policy breaches have been possible as rule did not support new version changes, introduced in sudo v1.9.1 released 2020-06-19, if OS had upgraded version. At least Fedora, maybe RHEL 9.

Promote cvtsudoers if available.

Various fixes and added some tests.

Maybe runaspw etc tests should be somewhere else and focus here only for includes in various forms?