### PR TITLE
Move kernel_module_disabled use more genric RHEL in conditionals

### DIFF
--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/missing_blacklist.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/missing_blacklist.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform multi_platform_rhel,multi_platform_ol
+
+rm -f /etc/modprobe.d/dccp-blacklist.conf
+echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -17,7 +17,7 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: '{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
   lineinfile:
     create: yes

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -18,7 +18,7 @@ else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
 	echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -6,7 +6,7 @@
       {{% if product in ["sle12", "sle15"] %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
       comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
-      {{% elif product in ["ol7", "ol8", "rhcos4", "rhel7", "rhel8"] %}}
+      {{% elif product in ["ol7", "ol8", "rhcos4"] or 'rhel' in product %}}
       <criteria operator="AND">
         <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
         comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
@@ -49,7 +49,7 @@
   </constant_variable>
 {{% endif %}}
 
-{{% if product in ["ol7", "ol8", "rhcos4", "rhel7", "rhel8", "sle12", "sle15"] %}}
+{{% if product in ["ol7", "ol8", "rhcos4", "sle12", "sle15"]  or 'rhel' in product %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} blacklisted">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted" />

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modules_load_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modules-load.d/{{{ KERNMODULE }}}.conf
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /etc/modules-load.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
@@ -4,6 +4,6 @@ if [[ ! -d /run/modprobe.d ]]; then
     mkdir -p /run/modprobe.d
 fi
 echo "install {{{ KERNMODULE }}} /bin/true" > /run/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /run/modprobe.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modules_load_d.pass.sh
@@ -5,6 +5,6 @@ if [[ ! -d /run/modules-load.d ]]; then
 fi
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /run/modules-load.d/{{{ KERNMODULE }}}.conf
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /run/modules-load.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modules_load_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modules_load_d.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modules-load.d/{{{ KERNMODULE }}}.conf
-{{% if product in ["ol7", "ol8", "rhel7", "rhel8"] %}}
+{{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modules-load.d/{{{ KERNMODULE }}}.conf
 {{% endif %}}


### PR DESCRIPTION


#### Description:
This PR changes the conditions in `kernel_module_disabled` to use `product in 'rhel'` vs `if product in ['rhel7, 'rhel8']`.

#### Rationale:

Listing versions causes issues when we release a new version of RHEL.
Fixes #9192 
