### PR TITLE
Remove bash machine platform condition from core pattern empty string

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern_empty_string/bash/shared.sh
@@ -3,11 +3,8 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-# Remediation is applicable only in certain platforms
-if [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]; then
 
 # Comment out any occurrences of kernel.core_pattern from /etc/sysctl.d/*.conf files
-
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf; do
 
   matching_list=$(grep -P '^(?!#).*[\s]*kernel.core_pattern.*$' $f | uniq )
@@ -53,8 +50,4 @@ else
     # \n is precaution for case where file ends without trailing newline
 
     printf '%s\n' "$formatted_output" >> "/etc/sysctl.conf"
-fi
-
-else
-    >&2 echo 'Remediation is not applicable, nothing was done'
 fi


### PR DESCRIPTION


#### Description:
- Remove bash machine platform condition from core pattern empty string.
  - This condition will be added by the build system when the content is
compiled. It was there before because the remediation was brought
straight from built templated content and at that stage the condition
was already put in place.
