### PR TITLE
Quote dots in regexps

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/rule.yml
@@ -58,5 +58,5 @@ template:
     vars:
         filepath: /etc/ssh/
         missing_file_pass: 'true'
-        file_regex: ^.*.pub$
+        file_regex: ^.*\.pub$
         filemode: '0644'

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/rule.yml
@@ -63,7 +63,7 @@ ocil: |-
 
     {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9"] %}}
     To verify that smart cards are enabled in PAM files, run the following command:
-    <pre>$ sudo grep -e "auth.*pam_sss.so.*\(allow_missing_name\|try_cert_auth\)" /etc/pam.d/smartcard-auth /etc/pam.d/system-auth</pre>
+    <pre>$ sudo grep -e "auth.*pam_sss\.so.*\(allow_missing_name\|try_cert_auth\)" /etc/pam.d/smartcard-auth /etc/pam.d/system-auth</pre>
     If configured properly, output should be
     <pre>
     /etc/pam.d/smartcard-auth:auth        sufficient                                   pam_sss.so allow_missing_name

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/tests/authselect_modified_pam.fail.sh
@@ -11,8 +11,8 @@ authselect select sssd --force
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_missing.fail.sh
@@ -7,5 +7,5 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
-sed -i --follow-symlinks '/session.*required.*pam_lastlog.so.*showfailed/d' $CUSTOM_POSTLOGIN
+sed -i --follow-symlinks '/session.*required.*pam_lastlog\.so.*showfailed/d' $CUSTOM_POSTLOGIN
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_line_present.pass.sh
@@ -7,10 +7,10 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
-if [ $(grep -c "^\s*session.*required.*pam_lastlog.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+if [ $(grep -c "^\s*session.*required.*pam_lastlog\.so\s\+showfailed\s*$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
     sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
 fi
-if [ $(grep -c "^\s*session.*pam_lastlog.so.*silent$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
-    sed -i --follow-symlinks 's/^\(session.*pam_lastlog.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
+if [ $(grep -c "^\s*session.*pam_lastlog\.so.*silent$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+    sed -i --follow-symlinks 's/^\(session.*pam_lastlog\.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_modified_pam.fail.sh
@@ -6,8 +6,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_silent_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_silent_present.fail.sh
@@ -7,6 +7,6 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
-sed -i --follow-symlinks '/session.*required.*pam_lastlog.so/d' $CUSTOM_POSTLOGIN
+sed -i --follow-symlinks '/session.*required.*pam_lastlog\.so/d' $CUSTOM_POSTLOGIN
 sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     required                   pam_lastlog.so silent showfailed\n&/' $CUSTOM_POSTLOGIN
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/authselect_wrong_control.fail.sh
@@ -6,7 +6,7 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
-if ! $(grep -q "^[^#].*pam_lastlog.so.*showfailed" $CUSTOM_POSTLOGIN); then
+if ! $(grep -q "^[^#].*pam_lastlog\.so.*showfailed" $CUSTOM_POSTLOGIN); then
     sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     optional                   pam_lastlog.so showfailed\n&/' $CUSTOM_POSTLOGIN
 else
     sed -r -i --follow-symlinks "s/(^session.*)(required|requisite)(.*pam_lastlog\.so.*)$/\1optional\3/" $CUSTOM_POSTLOGIN

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/no_space_before_silent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/no_space_before_silent.pass.sh
@@ -7,8 +7,8 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_POSTLOGIN="/etc/authselect/$CUSTOM_PROFILE/postlogin"
-if [ $(grep -c "^\s*session.*pam_lastlog.so.*silent$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
-    sed -i --follow-symlinks 's/^\(session.*pam_lastlog.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
+if [ $(grep -c "^\s*session.*pam_lastlog\.so.*silent$" $CUSTOM_POSTLOGIN) -eq 0 ]; then
+    sed -i --follow-symlinks 's/^\(session.*pam_lastlog\.so.*\) silent\( .*\)/\1\2/g' $CUSTOM_POSTLOGIN
 fi
 if [ $(grep -Ec "^\s*session\s+required\s+pam_lastlog\.so(\s.*)?\ssilent($|\s)" $CUSTOM_POSTLOGIN) -eq 0 ]; then
     # If no such line, add

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_control.fail.sh
@@ -3,7 +3,7 @@
 
 pam_file="/etc/pam.d/postlogin"
 
-if ! $(grep -q "^[^#].*pam_lastlog.so.*showfailed" $pam_file); then
+if ! $(grep -q "^[^#].*pam_lastlog\.so.*showfailed" $pam_file); then
 	sed -i --follow-symlinks '0,/^session.*/s/^session.*/session     optional                   pam_lastlog.so showfailed\n&/' "$pam_file"
 else
 	sed -r -i --follow-symlinks "s/(^session.*)(required|requisite)(.*pam_lastlog\.so.*)$/\1optional\3/" "$pam_file"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -3,7 +3,7 @@
 
 FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam.d/password-auth"
 
-for dir in $(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
+for dir in $(grep -oP "^\s*(?:auth.*pam_faillock\.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
             | sed -r 's/.*=\s*(\S+)/\1/'); do
     if ! semanage fcontext -a -t faillog_t "$dir(/.*)?"; then
         semanage fcontext -m -t faillog_t "$dir(/.*)?"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -11,7 +11,7 @@
   </definition>
   <ind:textfilecontent54_object id="object_account_password_selinux_faillock_dir_collector" version="1">
     <ind:filepath operation="pattern match">{{{ faillock_files | join("|")}}}</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*(?:auth.*pam_faillock\.so.*)?dir\s*=\s*(\S+)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/ansible/shared.yml
@@ -14,4 +14,4 @@
                                             'pam_pwhistory.so',
                                             'remember',
                                             '{{ var_password_pam_remember }}',
-                                            '^password.*requisite.*pam_pwquality.so') }}}
+                                            '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/bash/shared.sh
@@ -4,4 +4,4 @@
 
 var_password_pam_remember_control_flag="$(echo $var_password_pam_remember_control_flag | cut -d \, -f 1)"
 
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', "$var_password_pam_remember_control_flag", 'pam_pwhistory.so', 'remember', "$var_password_pam_remember", '^password.*requisite.*pam_pwquality.so') }}}
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', "$var_password_pam_remember_control_flag", 'pam_pwhistory.so', 'remember', "$var_password_pam_remember", '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_correct_value.pass.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
-    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_PASSWORD_AUTH
 else
-    sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_PASSWORD_AUTH
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_PASSWORD_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_missing_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_missing_argument.fail.sh
@@ -7,9 +7,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
-    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so use_authtok" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so use_authtok" $CUSTOM_PASSWORD_AUTH
 else
-    sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $CUSTOM_PASSWORD_AUTH
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $CUSTOM_PASSWORD_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_missing_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_missing_line.fail.sh
@@ -7,5 +7,5 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_modified_pam.fail.sh
@@ -6,8 +6,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_wrong_control.fail.sh
@@ -9,8 +9,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
-    sed -i --follow-symlinks "/^password.*required.*pam_pwquality.so/a password    $control     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
+    sed -i --follow-symlinks "/^password.*required.*pam_pwquality\.so/a password    $control     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_PASSWORD_AUTH
 else
     sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1$control\3/" $CUSTOM_PASSWORD_AUTH
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/authselect_wrong_value.fail.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
-    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_PASSWORD_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_PASSWORD_AUTH
 else
-    sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_PASSWORD_AUTH
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_PASSWORD_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value.pass.sh
@@ -9,7 +9,7 @@ control_flag='requisite'
 config_file=/etc/pam.d/password-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,12 +20,12 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1$control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_required.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_required.pass.sh
@@ -7,6 +7,6 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_requisite.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/correct_value_multiple_control_requisite.pass.sh
@@ -7,6 +7,6 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel7_correct_value_cis_l2.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel7_correct_value_cis_l2.pass.sh
@@ -9,7 +9,7 @@ control_flag='required'
 config_file=/etc/pam.d/password-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,12 +20,12 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1$control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_control.fail.sh
@@ -9,7 +9,7 @@ control_flag='required'
 config_file=/etc/pam.d/password-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,11 +20,11 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\$1control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value.fail.sh
@@ -9,7 +9,7 @@ control_flag='requisite'
 config_file=/etc/pam.d/password-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,11 +20,11 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\$1control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value_multiple_control_sufficient.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/wrong_value_multiple_control_sufficient.fail.sh
@@ -7,6 +7,6 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 echo "password sufficient pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/ansible/shared.yml
@@ -14,4 +14,4 @@
                                             'pam_pwhistory.so',
                                             'remember',
                                             '{{ var_password_pam_remember }}',
-                                            '^password.*requisite.*pam_pwquality.so') }}}
+                                            '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/bash/shared.sh
@@ -4,4 +4,4 @@
 
 var_password_pam_remember_control_flag="$(echo $var_password_pam_remember_control_flag | cut -d \, -f 1)"
 
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', "$var_password_pam_remember_control_flag", 'pam_pwhistory.so', 'remember', "$var_password_pam_remember", '^password.*requisite.*pam_pwquality.so') }}}
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', "$var_password_pam_remember_control_flag", 'pam_pwhistory.so', 'remember', "$var_password_pam_remember", '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_correct_value.pass.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
-    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
 else
-    sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_SYSTEM_AUTH
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_missing_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_missing_argument.fail.sh
@@ -7,9 +7,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
-    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so use_authtok" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so use_authtok" $CUSTOM_SYSTEM_AUTH
 else
-    sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $CUSTOM_SYSTEM_AUTH
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_missing_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_missing_line.fail.sh
@@ -7,5 +7,5 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_SYSTEM_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_SYSTEM_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_modified_pam.fail.sh
@@ -6,8 +6,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_wrong_control.fail.sh
@@ -9,8 +9,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
-    sed -i --follow-symlinks "/^password.*required.*pam_pwquality.so/a password    $control     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*required.*pam_pwquality\.so/a password    $control     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
 else
     sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1$control\3/" $CUSTOM_SYSTEM_AUTH
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/authselect_wrong_value.fail.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
-    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
 else
-    sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_SYSTEM_AUTH
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value.pass.sh
@@ -9,7 +9,7 @@ control_flag='requisite'
 config_file=/etc/pam.d/system-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,12 +20,12 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1$control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_required.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_required.pass.sh
@@ -7,6 +7,6 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 echo "password required pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_requisite.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/correct_value_multiple_control_requisite.pass.sh
@@ -7,6 +7,6 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 echo "password requisite pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel7_correct_value_cis_l2.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel7_correct_value_cis_l2.pass.sh
@@ -9,7 +9,7 @@ control_flag='required'
 config_file=/etc/pam.d/system-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,12 +20,12 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1$control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_control.fail.sh
@@ -9,7 +9,7 @@ control_flag='required'
 config_file=/etc/pam.d/system-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,11 +20,11 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\$1control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value.fail.sh
@@ -9,7 +9,7 @@ control_flag='requisite'
 config_file=/etc/pam.d/system-auth
 
 # is 'password required|requisite pam_pwhistory.so' here?
-if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 	# is the remember option set?
 	option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 	if [[ -z $option ]]; then
@@ -20,11 +20,11 @@ if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
 		sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 	fi
 	# ensure corect control is being used per os requirement
-	if ! grep -q "^password.*$control_flag.*pam_pwhistory.so.*" $config_file; then
+	if ! grep -q "^password.*$control_flag.*pam_pwhistory\.so.*" $config_file; then
 		#replace incorrect value
 		sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\$1control_flag\3/" $config_file
 	fi
 else
 	# no 'password required|requisite pam_pwhistory.so', add it
-	sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+	sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password $control_flag pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value_multiple_control_requisite.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/wrong_value_multiple_control_requisite.fail.sh
@@ -7,6 +7,6 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_PASSWORD_AUTH
 echo "password sufficient pam_pwhistory.so use_authtok remember=5 retry=3" >> $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -9,6 +9,6 @@
 {{% if product in [ "sle15" ] %}}
 {{{ ansible_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '') }}}
 {{% else %}}
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '^password.*requisite.*pam_pwquality.so') }}}
+{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '^password.*requisite.*pam_pwquality\.so') }}}
 {{% endif %}}
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '^password.*requisite.*pam_pwquality.so') }}}
+{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -5,6 +5,6 @@
 {{% if product in [ "sle15" ] %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/common-password', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '') }}}
 {{% else %}}
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '^password.*requisite.*pam_pwquality.so') }}}
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '^password.*requisite.*pam_pwquality\.so') }}}
 {{% endif %}}
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '^password.*requisite.*pam_pwquality.so') }}}
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_correct_value.pass.sh
@@ -10,10 +10,10 @@ authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
 for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $custom_pam_file); then
