### PR TITLE
Conditional for Ansible remediation on RHEL7

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -11,8 +11,13 @@
   register: user_names
 
 - name: Change the maximum time period between password changes
+{{% if product not in ["rhel7", "ol7"] %}}
   ansible.builtin.user:
     user: '{{ item }}'
     password_expire_max: '{{ var_accounts_maximum_age_login_defs }}'
+{{% else %}}
+  ansible.builtin.command: >
+    chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
+{{% endif %}}
   with_items: '{{ user_names.stdout_lines }}'
   when: user_names.stdout_lines | length > 0


### PR DESCRIPTION
#### Description:

The Ansible remediation for the `accounts_password_set_max_life_existing` rule was recently updated to use the `user` module with the `password_expire_max` parameter. However, this parameter was introduced on Ansible 2.11 while RHEL7 uses Ansible 2.9. Therefore, the former remediation approach was kept for RHEL7 via a Jinja2 conditional.

#### Rationale:

- Fixes #9431 
