### PR TITLE
Revert "Unselect empty groups during shorthand creation"

### DIFF
--- a/build-scripts/unselect_empty_xccdf_groups.py
+++ b/build-scripts/unselect_empty_xccdf_groups.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python3
+
+"""
+Takes given *resolved* XCCDF, goes through every profile. For every profile,
+every group that has no selected rules in that profile gets unselected.
+This tool operates in-place!
+
+This is necessary to make HTML guides shorter and the XCCDF itself more usable
+in tools such as SCAP Workbench.
+
+NOTE: This tool does *NOT* support datastreams! Run it on the XCCDFs before you
+build datastreams from them!
+
+Author: Martin Preisler <mpreisle@redhat.com>
+"""
+
+from __future__ import print_function
+
+import os
+import sys
+
+from optparse import OptionParser
+
+import ssg.constants
+import ssg.xml
+
+OSCAP_PATH = "oscap"
+
+XCCDF11_NS = ssg.constants.XCCDF11_NS
+TRUE_STRINGS = ["true", "1", "True", "TRUE"]
+
+
+def is_rule_selected(root_element, profile_element, rule_element):
+    rule_id = rule_element.get("id")
+
+    select_state = rule_element.get("selected") in TRUE_STRINGS
+
+    for selector in profile_element.findall("./{%s}select" % (XCCDF11_NS)):
+        if selector.get("idref") == rule_id:
+            select_state = selector.get("selected") in TRUE_STRINGS
+
+    return select_state
+
+
+def any_nested_selected_rules(root_element, profile_element, group_element,
+                              group_cache):
+    group_id = group_element.get("id")
+    if group_id in group_cache:
+        return group_cache[group_id]
+
+    for child_group in group_element.findall("./{%s}Group" % (XCCDF11_NS)):
+        if any_nested_selected_rules(
+            root_element, profile_element, child_group,
+            group_cache
+        ):
+            group_cache[group_id] = True
+            return True
+
+    for child_rule in group_element.findall("./{%s}Rule" % (XCCDF11_NS)):
+        if is_rule_selected(root_element, profile_element, child_rule):
+            group_cache[group_id] = True
+            return True
+
+    group_cache[group_id] = False
+    return False
+
+
+def main():
+    usage = "usage: %prog [options]"
+    parser = OptionParser(usage=usage)
+    parser.add_option(
+        "-i", "--input", dest="input_content", type="string",
+        action="store", help="INPUT can be XCCDF 1.1.4 benchmark"
+    )
+    parser.add_option(
+        "-o", "--output", dest="output", type="string",
+        action="store", help="Where the result XML tree should be written.")
+
+    (options, args) = parser.parse_args()
+
+    if options.input_content is None:
+        parser.print_help()
+        raise RuntimeError("No INPUT file provided, please use --input.")
+
+    if options.output is None:
+        parser.print_help()
+        raise RuntimeError("Please specify output with --output.")
+
+    input_tree = ssg.xml.open_xml(options.input_content)
+    root_element = input_tree.getroot()
+    if root_element.tag != "{%s}Benchmark" % (XCCDF11_NS):
+        raise RuntimeError(
+            "Make sure the input file is XCCDF 1.1.4 and the root element is "
+            "a benchmark!"
+        )
+
+    affected_profiles = []
+    group_elements = root_element.findall(".//{%s}Group" % (XCCDF11_NS))
+
+    for profile_element in root_element.findall("./{%s}Profile" % (XCCDF11_NS)):
+        # maps group IDs to number of nested selected XCCDF rules
+        group_cache = {}
+
+        for group_element in group_elements:
+            if not any_nested_selected_rules(
+                root_element, profile_element, group_element,
+                group_cache
+            ):
+                existing_selects = \
+                    list(profile_element.findall("./{%s}select" % (XCCDF11_NS)))
+
+                new_select = None
+                for existing_select in existing_selects:
+                    # prevent idref duplication
+                    if existing_select.get("idref") == group_element.get("id"):
+                        new_select = existing_select
+                        break
+
+                if new_select is None:
+                    new_select = \
+                        ssg.xml.ElementTree.Element("{%s}select" % (XCCDF11_NS))
+                    index = 0
+                    if len(existing_selects) > 0:
+                        prev_element = existing_selects[-1]
+                        # insert before the first notice
+                        index = list(profile_element).index(prev_element) + 1
+                    profile_element.insert(index, new_select)
+
+                new_select.set("idref", group_element.get("id"))
+                new_select.set("selected", "false")
+                new_select.tail = "\n"
+
+        affected_profiles.append(profile_element.get("id"))
+
+    input_tree.write(options.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -385,9 +385,10 @@ endmacro()
 macro(ssg_build_xccdf_final PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/unselect_empty_xccdf_groups.py" --input "${CMAKE_CURRENT_BINARY_DIR}/xccdf-linked.xml" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMAND "${SED_EXECUTABLE}" -i "s/oval-linked.xml/ssg-${PRODUCT}-oval.xml/g" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         COMMAND "${SED_EXECUTABLE}" -i "s/ocil-linked.xml/ssg-${PRODUCT}-ocil.xml/g" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-internal-${PRODUCT}-linked-xccdf-oval-ocil.xml
         COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-xccdf.xml"
     )

--- a/docs/manual/developer/07_understanding_build_system.md
+++ b/docs/manual/developer/07_understanding_build_system.md
@@ -119,6 +119,8 @@ refer to their help text for more information and usage:
    in a specific XCCDF/Datastream file.
  - `relabel_ids.py` -- updates various internal identifiers to their final
    resolved values (e.g., with the `xccdf_org.ssgproject.content_` prefix).
+ - `unselect_empty_xccdf_groups.py` -- updates the XCCDF document to remove
+   selections of groups without any rules.
  - `verify_references.py` -- used by the test system to verify cross-linkage
    of identifiers between XCCDF and OVAL/OCIL documents.
  - `yaml_to_shorthand.py` -- generates the shorthand XML document from the

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -187,7 +187,6 @@ class SelectionHandler(object):
         self.refine_rules = defaultdict(list)
         self.variables = dict()
         self.unselected = []
-        self.unselected_groups = []
         self.selected = []
 
     @property
@@ -433,7 +432,6 @@ class Profile(XCCDFEntity, SelectionHandler):
         metadata=lambda: None,
         reference=lambda: None,
         selections=lambda: list(),
-        unselected_groups=lambda: list(),
         platforms=lambda: set(),
         cpe_names=lambda: set(),
         platform=lambda: None,
@@ -502,12 +500,6 @@ class Profile(XCCDFEntity, SelectionHandler):
 
         for selection in self.unselected:
             unselect = ET.Element("{%s}select" % XCCDF11_NS)
-            unselect.set("idref", selection)
-            unselect.set("selected", "false")
-            element.append(unselect)
-
-        for selection in self.unselected_groups:
-            unselect = ET.Element("select")
             unselect.set("idref", selection)
             unselect.set("selected", "false")
             element.append(unselect)
@@ -613,32 +605,6 @@ class Profile(XCCDFEntity, SelectionHandler):
                     .format(rule_id=id_, profile_id=self.id_)
                 )
                 raise ValueError(msg)