-        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $custom_pam_file
+    if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $custom_pam_file); then
+        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $custom_pam_file
     else
-        sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $custom_pam_file
+        sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $custom_pam_file
     fi
 done
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_argument.fail.sh
@@ -9,10 +9,10 @@ authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
 for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $custom_pam_file); then
-        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so use_authtok" $custom_pam_file
+    if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $custom_pam_file); then
+        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so use_authtok" $custom_pam_file
     else
-        sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $custom_pam_file
+        sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $custom_pam_file
     fi
 done
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_line.fail.sh
@@ -9,6 +9,6 @@ authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
 for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    sed -i --follow-symlinks '/.*pam_pwhistory.so/d' $custom_pam_file
+    sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $custom_pam_file
 done
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_modified_pam.fail.sh
@@ -6,8 +6,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_wrong_value.fail.sh
@@ -10,10 +10,10 @@ authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
 for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $custom_pam_file); then
-        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $custom_pam_file
+    if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $custom_pam_file); then
+        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $custom_pam_file
     else
-        sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $custom_pam_file
+        sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $custom_pam_file
     fi
 done
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/correct_value.pass.sh
@@ -8,7 +8,7 @@ do
     config_file=/etc/pam.d/${auth_file}
 
 	# is 'password required|requisite pam_pwhistory.so' here?
