### PR TITLE
Rule `grub2_enable_fips_mode` is only applicable on systems that use GRUB2 

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/rule.yml
@@ -29,6 +29,9 @@ rationale: |-
 
 severity: high
 
+platforms:
+    - grub2
+
 identifiers:
     cce@rhel7: CCE-80359-3
 


### PR DESCRIPTION

#### Description:

- Add `grub2` platform to rule `grub2_enable_fips_mode`, it is not applicable if the system doesn't use GRUB2.

#### Rationale:

- GRUB2 is not available on s390x
- Similar to #9389
