### PR TITLE
Fix namespace of select elements

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -507,7 +507,7 @@ class Profile(XCCDFEntity, SelectionHandler):
             element.append(unselect)
 
         for selection in self.unselected_groups:
-            unselect = ET.Element("select")
+            unselect = ET.Element("{%s}select" % XCCDF11_NS)
             unselect.set("idref", selection)
             unselect.set("selected", "false")
             element.append(unselect)


### PR DESCRIPTION
In #9345 we have started to create elements with explicit XCCDF 1.1
namespace. However, meanwhile #9332 got merged and that adds a new
block that creates a `select` element, however, this wasn't updated
to create elements with explicit XCCDF 1.1 namespace. After merging
both #9345 and #9332, this omission caused that the namespace
of the `select` element was invalid and the build got broken.

