### PR TITLE
Fix selinux_context_elevation_for_sudo spelling

### DIFF
--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -331,4 +331,4 @@ selections:
     - sebool_ssh_sysadm_login
     - sudoers_default_includedir
     - package_aide_installed
-    - selinux_context_electation_for_sudo
+    - selinux_context_elevation_for_sudo


### PR DESCRIPTION
#### Description:

Fix spelling error in RHEL 7 STIG profile.

#### Rationale:

Fixes a small issue introduced in #9401.