### PR TITLE
Fix `kernel.core_pattern` with empty string rule

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
@@ -13,8 +13,10 @@ rationale: |-
 
 severity: medium
 
+{{% if product in ["rhel9"] %}}
 conflicts:
     - sysctl_kernel_core_pattern_empty_string
+{{% endif %}}
 
 identifiers:
     cce@rhcos4: CCE-82527-3

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
@@ -1,0 +1,32 @@
+# platform = multi_platform_all
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+- name: List /etc/sysctl.d/*.conf files
+  find:
+    paths:
+    - /etc/sysctl.d/
+    - /run/sysctl.d/
+    contains: ^[\s]*kernel.core_pattern.*$
+    patterns: '*.conf'
+    file_type: any
+  register: find_sysctl_d
+- name: Comment out any occurrences of kernel.core_pattern from /etc/sysctl.d/*.conf
+    files
+  replace:
+    path: '{{ item.path }}'
+    regexp: ^[\s]*kernel.core_pattern
+    replace: '#kernel.core_pattern'
+  loop: '{{ find_sysctl_d.files }}'
+- name: Comment out any occurrences of kernel.core_pattern with value from /etc/sysctl.conf files
+  replace:
+    path: /etc/sysctl.conf
+    regexp: ^[\s]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*\S+
+    replace: '#kernel.core_pattern'
+- name: Ensure sysctl kernel.core_pattern is set to empty
+  sysctl:
+    name: kernel.core_pattern
+    value: ' ' # ansible sysctl module doesn't allow empty string, a space string is allowed and has the same semantics as sysctl will ignore spaces
+    state: present
+    reload: true

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
@@ -24,8 +24,8 @@
 - name: Comment out any occurrences of kernel.core_pattern with value from /etc/sysctl.conf files
   replace:
     path: /etc/sysctl.conf
-    regexp: ^[\s]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*\S+
-    replace: '#kernel.core_pattern'
+    regexp: '^[\s]*kernel.core_pattern([ \t]*=[ \t]*\S+)'
+    replace: '#kernel.core_pattern\1'
 
 - name: Ensure sysctl kernel.core_pattern is set to empty
   sysctl:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/ansible/shared.yml
@@ -12,6 +12,7 @@
     patterns: '*.conf'
     file_type: any
   register: find_sysctl_d
+
 - name: Comment out any occurrences of kernel.core_pattern from /etc/sysctl.d/*.conf
     files
   replace:
@@ -19,11 +20,13 @@
     regexp: ^[\s]*kernel.core_pattern
     replace: '#kernel.core_pattern'
   loop: '{{ find_sysctl_d.files }}'
+
 - name: Comment out any occurrences of kernel.core_pattern with value from /etc/sysctl.conf files
   replace:
     path: /etc/sysctl.conf
     regexp: ^[\s]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*\S+
     replace: '#kernel.core_pattern'
+
 - name: Ensure sysctl kernel.core_pattern is set to empty
   sysctl:
     name: kernel.core_pattern

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
@@ -1,0 +1,60 @@
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
+# reboot = true
+# strategy = disable
+# complexity = low
+# disruption = medium
+# Remediation is applicable only in certain platforms
+if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
+
+# Comment out any occurrences of kernel.core_pattern from /etc/sysctl.d/*.conf files
+
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf; do
+
+  matching_list=$(grep -P '^(?!#).*[\s]*kernel.core_pattern.*$' $f | uniq )
+  if ! test -z "$matching_list"; then
+    while IFS= read -r entry; do
+      escaped_entry=$(sed -e 's|/|\\/|g' <<< "$entry")
+      # comment out "kernel.core_pattern" matches to preserve user data
+      sed -i "s/^${escaped_entry}$/# &/g" $f
+    done <<< "$matching_list"
+  fi
+done
+
+#
+# Set runtime for kernel.core_pattern
+#
+/sbin/sysctl -q -n -w kernel.core_pattern=""
+
+#
+# If kernel.core_pattern present in /etc/sysctl.conf, change value to empty
+#	else, add "kernel.core_pattern =" to /etc/sysctl.conf
+#
+# Test if the config_file is a symbolic link. If so, use --follow-symlinks with sed.
+# Otherwise, regular sed command will do.
+sed_command=('sed' '-i')
+if test -L "/etc/sysctl.conf"; then
+    sed_command+=('--follow-symlinks')
+fi
+
+# Strip any search characters in the key arg so that the key can be replaced without
+# adding any search characters to the config file.
+stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "^kernel.core_pattern")
+
+# shellcheck disable=SC2059
+printf -v formatted_output "%s=" "$stripped_key"
+
+# If the key exists, change it. Otherwise, add it to the config_file.
+# We search for the key string followed by a word boundary (matched by \>),
+# so if we search for 'setting', 'setting2' won't match.
+if LC_ALL=C grep -q -m 1 -i -e "^kernel.core_pattern\\>" "/etc/sysctl.conf"; then
+    escaped_formatted_output=$(sed -e 's|/|\\/|g' <<< "$formatted_output")
+    "${sed_command[@]}" "s/^kernel.core_pattern\\>.*/$escaped_formatted_output/gi" "/etc/sysctl.conf"
+else
+    # \n is precaution for case where file ends without trailing newline
+
+    printf '%s\n' "$formatted_output" >> "/etc/sysctl.conf"
+fi
+
+else
+    >&2 echo 'Remediation is not applicable, nothing was done'
+fi

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_ubuntu,multi_platform_sle
+# platform = multi_platform_all
 # reboot = true
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/oval/shared.xml
@@ -10,7 +10,9 @@
                          definition_ref="sysctl_kernel_core_pattern_empty_string_runtime"/>
     </criteria>
   </definition>
