### PR TITLE
Enable for sle anssi bp28 intermediary various rules

### DIFF
--- a/controls/anssi_sle.yml
+++ b/controls/anssi_sle.yml
@@ -785,6 +785,18 @@ controls:
       be customized for the systems deployment requirements.
     status: partial
     rules:
+    # Based on DAT-NT-012 R3
+    - package_chrony_installed
+    - chronyd_specify_remote_server
+
+    # Derived from DAT-NT-012 R4
+    - partition_for_var_log_audit
+
+    # Derived from DAT-NT-012 R5, these are also covered in R7
+    # The default remote loghost is logcollector.
+    # Change the default value to the hostname or IP of the system to send the logs to
+    - rsyslog_remote_loghost
+
     # Derived from DAT-NT-012 R12
     - package_rsyslog-gnutls_installed
     - rsyslog_remote_tls
@@ -832,7 +844,9 @@ controls:
     levels:
     - intermediary
     title: Configuring the local messaging service
-    # rules: TBD
+    status: automated
+    rules:
+    - postfix_network_listening_disabled
 
   - id: R49
     levels:
@@ -841,7 +855,8 @@ controls:
     status: partial # it is hard to define what are "service accounts"
     notes: >-
       Only the alias for root user is currently covered.
-    # rules: TBD
+    rules:
+    - postfix_client_configure_mail_alias
 
   - id: R50
     levels:

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
 
 {{{ bash_instantiate_variables("var_postfix_inet_interfaces") }}}
 

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/rule.yml
@@ -20,6 +20,8 @@ identifiers:
     cce@rhel7: CCE-80289-2
     cce@rhel8: CCE-82174-4
     cce@rhel9: CCE-90825-1
+    cce@sle12: CCE-91595-9
+    cce@sle15: CCE-91280-8
 
 references:
     anssi: BP28(R48)

--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -21,6 +21,7 @@ identifiers:
     cce@rhel7: CCE-83419-2
     cce@rhel8: CCE-82874-9
     cce@rhel9: CCE-84215-3
+    cce@sle12: CCE-91594-2
     cce@sle15: CCE-91229-5
 
 references:


### PR DESCRIPTION
#### Description:

- Enable for SLE12 and SLE15 rules for ANSSI bp28 profile

#### Rationale:

- Add CCE id for sle12 rule package_chrony_installed
- Add CCE ids for sle12 and sle15 for postfix_network_listening_disabled in context of anssi profile
- Enable sle support for postfix_network_listening_disabled rule remediations
