### PR TITLE
Remove jinja condition to make rule applicability to all products in Kerberos rules

### DIFF
--- a/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/rule.yml
+++ b/linux_os/guide/services/kerberos/kerberos_disable_no_keytab/rule.yml
@@ -1,5 +1,9 @@
 documentation_complete: true
 
+# new major OS versions will most likely not be applicable because of the
+# kerberos version higher than 1.17-18
+prodtype: ol7,ol8,rhcos4,rhel7,rhel8,rhel9
+
 title: 'Disable Kerberos by removing host keytab'
 
 description: |-
@@ -25,11 +29,8 @@ references:
     stigid@ol8: OL08-00-010161
     stigid@rhel8: RHEL-08-010161
 
-{{% if product in ["ol8", "rhel8"] %}}
 platforms:
-    - krb5_server_older_than_1_17-18
-    - krb5_workstation_older_than_1_17-18
-{{% endif %}}
+    - krb5_server_older_than_1_17-18 and krb5_workstation_older_than_1_17-18
 
 ocil_clause: 'a keytab file is present on the system'
 

--- a/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
+++ b/linux_os/guide/services/kerberos/package_krb5-server_removed/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+# new major OS versions will most likely not be applicable because of the
+# kerberos version higher than 1.17-18
 prodtype: ol7,ol8,rhel7,rhel8,rhel9
 
 title: 'Remove the Kerberos Server Package'
@@ -30,11 +32,8 @@ references:
     stigid@ol8: OL08-00-010163
     stigid@rhel8: RHEL-08-010163
 
-{{% if product in ["ol8", "rhel8"] %}}
 platforms:
     - krb5_server_older_than_1_17-18
-    - krb5_workstation_older_than_1_17-18
-{{% endif %}}
 
 ocil_clause: 'the package is installed'
 

--- a/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_krb5-workstation_removed/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+# new major OS versions will most likely not be applicable because of the
+# kerberos version higher than 1.17-18
 prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9
 
 title: 'Uninstall krb5-workstation Package'
@@ -25,11 +27,11 @@ references:
     stigid@rhel8: RHEL-08-010162
 
 platforms:
-{{{ rule_notapplicable_when_ovirt_installed() | indent(4)}}}
-{{%- if product in ["ol8", "rhel8"] %}}
-    - krb5_server_older_than_1_17-18
+{{%- if "rhel" in product %}}
+    - no_ovirt and krb5_workstation_older_than_1_17-18
+{{%- else %}}
     - krb5_workstation_older_than_1_17-18
-{{% endif %}}
+{{%- endif %}}
 
 warnings:
 {{{ warning_ovirt_rule_notapplicable("RHV hosts require ipa-client package, which has dependency on krb5-workstation") | indent(4) }}}

--- a/shared/checks/oval/krb5_workstation_older_than_1_17_18.xml
+++ b/shared/checks/oval/krb5_workstation_older_than_1_17_18.xml
@@ -18,7 +18,7 @@
     </definition>
     {{%- if pkg_system == "rpm" -%}}
     <linux:rpminfo_test check="all" check_existence="at_least_one_exists"
-            comment="Kerberos workstaton version is lesser than 1.17-18"
+            comment="Kerberos workstation version is lesser than 1.17-18"
             id="test_krb5_workstation_version_1_17_18" version="1">
         <linux:object object_ref="obj_krb5_workstation_version_1_17_18" />
         <linux:state state_ref="state_krb5_workstation_version_1_17_18" />
@@ -32,7 +32,7 @@
 
     {{%- elif pkg_system == "dpkg" -%}}
     <linux:dpkginfo_test check="at least one" check_existence="any_exist"
-            comment="Kerberos workstaton version is lesser than 1.17-18"
+            comment="Kerberos workstation version is lesser than 1.17-18"
             id="test_krb5_workstation_version_1_17_18" version="1">
         <linux:object object_ref="obj_krb5_workstation_version_1_17_18" />
         <linux:state state_ref="state_krb5_workstation_version_1_17_18" />

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -194,14 +194,18 @@ class CPEALLogicalTest(Function):
             arg.enrich_with_cpe_info(cpe_products)
 
     def to_bash_conditional(self):
+        child_bash_conds = [
+            a.to_bash_conditional() for a in self.args
+            if a.to_bash_conditional() != '']
+
+        if not child_bash_conds:
+            return ""
+
         cond = ""
         if self.is_not():
             cond += "! "
             op = " "
         cond += "( "
-        child_bash_conds = [
-            a.to_bash_conditional() for a in self.args
-            if a.to_bash_conditional() != '']
         if self.is_or():
             op = " || "
         elif self.is_and():
@@ -211,14 +215,18 @@ class CPEALLogicalTest(Function):
         return cond
 
     def to_ansible_conditional(self):
+        child_ansible_conds = [
+            a.to_ansible_conditional() for a in self.args
+            if a.to_ansible_conditional() != '']
+
+        if not child_ansible_conds:
+            return ""
+
         cond = ""
         if self.is_not():
             cond += "not "
             op = " "
         cond += "( "
-        child_ansible_conds = [
-            a.to_ansible_conditional() for a in self.args
-            if a.to_ansible_conditional() != '']
         if self.is_or():
             op = " or "
         elif self.is_and():

--- a/tests/unit/ssg-module/data/applicability/general.yml
+++ b/tests/unit/ssg-module/data/applicability/general.yml
@@ -27,3 +27,13 @@ cpes:
       bash_conditional: {{{ bash_pkg_conditional("yum") }}}
       ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}
 
+  - krb5_server_older_than_1_17-18:
+      name: "cpe:/a:krb5_server_older_than_1_17-18"
+      title: "Package krb5 server is installed and version is lesser than 1.17-18"
+      check_id: krb5_server_older_than_1_17_18
+
+  - krb5_workstation_older_than_1_17-18:
+      name: "cpe:/a:krb5_workstation_older_than_1_17-18"
+      title: "Package krb5 workstation is installed and version is lesser than 1.17-18"
+      check_id: krb5_workstation_older_than_1_17_18
+

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -219,6 +219,13 @@ def test_platform_from_text_or(product_cpes):
     assert fact_refs[1].get("name") == "cpe:/a:ntp"
 
 
+def test_platform_from_text_and_empty_conditionals(product_cpes):
+    platform = ssg.build_yaml.Platform.from_text(
+        "krb5_server_older_than_1_17-18 and krb5_workstation_older_than_1_17-18", product_cpes)
+    assert platform.to_bash_conditional() == ""
+    assert platform.to_ansible_conditional() == ""
+
+
 def test_platform_from_text_complex_expression(product_cpes):
     platform = ssg.build_yaml.Platform.from_text(
         "systemd and !yum and (ntp or chrony)", product_cpes)


### PR DESCRIPTION
#### Description:

- Remove jinja condition to make rule applicability to all products in Kerberos rules.

#### Rationale:

- The applicability should be there for all products, not only part of them. For example RHEL9 and OL9 should have a more recent version of the package so it should return not applicable.
- Related: https://bugzilla.redhat.com/show_bug.cgi?id=2099394