### PR TITLE
Remove redundant rules from RHEL9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
+++ b/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
@@ -6,8 +6,6 @@ controls:
         rules:
             - var_password_pam_remember=5
             - var_password_pam_remember_control_flag=required
-            - var_password_pam_unix_remember=5
             - accounts_password_pam_pwhistory_remember_password_auth
             - accounts_password_pam_pwhistory_remember_system_auth
-            - accounts_password_pam_unix_remember
         status: automated


### PR DESCRIPTION
#### Description:

The `accounts_password_pam_unix_remember` rule do the same as `accounts_password_pam_pwhistory_remember_password_auth` and `accounts_password_pam_pwhistory_remember_system_auth` rules together.

#### Rationale:

`accounts_password_pam_unix_remember` is not necessary since other rules are already doing the same.