-	if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+	if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 		# is the remember option set?
 		option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 		if [[ -z $option ]]; then
@@ -19,12 +19,12 @@ do
 			sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 		fi
 		# ensure corect control is being used per os requirement
-		if ! grep -q "^password.*requisite.*pam_pwhistory.so.*" $config_file; then
+		if ! grep -q "^password.*requisite.*pam_pwhistory\.so.*" $config_file; then
 			#replace incorrect value
 			sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1requisite\3/" $config_file
 		fi
 	else
 		# no 'password required|requisite pam_pwhistory.so', add it
-		sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password requisite pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+		sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password requisite pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 	fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value.fail.sh
@@ -8,7 +8,7 @@ do
     config_file=/etc/pam.d/${auth_file}
 
 	# is 'password required|requisite pam_pwhistory.so' here?
-	if grep -q "^password.*pam_pwhistory.so.*" $config_file; then
+	if grep -q "^password.*pam_pwhistory\.so.*" $config_file; then
 		# is the remember option set?
 		option=$(sed -rn 's/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\2/p' $config_file)
 		if [[ -z $option ]]; then
@@ -19,12 +19,12 @@ do
 			sed -r -i --follow-symlinks "s/^(.*pam_pwhistory\.so.*)(remember=[0-9]+)(.*)$/\1remember=$remember_cnt\3/" $config_file
 		fi
 		# ensure corect control is being used per os requirement
-		if ! grep -q "^password.*requisite.*pam_pwhistory.so.*" $config_file; then
+		if ! grep -q "^password.*requisite.*pam_pwhistory\.so.*" $config_file; then
 			#replace incorrect value
 			sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwhistory\.so.*)$/\1requisite\3/" $config_file
 		fi
 	else
 		# no 'password required|requisite pam_pwhistory.so', add it
-		sed -i --follow-symlinks "/^password.*pam_unix.so.*/i password requisite pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
+		sed -i --follow-symlinks "/^password.*pam_unix\.so.*/i password requisite pam_pwhistory.so use_authtok remember=$remember_cnt" $config_file
 	fi
 done

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/authselect_modified_pam.fail.sh
@@ -5,8 +5,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny/tests/conflicting_settings_authselect.fail.sh
@@ -17,8 +17,8 @@ echo "deny = 3" > /etc/security/faillock.conf
 {{{ bash_pam_faillock_enable() }}}
 
 for file in ${pam_files[@]}; do
-    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
-        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/deny=3/" \
+    if grep -qP "auth.*faillock\.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then
+        sed -i "/^\s*auth.*faillock\.so.*preauth/ s/$/deny=3/" \
             "$CUSTOM_PROFILE_DIR/$file"
     else 
         sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth deny=3" \

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/authselect_modified_pam.fail.sh
@@ -5,8 +5,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/tests/conflicting_settings_authselect.fail.sh
@@ -17,8 +17,8 @@ echo "even_deny_root" > /etc/security/faillock.conf
 {{{ bash_pam_faillock_enable() }}}
 
 for file in ${pam_files[@]}; do
-    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
-        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/even_deny_root/" \
+    if grep -qP "auth.*faillock\.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then
+        sed -i "/^\s*auth.*faillock\.so.*preauth/ s/$/even_deny_root/" \
             "$CUSTOM_PROFILE_DIR/$file"
     else 
         sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth even_deny_root" \

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/authselect_modified_pam.fail.sh
@@ -5,8 +5,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_interval/tests/conflicting_settings_authselect.fail.sh
@@ -17,8 +17,8 @@ echo "fail_interval = 900" > /etc/security/faillock.conf
 {{{ bash_pam_faillock_enable() }}}
 
 for file in ${pam_files[@]}; do
-    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
-        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/fail_interval=900/" \
+    if grep -qP "auth.*faillock\.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then
+        sed -i "/^\s*auth.*faillock\.so.*preauth/ s/$/fail_interval=900/" \
             "$CUSTOM_PROFILE_DIR/$file"
     else 
         sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth fail_interval=900" \

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_silent/bash/shared.sh
@@ -13,8 +13,8 @@ if [ -f $FAILLOCK_CONF ]; then
 else
     for pam_file in "${AUTH_FILES[@]}"
     do
-        if ! grep -qE '^\s*auth.*pam_faillock.so\s*preauth.*silent' "$pam_file"; then
-            sed -i --follow-symlinks '/^\s*auth.*pam_faillock.so.*preauth/ s/$/ silent/' "$pam_file"
+        if ! grep -qE '^\s*auth.*pam_faillock\.so\s*preauth.*silent' "$pam_file"; then
+            sed -i --follow-symlinks '/^\s*auth.*pam_faillock\.so.*preauth/ s/$/ silent/' "$pam_file"
         fi
     done
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/authselect_modified_pam.fail.sh
@@ -5,8 +5,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/conflicting_settings_authselect.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/tests/conflicting_settings_authselect.fail.sh
@@ -17,8 +17,8 @@ echo "unlock_time=600" > /etc/security/faillock.conf
 {{{ bash_pam_faillock_enable() }}}
 
 for file in ${pam_files[@]}; do
-    if grep -qP "auth.*faillock.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then 
-        sed -i "/^\s*auth.*faillock.so.*preauth/ s/$/unlock_time=600/" \
+    if grep -qP "auth.*faillock\.so.*preauth" $CUSTOM_PROFILE_DIR/$file; then
+        sed -i "/^\s*auth.*faillock\.so.*preauth/ s/$/unlock_time=600/" \
             "$CUSTOM_PROFILE_DIR/$file"
     else 
         sed -i "0,/^\s*auth.*/i auth required pam_faillock.so preauth unlock_time=600" \

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/ansible/shared.yml
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = medium
 
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit.so') }}}
+{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit.so') }}}
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/authselect_correct_entry.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/authselect_correct_entry.pass.sh
@@ -7,7 +7,7 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_SYSTEM_AUTH) -eq 0 ]; then
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $CUSTOM_SYSTEM_AUTH) -eq 0 ]; then
     sed -i --follow-symlinks '0,/^password.*/s/^password.*/password     requisite   pam_pwquality.so\n&/' $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/authselect_wrong_control.fail.sh
