### PR TITLE
Remove pam_unix_rounds rules from the RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
+++ b/controls/srg_gpos/SRG-OS-000073-GPOS-00041.yml
@@ -9,7 +9,4 @@ controls:
             - set_password_hashing_algorithm_systemauth
             - set_password_hashing_min_rounds_logindefs
             - accounts_password_all_shadowed_sha512
-            - accounts_password_pam_unix_rounds_password_auth
-            - var_password_pam_unix_rounds=5000
-            - accounts_password_pam_unix_rounds_system_auth
         status: automated


### PR DESCRIPTION
#### Description:

Remove 
* accounts_password_pam_unix_rounds_password_auth
* accounts_password_pam_unix_rounds_system_auth

as they are not in the RHEL 8 STIG.

#### Rationale:

Fixes #8472