-</def-group><def-group>
+</def-group>
+
+<def-group>
   <definition class="compliance" id="sysctl_kernel_core_pattern_empty_string_runtime" version="3">
     {{{ oval_metadata("The kernel 'kernel.core_pattern' parameter should be set to an empty string in the system runtime.") }}}
     <criteria operator="AND">
@@ -23,21 +25,15 @@
                     comment="kernel runtime parameter kernel.core_pattern set to an empty string"
                     check="all" check_existence="all_exist" state_operator="OR">
     <unix:object object_ref="object_sysctl_kernel_core_pattern_empty_string_runtime"/>
-
     <unix:state state_ref="state_sysctl_kernel_core_pattern_empty_string_runtime"/>
-
   </unix:sysctl_test>
 
   <unix:sysctl_object id="object_sysctl_kernel_core_pattern_empty_string_runtime" version="1">
     <unix:name>kernel.core_pattern</unix:name>
   </unix:sysctl_object>
 
-
   <unix:sysctl_state id="state_sysctl_kernel_core_pattern_empty_string_runtime" version="1">
-
-    <unix:value datatype="string"
-                operation="equals"></unix:value>
-
+    <unix:value datatype="string" operation="equals"></unix:value>
   </unix:sysctl_state>
 
 </def-group>
@@ -53,18 +49,17 @@
                    test_ref="test_sysctl_kernel_core_pattern_empty_string_static_etc_sysctld"/>
         <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /run/sysctl.d/*.conf"
                    test_ref="test_sysctl_kernel_core_pattern_empty_string_static_run_sysctld"/>
-
       </criteria>
 
       <criterion comment="Check that kernel_core_pattern is defined in only one file" test_ref="test_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
     </criteria>
   </definition>
+
   <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static" version="1"
                               check="all" check_existence="all_exist"
                               comment="kernel.core_pattern static configuration" state_operator="OR">
     <ind:object object_ref="object_static_sysctl_sysctl_kernel_core_pattern_empty_string"/>
     <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
-
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_etc_sysctld" version="1" check="all"
@@ -165,7 +160,6 @@
     <unix:canonical_path operation="pattern match">^(?!(\/etc\/sysctl\.conf$|(\/etc|\/run|\/usr\/lib)\/sysctl\.d\/)).*$</unix:canonical_path>
   </unix:symlink_state>
 
-
   <local_variable comment="List of conf files" datatype="string" id="local_var_conf_files_sysctl_kernel_core_pattern_empty_string" version="1">
     <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered" item_field="filepath" />
   </local_variable>
@@ -189,7 +183,6 @@
   <ind:textfilecontent54_object id="object_static_run_usr_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
     <set>
       <object_reference>object_static_run_sysctld_sysctl_kernel_core_pattern_empty_string</object_reference>
-
     </set>
   </ind:textfilecontent54_object>
 
@@ -213,9 +206,7 @@
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_static_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
-
     <ind:subexpression operation="equals" datatype="string"></ind:subexpression>
-
   </ind:textfilecontent54_state>
 
 </def-group>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/oval/shared.xml
@@ -1,0 +1,221 @@
+
+
+<def-group>
+  <definition class="compliance" id="sysctl_kernel_core_pattern_empty_string" version="3">
+    {{{ oval_metadata("The kernel 'kernel.core_pattern' parameter should be set to the appropriate value in both system configuration and system runtime.") }}}
+    <criteria operator="AND">
+      <extend_definition comment="kernel.core_pattern configuration setting check"
+                         definition_ref="sysctl_kernel_core_pattern_empty_string_static"/>
+      <extend_definition comment="kernel.core_pattern runtime setting check"
+                         definition_ref="sysctl_kernel_core_pattern_empty_string_runtime"/>
+    </criteria>
+  </definition>
+</def-group><def-group>
+  <definition class="compliance" id="sysctl_kernel_core_pattern_empty_string_runtime" version="3">
+    {{{ oval_metadata("The kernel 'kernel.core_pattern' parameter should be set to an empty string in the system runtime.") }}}
+    <criteria operator="AND">
+      <criterion comment="kernel runtime parameter kernel.core_pattern set to an empty string"
+                 test_ref="test_sysctl_kernel_core_pattern_empty_string_runtime"/>
+    </criteria>
+  </definition>
+
+  <unix:sysctl_test id="test_sysctl_kernel_core_pattern_empty_string_runtime" version="1"
+                    comment="kernel runtime parameter kernel.core_pattern set to an empty string"
+                    check="all" check_existence="all_exist" state_operator="OR">
+    <unix:object object_ref="object_sysctl_kernel_core_pattern_empty_string_runtime"/>
+
+    <unix:state state_ref="state_sysctl_kernel_core_pattern_empty_string_runtime"/>
+
+  </unix:sysctl_test>
+
+  <unix:sysctl_object id="object_sysctl_kernel_core_pattern_empty_string_runtime" version="1">
+    <unix:name>kernel.core_pattern</unix:name>
+  </unix:sysctl_object>
+
+
+  <unix:sysctl_state id="state_sysctl_kernel_core_pattern_empty_string_runtime" version="1">
+
+    <unix:value datatype="string"
+                operation="equals"></unix:value>
+
+  </unix:sysctl_state>
+
+</def-group>
+<def-group>
+  <definition class="compliance" id="sysctl_kernel_core_pattern_empty_string_static" version="3">
+    {{{ oval_metadata("The kernel 'kernel.core_pattern' parameter should be set to an empty string in the system configuration.") }}}
+    <criteria operator="AND">
+      <criteria operator="OR">
+        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /etc/sysctl.conf"
+                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static"/>
+        <!-- see sysctl.d(5) -->
+        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /etc/sysctl.d/*.conf"
+                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static_etc_sysctld"/>
+        <criterion comment="kernel static parameter kernel.core_pattern set to an empty string in /run/sysctl.d/*.conf"
+                   test_ref="test_sysctl_kernel_core_pattern_empty_string_static_run_sysctld"/>
+
+      </criteria>
+
+      <criterion comment="Check that kernel_core_pattern is defined in only one file" test_ref="test_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static" version="1"
+                              check="all" check_existence="all_exist"
+                              comment="kernel.core_pattern static configuration" state_operator="OR">
+    <ind:object object_ref="object_static_sysctl_sysctl_kernel_core_pattern_empty_string"/>
+    <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
+
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_etc_sysctld" version="1" check="all"
+                          comment="kernel.core_pattern static configuration in /etc/sysctl.d/*.conf" state_operator="OR">
+    <ind:object object_ref="object_static_etc_sysctld_sysctl_kernel_core_pattern_empty_string"/>
+    <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
+
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_test id="test_sysctl_kernel_core_pattern_empty_string_static_run_sysctld" version="1" check="all"
+                          comment="kernel.core_pattern static configuration in /run/sysctl.d/*.conf" state_operator="OR">
+    <ind:object object_ref="object_static_run_sysctld_sysctl_kernel_core_pattern_empty_string"/>
+    <ind:state state_ref="state_static_sysctld_sysctl_kernel_core_pattern_empty_string"/>
+
+  </ind:textfilecontent54_test>
+  <ind:variable_test check="all" check_existence="all_exist" comment="Check that only one file contains kernel_core_pattern"
+  id="test_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" version="1">
+    <ind:object object_ref="object_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
+    <ind:state state_ref="state_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" />
+  </ind:variable_test>
+
+  <ind:variable_object id="object_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" version="1">
+    <ind:var_ref>local_var_sysctl_kernel_core_pattern_empty_string_counter</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_state id="state_sysctl_kernel_core_pattern_empty_string_defined_in_one_file" version="1">
+    <ind:value operation="equals" datatype="int">1</ind:value>
+  </ind:variable_state>
+
+  <local_variable comment="Count unique sysctls" datatype="int" id="local_var_sysctl_kernel_core_pattern_empty_string_counter" version="1">
+    <count>
+      <unique>
+        <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls" item_field="filepath" />
+      </unique>
+    </count>
+  </local_variable>
+
+  <ind:textfilecontent54_object id="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls" version="1">
+    <set>
+      <object_reference>object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered</object_reference>
+      <filter action="exclude">state_sysctl_kernel_core_pattern_empty_string_filepath_is_symlink</filter>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_sysctl_kernel_core_pattern_empty_string_filepath_is_symlink" version="1">
+    <ind:filepath operation="equals" var_check="at least one" var_ref="local_var_sysctl_kernel_core_pattern_empty_string_safe_symlinks" datatype="string" />
+  </ind:textfilecontent54_state>
+
+  <!-- <no symlink handling> -->
+  <!-- We craft a variable with blank string to combine with the symlink paths found.
+       This ultimately avoids referencing a variable with "no values",
+       we reference a variable with a blank string -->
+  <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_sysctl_kernel_core_pattern_empty_string_safe_symlinks" version="1">
+    <unique>
+      <object_component object_ref="var_object_symlink_sysctl_kernel_core_pattern_empty_string" item_field="value" />
+    </unique>
+  </local_variable>
+
+  <ind:variable_object id="var_object_symlink_sysctl_kernel_core_pattern_empty_string" comment="combine the blank string with symlink paths found" version="1">
+    <set>
+      <object_reference>var_obj_symlink_sysctl_kernel_core_pattern_empty_string</object_reference>
+      <object_reference>var_obj_blank_sysctl_kernel_core_pattern_empty_string</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <ind:variable_object id="var_obj_blank_sysctl_kernel_core_pattern_empty_string" comment="variable object of the blank string" version="1">
+    <ind:var_ref>local_var_blank_path_sysctl_kernel_core_pattern_empty_string</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable comment="Blank string" datatype="string" id="local_var_blank_path_sysctl_kernel_core_pattern_empty_string" version="1">
+    <literal_component datatype="string"></literal_component>
+  </local_variable>
+
+  <ind:variable_object id="var_obj_symlink_sysctl_kernel_core_pattern_empty_string" comment="variable object of the symlinks found" version="1">
+    <ind:var_ref>local_var_symlinks_sysctl_kernel_core_pattern_empty_string</ind:var_ref>
+  </ind:variable_object>
+  <!-- </no symlink handling> -->
+
+  <local_variable comment="Unique list of symlink conf files" datatype="string" id="local_var_symlinks_sysctl_kernel_core_pattern_empty_string" version="1">
+    <unique>
+      <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_symlinks" item_field="filepath" />
+    </unique>
+  </local_variable>
+
+  <!-- "pattern match" doesn't seem to work with symlink_object, not sure if a bug or not.
+       Workaround by querying for all conf files found -->
+  <unix:symlink_object comment="Symlinks referencing files in default dirs" id="object_sysctl_kernel_core_pattern_empty_string_symlinks" version="1">
+    <unix:filepath operation="equals" var_ref="local_var_conf_files_sysctl_kernel_core_pattern_empty_string" />
+    <filter action="exclude">state_symlink_points_outside_usual_dirs_sysctl_kernel_core_pattern_empty_string</filter>
+  </unix:symlink_object>
+
+  <!-- The state matches symlinks that don't point to the default dirs, i.e. paths that are not:
+       ^/etc/sysctl.conf$
+       ^/etc/sysctl.d/.*$
+       ^/run/sysctl.d/.*$
+       ^/usr/lib/sysctl.d/.*$ -->
+  <unix:symlink_state comment="State that matches symlinks referencing files not in the default dirs" id="state_symlink_points_outside_usual_dirs_sysctl_kernel_core_pattern_empty_string" version="1">
+    <unix:canonical_path operation="pattern match">^(?!(\/etc\/sysctl\.conf$|(\/etc|\/run|\/usr\/lib)\/sysctl\.d\/)).*$</unix:canonical_path>
+  </unix:symlink_state>
+
+
+  <local_variable comment="List of conf files" datatype="string" id="local_var_conf_files_sysctl_kernel_core_pattern_empty_string" version="1">
+    <object_component object_ref="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered" item_field="filepath" />
+  </local_variable>
+
+  <!-- Avoid directly referencing a possibly empty collection, one empty collection will cause the
+       variable to have no value even when there are valid objects. -->
+  <ind:textfilecontent54_object id="object_sysctl_kernel_core_pattern_empty_string_static_set_sysctls_unfiltered" version="1">
+    <set>
+      <object_reference>object_static_etc_sysctls_sysctl_kernel_core_pattern_empty_string</object_reference>
+      <object_reference>object_static_run_usr_sysctls_sysctl_kernel_core_pattern_empty_string</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_etc_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
+    <set>
+      <object_reference>object_static_sysctl_sysctl_kernel_core_pattern_empty_string</object_reference>
+      <object_reference>object_static_etc_sysctld_sysctl_kernel_core_pattern_empty_string</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_run_usr_sysctls_sysctl_kernel_core_pattern_empty_string" version="1">
+    <set>
+      <object_reference>object_static_run_sysctld_sysctl_kernel_core_pattern_empty_string</object_reference>
+
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_sysctl_sysctl_kernel_core_pattern_empty_string" version="1">
+    <ind:filepath>/etc/sysctl.conf</ind:filepath>
+    <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_etc_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
+    <ind:path>/etc/sysctl.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_run_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
+    <ind:path>/run/sysctl.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^[[:blank:]]*kernel.core_pattern[[:blank:]]*=[[:blank:]]*(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_static_sysctld_sysctl_kernel_core_pattern_empty_string" version="1">
+
+    <ind:subexpression operation="equals" datatype="string"></ind:subexpression>
+
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/rule.yml
@@ -1,18 +1,18 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,ol9,rhcos4,rhel8,rhel9
+prodtype: rhel9
 
 title: 'Disable storing core dumps'
 
 description: |-
     The <tt>kernel.core_pattern</tt> option specifies the core dumpfile pattern
-    name. It can be set to an empty string <tt>''</tt>. In this case, the kernel
+    name. It can be set to an empty string. In this case, the kernel
     behaves differently based on another related option. If
     <tt>kernel.core_uses_pid</tt> is set to <tt>1</tt>, then a file named as
     <tt>.PID</tt> (where <tt>PID</tt> is process ID of the crashed process) is
     created in the working directory. If <tt>kernel.core_uses_pid</tt> is set to
     <tt>0</tt>, no coredump is saved.
-    {{{ describe_sysctl_option_value(sysctl="kernel.core_pattern", value="''") }}}'
+    {{{ describe_sysctl_option_value(sysctl="kernel.core_pattern", value="") }}}
 
 rationale: |-
     A core dump includes a memory image taken at the time the operating system
@@ -30,17 +30,16 @@ conflicts:
 identifiers:
     cce@rhel9: CCE-86005-6
 
+references:
+    ospp: FMT_SMF_EXT.1
+
 ocil_clause: |-
-    the returned line does not have a value of ''.
+    the returned line does not have an empty string
 
 ocil: |
-    {{{ ocil_sysctl_option_value(sysctl="kernel.core_pattern", value="''") }}}
+    The runtime status of the <code>kernel.core_pattern</code> kernel parameter can be queried
+    by running the following command:
+    <pre>$ sysctl kernel.core_pattern | cat -A</pre>
+    <code>kernel.core_pattern = $</code>
 
 platform: machine
-
-template:
-    name: sysctl
-    vars:
-        sysctlvar: kernel.core_pattern
-        sysctlval: "''"
-        datatype: string

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/correct_value.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern=""

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/correct_value_with_spaces.pass.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/correct_value_with_spaces.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=    " >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern=""

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=|/bin/false" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern="|/bin/false"

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_d_directory.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_d_directory.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=|/bin/false" >> /etc/sysctl.d/98-sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern=""

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_runtime.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_runtime.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=" >> /etc/sysctl.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern="|/bin/false"

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_three_entries.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_three_entries.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=|/bin/false" >> /etc/sysctl.conf
+echo "kernel.core_pattern=" >> /etc/sysctl.conf
+echo "kernel.core_pattern=|/bin/false" >> /etc/sysctl.conf
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern=""

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_two_entries.fail.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/tests/wrong_value_two_entries.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/kernel.core_pattern/d" /etc/sysctl.conf
+echo "kernel.core_pattern=|/bin/false" >> /etc/sysctl.conf
+echo "kernel.core_pattern=" >> /etc/sysctl.conf
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w kernel.core_pattern=""

--- a/products/rhel9/profiles/ospp.profile
+++ b/products/rhel9/profiles/ospp.profile
@@ -110,7 +110,7 @@ selections:
     - package_gnutls-utils_installed
 
     ### Login
-    - sysctl_kernel_core_pattern
+    - sysctl_kernel_core_pattern_empty_string
     - sysctl_kernel_core_uses_pid
     - service_systemd-coredump_disabled
     - var_authselect_profile=minimal

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -90,7 +90,7 @@ def parse_affected(cur_dir, env_yaml):
 
                 except ValueError as e:
                     print("No <affected> element found in file {}. "
-                        " Parsed XML was:\n{}".format(oval, item))
+                          " Parsed XML was:\n{}".format(oval, item))
                     raise e
 
 

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 
 import os
+import re
 import sys
 
 import ssg.constants
@@ -73,19 +74,24 @@ def parse_affected(cur_dir, env_yaml):
             if not xml_content:
                 continue
 
-            oval_contents = ssg.utils.split_string_content(xml_content)
+            # split multiple def group into a list so multiple definitions in one OVAL also work
+            # this findall does not preserv the <def-group> tag but it's not necessary for the
+            # purpose of the test
+            xml_content_list = re.findall(r'<def-group>(.+?)</def-group>', xml_content, re.DOTALL)
+            for item in xml_content_list:
+                oval_contents = ssg.utils.split_string_content(item)
 
-            try:
-                results = ssg.oval.parse_affected(oval_contents)
+                try:
+                    results = ssg.oval.parse_affected(oval_contents)
 
-                assert len(results) == 3
-                assert isinstance(results[0], int)
-                assert isinstance(results[1], int)
+                    assert len(results) == 3
+                    assert isinstance(results[0], int)
+                    assert isinstance(results[1], int)
 
-            except ValueError as e:
-                print("No <affected> element found in file {}. "
-                      " Parsed XML was:\n{}".format(oval, xml_content))
-                raise e
+                except ValueError as e:
+                    print("No <affected> element found in file {}. "
+                        " Parsed XML was:\n{}".format(oval, item))
+                    raise e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Description:

- Fix `kernel.core_pattern` with empty string rule
  - Create custom content for core_pattern with empty string as current template does not work with empty string.
