### PR TITLE
Remove support for upstart init system

### DIFF
--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/oval/shared.xml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/oval/shared.xml
@@ -1,5 +1,5 @@
-{{%- if init_system == "systemd" and target_oval_version == [5, 10] -%}}
-{{# this is the only scenario this definition cannot handle, there is no good alternative for symlink_test for OVAL 5.10 #}}
+{{%- if target_oval_version == [5, 10] -%}}
+{{# there is no good alternative for symlink_test for OVAL 5.10 #}}
 {{%- else -%}}
 <def-group>
   <definition class="compliance" id="xwindows_runlevel_target" version="1">

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,15 +1,3 @@
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
-{{% if init_system == "systemd" -%}}
 systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target
-{{%- else %}}
-# If system does not contain control-alt-delete.override,
-if [ ! -f /etc/init/control-alt-delete.override ]; then
-	# but does have control-alt-delete.conf file,
-	if [ -f /etc/init/control-alt-delete.conf ]; then
-		# then copy .conf to .override to maintain persistency
-		cp /etc/init/control-alt-delete.conf /etc/init/control-alt-delete.override
-	fi
-fi
-sed -i 's,^exec.*$,exec /usr/bin/logger -p authpriv.notice -t init "Ctrl-Alt-Del was pressed and ignored",' /etc/init/control-alt-delete.override
-{{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/oval/shared.xml
@@ -1,22 +1,14 @@
-{{%- if init_system == "systemd" and target_oval_version == [5, 10] -%}}
-{{# this is the only scenario this definition cannot handle, there is no good alternative for symlink_test for OVAL 5.10 #}}
+{{%- if target_oval_version == [5, 10] -%}}
+{{# there is no good alternative for symlink_test for OVAL 5.10 #}}
 {{%- else -%}}
 <def-group>
   <definition class="compliance" id="disable_ctrlaltdel_reboot" version="1">
     {{{ oval_metadata("By default, the system will reboot when the
       Ctrl-Alt-Del key sequence is pressed.") }}}
-    {{%- if init_system == "systemd" -%}}
     <criteria>
       <criterion comment="Disable Ctrl-Alt-Del systemd softlink exists" test_ref="test_disable_ctrlaltdel_exists" />
     </criteria>
-    {{%- else -%}}
-    <criteria>
-      <criterion comment="Disable Ctrl-Alt-Del key sequence" test_ref="test_disable_ctrlaltdel" />
-      <criterion comment="Disable Ctrl-Alt-Del key sequence override exists" test_ref="test_disable_ctrlaltdel_exists" />
-    </criteria>
-    {{%- endif -%}}
   </definition>
-  {{%- if init_system == "systemd" -%}}
   <unix:symlink_test check="all" check_existence="all_exist" comment="Disable Ctrl-Alt-Del key sequence override exists" id="test_disable_ctrlaltdel_exists" version="1">
     <unix:object object_ref="object_disable_ctrlaltdel_exists" />
     <unix:state state_ref="state_disable_ctrlaltdel_exists" />
@@ -28,22 +20,5 @@
     <unix:filepath>/etc/systemd/system/ctrl-alt-del.target</unix:filepath>
     <unix:canonical_path>/dev/null</unix:canonical_path>
   </unix:symlink_state>
-  {{%- else -%}}
-  <ind:textfilecontent54_test check="all" check_existence="none_exist" comment="Disable Ctrl-Alt-Del key sequence" id="test_disable_ctrlaltdel" version="1">
-    <ind:object object_ref="object_test_disable_ctrlaltdel" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object comment="Disable Ctrl-Alt-Del key sequence" id="object_test_disable_ctrlaltdel" version="1">
-    <ind:filepath>/etc/init/control-alt-delete.override</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*exec[\s]*/sbin/shutdown[\s]*\-r[\s]*now.*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <unix:file_test check="all" check_existence="all_exist" comment="Disable Ctrl-Alt-Del key sequence override exists" id="test_disable_ctrlaltdel_exists" version="1">
-    <unix:object object_ref="object_test_disable_ctrlaltdel_exists" />
-  </unix:file_test>
-  <unix:file_object comment="Disable Ctrl-Alt-Del key sequence override exists" id="object_test_disable_ctrlaltdel_exists" version="1">
-    <unix:filepath>/etc/init/control-alt-delete.override</unix:filepath>
-  </unix:file_object>
-  {{%- endif -%}}
 </def-group>
 {{%- endif -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/ansible/shared.yml
@@ -4,7 +4,6 @@
 # complexity = low
 # disruption = low
 
-{{% if init_system == "systemd" -%}}
 - name: require single user mode password
   lineinfile:
       create: yes
@@ -17,11 +16,3 @@
       {{%- else -%}}
       line: 'ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"'
       {{%- endif %}}
-{{%- else -%}}
-- name: require single user mode password
-  lineinfile:
-      create: yes
-      dest: /etc/sysconfig/init
-      regexp: "^#?SINGLE="
-      line: "SINGLE=/sbin/sulogin"
-{{%- endif %}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/bash/shared.sh
@@ -1,7 +1,5 @@
 # platform = multi_platform_all
 
-{{% if init_system == "systemd" -%}}
-
 service_file="/usr/lib/systemd/system/rescue.service"
 
 {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15"] -%}}
@@ -17,11 +15,3 @@ if grep "^ExecStart=.*" "$service_file" ; then
 else
     echo "ExecStart=-$sulogin" >> "$service_file"
 fi
-
-{{%- else -%}}
-grep -q ^SINGLE /etc/sysconfig/init && \
-  sed -i "s/SINGLE.*/SINGLE=\/sbin\/sulogin/g" /etc/sysconfig/init
-if ! [ $? -eq 0 ]; then
-    echo "SINGLE=/sbin/sulogin" >> /etc/sysconfig/init
-fi
-{{%- endif -%}}

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/oval/shared.xml
@@ -2,7 +2,6 @@
   <definition class="compliance" id="require_singleuser_auth" version="1">
     {{{ oval_metadata("The requirement for a password to boot into single-user mode
       should be configured correctly.") }}}
-    {{%- if init_system == "systemd" -%}}
     <criteria operator="AND">
       <criterion comment="Conditions are satisfied"
       test_ref="test_require_rescue_service" />
@@ -12,14 +11,7 @@
       <criterion test_ref="test_no_custom_rescue_service" negate="true"/>
       {{%- endif -%}}
     </criteria>
-    {{%- else -%}}
-    <criteria>
-      <criterion comment="Conditions are satisfied"
-      test_ref="test_require_singleuser_auth" />
-    </criteria>
-    {{%- endif -%}}
   </definition>
-  {{%- if init_system == "systemd" -%}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
     comment="Tests that
     {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "rhcos4", "sle12", "sle15"] -%}}
@@ -77,17 +69,5 @@
     <unix:path operation="equals">/etc/systemd/system</unix:path>
     <unix:filename operation="pattern match">^runlevel1.target$</unix:filename>
   </unix:file_object>
-  {{%- endif -%}}
-  {{%- else -%}}
-  <ind:textfilecontent54_test check="all" check_existence="all_exist"
-  comment="Tests that the SINGLE variable in the /etc/sysconfig/init file is set to /sbin/sulogin, to ensure that a password must be entered to access single user mode"
-  id="test_require_singleuser_auth" version="1">
-    <ind:object object_ref="obj_require_singleuser_auth" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="obj_require_singleuser_auth" version="1">
-    <ind:filepath>/etc/sysconfig/init</ind:filepath>
-    <ind:pattern operation="pattern match">^SINGLE=/sbin/sulogin[\s]*</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
   {{%- endif -%}}
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/require_singleuser_auth/rule.yml
@@ -94,7 +94,6 @@ platform: machine
 fixtext: |-
     Configure {{{ full_name }}} to require authentication in single user mode.
 
-    {{% if init_system == "systemd" -%}}
     Add or update the following line in "/usr/lib/systemd/system/rescue.service":
     {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9", "sle12", "sle15"] -%}}
     ExecStart=-/usr/lib/systemd/systemd-sulogin-shell rescue
@@ -102,10 +101,6 @@ fixtext: |-
     ExecStart=-/bin/sh -c "/usr/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"
     {{%- else -%}}
     ExecStart=-/bin/sh -c "/sbin/sulogin; /usr/bin/systemctl --fail --no-block default"
-    {{%- endif %}}
-    {{%- else -%}}
-    Add or update the following line in "/etc/sysconfig/init":
-    SINGLE=/sbin/sulogin
     {{%- endif %}}
 
 srg_requirement: '{{{ full_name }}} must require authentication upon booting into rescue mode.'

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/bash/shared.sh
@@ -5,6 +5,4 @@ if ! grep -s "^\s*cron\.\*\s*/var/log/cron$" /etc/rsyslog.conf /etc/rsyslog.d/*.
 	echo "cron.*	/var/log/cron" >> /etc/rsyslog.d/cron.conf
 fi
 
-{{% if init_system == "systemd" %}}
 systemctl restart rsyslog.service
-{{% endif %}}

--- a/shared/checks/oval/audit_rules_auditctl.xml
+++ b/shared/checks/oval/audit_rules_auditctl.xml
@@ -14,7 +14,6 @@
   </definition>
 
   <!-- Test the auditctl case -->
-{{% if init_system == "systemd" %}}
   <ind:textfilecontent54_test check="all" comment="audit auditctl" id="test_audit_rules_auditctl" version="1">
     <ind:object object_ref="object_audit_rules_auditctl" />
   </ind:textfilecontent54_test>
@@ -23,20 +22,5 @@
     <ind:pattern operation="pattern match">^ExecStartPost=\-\/sbin\/auditctl.*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{% else %}}
-  {{# Older versions of audit didn't have option to use augenrules, hence check_existence="any_exist" #}}
-  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="audit auditctl" id="test_audit_rules_auditctl" version="1">
-    <ind:object object_ref="object_audit_rules_auditctl" />
-    <ind:state state_ref="state_audit_rules_auditctl" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_audit_rules_auditctl" version="1">
-    <ind:filepath>/etc/sysconfig/auditd</ind:filepath>
-    <ind:pattern operation="pattern match">^USE_AUGENRULES="(.*)"$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_audit_rules_auditctl" version="1">
-    <ind:subexpression datatype="string" operation="equals">no</ind:subexpression>
-  </ind:textfilecontent54_state>
-{{% endif %}}
 
 </def-group>

--- a/shared/checks/oval/audit_rules_augenrules.xml
+++ b/shared/checks/oval/audit_rules_augenrules.xml
@@ -17,18 +17,10 @@
   <ind:textfilecontent54_test check="all" comment="audit augenrules" id="test_audit_rules_augenrules" version="1">
     <ind:object object_ref="object_audit_rules_augenrules" />
   </ind:textfilecontent54_test>
-{{% if init_system == "systemd" %}}
   <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
     <ind:filepath>/usr/lib/systemd/system/auditd.service</ind:filepath>
     <ind:pattern operation="pattern match">^(ExecStartPost=\-\/sbin\/augenrules.*$|Requires=augenrules.service)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-{{% else %}}
-  <ind:textfilecontent54_object id="object_audit_rules_augenrules" version="1">
-    <ind:filepath>/etc/sysconfig/auditd</ind:filepath>
-    <ind:pattern operation="pattern match">^USE_AUGENRULES="yes"$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-{{% endif %}}
 
 </def-group>

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -268,10 +268,6 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
 {{%- endmacro %}}
 
 
-{{%- macro upstart_describe_socket_enable(socket) %}}
-{{%- endmacro %}}
-
-
 {{#
 Inserts a rule description for a case when a socket should be enabled,
 substituting the correct init system.
@@ -284,8 +280,6 @@ substituting the correct init system.
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_describe_socket_enable(socket) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_describe_socket_enable(socket) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
@@ -390,19 +384,6 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 {{%- endmacro %}}
 
 
-{{#
-    Describe how to enable a service in upstart.
-
-:param service: The service to check
-:type service: str
-
-#}}
-{{%- macro upstart_describe_service_enable(service) %}}
-    The <code>{{{ service }}}</code> service can be enabled with the following command:
-    <pre>$ sudo chkconfig --level 2345 {{{ service }}} on</pre>
-{{%- endmacro %}}
-
-
 {{%- macro systemd_describe_timer_enable(timer) %}}
     The <code>{{{ timer }}}</code> timer can be enabled with the following command:
     <pre>$ sudo systemctl enable {{{ timer }}}.timer</pre>
@@ -440,8 +421,6 @@ substituting the correct init system.
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_describe_service_enable(service) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_describe_service_enable(service) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -255,10 +255,6 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
 {{%- endmacro %}}
 
 
-{{%- macro upstart_describe_socket_disable(socket) %}}
-{{%- endmacro %}}
-
-
 {{#
     Describe how to enable a socket in systemd.
 
@@ -309,8 +305,6 @@ substituting the correct init system.
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_describe_socket_disable(socket) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_describe_socket_disable(socket) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
@@ -397,19 +391,6 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 
 
 {{#
-    Describe how to disable a service in upstart.
-
-:param service: The service to check
-:type service: str
-
-#}}
-{{%- macro upstart_describe_service_disable(service) %}}
-    The <code>{{{ service }}}</code> service can be disabled with the following command:
-    <pre>$ sudo chkconfig {{{ service }}} off</pre>
-{{%- endmacro %}}
-
-
-{{#
     Describe how to enable a service in upstart.
 
 :param service: The service to check
@@ -480,8 +461,6 @@ substituting the correct init system.
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_describe_service_disable(service) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_describe_service_disable(service) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -779,14 +779,6 @@ dconf update
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.
 /usr/bin/systemctl reset-failed "{{{ service }}}"
-{{%- elif init_system == "upstart" -%}}
-  {{%- if service_state == "disable" -%}}
-/sbin/service "{{{ service }}}" disable
-/sbin/chkconfig --level 0123456 "{{{ service }}}" off
-  {{%- else -%}}
-/sbin/service "{{{ service }}}" enable
-/sbin/chkconfig --level 0123456 "{{{ service }}}" on
-  {{%- endif -%}}
 {{%- endif -%}}
 
 {{%- if xinetd != "" -%}}

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -280,21 +280,6 @@ ocil: |-
 
 
 {{#
-    Describe how to check if a service is enabled via upstart.
-
-:param service: The service to check
-:type service: str
-
-#}}
-{{%- macro upstart_ocil_service_enabled(service) %}}
-    Run the following command to determine the current status of the
-    <code>{{{ service }}}</code> service:
-    <pre>$ sudo service {{{ service }}} status</pre>
-    If the service is enabled, it should return the following: <pre>{{{ service }}} is running...</pre>
-{{%- endmacro %}}
-
-
-{{#
     Inserts an OCIL for a case when a service should be enabled,
     substituting the correct init system.
 
@@ -306,8 +291,6 @@ ocil: |-
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_ocil_service_enabled(service) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_ocil_service_enabled(service) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -818,7 +818,7 @@ ocil_clause: "{{{ sebool }}} is not enabled"
 {{# Timer enabled macros #}}
 
 {{#
-    Describe how to check if timer is enabled in upstart.
+    Describe how to check if timer is enabled in systemd.
 
 :param service: The service to check
 :type service: str

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -367,29 +367,6 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 
 
 {{#
-    Describe how to check if a service is disabled via upstart.
-
-:param service: The service to check
-:type service: str
-
-#}}
-{{%- macro upstart_ocil_service_disabled(service) %}}
-    To check that the <code>{{{ service }}}</code> service is disabled in system boot configuration, run the following command:
-    <pre>$ sudo chkconfig <code>{{{ service }}}</code> --list</pre>
-    Output should indicate the <code>{{{ service }}}</code> service has either not been installed,
-    or has been disabled at all runlevels, as shown in the example below:
-    <pre>$ sudo chkconfig <code>{{{ service }}}</code> --list
-    <code>{{{ service }}}</code>       0:off   1:off   2:off   3:off   4:off   5:off   6:off</pre>
-
-    Run the following command to verify <code>{{{ service }}}</code> is disabled through current runtime configuration:
-    <pre>$ sudo service {{{ service }}} status</pre>
-
-    If the service is disabled the command will return the following output:
-    <pre>{{{ service }}} is stopped</pre>
-{{%- endmacro %}}
-
-
-{{#
     Inserts an OCIL for a case when a service should be disabled,
     substituting the correct init system.
 
@@ -401,8 +378,6 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_ocil_service_disabled(service) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_ocil_service_disabled(service) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
     {{%- endif -%}}
@@ -496,20 +471,6 @@ ocil_clause: "service and/or socket are running"
 
 
 {{#
-    OCIL and OCIL clause for ensure socket is disabled in systemd.
-
-:param name: The socket to check
-:type name: str
-
-#}}
-{{%- macro upstart_complete_ocil_entry_socket_and_service_disabled(name) %}}
-ocil:
-
-ocil_clause: "service and/or socket are running"
-{{%- endmacro %}}
-
-
-{{#
     Inserts an OCIL for a case when a service and a corresponding socket should be
     disabled, substituting the correct init system.
 
@@ -521,8 +482,6 @@ ocil_clause: "service and/or socket are running"
   {{% if init_system is defined %}}
     {{%- if init_system == "systemd" -%}}
         {{{ systemd_complete_ocil_entry_socket_and_service_disabled(service) }}}
-    {{%- elif init_system == "upstart" -%}}
-        {{{ upstart_complete_ocil_entry_socket_and_service_disabled(service) }}}
     {{%- else -%}}
 ocil: |-
     JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.

--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -30,12 +30,6 @@
     state: "stopped"
     masked: "yes"
   when: '"{{{ DAEMONNAME }}}.socket" in socket_file_exists.stdout_lines[1]'
-{{% elif init_system == "upstart" %}}
-- name: Stop {{{ SERVICENAME }}}
-  command: /sbin/service '{{{ DAEMONNAME }}}' stop
-
-- name: Switch off {{{ SERVICENAME }}}
-  command: /sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
 {{%- else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}

--- a/shared/templates/service_disabled/bash.template
+++ b/shared/templates/service_disabled/bash.template
@@ -19,10 +19,6 @@ fi
 # so let's reset the state so OVAL checks pass.
 # Service should be 'inactive', not 'failed' after reboot though.
 "$SYSTEMCTL_EXEC" reset-failed '{{{ DAEMONNAME }}}.service' || true
-{{% elif init_system == "upstart" %}}
-
-/sbin/service '{{{ DAEMONNAME }}}' stop
-/sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' off
 {{%- else %}}
 
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'

--- a/shared/templates/service_disabled/oval.template
+++ b/shared/templates/service_disabled/oval.template
@@ -2,7 +2,8 @@
 
 {{%- set package_removed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_removed" -%}}
 
-{{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
+{{% if init_system == "systemd" %}}
+  {{% if target_oval_version >= [5, 11] %}}
 
   {{# we are using systemd and our target OVAL version does support the systemd related tests #}}
 
@@ -39,102 +40,6 @@
   <linux:systemdunitproperty_state id="state_service_loadstate_is_masked_{{{ SERVICENAME }}}" version="1" comment="LoadState is set to masked">
       <linux:value>masked</linux:value>
   </linux:systemdunitproperty_state>
-
-{{% else %}}
-
-  {{% if init_system != "systemd" %}}
-  {{# we are not using systemd, it doesn't matter if we can or cannot use OVAL 5.11, let us just use the runlevel test #}}
-
-  <definition class="compliance" id="{{{ _RULE_ID }}}"
-  version="1">
-    {{{ oval_metadata("The " + SERVICENAME + " service should be disabled if possible.", affected_platforms=["multi_platform_all"]) }}}
-   <criteria comment="package {{{ PACKAGENAME }}} removed or service {{{ SERVICENAME }}} is not configured to start" operator="OR">
-    <criterion comment="{{{ PACKAGENAME }}} removed" test_ref="{{{ package_removed_test_id }}}" />
-    <criteria operator="AND" comment="service {{{ SERVICENAME }}} is not configured to start">
-      <criterion comment="{{{ SERVICENAME }}} runlevel 0" test_ref="test_runlevel0_{{{ SERVICENAME }}}_off" />
-      <criterion comment="{{{ SERVICENAME }}} runlevel 1" test_ref="test_runlevel1_{{{ SERVICENAME }}}_off" />
-      <criterion comment="{{{ SERVICENAME }}} runlevel 2" test_ref="test_runlevel2_{{{ SERVICENAME }}}_off" />
-      <criterion comment="{{{ SERVICENAME }}} runlevel 3" test_ref="test_runlevel3_{{{ SERVICENAME }}}_off" />
-      <criterion comment="{{{ SERVICENAME }}} runlevel 4" test_ref="test_runlevel4_{{{ SERVICENAME }}}_off" />
-      <criterion comment="{{{ SERVICENAME }}} runlevel 5" test_ref="test_runlevel5_{{{ SERVICENAME }}}_off" />
-      <criterion comment="{{{ SERVICENAME }}} runlevel 6" test_ref="test_runlevel6_{{{ SERVICENAME }}}_off" />
-    </criteria>
-    </criteria>
-  </definition>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel0_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel0_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel1_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel1_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel2_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel2_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel3_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel3_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel4_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel4_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel5_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel5_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_test check="all" check_existence="any_exist"
-  comment="Runlevel test" id="test_runlevel6_{{{ SERVICENAME }}}_off"
-  version="2">
-    <unix:object object_ref="obj_runlevel6_{{{ SERVICENAME }}}_off" />
-    <unix:state state_ref="state_service_{{{ SERVICENAME }}}_off" />
-  </unix:runlevel_test>
-  <unix:runlevel_object id="obj_runlevel0_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">0</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel1_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">1</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel2_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">2</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel3_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">3</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel4_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">4</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel5_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">5</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_object id="obj_runlevel6_{{{ SERVICENAME }}}_off" version="1">
-    <unix:service_name>{{{ SERVICENAME }}}</unix:service_name>
-    <unix:runlevel operation="equals">6</unix:runlevel>
-  </unix:runlevel_object>
-  <unix:runlevel_state comment="not configured to start" id="state_service_{{{ SERVICENAME }}}_off" version="1">
-    <unix:start datatype="boolean">false</unix:start>
-    <unix:kill datatype="boolean">true</unix:kill>
-  </unix:runlevel_state>
 
   {{% else %}}
 
@@ -180,7 +85,6 @@
   </unix:file_state>
 
   {{% endif %}}
-
 {{% endif %}}
 
 {{{ oval_test_package_removed(package=PACKAGENAME, test_id=package_removed_test_id) }}}

--- a/shared/templates/service_enabled/bash.template
+++ b/shared/templates/service_enabled/bash.template
@@ -9,10 +9,6 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
-{{% elif init_system == "upstart" %}}
-
-/sbin/service '{{{ DAEMONNAME }}}' start
-/sbin/chkconfig --level 0123456 '{{{ DAEMONNAME }}}' on
 {{% else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}

--- a/shared/templates/service_enabled/oval.template
+++ b/shared/templates/service_enabled/oval.template
@@ -2,7 +2,7 @@
 
 {{%- set package_installed_test_id = "test_service_" + SERVICENAME + "_package_" + PACKAGENAME + "_installed" -%}}
 
-{{% if init_system == "systemd" and target_oval_version >= [5, 11] %}}
+{{% if target_oval_version >= [5, 11] %}}
 
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
     {{{ oval_metadata("The " + SERVICENAME + " service should be enabled if possible.") }}}


### PR DESCRIPTION
#### Description:

- Remove checks and remediations that used to support products that used`upstart`.

#### Rationale:

- No product uses `upstart` at the moment.
- Removes unused code from the project.
