### PR TITLE
Update Ansible styleguide to prefix tasks names

### DIFF
--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -325,6 +325,7 @@ Value must be low, medium, or high.
 * Shall follow all the rules in the [YAML](manual/developer/04_style_guide:yaml) section
 * Should prefer using Ansible modules over just calling system commands
 * Shall be written to pass [`ansible-lint`](https://github.com/ansible-community/ansible-lint)
+* Task names should be prefixed by `{{{ rule_title }}}`, e.g. `- name: "{{{ rule_title }}} - ensure correct banner"`
 
 ### Bash
 


### PR DESCRIPTION
#### Description:

Ansible playbooks which included many rules, like a remediation playbook related to a profile, may have many tasks with the same name but used by different rules. Including the `{{{ rule_title }}}` as prefix make it easier for humans to quickly understand the playbook output.

#### Rationale:

Besides helping with auditing and debugging, may also help the #7418 and #7433