@@ -6,8 +6,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_PASSWORD_AUTH) -eq 0 ]; then
-    sed -i --follow-symlinks "/^account.*required.*pam_permit.so/a password    optional     pam_pwquality.so" $CUSTOM_PASSWORD_AUTH
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $CUSTOM_PASSWORD_AUTH) -eq 0 ]; then
+    sed -i --follow-symlinks "/^account.*required.*pam_permit\.so/a password    optional     pam_pwquality.so" $CUSTOM_PASSWORD_AUTH
 else
     sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwquality\.so.*)$/\1optional\3/" $CUSTOM_PASSWORD_AUTH
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/correct_entry.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/correct_entry.pass.sh
@@ -3,6 +3,6 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 config_file=/etc/pam.d/password-auth
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $config_file) -eq 0 ]; then
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $config_file) -eq 0 ]; then
     sed -i --follow-symlinks '0,/^password.*/s/^password.*/password		requisite	pam_pwquality.so\n&/' $config_file
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/wrong_control.fail.sh
@@ -3,8 +3,8 @@
 
 pam_file="/etc/pam.d/password-auth"
 
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $pam_file) -eq 0 ]; then
-	sed -i --follow-symlinks "/^account.*required.*pam_permit.so/a password    optional     pam_pwquality.so" "$pam_file"
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $pam_file) -eq 0 ]; then
+	sed -i --follow-symlinks "/^account.*required.*pam_permit\.so/a password    optional     pam_pwquality.so" "$pam_file"
 else
 	sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwquality\.so.*)$/\1optional\3/" "$pam_file"
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/ansible/shared.yml
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = medium
 
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit.so') }}}
+{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit.so') }}}
+{{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwquality.so', '', '', '^account.*required.*pam_permit\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/authselect_correct_entry.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/authselect_correct_entry.pass.sh
@@ -7,7 +7,7 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_SYSTEM_AUTH) -eq 0 ]; then
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $CUSTOM_SYSTEM_AUTH) -eq 0 ]; then
     sed -i --follow-symlinks '0,/^password.*/s/^password.*/password     requisite   pam_pwquality.so\n&/' $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/authselect_wrong_control.fail.sh
@@ -6,8 +6,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $CUSTOM_SYSTEM_AUTH) -eq 0 ]; then
-    sed -i --follow-symlinks "/^account.*required.*pam_permit.so/a password    optional     pam_pwquality.so" $CUSTOM_SYSTEM_AUTH
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $CUSTOM_SYSTEM_AUTH) -eq 0 ]; then
+    sed -i --follow-symlinks "/^account.*required.*pam_permit\.so/a password    optional     pam_pwquality.so" $CUSTOM_SYSTEM_AUTH
 else
     sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwquality\.so.*)$/\1optional\3/" $CUSTOM_SYSTEM_AUTH
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/correct_entry.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/correct_entry.pass.sh
@@ -3,6 +3,6 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 config_file=/etc/pam.d/password-auth
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $config_file) -eq 0 ]; then
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $config_file) -eq 0 ]; then
     sed -i --follow-symlinks '0,/^password.*/s/^password.*/password		requisite	pam_pwquality.so\n&/' $config_file
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/tests/wrong_control.fail.sh
@@ -3,8 +3,8 @@
 
 pam_file="/etc/pam.d/system-auth"
 
