### PR TITLE
Fix e2e expected test result for configure_usbguard_auditbackend

### DIFF
--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/ocp4/e2e.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/tests/ocp4/e2e.yml
@@ -1,4 +1,5 @@
 ---
 default_result: NOT-APPLICABLE
+result_after_remediation: PASS
 exclude_from_count: EXCLUDE
 


### PR DESCRIPTION
Fix e2e expected test result for configure_usbguard_auditbackend. The CPE evaluation changed after remediation applied, and it is causing some issue in e2e test.