### PR TITLE
Fix missing OCIL text and 800-53 references

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -1188,9 +1188,10 @@ macro(ssg_build_html_stig_tables_per_profile PRODUCT STIG_PROFILE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${STIG_PROFILE}" -stringparam testinfo "y" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${STIG_PROFILE}" -stringparam testinfo "y" -stringparam ocil-document "${CMAKE_BINARY_DIR}/${PRODUCT}/ocil-linked.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        DEPENDS "${CMAKE_BINARY_DIR}/${PRODUCT}/ocil-linked.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML STIG test info document for ${STIG_PROFILE}"
     )

--- a/shared/transforms/shared_xccdf2table-profileccirefs.xslt
+++ b/shared/transforms/shared_xccdf2table-profileccirefs.xslt
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.2" xmlns:xccdf-1.1="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="https://public.cyber.mil/stigs/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5">
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.2" xmlns:xccdf-1.1="http://checklists.nist.gov/xccdf/1.1" xmlns:cci="http://iase.disa.mil/cci" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:ovalns="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:ocil2="http://scap.nist.gov/schema/ocil/2.0">
 
 <!-- this style sheet expects parameter $profile, which is the id of the Profile to be shown -->
 
@@ -8,6 +8,9 @@
 
 <xsl:param name="profile" select="''"/>
 <xsl:param name="testinfo" select="''" />
+
+<xsl:param name="ocil-document" select="''"/>
+<xsl:variable name="ocil" select="document($ocil-document)/ocil2:ocil"/>
 
 <xsl:variable name="profile_id" select="concat('xccdf_org.ssgproject.content_profile_', $profile)" />
 
@@ -78,7 +81,9 @@
 
 			<td>
 			<!-- print the manual check text -->
-			<xsl:apply-templates select="cdf:check" /> 
+				<pre>
+					<xsl:apply-templates select="cdf:check[@system='http://scap.nist.gov/schema/ocil/2']"/>
+				</pre>
 			</td>
 
 			<td> 
@@ -123,28 +128,6 @@
 		</xsl:if>
 	</xsl:template>
 
-
-	<xsl:template match="cdf:check">
-	    <xsl:if test="@system=$ociltransitional">
-			<xsl:apply-templates select="cdf:check-content" />
-			<!-- print clause with "finding" text -->
-			 <xsl:if test="cdf:check-export/@export-name != ''">
-			 <br/>If <xsl:value-of select="cdf:check-export/@export-name" />, this is a finding. 
-			 </xsl:if>
-		</xsl:if>
-<!--	    <xsl:if test="@system=$ovaluri">
-		<xsl:for-each select="cdf:check-export">
-			<xsl:variable name="rulevar" select="@value-id" />
-				<xsl:for-each select="/cdf:Benchmark/cdf:Profile[@id=$profile]/cdf:refine-value">
-					<xsl:if test="@idref=$rulevar">
-						<xsl:value-of select="@selector" />
-					</xsl:if>
-				</xsl:for-each>
-		</xsl:for-each>
-		</xsl:if> -->
-	</xsl:template>
-
-
     <!-- getting rid of XHTML namespace -->
 	<xsl:template match="xhtml:*">
 		<xsl:element name="{local-name()}">
@@ -172,4 +155,11 @@
         <xsl:apply-templates select="@*|node()" />
     </xsl:template>
 
+	<xsl:template match="cdf:check[@system='http://scap.nist.gov/schema/ocil/2']">
+		<xsl:variable name="questionaireId" select="cdf:check-content-ref/@name"/>
+		<xsl:variable name="questionaire" select="$ocil/ocil2:questionnaires/ocil2:questionnaire[@id=$questionaireId]"/>
+		<xsl:variable name="testActionRef" select="$questionaire/ocil2:actions/ocil2:test_action_ref/text()"/>
+		<xsl:variable name="questionRef" select="$ocil/ocil2:test_actions/*[@id=$testActionRef]/@question_ref"/>
+		<xsl:value-of select="$ocil/ocil2:questions/ocil2:*[@id=$questionRef]/ocil2:question_text"/>
+	</xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
In #9325 we discovered that the
`table-${PRODUCT}-${STIG_PROFILE}-testinfo.html` is missing contents in
`Check Text (OCIL Check)` and `800-53 Refs` columns.

However, it isn't caused by #9325, these data were empty even before,
the reasons are:
- the template doesn't expect OCIL as a separate file, it expects
  OCIL data embedded in XCCDF as it used to be in past
- the template used a wrong XML namespace for CCI list so the
  CCI list couldn't be parsed by the template.

This commit tries to solve these 2 problems. However, there are
offensive `<sub>` elements in the HTML output which need still to be
resolved on the level of `ocil-unlinked.xml` generator (it isn't a
problem in this template).