-if [ $(grep -c "^\s*password.*requisite.*pam_pwquality.so" $pam_file) -eq 0 ]; then
-	sed -i --follow-symlinks "/^account.*required.*pam_permit.so/a password    optional     pam_pwquality.so" "$pam_file"
+if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $pam_file) -eq 0 ]; then
+	sed -i --follow-symlinks "/^account.*required.*pam_permit\.so/a password    optional     pam_pwquality.so" "$pam_file"
 else
 	sed -r -i --follow-symlinks "s/(^password.*)(required|requisite)(.*pam_pwquality\.so.*)$/\1optional\3/" "$pam_file"
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_correct_value.pass.sh
@@ -6,7 +6,7 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^password.*sufficient.*pam_unix.so.*sha512" "$CUSTOM_PASSWORD_AUTH"); then
-    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' "$CUSTOM_PASSWORD_AUTH"
+if ! $(grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$CUSTOM_PASSWORD_AUTH"); then
+    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$CUSTOM_PASSWORD_AUTH"
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_missing_option.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_missing_option.fail.sh
@@ -6,5 +6,5 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/sha512//g' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_modified_pam.fail.sh
@@ -6,5 +6,5 @@
 PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
 
 # This modification will break the integrity checks done by authselect.
-sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/sha512//g' $PASSWORD_AUTH_FILE
+sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' $PASSWORD_AUTH_FILE
 echo "session     optional    pam_unix.so" >> $PASSWORD_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/authselect_wrong_control.fail.sh
@@ -6,8 +6,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^password.*sufficient.*pam_unix.so.*sha512" $CUSTOM_PASSWORD_AUTH); then
-    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^password.*sufficient.*pam_unix\.so.*sha512" $CUSTOM_PASSWORD_AUTH); then
+    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' $CUSTOM_PASSWORD_AUTH
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/correct.pass.sh
@@ -3,6 +3,6 @@
 
 pam_file="/etc/pam.d/password-auth"
 
-if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" "$pam_file"; then
-	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' "$pam_file"
+if ! grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$pam_file"; then
+	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/missing.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 
-sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/sha512//g' "/etc/pam.d/password-auth"
+sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/wrong_control.fail.sh
@@ -3,7 +3,7 @@
 
 pam_file="/etc/pam.d/password-auth"
 
-if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" "$pam_file"; then
-	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' "$pam_file"
+if ! grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$pam_file"; then
+	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' "$pam_file"
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' "$pam_file"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -84,7 +84,7 @@ ocil: |-
     and ensure that the <tt>pam_unix.so</tt> module  is configured to use the argument
     <tt>sha512</tt>:
 
-    <pre>$ sudo grep "^password.*pam_unix.so.*sha512" {{{ pam_passwd_file_path }}}
+    <pre>$ sudo grep "^password.*pam_unix\.so.*sha512" {{{ pam_passwd_file_path }}}
     {{% if product in ["sle12", "sle15"] -%}}
     password required pam_unix.so sha512
     {{% else %}}

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_correct_value.pass.sh
@@ -6,7 +6,7 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^password.*sufficient.*pam_unix.so.*sha512" "$CUSTOM_SYSTEM_AUTH"); then
-    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' "$CUSTOM_SYSTEM_AUTH"
+if ! $(grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$CUSTOM_SYSTEM_AUTH"); then
+    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$CUSTOM_SYSTEM_AUTH"
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_missing_option.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_missing_option.fail.sh
@@ -6,5 +6,5 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/sha512//g' $CUSTOM_SYSTEM_AUTH
+sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' $CUSTOM_SYSTEM_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_modified_pam.fail.sh
@@ -6,5 +6,5 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/sha512//g' $SYSTEM_AUTH_FILE
+sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' $SYSTEM_AUTH_FILE
 echo "session     optional    pam_unix.so" >> $SYSTEM_AUTH_FILE

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/authselect_wrong_control.fail.sh
@@ -6,8 +6,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^password.*sufficient.*pam_unix.so.*sha512" $CUSTOM_SYSTEM_AUTH); then
-    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^password.*sufficient.*pam_unix\.so.*sha512" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' $CUSTOM_SYSTEM_AUTH
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' $CUSTOM_SYSTEM_AUTH
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' $CUSTOM_SYSTEM_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
@@ -3,6 +3,6 @@
 
 pam_file="/etc/pam.d/system-auth"
 
-if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" "$pam_file"; then
-	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' "$pam_file"
+if ! grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$pam_file"; then
+	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
 fi

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
 
-sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/sha512//g' "/etc/pam.d/system-auth"
+sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_control.fail.sh
@@ -3,7 +3,7 @@
 
 pam_file="/etc/pam.d/system-auth"
 
-if ! grep -q "^password.*sufficient.*pam_unix.so.*sha512" "$pam_file"; then
-	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix.so/ s/$/ sha512/' "$pam_file"
+if ! grep -q "^password.*sufficient.*pam_unix\.so.*sha512" "$pam_file"; then
+	sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/$/ sha512/' "$pam_file"
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' "$pam_file"
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' "$pam_file"

--- a/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/grub2_disable_interactive_boot/oval/shared.xml
@@ -40,7 +40,7 @@
   <ind:textfilecontent54_object id="object_grub2_disable_interactive_boot_grub_cmdline_linux_default"
   version="1">
     <ind:filepath>/etc/default/grub</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=".*systemd.confirm_spawn=(?:1|yes|true|on).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*GRUB_CMDLINE_LINUX_DEFAULT=".*systemd\.confirm_spawn=(?:1|yes|true|on).*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_emergency_target_auth/oval/shared.xml
@@ -39,7 +39,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_emergency_service_emergency" version="1">
     <ind:filepath>/usr/lib/systemd/system/emergency.target</ind:filepath>
-    <ind:pattern operation="pattern match">^Requires=.*emergency.service</ind:pattern>
+    <ind:pattern operation="pattern match">^Requires=.*emergency\.service</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -50,7 +50,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_require_rescue_service_runlevel1" version="1">
     <ind:filepath>/usr/lib/systemd/system/runlevel1.target</ind:filepath>
-    <ind:pattern operation="pattern match">^Requires=.*rescue.service</ind:pattern>
+    <ind:pattern operation="pattern match">^Requires=.*rescue\.service</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -74,7 +74,7 @@ ocil: |-
     {{% if product not in ["ol8", "rhel8"] %}}
     Then, verify that the rescue service is in the runlevel1.target.
     Run the following command:
-    <pre>$ sudo grep "^Requires=.*rescue.service" /usr/lib/systemd/system/runlevel1.target</pre>
+    <pre>$ sudo grep "^Requires=.*rescue\.service" /usr/lib/systemd/system/runlevel1.target</pre>
     The output should be the following:
     <pre>Requires=sysinit.target rescue.service</pre>
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/oval/shared.xml
@@ -17,7 +17,7 @@
 
   <ind:textfilecontent54_object id="object_configure_opensc_card_drivers"
   version="1">
-    <ind:filepath operation="pattern match">^/etc/opensc.*.conf$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/opensc.*\.conf$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]+card_drivers[\s]+=[\s]+(\S+);$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_nss_db/oval/shared.xml
@@ -16,7 +16,7 @@
   <ind:textfilecontent54_object id="object_configure_opensc_nss_db"
   version="1">
     <ind:filepath>/etc/pki/nssdb/pkcs11.txt</ind:filepath>
-    <ind:pattern operation="pattern match">^library=opensc.*.so$</ind:pattern>
+    <ind:pattern operation="pattern match">^library=opensc.*\.so$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/oval/shared.xml
@@ -17,7 +17,7 @@
 
   <ind:textfilecontent54_object id="object_force_opensc_card_drivers"
   version="1">
-    <ind:filepath operation="pattern match">^/etc/opensc.*.conf$</ind:filepath>
+    <ind:filepath operation="pattern match">^/etc/opensc.*\.conf$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]+force_card_driver[\s]+=[\s]+(\S+);$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/bash/shared.sh
@@ -22,8 +22,8 @@
 # Define system-auth config location
 SYSTEM_AUTH_CONF="/etc/pam.d/system-auth"
 # Define expected 'pam_env.so' row in $SYSTEM_AUTH_CONF
-PAM_ENV_SO="auth.*required.*pam_env.so"
-PAM_FAIL_DELAY="auth.*required.*pam_faildelay.so"
+PAM_ENV_SO="auth.*required.*pam_env\.so"
+PAM_FAIL_DELAY="auth.*required.*pam_faildelay\.so"
 
 # Define 'pam_succeed_if.so' row to be appended past $PAM_ENV_SO row into $SYSTEM_AUTH_CONF
 SYSTEM_AUTH_PAM_SUCCEED="\
@@ -40,7 +40,7 @@ SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
 # Define 'pam_pkcs11.so' auth section to be appended past $PAM_ENV_SO into $SMARTCARD_AUTH_CONF
 SMARTCARD_AUTH_SECTION="auth        [success=done ignore=ignore default=die] pam_pkcs11.so nodebug wait_for_card"
 # Define expected 'pam_permit.so' row in $SMARTCARD_AUTH_CONF
-PAM_PERMIT_SO="account.*required.*pam_permit.so"
+PAM_PERMIT_SO="account.*required.*pam_permit\.so"
 # Define 'pam_pkcs11.so' password section
 SMARTCARD_PASSWORD_SECTION="password    required      pam_pkcs11.so"
 
@@ -61,26 +61,26 @@ then
 fi
 
 # Then also correct the SMARTCARD_AUTH_CONF
-if ! grep -q 'auth.*pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+if ! grep -q 'auth.*pam_pkcs11\.so' "$SMARTCARD_AUTH_CONF"
 then
 	# Append (expected) SMARTCARD_AUTH_SECTION row past the pam_env.so into SMARTCARD_AUTH_CONF file
 	sed -i --follow-symlinks -e '/^'"$PAM_ENV_SO"'/a \
         '"$SMARTCARD_AUTH_SECTION" "$SMARTCARD_AUTH_CONF"
 else
