### PR TITLE
Fix bash and OVAL in account_password_selinux_faillock_dir

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/bash/shared.sh
@@ -2,14 +2,21 @@
 # platform = multi_platform_all
 
 FAILLOCK_CONF_FILES="/etc/security/faillock.conf /etc/pam.d/system-auth /etc/pam.d/password-auth"
+faillock_dirs=$(grep -oP "^\s*(?:auth.*pam_faillock.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
+               | sed -r 's/.*=\s*(\S+)/\1/')
 
-for dir in $(grep -oP "^\s*(?:auth.*pam_faillock\.so.*)?dir\s*=\s*(\S+)" $FAILLOCK_CONF_FILES \
-            | sed -r 's/.*=\s*(\S+)/\1/'); do
-    if ! semanage fcontext -a -t faillog_t "$dir(/.*)?"; then
-        semanage fcontext -m -t faillog_t "$dir(/.*)?"
-    fi
-    if [ ! -e $dir ]; then
-        mkdir -p $dir
-    fi
-    restorecon -R -v $dir
-done
+if [ -n "$faillock_dirs" ]; then
+    for dir in $faillock_dirs; do
+        if ! semanage fcontext -a -t faillog_t "$dir(/.*)?"; then
+            semanage fcontext -m -t faillog_t "$dir(/.*)?"
+        fi
+        if [ ! -e $dir ]; then
+            mkdir -p $dir
+        fi
+        restorecon -R -v $dir
+    done
+else
+echo "
+The pam_faillock.so dir option is not set in the system.
+If this is not expected, make sure pam_faillock.so is properly configured."
+fi

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -42,8 +42,13 @@
     <linux:type datatype="string" operation="equals">faillog_t</linux:type>
   </linux:selinuxsecuritycontext_state>
 
-  <ind:textfilecontent54_test id="test_account_password_selinux_faillock_dir_not_set" version="1"
-    check="all" check_existence="none_exist" comment="No faillock tally dir was found">
-    <ind:object object_ref="object_account_password_selinux_faillock_dir_collector"/>
-  </ind:textfilecontent54_test>
+  <ind:variable_test id="test_account_password_selinux_faillock_dir_not_set" check="all"
+                     check_existence="none_exist" version="1"
+                     comment="Check the existence of faillock tally dirs">
+    <ind:object object_ref="object_account_password_selinux_faillock_dir_not_set"/>
+  </ind:variable_test>
+
+  <ind:variable_object id="object_account_password_selinux_faillock_dir_not_set" version="1">
+    <ind:var_ref>var_account_password_selinux_faillock_dir_collector</ind:var_ref>
+  </ind:variable_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -32,7 +32,7 @@
 
   <linux:selinuxsecuritycontext_object id="object_account_password_selinux_faillock_dir"
     comment="SELinux context information from pam_faillock.so tally directories" version="1">
-    <linux:path operation="equals" var_check="all"
+    <linux:path operation="equals" var_check="at least one"
                 var_ref="var_account_password_selinux_faillock_dir_collector"/>
     <linux:filename xsi:nil="true"/>
   </linux:selinuxsecuritycontext_object>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/oval/shared.xml
@@ -4,9 +4,11 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
   {{{ oval_metadata("An SELinux Context must be configued for the Faillock directory.") }}}
-    <criteria operator="AND">
+    <criteria operator="OR">
       <criterion test_ref="test_account_password_selinux_faillock_dir"
-                 comment="the faillock directory should have faillog_t as context"/>
+                 comment="The faillock directories should have faillog_t as context"/>
+      <criterion test_ref="test_account_password_selinux_faillock_dir_not_set"
+                 comment="There is no faillock directory set in pam_faillock.so settings"/>
     </criteria>
   </definition>
   <ind:textfilecontent54_object id="object_account_password_selinux_faillock_dir_collector" version="1">
@@ -39,4 +41,9 @@
     comment="faillog_t context is set">
     <linux:type datatype="string" operation="equals">faillog_t</linux:type>
   </linux:selinuxsecuritycontext_state>
+
+  <ind:textfilecontent54_test id="test_account_password_selinux_faillock_dir_not_set" version="1"
+    check="all" check_existence="none_exist" comment="No faillock tally dir was found">
+    <ind:object object_ref="object_account_password_selinux_faillock_dir_collector"/>
+  </ind:textfilecontent54_test>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value_multiple_dirs.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value_multiple_dirs.pass.sh
@@ -4,7 +4,7 @@
 
 truncate -s 0 /etc/security/faillock.conf
 echo "dir=/var/log/faillock" > /etc/security/faillock.conf
-echo "auth  required pam_faillock.so dir=/var/log/faillock_admins"
+echo "auth  required pam_faillock.so dir=/var/log/faillock_admins" >> /etc/pam.d/system-auth
 
 mkdir /var/log/faillock /var/log/faillock_admins
 semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/faillock_dir_not_set.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/faillock_dir_not_set.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = policycoreutils-python-utils
+# platform = multi_platform_all
+
+PAM_FILES="/etc/pam.d/password-auth /etc/pam.d/system-auth"
+truncate -s 0 /etc/security/faillock.conf
+sed -i --follow-symlinks -E 's/(\h*auth\b.*\bpam_faillock\.so\b.*)dir=.*/\1/g' $PAM_FILES

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value_multiple_dirs.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value_multiple_dirs.fail.sh
@@ -4,7 +4,7 @@
 
 truncate -s 0 /etc/security/faillock.conf
 echo "dir=/var/log/faillock" > /etc/security/faillock.conf
-echo "auth  required pam_faillock.so dir=/var/log/faillock_admins"
+echo "auth  required pam_faillock.so dir=/var/log/faillock_admins" >> /etc/pam.d/system-auth
 
 mkdir /var/log/faillock /var/log/faillock_admins
 semanage fcontext -a -t tmp_t "/var/log/faillock(/.*)?"


### PR DESCRIPTION
#### Description:

The `account_password_selinux_faillock_dir` rule intended to fix the SELinux fcontext in faillock data dirs when they are defined. However, there is no necessary action if there is no faillock dirs defined in the system settings.
In this case, the rule should pass. New test scenario was also included for this case.

#### Rationale:

Fix an issue of the rule failing when there is no faillock data directory defined in the `pam_faillock.so` settings.
In these situations, the following error was returned before this patch:
```Referenced variable has no values (oval:ssg-var_account_password_selinux_faillock_dir_collector:var```

The patch fix this issue by treating this scenario with an additional OVAL test.