### PR TITLE
Use correct defition of template value parameter in api_server_bind_address

### DIFF
--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -49,7 +49,7 @@ template:
     entity_check: "all"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.servingInfo["bindAddress"]'
-    xccdf_value: var_apiserver_bind_address
+    xccdf_variable: var_apiserver_bind_address
     embedded_data: "true"
     values:
     - value: '(.+)'


### PR DESCRIPTION
The correct parameter is `xccdf_variable`

https://complianceascode.readthedocs.io/en/latest/templates/template_reference.html#yamlfile-value