-    if ! grep -q 'auth.*pam_pkcs11.so.*no_debug.*wait_for_card' "$SMARTCARD_AUTH_CONF"
+    if ! grep -q 'auth.*pam_pkcs11\.so.*no_debug.*wait_for_card' "$SMARTCARD_AUTH_CONF"
     then
-        sed -i --follow-symlinks -e 's/^auth.*pam_pkcs11.so.*/'"$SMARTCARD_AUTH_SECTION"'/' "$SMARTCARD_AUTH_CONF"
+        sed -i --follow-symlinks -e 's/^auth.*pam_pkcs11\.so.*/'"$SMARTCARD_AUTH_SECTION"'/' "$SMARTCARD_AUTH_CONF"
     fi
 fi
-if ! grep -q 'password.*pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+if ! grep -q 'password.*pam_pkcs11\.so' "$SMARTCARD_AUTH_CONF"
 then
 	# Append (expected) SMARTCARD_PASSWORD_SECTION row past the pam_permit.so into SMARTCARD_AUTH_CONF file
 	sed -i --follow-symlinks -e '/^'"$PAM_PERMIT_SO"'/a \
         '"$SMARTCARD_PASSWORD_SECTION" "$SMARTCARD_AUTH_CONF"
 else
-    if ! grep -q 'password.*required.*pam_pkcs11.so' "$SMARTCARD_AUTH_CONF"
+    if ! grep -q 'password.*required.*pam_pkcs11\.so' "$SMARTCARD_AUTH_CONF"
     then
-        sed -i --follow-symlinks -e 's/password.*pam_pkcs11.so.*/'"$SMARTCARD_PASSWORD_SECTION"'/' "$SMARTCARD_AUTH_CONF"
+        sed -i --follow-symlinks -e 's/password.*pam_pkcs11\.so.*/'"$SMARTCARD_PASSWORD_SECTION"'/' "$SMARTCARD_AUTH_CONF"
     fi
 fi
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/configure_pam_stack.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/configure_pam_stack.sh
@@ -5,7 +5,7 @@
 # Define system-auth config location
 SYSTEM_AUTH_CONF="/etc/pam.d/system-auth"
 # Define expected 'pam_env.so' row in $SYSTEM_AUTH_CONF
-PAM_ENV_SO="auth.*required.*pam_env.so"
+PAM_ENV_SO="auth.*required.*pam_env\.so"
 
 # Define 'pam_succeed_if.so' row to be appended past $PAM_ENV_SO row into $SYSTEM_AUTH_CONF
 SYSTEM_AUTH_PAM_SUCCEED="\
@@ -23,7 +23,7 @@ SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
 SMARTCARD_AUTH_SECTION="\
 auth        [success=done ignore=ignore default=die] pam_pkcs11.so wait_for_card card_only"
 # Define expected 'pam_permit.so' row in $SMARTCARD_AUTH_CONF
-PAM_PERMIT_SO="account.*required.*pam_permit.so"
+PAM_PERMIT_SO="account.*required.*pam_permit\.so"
 # Define 'pam_pkcs11.so' password section
 SMARTCARD_PASSWORD_SECTION="\
 password    required      pam_pkcs11.so"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled_with_faillock.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled_with_faillock.pass.sh
@@ -8,7 +8,7 @@ systemctl start pcscd.socket
 
 
 SMARTCARD_AUTH_CONF="/etc/pam.d/smartcard-auth"
-PAM_ENV_SO="auth.*required.*pam_env.so"
+PAM_ENV_SO="auth.*required.*pam_env\.so"
 PAM_FAILLOCK_PREAUTH="auth        required      pam_faillock.so preauth silent deny=4 unlock_time=1200"
 SYSTEM_AUTH_PAM_PKCS11="auth [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_pkcs11.so nodebug"
 PAM_FAILLOCK_AUTHFAIL="auth        required      pam_faillock.so authfail deny=4 unlock_time=1200"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_pam_faildelay.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_pam_faildelay.pass.sh
@@ -7,5 +7,5 @@ systemctl start pcscd.socket
 . ./configure_pam_stack.sh
 
 # Add pam_faildelay line to system-auth
-PAM_ENV_SO="auth.*required.*pam_env.so"
-sed -i --follow-symlinks '/auth.*required.*pam_env.so/ a auth        required                                     pam_faildelay.so delay=2000000' /etc/pam.d/system-auth
+PAM_ENV_SO="auth.*required.*pam_env\.so"
+sed -i --follow-symlinks '/auth.*required.*pam_env\.so/ a auth        required                                     pam_faildelay.so delay=2000000' /etc/pam.d/system-auth

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/correct_value.pass.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/i auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/stricter_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/stricter_value.pass.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=34' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/i auth required pam_lastlog.so inactive=34' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_order.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_order.fail.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/a auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/a auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_password_auth/tests/wrong_value.fail.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=36' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/i auth required pam_lastlog.so inactive=36' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/correct_value.pass.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/i auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/stricter_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/stricter_value.pass.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=34' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/i auth required pam_lastlog.so inactive=34' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_order.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_order.fail.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/a auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/a auth required pam_lastlog.so inactive=35' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_inactivity_system_auth/tests/wrong_value.fail.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-sed -i '/^\s*auth.*sufficient.*pam_unix.so/i auth required pam_lastlog.so inactive=36' $CUSTOM_PAM_FILE
+sed -i '/^\s*auth.*sufficient.*pam_unix\.so/i auth required pam_lastlog.so inactive=36' $CUSTOM_PAM_FILE
 
 authselect apply-changes

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_argument_missing.fail.sh
@@ -8,7 +8,7 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
 # Remove rounds parameter from line if present
-if $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1 \3/g" $CUSTOM_PASSWORD_AUTH
+if $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1 \3/g" $CUSTOM_PASSWORD_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_correct_value.pass.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_PASSWORD_AUTH
 else
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_PASSWORD_AUTH
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_PASSWORD_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_modified_pam.fail.sh
@@ -7,8 +7,8 @@
 ROUNDS=5000
 PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $PASSWORD_AUTH_FILE); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $PASSWORD_AUTH_FILE
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $PASSWORD_AUTH_FILE); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $PASSWORD_AUTH_FILE
 else
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $PASSWORD_AUTH_FILE
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $PASSWORD_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_control.fail.sh
@@ -8,8 +8,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_PASSWORD_AUTH
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' $CUSTOM_PASSWORD_AUTH
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' $CUSTOM_PASSWORD_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_value.fail.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_PASSWORD_AUTH
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_PASSWORD_AUTH); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_PASSWORD_AUTH
 else
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_PASSWORD_AUTH
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_PASSWORD_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/wrong_control.fail.sh
@@ -6,7 +6,7 @@
 ROUNDS=65536
 pam_file="/etc/pam.d/password-auth"
 
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $pam_file); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $pam_file
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $pam_file); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $pam_file
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' $pam_file
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' $pam_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_argument_missing.fail.sh
@@ -8,7 +8,7 @@ CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
 # Remove rounds parameter from line if present
