### PR TITLE
Jinja inside jinja

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_at_allow/rule.yml
@@ -16,7 +16,7 @@ description: |-
     If <tt>/etc/at.allow</tt> exists, it must have permissions <tt>{{{ target_perms_octal }}}</tt>
     or more restrictive.
 
-    {{{ describe_file_permissions(file="/etc/at.allow", perms="{{{ target_perms_octal }}}") }}}
+    {{{ describe_file_permissions(file="/etc/at.allow", perms=target_perms_octal) }}}
 
 rationale: |-
     If the permissions of the at.allow file are not set to {{{ target_perms_octal }}} or more restrictive,

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/rule.yml
@@ -16,7 +16,7 @@ description: |-
     If <tt>/etc/cron.allow</tt> exists, it must have permissions <tt>{{{ target_perms_octal }}}</tt>
     or more restrictive.
 
-    {{{ describe_file_permissions(file="/etc/cron.allow", perms="{{{ target_perms_octal }}}") }}}
+    {{{ describe_file_permissions(file="/etc/cron.allow", perms=target_perms_octal) }}}
 
 rationale: |-
     If the permissions of the cron.allow file are not set to {{{ target_perms_octal }}} or more restrictive,

--- a/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_client_only/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_client_only" version="1">
-    {{{ oval_metadata("Configure the port setting in {{{ chrony_conf_path }}} to disable
+    {{{ oval_metadata("Configure the port setting in " ~ chrony_conf_path ~ " to disable
       server operation.") }}}
     <criteria operator="AND">
       <extend_definition definition_ref="service_chronyd_enabled" comment="service chronyd enabled" />

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group oval_version="5.11">
   <definition class="compliance" id="chronyd_no_chronyc_network" version="1">
-    {{{ oval_metadata("Configure the cmdport setting in {{{ chrony_conf_path }}} to disable
+    {{{ oval_metadata("Configure the cmdport setting in " ~ chrony_conf_path ~ " to disable
       chronyc management connections over network.") }}}
     <criteria operator="AND">
       <extend_definition definition_ref="service_chronyd_enabled" comment="service chronyd enabled" />

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
@@ -1,7 +1,7 @@
 {{%- set parameter = "RekeyLimit" %}}
 {{%- set sshd_config_path = "/etc/ssh/sshd_config" %}}
 {{%- set sshd_config_dir = "/etc/ssh/sshd_config.d" -%}}
-{{%- set description = "Ensure {{{ parameter }}} is configured with the appropriate value in " ~ sshd_config_path %}}
+{{%- set description = "Ensure " ~ parameter ~ " is configured with the appropriate value in " ~ sshd_config_path %}}
 {{%- if sshd_distributed_config == "true" %}}
 {{%- set description = description  ~ " or in " ~ sshd_config_dir -%}}
 {{%- endif %}}

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -8,7 +8,7 @@ description: |-
     The file <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> should
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
-    {{{ describe_file_group_owner(file="{{{ grub2_boot_path }}}/grub.cfg", group="root") }}}
+    {{{ describe_file_group_owner(file=grub2_boot_path ~ "/grub.cfg", group="root") }}}
 
 rationale: |-
     The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -43,14 +43,14 @@ references:
     pcidss: Req-7.1
     srg: SRG-OS-000480-GPOS-00227
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(grub2_boot_path + "/grub.cfg", "root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file=grub2_boot_path + "/grub.cfg", group="root") }}}
+    {{{ ocil_file_group_owner(file=grub2_boot_path ~ "/grub.cfg", group="root") }}}
 
-fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path + "/grub.cfg", "root") }}}'
+fixtext: '{{{ fixtext_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
-srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path + "/grub.cfg", "root") }}}'
+srg_requirement: '{{{ srg_requirement_file_group_owner(grub2_boot_path ~ "/grub.cfg", "root") }}}'
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_owner_grub2_cfg/rule.yml
@@ -8,7 +8,7 @@ description: |-
     The file <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> should
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
-    {{{ describe_file_owner(file="{{{ grub2_boot_path }}}/grub.cfg", owner="root") }}}
+    {{{ describe_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}
 
 rationale: 'Only root should be able to modify important boot parameters.'
 
@@ -42,10 +42,10 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="{{{ grub2_boot_path }}}/grub.cfg", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="{{{ grub2_boot_path }}}/grub.cfg", owner="root") }}}
+    {{{ ocil_file_owner(file=grub2_boot_path ~ "/grub.cfg", owner="root") }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_permissions_grub2_cfg/rule.yml
@@ -6,7 +6,7 @@ title: 'Verify {{{ grub2_boot_path }}}/grub.cfg Permissions'
 
 description: |-
     File permissions for <tt>{{{ grub2_boot_path }}}/grub.cfg</tt> should be set to 600.
-    {{{ describe_file_permissions(file="{{{ grub2_boot_path }}}/grub.cfg", perms="600") }}}
+    {{{ describe_file_permissions(file=grub2_boot_path ~ "/grub.cfg", perms="600") }}}
 
 rationale: |-
     Proper permissions ensure that only the root user can modify important boot

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/oval/shared.xml
@@ -34,7 +34,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_bootloader_unique_superuser" version="1">
-    <ind:filepath>{{{ grub2_boot_path + "/grub.cfg" }}}</ind:filepath>
+    <ind:filepath>{{{ grub2_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match"
           >^[\s]*set[\s]+superusers="(?i)\b(?!(?:root|admin|administrator)\b)(\w+)"$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
@@ -57,7 +57,7 @@ ocil_clause: 'superuser account is not set or is set to root, admin, administrat
 ocil: |-
     To verify the boot loader superuser account has been set, run the following
     command:
-    <pre>sudo grep -A1 "superusers" {{{ grub2_boot_path + "/grub.cfg" }}}</pre>
+    <pre>sudo grep -A1 "superusers" {{{ grub2_boot_path }}}/grub.cfg</pre>
     The output should show the following:
     <pre>set superusers="<b>superusers-account</b>"
     export superusers</pre>

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_no_removeable_media/oval/shared.xml
@@ -1,1 +1,1 @@
-{{{ oval_check_config_file(path=grub2_boot_path + '/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="['|\(](?!fd)(?!cd)(?!usb).*['|\)]", missing_parameter_pass=false, missing_config_file_fail=true) }}}
+{{{ oval_check_config_file(path=grub2_boot_path ~ '/grub.cfg', prefix_regex='^[ \\t]*', parameter='set root', separator_regex='=', value="['|\(](?!fd)(?!cd)(?!usb).*['|\)]", missing_parameter_pass=false, missing_config_file_fail=true) }}}

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
@@ -8,7 +8,7 @@ description: |-
     The file <tt>{{{ grub2_uefi_boot_path }}}/grub.cfg</tt> should
     be group-owned by the <tt>root</tt> group to prevent
     destruction or modification of the file.
-    {{{ describe_file_group_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", group="root") }}}
+    {{{ describe_file_group_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", group="root") }}}
 
 rationale: |-
     The <tt>root</tt> group is a highly-privileged group. Furthermore, the group-owner of this
@@ -37,10 +37,10 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
 
-ocil_clause: '{{{ ocil_clause_file_group_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", group="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_group_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", group="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_group_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", group="root") }}}
+    {{{ ocil_file_group_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", group="root") }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_owner_efi_grub2_cfg/rule.yml
@@ -8,7 +8,7 @@ description: |-
     The file <tt>{{{ grub2_uefi_boot_path }}}/grub.cfg</tt> should
     be owned by the <tt>root</tt> user to prevent destruction
     or modification of the file.
-    {{{ describe_file_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", owner="root") }}}
+    {{{ describe_file_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", owner="root") }}}
 
 rationale: 'Only root should be able to modify important boot parameters.'
 
@@ -35,10 +35,10 @@ references:
     nist-csf: PR.AC-4,PR.DS-5
     pcidss: Req-7.1
 
-ocil_clause: '{{{ ocil_clause_file_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", owner="root") }}}'
+ocil_clause: '{{{ ocil_clause_file_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", owner="root") }}}'
 
 ocil: |-
-    {{{ ocil_file_owner(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", owner="root") }}}
+    {{{ ocil_file_owner(file=grub2_uefi_boot_path ~ "/grub.cfg", owner="root") }}}
 
 platform: machine
 

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_permissions_efi_grub2_cfg/rule.yml
@@ -7,7 +7,7 @@ title: 'Verify the UEFI Boot Loader grub.cfg Permissions'
 
 description: |-
     File permissions for <tt>{{{ grub2_uefi_boot_path }}}/grub.cfg</tt> should be set to 700.
-    {{{ describe_file_permissions(file="{{{ grub2_uefi_boot_path }}}/grub.cfg", perms="700") }}}
+    {{{ describe_file_permissions(file=grub2_uefi_boot_path ~ "/grub.cfg", perms="700") }}}
 
 rationale: |-
     Proper permissions ensure that only the root user can modify important boot

--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_admin_username/oval/shared.xml
@@ -34,7 +34,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_bootloader_uefi_unique_superuser" version="1">
-    <ind:filepath>{{{ grub2_uefi_boot_path + "/grub.cfg" }}}</ind:filepath>
+    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match"
           >^[\s]*set[\s]+superusers="(?i)\b(?!(?:root|admin|administrator)\b)(\w+)"$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
@@ -15,7 +15,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_uefi_no_removeable_media" version="1">
-    <ind:filepath>{{{ grub2_uefi_boot_path + "/grub.cfg" }}}</ind:filepath>
+    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^[ \t]*set root=(.+?)[ \t]*(?:$|#)</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/uefi_no_removeable_media/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("Ensure the system is not configured to use a boot loader on removable media.") }}}
     <criteria comment="The respective application or service is configured correctly or system boot mode is not UEFI" operator="OR">
       <criterion comment="Check the set root in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_uefi_no_removeable_media" />
-      {{{ oval_file_absent_criterion(grub2_uefi_boot_path + "/grub.cfg") }}}
+      {{{ oval_file_absent_criterion(grub2_uefi_boot_path ~ "/grub.cfg") }}}
     </criteria>
   </definition>
 
@@ -24,5 +24,5 @@
     <ind:subexpression datatype="string" operation="pattern match">^['|\(](?!fd)(?!cd)(?!usb).*['|\)]$</ind:subexpression>
   </ind:textfilecontent54_state>
 
-  {{{ oval_file_absent(grub2_uefi_boot_path + "/grub.cfg") }}}
+  {{{ oval_file_absent(grub2_uefi_boot_path ~ "/grub.cfg") }}}
 </def-group>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="aide_check_audit_tools" version="1">
-    {{{ oval_metadata("The {{{ full_name }}} operating system file integrity tool must be configured to protect the integrity of the audit tools.", title="Configure AIDE to Verify the Audit Tools") }}}
+    {{{ oval_metadata("The " ~ full_name ~ " operating system file integrity tool must be configured to protect the integrity of the audit tools.", title="Configure AIDE to Verify the Audit Tools") }}}
     <criteria operator="AND">
       <extend_definition comment="Aide is installed" definition_ref="package_aide_installed" />
       <criterion comment="auditctl is checked in {{{ aide_conf_path }}}" test_ref="test_aide_verify_auditctl" />

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1106,7 +1106,7 @@ Part of the grub2_bootloader_argument(_absent) templates.
     {{%- set grub_helper_args = [] -%}}
 {{%- elif product in ["sle12", "sle15"] -%}}
     {{%- set grub_helper_executable = "grub2-mkconfig" -%}}
-    {{%- set grub_helper_args = ["-o " + grub2_boot_path + "/grub2.cfg"] -%}}
+    {{%- set grub_helper_args = ["-o " ~ grub2_boot_path ~ "/grub2.cfg"] -%}}
 {{%- else -%}}
     {{%- set grub_helper_executable = "grubby" -%}}
     {{%- if action == "update" -%}}

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -4,6 +4,6 @@
 # complexity = low
 # disruption = low
 
-{{{ bash_instantiate_variables("var_password_pam_" + VARIABLE) }}}
+{{{ bash_instantiate_variables("var_password_pam_" ~ VARIABLE) }}}
 
-{{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' + VARIABLE , '$var_password_pam_' + VARIABLE , '%s = %s') }}}
+{{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' ~ VARIABLE , '$var_password_pam_' ~ VARIABLE , '%s = %s') }}}

--- a/shared/templates/kernel_build_config/oval.template
+++ b/shared/templates/kernel_build_config/oval.template
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}"
   version="1">
-    {{{ oval_metadata("The kernel " + CONFIG + " should have value " + (VALUE if VALUE else "according to " + VARIABLE), affected_platforms=["multi_platform_all"]) }}}
+    {{{ oval_metadata("The kernel " ~ CONFIG ~ " should have value " ~ (VALUE if VALUE else "according to " ~ VARIABLE), affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="OR">
       <criteria operator="AND">
         <criterion comment="Check presence of build configuration of installed kernels"
@@ -17,7 +17,7 @@
   </definition>
 
   <ind:textfilecontent54_test check="all"
-  comment="Check /boot/config-.* files for {{{ CONFIG }}}{{{ '=' + VALUE if VALUE else " according to " + VARIABLE }}}"
+  comment="Check /boot/config-.* files for {{{ CONFIG }}}{{{ '=' ~ VALUE if VALUE else " according to " ~ VARIABLE }}}"
   id="test_kernel_{{{ CONFIG | lower }}}" version="1">
     <ind:object object_ref="object_kernel_{{{ CONFIG | lower }}}" />
     <ind:state state_ref="state_kernel_{{{ CONFIG | lower }}}" />

--- a/shared/templates/mount/oval.template
+++ b/shared/templates/mount/oval.template
@@ -1,7 +1,7 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("If stored locally, create a separate partition for
-      {{{ MOUNTPOINT }}}. If {{{ MOUNTPOINT }}} will be mounted from another
+      " ~ MOUNTPOINT ~ ". If " ~ MOUNTPOINT ~ " will be mounted from another
       system such as an NFS server, then creating a separate partition is not
       necessary at this time, and the mountpoint can instead be configured
       later.") }}}

--- a/shared/templates/mount_option/oval.template
+++ b/shared/templates/mount_option/oval.template
@@ -1,6 +1,6 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="2">
-    {{{ oval_metadata(MOUNTPOINT + " should be mounted with mount option " + MOUNTOPTION + ".") }}}
+    {{{ oval_metadata(MOUNTPOINT ~ " should be mounted with mount option " ~ MOUNTOPTION ~ ".") }}}
     <criteria operator="OR">
       <criterion comment="{{{ MOUNTOPTION }}} on {{{ MOUNTPOINT }}}"
         test_ref="test_{{{ POINTID }}}_partition_{{{ MOUNTOPTIONID }}}_optional_{{{ MOUNT_HAS_TO_EXIST }}}"/>

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -21,7 +21,7 @@ for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf; do
 done
 
 {{%- if SYSCTLVAL == "" or SYSCTLVAL is not string %}}
-{{{ bash_instantiate_variables("sysctl_" + SYSCTLID + "_value") }}}
+{{{ bash_instantiate_variables("sysctl_" ~ SYSCTLID ~ "_value") }}}
 
 #
 # Set runtime for {{{ SYSCTLVAR }}}
@@ -32,7 +32,7 @@ done
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to appropriate value
 #	else, add "{{{ SYSCTLVAR }}} = value" to /etc/sysctl.conf
 #
-{{{ bash_replace_or_append('/etc/sysctl.conf', '^' + SYSCTLVAR , '$sysctl_' + SYSCTLID + '_value') }}}
+{{{ bash_replace_or_append('/etc/sysctl.conf', '^' ~ SYSCTLVAR , '$sysctl_' ~ SYSCTLID ~ '_value') }}}
 {{%- else %}}
 
 #
@@ -44,5 +44,5 @@ done
 # If {{{ SYSCTLVAR }}} present in /etc/sysctl.conf, change value to "{{{ SYSCTLVAL }}}"
 #	else, add "{{{ SYSCTLVAR }}} = {{{ SYSCTLVAL }}}" to /etc/sysctl.conf
 #
-{{{ bash_replace_or_append('/etc/sysctl.conf', '^' + SYSCTLVAR , SYSCTLVAL ) }}}
+{{{ bash_replace_or_append('/etc/sysctl.conf', '^' ~ SYSCTLVAR , SYSCTLVAL ) }}}
 {{%- endif %}}


### PR DESCRIPTION
#### Description:

Avoid double expansion need in jinja macros, style issues.

#### Rationale:

This ```grep -Pr '{{{.*}}}' ``` probably should not find any entries.

Style issue to prefer `~` as concatenation character instead of `+`. Former converts both values to string before concatenation, which most probably is what you want.