### PR TITLE
Print check IDs in compare results

### DIFF
--- a/utils/compare_results.py
+++ b/utils/compare_results.py
@@ -134,35 +134,34 @@ def get_results(xml: ElementTree.ElementTree) -> dict:
     return rules
 
 
-def get_identifiers(xml: ElementTree.ElementTree) -> dict:
+def get_identifiers(rule: ElementTree.ElementTree) -> dict:
+    try:
+        return rule.find('xccdf-1.2:ident', PREFIX_TO_NS).text
+    except AttributeError:
+        return "MISSING_IDREF"
+
+
+def get_check_ids(rule: ElementTree.ElementTree) -> dict:
+    try:
+        check_content_ref = rule.find('xccdf-1.2:check/xccdf-1.2:check-content-ref', PREFIX_TO_NS)
+        check_name = check_content_ref.get('name', "")
+        return re.search(r'oval:ssg-(.*):def:\d+', check_name).group(1)
+    except AttributeError:
+        return ""
+
+
+def loop_rule_results(xml: ElementTree.ElementTree) -> dict:
     rules = dict()
 
     results_xml = xml.findall('.//xccdf-1.2:rule-result', PREFIX_TO_NS)
     for result in results_xml:
+        rule = dict()
         idref = result.attrib['idref']
         idref = idref.replace("xccdf_mil.disa.stig_rule_", "")
-        try:
-            rules[idref] = result.find('xccdf-1.2:ident', PREFIX_TO_NS).text
-        except AttributeError:
-            rules[idref] = "MISSING_IDREF"
+        rules[idref] = rule
 
-    return rules
-
-
-def get_check_ids(xml: ElementTree.ElementTree) -> dict:
-    rules = dict()
-
-    results_xml = xml.findall('.//xccdf-1.2:rule-result', PREFIX_TO_NS)
-    for result in results_xml:
-        idref = result.attrib['idref']
-        idref = idref.replace("xccdf_mil.disa.stig_rule_", "")
-        try:
-            check_content_ref = result.find('xccdf-1.2:check/xccdf-1.2:check-content-ref', PREFIX_TO_NS)
-            check_name = check_content_ref.get('name', "")
-            rules[idref] = re.search(r'oval:ssg-(.*):def:\d+', check_name).group(1)
-        except AttributeError:
-            rules[idref] = ""
-
+        rule['ident'] = get_identifiers(result)
+        rule['check'] = get_check_ids(result)
     return rules
 
 
@@ -208,17 +207,17 @@ def get_results_by_stig(results: dict, stigs: dict) -> dict:
     return base_stig_results
 
 
-def print_summary(comparison: Comparison, base_ident: dict, check_ids: dict, target_ident: dict) -> None:
+def print_summary(comparison: Comparison, base: dict, target: dict) -> None:
     print(f'Same Status: {len(comparison.same_status)}')
     for rule in comparison.same_status:
-        print(f'  {base_ident[rule]} {target_ident[rule]} - {rule} {check_ids[rule]:<75}'
+        print(f'  {base[rule]["ident"]} {target[rule]["ident"]} - {rule} {base[rule]["check"]:<75}'
               f'{comparison.base_results[rule]}')
     print(f'Missing in target: {len(comparison.missing_in_target)}')
     for rule in comparison.missing_in_target:
-        print(f'  {base_ident[rule]} - {rule} {check_ids[rule]:<75}')
+        print(f'  {base[rule]["ident"]} - {rule} {base[rule]["check"]:<75}')
     print(f'Different results: {len(comparison.different_results)}')
     for rule, value in comparison.different_results.items():
-        print(f'  {base_ident[rule]} {target_ident[rule]} - {rule} {check_ids[rule]:<75}'
+        print(f'  {base[rule]["ident"]} {target[rule]["ident"]} - {rule} {base[rule]["check"]:<75}'
               f'{value[0]} - {value[1]}')
 
 
@@ -258,10 +257,9 @@ def main():
     base_tree = ssg.xml.open_xml(args.base)
     target_tree = ssg.xml.open_xml(args.target)
     comparison = match_results(base_tree, target_tree)
-    base_ident = get_identifiers(base_tree)
-    check_ids = get_check_ids(base_tree)
-    target_tree = get_identifiers(target_tree)
-    print_summary(comparison, base_ident, check_ids, target_tree)
+    base_rules = loop_rule_results(base_tree)
+    target_rules = loop_rule_results(target_tree)
+    print_summary(comparison, base_rules, target_rules)
     if comparison.are_results_same():
         exit(0)
     else:

--- a/utils/compare_results.py
+++ b/utils/compare_results.py
@@ -134,14 +134,14 @@ def get_results(xml: ElementTree.ElementTree) -> dict:
     return rules
 
 
-def get_identifiers(rule: ElementTree.ElementTree) -> dict:
+def get_identifiers(rule: ElementTree.ElementTree) -> str:
     try:
         return rule.find('xccdf-1.2:ident', PREFIX_TO_NS).text
     except AttributeError:
         return "MISSING_IDREF"
 
 
-def get_check_ids(rule: ElementTree.ElementTree) -> dict:
+def get_check_ids(rule: ElementTree.ElementTree) -> str:
     try:
         check_content_ref = rule.find('xccdf-1.2:check/xccdf-1.2:check-content-ref', PREFIX_TO_NS)
         check_name = check_content_ref.get('name', "")


### PR DESCRIPTION
#### Description:

- Print IDs when comparing results.
  - The printed IDs are based off of the checks ran during evaluation.
  As `--stig-viewer` mode is used to compare with STIG Benchmark, there is no other place to derive this information from.
  This can be improved if `--stig-viewer` could replace CaC rule IDs with STIG rule IDS in the ARF results. Currently only the XCCDF results are affected by `--stig-viewer`.
- Small refactor to loop through the `rule-results` once instead of multiple times.

#### Rationale:

- Makes it easier to interpret data from the comparison
  - It is difficult to get some meaning from the CCEs.

#### Before
```
  CCE-83774-0 - SV-230524r744026_rule
  CCE-83411-9 - SV-230553r809324_rule
  CCE-83380-6 - SV-251718r809378_rule
Different results: 8
  CCE-82472-2 CCI-000198 - SV-230364r627750_rule                                                         fail - pass
  CCE-80829-5 CCI-000213 - SV-230234r743922_rule                                                         notapplicable - pass
  CCE-82215-5 CCI-000366 - SV-230311r833305_rule                                                         pass - fail
  CCE-80953-3 CCI-000366 - SV-230546r833361_rule                                                         pass - fail
  CCE-85887-8 CCI-000803 - SV-237640r646890_rule                                                         notapplicable - pass
  CCE-82175-1 CCI-000803 - SV-230238r646862_rule                                                         notapplicable - pass
  CCE-82434-2 CCI-000366 - SV-230557r627750_rule                                                         notapplicable - pass
  CCE-82424-3 CCI-000366 - SV-230287r743951_rule                                                         pass - fail
```

#### After
```                                       
  CCE-83774-0 - SV-230524r744026_rule usbguard_generate_policy                                                   
  CCE-83411-9 - SV-230553r809324_rule xwindows_remove_packages                                                   
  CCE-83380-6 - SV-251718r809378_rule xwindows_runlevel_target                                                   
Different results: 8
  CCE-82472-2 CCI-000198 - SV-230364r627750_rule accounts_password_set_min_life_existing                                    fail - pass
  CCE-80829-5 CCI-000213 - SV-230234r743922_rule                                                                            notapplicable - pass
  CCE-82215-5 CCI-000366 - SV-230311r833305_rule sysctl_kernel_core_pattern                                                 pass - fail
  CCE-80953-3 CCI-000366 - SV-230546r833361_rule sysctl_kernel_yama_ptrace_scope                                            pass - fail
  CCE-85887-8 CCI-000803 - SV-237640r646890_rule                                                                            notapplicable - pass
  CCE-82175-1 CCI-000803 - SV-230238r646862_rule                                                                            notapplicable - pass
  CCE-82434-2 CCI-000366 - SV-230557r627750_rule                                                                            notapplicable - pass
  CCE-82424-3 CCI-000366 - SV-230287r743951_rule file_permissions_sshd_private_key                                          pass - fail
```