-if $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1 \3/g" $CUSTOM_SYSTEM_AUTH
+if $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1 \3/g" $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_correct_value.pass.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_SYSTEM_AUTH
 else
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_SYSTEM_AUTH
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_modified_pam.fail.sh
@@ -7,8 +7,8 @@
 ROUNDS=5000
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $SYSTEM_AUTH_FILE
 else
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $SYSTEM_AUTH_FILE
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_control.fail.sh
@@ -8,8 +8,8 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_SYSTEM_AUTH
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' $CUSTOM_SYSTEM_AUTH
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' $CUSTOM_SYSTEM_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_value.fail.sh
@@ -8,9 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_SYSTEM_AUTH
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $CUSTOM_SYSTEM_AUTH); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $CUSTOM_SYSTEM_AUTH
 else
-	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_SYSTEM_AUTH
+	sed -r -i --follow-symlinks "s/(^\s*password.*pam_unix\.so.*)(rounds=[[:digit:]]+)(.*)/\1rounds=$ROUNDS \3/g" $CUSTOM_SYSTEM_AUTH
 fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/wrong_control.fail.sh
@@ -6,7 +6,7 @@
 ROUNDS=65536
 pam_file="/etc/pam.d/system-auth"
 
-if ! $(grep -q "^\s*password.*pam_unix.so.*rounds=" $pam_file); then
-	sed -i --follow-symlinks "/^\s*password.*pam_unix.so/ s/$/ rounds=$ROUNDS/" $pam_file
+if ! $(grep -q "^\s*password.*pam_unix\.so.*rounds=" $pam_file); then
+	sed -i --follow-symlinks "/^\s*password.*pam_unix\.so/ s/$/ rounds=$ROUNDS/" $pam_file
 fi
-sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix.so.*)/\1optional\2/' $pam_file
+sed -i --follow-symlinks -E 's/^(password.*)sufficient(.*pam_unix\.so.*)/\1optional\2/' $pam_file

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_modified_pam.fail.sh
@@ -6,8 +6,8 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 # This modification will break the integrity checks done by authselect.
-if ! $(grep -q "^[^#].*pam_pwhistory.so.*remember=" $SYSTEM_AUTH_FILE); then
-	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $SYSTEM_AUTH_FILE); then
+	sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so" $SYSTEM_AUTH_FILE
 else
-   sed -i --follow-symlinks "s/\(.*pam_pwhistory.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
+   sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1/g" $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/authselect_nullok_present.fail.sh
@@ -5,7 +5,7 @@
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
 authselect select sssd --force
-if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
+if ! $(grep -q "^[^#].*pam_unix\.so.*nullok" $SYSTEM_AUTH_FILE); then
     authselect disable-feature without-nullok
     authselect apply-changes
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present.fail.sh
@@ -3,6 +3,6 @@
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"
 
-if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $SYSTEM_AUTH_FILE); then
-    sed -i --follow-symlinks 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_unix\.so.*nullok" $SYSTEM_AUTH_FILE); then
+    sed -i --follow-symlinks 's/\([\s].*pam_unix\.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $SYSTEM_AUTH_FILE
 fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present_password_auth.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords/tests/nullok_present_password_auth.fail.sh
@@ -3,6 +3,6 @@
 
 PASSWORD_AUTH_FILE="/etc/pam.d/password-auth"
 
-if ! $(grep -q "^[^#].*pam_unix.so.*nullok" $PASSWORD_AUTH_FILE); then
-    sed -i --follow-symlinks 's/\([\s].*pam_unix.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $PASSWORD_AUTH_FILE
+if ! $(grep -q "^[^#].*pam_unix\.so.*nullok" $PASSWORD_AUTH_FILE); then
+    sed -i --follow-symlinks 's/\([\s].*pam_unix\.so.*\)\s\(try_first_pass.*\)/\1nullok \2/' $PASSWORD_AUTH_FILE
 fi

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there.fail.sh
@@ -4,7 +4,7 @@
 
 # Removes audit argument from kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"
-if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
+if grep -q '^.*random\.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there_etcdefaultgrub.fail.sh
@@ -6,7 +6,7 @@ fi
 
 {{% if product == "rhel8" %}}
 file="/boot/grub2/grubenv"
-if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
+if grep -q '^.*random\.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
 {{% else %}}

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled.pass.sh
@@ -2,7 +2,7 @@
 
 # make sure that the option is not configured through boot parameter
 file="/boot/grub2/grubenv"
-if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
+if grep -q '^.*random\.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
 

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
@@ -3,7 +3,7 @@
 # make sure that the option is not configured through boot parameter
 {{% if product == "rhel8" %}}
 file="/boot/grub2/grubenv"
-if grep -q '^.*random.trust_cpu=.*'  "$file" ; then
+if grep -q '^.*random\.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
 {{% else %}}

--- a/linux_os/guide/system/bootloader-zipl/zipl_systemd_debug-shell_argument_absent/ansible/shared.yml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_systemd_debug-shell_argument_absent/ansible/shared.yml
@@ -9,7 +9,7 @@
     - name: "Check how many boot entries set systemd.debug-shell"
       find:
         paths: "/boot/loader/entries/"
-        contains: "^options .*systemd.debug-shell.*$"
+        contains: "^options .*systemd\\.debug-shell.*$"
         patterns: "*.conf"
       register: n_entries
 
@@ -26,7 +26,7 @@
       find:
         paths: "/etc/kernel/"
         patterns: "cmdline"
-        contains: "^.*systemd.debug-shell.*$"
+        contains: "^.*systemd\\.debug-shell.*$"
       register: cmdline_find
 
     - name: "Remove systemd.debug-shell from /etc/kernel/cmdline"

--- a/linux_os/guide/system/bootloader-zipl/zipl_systemd_debug-shell_argument_absent/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-zipl/zipl_systemd_debug-shell_argument_absent/oval/shared.xml
@@ -15,7 +15,7 @@
     <ind:state state_ref="state_zipl_systemd_debug-shell_argument_in_boot_loader_entries_conf" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_zipl_systemd_debug-shell_argument_in_boot_loader_entries_conf" version="1">
