### PR TITLE
Update accounts_password template's OVAL

### DIFF
--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -6,4 +6,10 @@
 
 {{{ bash_instantiate_variables("var_password_pam_" ~ VARIABLE) }}}
 
+{{% if product == "ol8" %}}
+if grep -sq {{{ VARIABLE }}} /etc/security/pwquality.conf.d/*.conf ; then 
+    sed -i "/{{{ VARIABLE }}}/d" /etc/security/pwquality.conf.d/*.conf
+fi
+{{% endif %}}
+
 {{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' ~ VARIABLE , '$var_password_pam_' ~ VARIABLE , '%s = %s') }}}

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -1,3 +1,8 @@
+{{% if product == "ol8" %}}
+{{% set filepath_regex="^/etc/security/pwquality\.conf(\.d/[^/]+\.conf)?$" %}}
+{{% else %}}
+{{% set filepath_regex="^/etc/security/pwquality\.conf$" %}}
+{{% endif %}}
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="3">
     {{{ oval_metadata("The password " + VARIABLE + " should meet minimum requirements") }}}
@@ -5,9 +10,6 @@
       <extend_definition comment="pwquality.so exists in system-auth" definition_ref="accounts_password_pam_pwquality" />
       <criteria operator="OR">
         <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
-        {{% if product == "ol8" %}}
-        <criterion comment="/etc/security/pwquality.conf.d/*.conf" test_ref="test_password_pam_pwquality_d_{{{ VARIABLE }}}" />
-        {{% endif %}}
       </criteria>
     </criteria>
   </definition>
@@ -23,25 +25,10 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
-    <ind:filepath>/etc/security/pwquality.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
+    <ind:filepath operation="pattern match">{{{ filepath_regex }}}</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*{{{ VARIABLE }}}[\s]*=[\s]*(-?\d+)(?:[\s]|$)</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
-  
-  {{% if product == "ol8" %}}
-  <ind:textfilecontent54_test check="all"
-  comment="check the configuration of /etc/security/pwquality.conf.d/*.conf"
-  id="test_password_pam_pwquality_d_{{{ VARIABLE }}}" version="1">
-    <ind:object object_ref="obj_password_pam_pwquality_d_{{{ VARIABLE }}}" />
-    <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="obj_password_pam_pwquality_d_{{{ VARIABLE }}}" version="1">
-    <ind:filepath operation="pattern match">^/etc/security/pwquality.conf.d/.*\.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*{{{ VARIABLE }}}[\s]*=[\s]*({{{ SIGN }}}\d+)(?:[\s]|$)</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-  {{% endif %}}
 
   <ind:textfilecontent54_state id="state_password_pam_{{{ VARIABLE }}}" version="3">
     <ind:subexpression datatype="int" operation="{{{ OPERATION }}}" var_ref="var_password_pam_{{{ VARIABLE }}}" />

--- a/shared/templates/accounts_password/template.py
+++ b/shared/templates/accounts_password/template.py
@@ -1,7 +1,5 @@
 from ssg.utils import parse_template_boolean_value
 
 def preprocess(data, lang):
-    if lang == "oval":
-        data["sign"] = "-?" if data["variable"].endswith("credit") else ""
     data["zero_comparison_operation"] = data.get("zero_comparison_operation", None)
     return data


### PR DESCRIPTION
#### Description:

- Simplify accounts_password template's OVAL to only use one object
- Update the regex that collects the configuration 

#### Rationale:

- This fixes the behavior in OL8 as the  ZERO_COMPARISON_OPERATION related state wasn't being used in `/etc/security/pwquality.conf.d/*.conf` files
- The new regex allows OVAL to see the negative numbers to catch wrong values