-
-    def _find_empty_groups(self, group, profile_rules):
-        is_empty = True
-        empty_groups = []
-        for child in group.groups.values():
-            child_empty, child_empty_groups = self._find_empty_groups(child, profile_rules)
-            if not child_empty:
-                is_empty = False
-            empty_groups.extend(child_empty_groups)
-        if is_empty:
-            group_rules = set(group.rules.keys())
-            if profile_rules & group_rules:
-                is_empty = False
-        if is_empty:
-            empty_groups.append(group.id_)
-        return is_empty, empty_groups
-
-    def unselect_empty_groups(self, root_group):
-        # Unselecting empty groups is necessary to make HTML guides shorter
-        # and the XCCDF more usable in tools such as SCAP Workbench.
-        profile_rules = set(self.selected)
-        is_empty, empty_groups = self._find_empty_groups(root_group, profile_rules)
-        if is_empty:
-            msg = "Profile {0} unselects all groups.".format(self.id_)
-            raise ValueError(msg)
-        self.unselected_groups.extend(sorted(empty_groups))
 
     def __sub__(self, other):
         profile = Profile(self.id_)
@@ -946,10 +912,6 @@ class Benchmark(XCCDFEntity):
                 continue
 
             self.profiles.append(new_profile)
-
-    def unselect_empty_groups(self):
-        for p in self.profiles:
-            p.unselect_empty_groups(self)
 
     def to_xml_element(self, env_yaml=None, product_cpes=None):
         root = ET.Element('{%s}Benchmark' % XCCDF11_NS)
@@ -1854,8 +1816,6 @@ class DirectoryLoader(object):
             prodtypes = parse_prodtype(group.prodtype)
             if "all" in prodtypes or self.product in prodtypes:
                 self.all_groups[group.id_] = group
-            else:
-                return None
 
         return group
 
@@ -2036,7 +1996,6 @@ class LinearLoader(object):
             except KeyError as exc:
                 # Add only the groups we have compiled and loaded
                 pass
-        self.benchmark.unselect_empty_groups()
 
     def load_compiled_content(self):
         self.fixes = ssg.build_remediations.load_compiled_remediations(self.fixes_dir)


### PR DESCRIPTION

#### Description:

This reverts commit 62f33f08257cff7f9ce37cb874128052b1b42d8d.

#### Rationale:

The Compliance Operator CI runs started failing with:
OpenSCAP Error: File '/content/ssg-ocp4-ds.xml' line 662: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 802: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 843: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1017: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1201: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1362: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1543: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1694: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1864: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 1999: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 2141: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 2284: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
File '/content/ssg-ocp4-ds.xml' line 2433: Element 'select': This element is not expected. Expected is one of ( {http://checklists.nist.gov/xccdf/1.2}metadata, {http://checklists.nist.gov/xccdf/1.2}signature ).
 [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:723]
Invalid SCAP Source Datastream (1.3) content in /content/ssg-ocp4-ds.xml. [/builddir/build/BUILD/openscap-1.3.6/src/source/oscap_source.c:353]
Invalid SCAP Source Datastream (1.3) content in /content/ssg-ocp4-ds.xml [/builddir/build/BUILD/openscap-1.3.6/src/XCCDF/xccdf_session.c:839]

git bisect points to commit 62f33f08257cff7f9ce37cb874128052b1b42d8d. Let's revert it.