-    <ind:filepath operation="pattern match">^/boot/loader/entries/.*.conf</ind:filepath>
+    <ind:filepath operation="pattern match">^/boot/loader/entries/.*\.conf</ind:filepath>
     <ind:pattern operation="pattern match">^options (.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/products/vsel/guide/vsel/on_demand_settings/ods_extensions/oval/shared.xml
+++ b/products/vsel/guide/vsel/on_demand_settings/ods_extensions/oval/shared.xml
@@ -19,7 +19,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_ods_filter_extensions" version="1">
     <ind:filepath>/var/opt/NAI/LinuxShield/etc/ods.cfg</ind:filepath>
-    <ind:pattern operation="pattern match">^.*.extensions.mode: (.*)$</ind:pattern>
+    <ind:pattern operation="pattern match">^.*\.extensions\.mode: (.*)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_ods_filter_extensions" version="1">

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -812,7 +812,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     - name: {{{ rule_title }}} - Check if pam_faillock.so is already enabled
       ansible.builtin.lineinfile:
         path: /etc/pam.d/system-auth
-        regexp: .*auth.*pam_faillock.so (preauth|authfail)
+        regexp: .*auth.*pam_faillock\.so (preauth|authfail)
         state: absent
       check_mode: yes
       changed_when: false
@@ -822,7 +822,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: '{{ item }}'
         line: auth        required      pam_faillock.so preauth
-        insertbefore: ^auth.*sufficient.*pam_unix.so.*
+        insertbefore: ^auth.*sufficient.*pam_unix\.so.*
         state: present
       loop:
         - /etc/pam.d/system-auth
@@ -834,7 +834,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: '{{ item }}'
         line: auth        required      pam_faillock.so authfail
-        insertbefore: ^auth.*required.*pam_deny.so.*
+        insertbefore: ^auth.*required.*pam_deny\.so.*
         state: present
       loop:
         - /etc/pam.d/system-auth
@@ -846,7 +846,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
       ansible.builtin.lineinfile:
         path: '{{ item }}'
         line: account     required      pam_faillock.so
-        insertbefore: ^account.*required.*pam_unix.so.*
+        insertbefore: ^account.*required.*pam_unix\.so.*
         state: present
       loop:
         - /etc/pam.d/system-auth
@@ -905,7 +905,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     - name: {{{ rule_title }}} - Check if pam_faillock.so {{{ parameter }}} parameter is already enabled in pam files
       ansible.builtin.lineinfile:
         path: /etc/pam.d/system-auth
-        regexp: .*auth.*pam_faillock.so (preauth|authfail).*{{{ parameter }}}
+        regexp: .*auth.*pam_faillock\.so (preauth|authfail).*{{{ parameter }}}
         state: absent
       check_mode: yes
       changed_when: false

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -997,11 +997,11 @@ AUTH_FILES=("/etc/pam.d/system-auth" "/etc/pam.d/password-auth")
 for pam_file in "${AUTH_FILES[@]}"
 do
     if ! grep -qE '^\s*auth\s+required\s+pam_faillock\.so\s+(preauth silent|authfail).*$' "$pam_file" ; then
-        sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix.so.*/i auth        required      pam_faillock.so preauth silent' "$pam_file"
-        sed -i --follow-symlinks '/^auth.*required.*pam_deny.so.*/i auth        required      pam_faillock.so authfail' "$pam_file"
-        sed -i --follow-symlinks '/^account.*required.*pam_unix.so.*/i account     required      pam_faillock.so' "$pam_file"
+        sed -i --follow-symlinks '/^auth.*sufficient.*pam_unix\.so.*/i auth        required      pam_faillock.so preauth silent' "$pam_file"
+        sed -i --follow-symlinks '/^auth.*required.*pam_deny\.so.*/i auth        required      pam_faillock.so authfail' "$pam_file"
+        sed -i --follow-symlinks '/^account.*required.*pam_unix\.so.*/i account     required      pam_faillock.so' "$pam_file"
     fi
-    sed -Ei 's/(auth.*)(\[default=die\])(.*pam_faillock.so)/\1required     \3/g' "$pam_file"
+    sed -Ei 's/(auth.*)(\[default=die\])(.*pam_faillock\.so)/\1required     \3/g' "$pam_file"
 done
 {{%- endmacro -%}}
 
@@ -1051,25 +1051,25 @@ if [ -f $FAILLOCK_CONF ]; then
 else
     for pam_file in "${AUTH_FILES[@]}"
     do
-        if ! grep -qE '^\s*auth.*pam_faillock.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
+        if ! grep -qE '^\s*auth.*pam_faillock\.so (preauth|authfail).*{{{ option }}}' "$pam_file"; then
             {{%- if value == '' %}}
-            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*silent.*/ s/$/ {{{ option }}}/' "$pam_file"
             {{%- if authfail %}}
-            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*authfail.*/ s/$/ {{{ option }}}/' "$pam_file"
             {{%- endif %}}
             {{%- else %}}
-            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*preauth.*silent.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*preauth.*silent.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
             {{%- if authfail %}}
-            sed -i --follow-symlinks '/^auth.*required.*pam_faillock.so.*authfail.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
+            sed -i --follow-symlinks '/^auth.*required.*pam_faillock\.so.*authfail.*/ s/$/ {{{ option }}}='"{{{ value }}}"'/' "$pam_file"
             {{%- endif %}}
             {{%- endif %}}
         {{%- if value == '' %}}
         fi
         {{%- else %}}
         else
-            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*preauth.*silent.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*preauth.*silent.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
             {{%- if authfail %}}
-            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
+            sed -i --follow-symlinks 's/\(^auth.*required.*pam_faillock\.so.*authfail.*\)\('"{{{ option }}}"'=\)[0-9]\+\(.*\)/\1\2'"{{{ value }}}"'\3/' "$pam_file"
             {{%- endif %}}
         fi
         {{%- endif %}}

--- a/shared/templates/grub2_bootloader_argument/oval.template
+++ b/shared/templates/grub2_bootloader_argument/oval.template
@@ -148,7 +148,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_grub2_rescue_entry_for_{{{ _RULE_ID }}}" version="1">
-    <ind:filename operation="pattern match">.*rescue.conf$</ind:filename>
+    <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
   </ind:textfilecontent54_state>
 {{%- endif %}}
 

--- a/shared/templates/grub2_bootloader_argument_absent/oval.template
+++ b/shared/templates/grub2_bootloader_argument_absent/oval.template
@@ -144,7 +144,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_grub2_rescue_entry_for_{{{ _RULE_ID }}}" version="1">
-    <ind:filename operation="pattern match">.*rescue.conf$</ind:filename>
+    <ind:filename operation="pattern match">.*rescue\.conf$</ind:filename>
   </ind:textfilecontent54_state>
 {{%- endif %}}
 


### PR DESCRIPTION
#### Description:

Quote dot (.) in regexps where it is not meant to mean any char just dot.

#### Rationale:

Mainly to root out mistakes. I just see it bad policy to leave regexp metacharacters not quoted when they are not regexp metacharacters.

First pam_foo.so made using script.
Second other regexp with string, also made using script.
Third discovery with script and then made by hand.

This probably is not all cases, just what I was able to find easily and be sure enough there should be no regressions.