### PR TITLE
Generate XCCDF 1.2 directly

### DIFF
--- a/build-scripts/cpe_generate.py
+++ b/build-scripts/cpe_generate.py
@@ -13,6 +13,7 @@ import ssg.id_translate
 import ssg.products
 import ssg.xml
 import ssg.yaml
+from ssg.constants import XCCDF12_NS
 
 # This script requires two arguments: an OVAL file and a CPE dictionary file.
 # It is designed to extract any inventory definitions and the tests, states,
@@ -20,7 +21,6 @@ import ssg.yaml
 # OVAL CPE file, along with a synchronized CPE dictionary file.
 
 oval_ns = "http://oval.mitre.org/XMLSchema/oval-definitions-5"
-xccdf_ns = "http://checklists.nist.gov/xccdf/1.1"
 cpe_ns = "http://cpe.mitre.org/dictionary/2.0"
 
 
@@ -129,7 +129,7 @@ def main():
     # Lets scrape the shorthand for the list of platforms referenced
     benchmark_cpe_names = set()
     shorthandtree = ssg.xml.parse_file(args.shorthandfile)
-    for platform in shorthandtree.findall(".//{%s}platform" % xccdf_ns):
+    for platform in shorthandtree.findall(".//{%s}platform" % XCCDF12_NS):
         cpe_name = platform.get("idref")
         # skip CPE AL platforms (they are handled later)
         # this is temporary solution until we get rid of old type of platforms in the benchmark

--- a/build-scripts/relabel_ids.py
+++ b/build-scripts/relabel_ids.py
@@ -43,7 +43,7 @@ def main():
     # Step over xccdf file, and find referenced check files
     xccdftree = ssg.xml.parse_file(xccdffile)
 
-    checks = xccdftree.findall(".//{%s}check" % ssg.constants.XCCDF11_NS)
+    checks = xccdftree.findall(".//{%s}check" % ssg.constants.XCCDF12_NS)
 
     translator = ssg.id_translate.IDTranslator(idname)
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -450,10 +450,10 @@ macro(ssg_build_sds PRODUCT)
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-12 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-12 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds-1.2.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
+            DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
             DEPENDS generate-ssg-${PRODUCT}-oval.xml
             DEPENDS generate-ssg-${PRODUCT}-ocil.xml
             DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
@@ -467,9 +467,9 @@ macro(ssg_build_sds PRODUCT)
     else()
         add_custom_command(
             OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compose_ds.py" --xccdf "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --cpe-dict "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-dictionary.xml" --cpe-oval "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-cpe-oval.xml" --output-13 "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
             COMMAND "${XMLLINT_EXECUTABLE}" --nsclean --format --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
-            DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
+            DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
             DEPENDS generate-ssg-${PRODUCT}-oval.xml
             DEPENDS generate-ssg-${PRODUCT}-ocil.xml
             DEPENDS generate-ssg-${PRODUCT}-cpe-dictionary.xml
@@ -1141,16 +1141,16 @@ macro(ssg_build_html_stig_tables PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/create-stig-overlay.py" --quiet --disa-xccdf="${DISA_STIG_REF}" --ssg-xccdf="${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml" -o "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/create-stig-overlay.py" --quiet --disa-xccdf="${DISA_STIG_REF}" --ssg-xccdf="${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" -o "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS "${DISA_STIG_REF}"
         COMMENT "[${PRODUCT}-tables] generating STIG XML overlay"
     )
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/unlinked-stig-xccdf.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam overlay "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml" --stringparam ocil-document "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/unlinked-stig-xccdf.xml" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf-apply-overlay-stig.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam overlay "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml" --stringparam ocil-document "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --output "${CMAKE_CURRENT_BINARY_DIR}/unlinked-stig-xccdf.xml" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf-apply-overlay-stig.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf-apply-overlay-stig.xslt"
         DEPENDS "${CMAKE_BINARY_DIR}/${PRODUCT}/overlays/stig_overlay.xml"
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
@@ -1184,9 +1184,9 @@ macro(ssg_build_html_stig_tables_per_profile PRODUCT STIG_PROFILE)
     add_custom_command(
         OUTPUT "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html"
         COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_BINARY_DIR}/tables"
-        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${STIG_PROFILE}" -stringparam testinfo "y" -stringparam ocil-document "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
-        DEPENDS generate-ssg-${PRODUCT}-xccdf-1.2.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
+        COMMAND "${XSLTPROC_EXECUTABLE}" -stringparam profile "${STIG_PROFILE}" -stringparam testinfo "y" -stringparam ocil-document "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml" --output "${CMAKE_BINARY_DIR}/tables/table-${PRODUCT}-${STIG_PROFILE}-testinfo.html" "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
+        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
+        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/transforms/xccdf2table-profileccirefs.xslt"
         COMMENT "[${PRODUCT}-tables] generating HTML STIG test info document for ${STIG_PROFILE}"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -393,16 +393,6 @@ macro(ssg_build_xccdf_final PRODUCT)
         DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
     )
 
-    add_custom_command(
-        OUTPUT "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
-        COMMAND "${XSLTPROC_EXECUTABLE}" --stringparam reverse_DNS "org.${SSG_VENDOR}.content" --output "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml" "${OPENSCAP_XCCDF_XSL_1_2}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
-        DEPENDS generate-ssg-${PRODUCT}-xccdf.xml
-        COMMENT "[${PRODUCT}-content] generating ssg-${PRODUCT}-xccdf-1.2.xml"
-    )
-    add_custom_target(
-        generate-ssg-${PRODUCT}-xccdf-1.2.xml
-        DEPENDS "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-xccdf-1.2.xml"
-    )
 endmacro()
 
 # Apply a final xmllint pass over the OVAL document to pretty-format the output
@@ -723,7 +713,6 @@ macro(ssg_build_product PRODUCT)
     add_dependencies(
         ${PRODUCT}-content
         generate-ssg-${PRODUCT}-xccdf.xml
-        generate-ssg-${PRODUCT}-xccdf-1.2.xml
         generate-ssg-${PRODUCT}-oval.xml
         generate-ssg-${PRODUCT}-ocil.xml
         generate-ssg-${PRODUCT}-cpe-dictionary.xml

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -377,8 +377,6 @@ ssg-rhel7-ds.xml
 ssg-rhel7-ds-1.2.xml
 ssg-rhel7-ocil.xml
 ssg-rhel7-oval.xml
-ssg-rhel7-pcidss-xccdf-1.2.xml
-ssg-rhel7-xccdf-1.2.xml
 ssg-rhel7-xccdf.xml
 ```
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -16,7 +16,7 @@ from . import constants
 from .jinja import process_file_with_macros as jinja_process_file
 
 from .xml import ElementTree
-from .constants import XCCDF11_NS
+from .constants import XCCDF12_NS
 
 REMEDIATION_TO_EXT_MAP = {
     'anaconda': '.anaconda',
@@ -664,8 +664,10 @@ def expand_xccdf_subs(fix, remediation_type):
 
         # we cannot combine elements and text easily
         # so text is in ".tail" of element
-        xccdfvarsub = ElementTree.SubElement(fix, "{%s}sub" % XCCDF11_NS, idref=varname)
+        xccdfvarsub = ElementTree.SubElement(
+            fix, "{%s}sub" % XCCDF12_NS, idref=constants.OSCAP_VALUE + varname)
         xccdfvarsub.tail = text_between_vars
+        xccdfvarsub.set("use", "legacy")
 
 
 def load_compiled_remediations(fixes_dir):

--- a/ssg/build_renumber.py
+++ b/ssg/build_renumber.py
@@ -5,8 +5,10 @@ import collections
 import os
 
 
-from .constants import OSCAP_RULE, OSCAP_VALUE, oval_namespace, XCCDF12_NS, cce_uri, ocil_cs, ocil_namespace
-from .constants import OVAL_TO_XCCDF_DATATYPE_CONSTRAINTS
+from .constants import (
+    OSCAP_RULE, OSCAP_VALUE, oval_namespace, XCCDF12_NS, cce_uri, ocil_cs,
+    ocil_namespace, OVAL_TO_XCCDF_DATATYPE_CONSTRAINTS
+)
 from .parse_oval import resolve_definition, find_extending_defs, get_container_groups
 from .xml import parse_file, map_elements_to_their_ids
 

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -960,8 +960,9 @@ class Benchmark(XCCDFEntity):
         root = ET.Element('{%s}Benchmark' % XCCDF12_NS)
         root.set('id', OSCAP_BENCHMARK + self.id_)
         root.set('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
-        root.set('xsi:schemaLocation',
-                 'http://checklists.nist.gov/xccdf/1.2 xccdf-1.2.4.xsd')
+        root.set(
+            'xsi:schemaLocation',
+            'http://checklists.nist.gov/xccdf/1.2 xccdf-1.2.4.xsd')
         root.set('style', 'SCAP_1.2')
         root.set('resolved', 'true')
         root.set('xml:lang', 'en-US')

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -487,6 +487,13 @@ class Profile(XCCDFEntity, SelectionHandler):
         else:
             return noop_rule_filterfunc
 
+    def _add_selects(self, element, selections, prefix, selected):
+        for selection in selections:
+            select = ET.Element("{%s}select" % XCCDF12_NS)
+            select.set("idref", prefix + selection)
+            select.set("selected", selected)
+            element.append(select)
+
     def to_xml_element(self):
         element = ET.Element('{%s}Profile' % XCCDF12_NS)
         element.set("id", OSCAP_PROFILE + self.id_)
@@ -506,23 +513,9 @@ class Profile(XCCDFEntity, SelectionHandler):
             plat = ET.SubElement(element, "{%s}platform" % XCCDF12_NS)
             plat.set("idref", cpe_name)
 
-        for selection in self.selected:
-            select = ET.Element("{%s}select" % XCCDF12_NS)
-            select.set("idref", OSCAP_RULE + selection)
-            select.set("selected", "true")
-            element.append(select)
-
-        for selection in self.unselected:
-            unselect = ET.Element("{%s}select" % XCCDF12_NS)
-            unselect.set("idref", OSCAP_RULE + selection)
-            unselect.set("selected", "false")
-            element.append(unselect)
-
-        for selection in self.unselected_groups:
-            unselect = ET.Element("{%s}select" % XCCDF12_NS)
-            unselect.set("idref", OSCAP_GROUP + selection)
-            unselect.set("selected", "false")
-            element.append(unselect)
+        self._add_selects(element, self.selected, OSCAP_RULE, "true")
+        self._add_selects(element, self.unselected, OSCAP_RULE, "false")
+        self._add_selects(element, self.unselected_groups, OSCAP_GROUP, "false")
 
         for value_id, selector in self.variables.items():
             refine_value = ET.Element("{%s}refine-value" % XCCDF12_NS)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -965,7 +965,6 @@ class Benchmark(XCCDFEntity):
 
     def to_xml_element(self, env_yaml=None, product_cpes=None):
         root = ET.Element('{%s}Benchmark' % XCCDF12_NS)
-        root.set('id', self.id_)
         root.set('id', OSCAP_BENCHMARK + self.id_)
         root.set('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
         root.set('xsi:schemaLocation',

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1148,7 +1148,7 @@ class Group(XCCDFEntity):
 
     def to_xml_element(self, env_yaml=None):
         group = ET.Element('{%s}Group' % XCCDF12_NS)
-        group.set('id', OSCAP_GROUP +  self.id_)
+        group.set('id', OSCAP_GROUP + self.id_)
         title = ET.SubElement(group, '{%s}title' % XCCDF12_NS)
         title.text = self.title
         add_sub_element(group, 'description', XCCDF12_NS, self.description)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -16,7 +16,13 @@ import yaml
 
 import ssg.build_remediations
 from .build_cpe import CPEDoesNotExist, CPEALLogicalTest, CPEALFactRef
-from .constants import (XCCDF11_NS,
+from .constants import (XCCDF12_NS,
+                        XCCDF_REFINABLE_PROPERTIES,
+                        OSCAP_BENCHMARK,
+                        OSCAP_GROUP,
+                        OSCAP_PROFILE,
+                        OSCAP_RULE,
+                        OSCAP_VALUE,
                         XCCDF_REFINABLE_PROPERTIES,
                         SCE_SYSTEM,
                         cce_uri,
@@ -84,6 +90,12 @@ def add_sub_element(parent, tag, ns, data):
                .format(parent.tag, ustr))
         raise RuntimeError(msg)
 
+    # Apart from HTML and XML elements the rule descriptions and similar
+    # also contain <xccdf:sub> elements, where we need to add the prefix
+    # to create a full reference.
+    for x in element.findall(".//{%s}sub" % XCCDF12_NS):
+        x.set("idref", OSCAP_VALUE + x.get("idref"))
+        x.set("use", "legacy")
     parent.append(element)
     return element
 
@@ -120,7 +132,7 @@ def add_warning_elements(element, warnings):
     # Each of the {dict} should have only one key/value pair.
     for warning_dict in warnings:
         warning = add_sub_element(
-            element, "warning", XCCDF11_NS, list(warning_dict.values())[0])
+            element, "warning", XCCDF12_NS, list(warning_dict.values())[0])
         warning.set("category", list(warning_dict.keys())[0])
 
 
@@ -128,7 +140,7 @@ def add_nondata_subelements(element, subelement, attribute, attr_data):
     """Add multiple iterations of a sublement that contains an attribute but no data
        For example, <requires id="my_required_id"/>"""
     for data in attr_data:
-        req = ET.SubElement(element, subelement)
+        req = ET.SubElement(element, "{%s}%s" % (XCCDF12_NS, subelement))
         req.set(attribute, data)
 
 
@@ -159,13 +171,13 @@ def add_reference_elements(element, references, ref_uri_dict):
                         .format(ref_type, ref_vals, self.id_))
                     raise ValueError(msg)
 
-            ref = ET.SubElement(element, '{%s}reference' % XCCDF11_NS)
+            ref = ET.SubElement(element, '{%s}reference' % XCCDF12_NS)
             ref.set("href", ref_href)
             ref.text = ref_val
 
 
 def add_benchmark_metadata(element, contributors_file):
-    metadata = ET.SubElement(element, "{%s}metadata" % XCCDF11_NS)
+    metadata = ET.SubElement(element, "{%s}metadata" % XCCDF12_NS)
 
     publisher = ET.SubElement(metadata, "{%s}publisher" % dc_namespace)
     publisher.text = SSG_PROJECT_NAME
@@ -476,51 +488,51 @@ class Profile(XCCDFEntity, SelectionHandler):
             return noop_rule_filterfunc
 
     def to_xml_element(self):
-        element = ET.Element('{%s}Profile' % XCCDF11_NS)
-        element.set("id", self.id_)
+        element = ET.Element('{%s}Profile' % XCCDF12_NS)
+        element.set("id", OSCAP_PROFILE + self.id_)
         if self.extends:
             element.set("extends", self.extends)
-        title = add_sub_element(element, "title", XCCDF11_NS, self.title)
+        title = add_sub_element(element, "title", XCCDF12_NS, self.title)
         title.set("override", "true")
         desc = add_sub_element(
-            element, "description", XCCDF11_NS, self.description)
+            element, "description", XCCDF12_NS, self.description)
         desc.set("override", "true")
 
         if self.reference:
             add_sub_element(
-                element, "reference", XCCDF11_NS, escape(self.reference))
+                element, "reference", XCCDF12_NS, escape(self.reference))
 
         for cpe_name in self.cpe_names:
-            plat = ET.SubElement(element, "{%s}platform" % XCCDF11_NS)
+            plat = ET.SubElement(element, "{%s}platform" % XCCDF12_NS)
             plat.set("idref", cpe_name)
 
         for selection in self.selected:
-            select = ET.Element("{%s}select" % XCCDF11_NS)
-            select.set("idref", selection)
+            select = ET.Element("{%s}select" % XCCDF12_NS)
+            select.set("idref", OSCAP_RULE + selection)
             select.set("selected", "true")
             element.append(select)
 
         for selection in self.unselected:
-            unselect = ET.Element("{%s}select" % XCCDF11_NS)
-            unselect.set("idref", selection)
+            unselect = ET.Element("{%s}select" % XCCDF12_NS)
+            unselect.set("idref", OSCAP_RULE + selection)
             unselect.set("selected", "false")
             element.append(unselect)
 
         for selection in self.unselected_groups:
-            unselect = ET.Element("{%s}select" % XCCDF11_NS)
-            unselect.set("idref", selection)
+            unselect = ET.Element("{%s}select" % XCCDF12_NS)
+            unselect.set("idref", OSCAP_GROUP + selection)
             unselect.set("selected", "false")
             element.append(unselect)
 
         for value_id, selector in self.variables.items():
-            refine_value = ET.Element("{%s}refine-value" % XCCDF11_NS)
-            refine_value.set("idref", value_id)
+            refine_value = ET.Element("{%s}refine-value" % XCCDF12_NS)
+            refine_value.set("idref", OSCAP_VALUE + value_id)
             refine_value.set("selector", selector)
             element.append(refine_value)
 
         for refined_rule, refinement_list in self.refine_rules.items():
-            refine_rule = ET.Element("{%s}refine-rule" % XCCDF11_NS)
-            refine_rule.set("idref", refined_rule)
+            refine_rule = ET.Element("{%s}refine-rule" % XCCDF12_NS)
+            refine_rule.set("idref", OSCAP_RULE + refined_rule)
             for refinement in refinement_list:
                 refine_rule.set(refinement[0], refinement[1])
             element.append(refine_rule)
@@ -807,22 +819,22 @@ class Value(XCCDFEntity):
         return value
 
     def to_xml_element(self):
-        value = ET.Element('{%s}Value' % XCCDF11_NS)
-        value.set('id', self.id_)
+        value = ET.Element('{%s}Value' % XCCDF12_NS)
+        value.set('id', OSCAP_VALUE + self.id_)
         value.set('type', self.type)
         if self.operator != "equals":  # equals is the default
             value.set('operator', self.operator)
         if self.interactive:  # False is the default
             value.set('interactive', 'true')
-        title = ET.SubElement(value, '{%s}title' % XCCDF11_NS)
+        title = ET.SubElement(value, '{%s}title' % XCCDF12_NS)
         title.text = self.title
-        add_sub_element(value, 'description', XCCDF11_NS, self.description)
+        add_sub_element(value, 'description', XCCDF12_NS, self.description)
         add_warning_elements(value, self.warnings)
 
         for selector, option in self.options.items():
             # do not confuse Value with big V with value with small v
             # value is child element of Value
-            value_small = ET.SubElement(value, '{%s}value' % XCCDF11_NS)
+            value_small = ET.SubElement(value, '{%s}value' % XCCDF12_NS)
             # by XCCDF spec, default value is value without selector
             if selector != "default":
                 value_small.set('selector', str(selector))
@@ -952,24 +964,25 @@ class Benchmark(XCCDFEntity):
             p.unselect_empty_groups(self)
 
     def to_xml_element(self, env_yaml=None, product_cpes=None):
-        root = ET.Element('{%s}Benchmark' % XCCDF11_NS)
+        root = ET.Element('{%s}Benchmark' % XCCDF12_NS)
         root.set('id', self.id_)
+        root.set('id', OSCAP_BENCHMARK + self.id_)
         root.set('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
         root.set('xsi:schemaLocation',
-                 'http://checklists.nist.gov/xccdf/1.1 xccdf-1.1.4.xsd')
-        root.set('style', 'SCAP_1.1')
+                 'http://checklists.nist.gov/xccdf/1.2 xccdf-1.2.4.xsd')
+        root.set('style', 'SCAP_1.2')
         root.set('resolved', 'true')
         root.set('xml:lang', 'en-US')
-        status = ET.SubElement(root, '{%s}status' % XCCDF11_NS)
+        status = ET.SubElement(root, '{%s}status' % XCCDF12_NS)
         status.set('date', datetime.date.today().strftime("%Y-%m-%d"))
         status.text = self.status
-        add_sub_element(root, "title", XCCDF11_NS, self.title)
-        add_sub_element(root, "description", XCCDF11_NS, self.description)
+        add_sub_element(root, "title", XCCDF12_NS, self.title)
+        add_sub_element(root, "description", XCCDF12_NS, self.description)
         notice = add_sub_element(
-            root, "notice", XCCDF11_NS, self.notice_description)
+            root, "notice", XCCDF12_NS, self.notice_description)
         notice.set('id', self.notice_id)
-        add_sub_element(root, "front-matter", XCCDF11_NS, self.front_matter)
-        add_sub_element(root, "rear-matter",  XCCDF11_NS, self.rear_matter)
+        add_sub_element(root, "front-matter", XCCDF12_NS, self.front_matter)
+        add_sub_element(root, "rear-matter",  XCCDF12_NS, self.rear_matter)
         # if there are no platforms, do not output platform-specification at all
         if len(self.product_cpes.platforms) > 0:
             cpe_platform_spec = ET.Element(
@@ -981,10 +994,10 @@ class Benchmark(XCCDFEntity):
         # The Benchmark applicability is determined by the CPEs
         # defined in the product.yml
         for cpe_name in self.product_cpe_names:
-            plat = ET.SubElement(root, "{%s}platform" % XCCDF11_NS)
+            plat = ET.SubElement(root, "{%s}platform" % XCCDF12_NS)
             plat.set("idref", cpe_name)
 
-        version = ET.SubElement(root, '{%s}version' % XCCDF11_NS)
+        version = ET.SubElement(root, '{%s}version' % XCCDF12_NS)
         version.text = self.version
         version.set('update', SSG_BENCHMARK_LATEST_URI)
 
@@ -1134,25 +1147,26 @@ class Group(XCCDFEntity):
         return yaml_contents
 
     def to_xml_element(self, env_yaml=None):
-        group = ET.Element('{%s}Group' % XCCDF11_NS)
-        group.set('id', self.id_)
-        title = ET.SubElement(group, '{%s}title' % XCCDF11_NS)
+        group = ET.Element('{%s}Group' % XCCDF12_NS)
+        group.set('id', OSCAP_GROUP +  self.id_)
+        title = ET.SubElement(group, '{%s}title' % XCCDF12_NS)
         title.text = self.title
-        add_sub_element(group, 'description', XCCDF11_NS, self.description)
+        add_sub_element(group, 'description', XCCDF12_NS, self.description)
         add_warning_elements(group, self.warnings)
 
         # This is where references should be put if there are any
         # This is where rationale should be put if there are any
 
         for cpe_platform_name in self.cpe_platform_names:
-            platform_el = ET.SubElement(group, "{%s}platform" % XCCDF11_NS)
+            platform_el = ET.SubElement(group, "{%s}platform" % XCCDF12_NS)
             platform_el.set("idref", "#"+cpe_platform_name)
 
         add_nondata_subelements(
-            group, "{%s}requires" % XCCDF11_NS, "idref", self.requires)
+            group, "requires", "idref",
+            list(map(lambda x: OSCAP_GROUP + x, self.requires)))
         add_nondata_subelements(
-            group, "{%s}conflicts" % XCCDF11_NS, "idref", self.conflicts)
-
+            group, "conflicts", "idref",
+            list(map(lambda x: OSCAP_GROUP + x, self.conflicts)))
         for _value in self.values.values():
             group.append(_value.to_xml_element())
 
@@ -1559,7 +1573,7 @@ class Rule(XCCDFEntity):
 
     def _add_fixes_elements(self, rule_el):
         for fix_type, fix in self.fixes.items():
-            fix_el = ET.SubElement(rule_el, "{%s}fix" % XCCDF11_NS)
+            fix_el = ET.SubElement(rule_el, "{%s}fix" % XCCDF12_NS)
             fix_el.set("system", FIX_TYPE_TO_SYSTEM[fix_type])
             fix_el.set("id", self.id_)
             fix_contents, config = fix
@@ -1572,12 +1586,12 @@ class Rule(XCCDFEntity):
             ssg.build_remediations.expand_xccdf_subs(fix_el, fix_type)
 
     def to_xml_element(self, env_yaml=None):
-        rule = ET.Element('{%s}Rule' % XCCDF11_NS)
+        rule = ET.Element('{%s}Rule' % XCCDF12_NS)
         rule.set('selected', 'false')
-        rule.set('id', self.id_)
+        rule.set('id', OSCAP_RULE + self.id_)
         rule.set('severity', self.severity)
-        add_sub_element(rule, 'title', XCCDF11_NS, self.title)
-        add_sub_element(rule, 'description', XCCDF11_NS, self.description)
+        add_sub_element(rule, 'title', XCCDF12_NS, self.title)
+        add_sub_element(rule, 'description', XCCDF12_NS, self.description)
         add_warning_elements(rule, self.warnings)
 
         if env_yaml:
@@ -1586,19 +1600,21 @@ class Rule(XCCDFEntity):
             ref_uri_dict = SSG_REF_URIS
         add_reference_elements(rule, self.references, ref_uri_dict)
 
-        add_sub_element(rule, 'rationale', XCCDF11_NS, self.rationale)
+        add_sub_element(rule, 'rationale', XCCDF12_NS, self.rationale)
 
         for cpe_platform_name in sorted(self.cpe_platform_names):
-            platform_el = ET.SubElement(rule, "{%s}platform" % XCCDF11_NS)
+            platform_el = ET.SubElement(rule, "{%s}platform" % XCCDF12_NS)
             platform_el.set("idref", "#"+cpe_platform_name)
 
         add_nondata_subelements(
-            rule, "{%s}requires" % XCCDF11_NS, "idref", self.requires)
+            rule, "requires", "idref",
+            list(map(lambda x: OSCAP_RULE + x, self.requires)))
         add_nondata_subelements(
-            rule, "{%s}conflicts" % XCCDF11_NS, "idref", self.conflicts)
+            rule, "conflicts", "idref",
+            list(map(lambda x: OSCAP_RULE + x, self.conflicts)))
 
         for ident_type, ident_val in self.identifiers.items():
-            ident = ET.SubElement(rule, '{%s}ident' % XCCDF11_NS)
+            ident = ET.SubElement(rule, '{%s}ident' % XCCDF12_NS)
             if ident_type == 'cce':
                 ident.set('system', cce_uri)
                 ident.text = ident_val
@@ -1632,15 +1648,15 @@ class Rule(XCCDFEntity):
                 # is present, and add update ocil_parent accordingly.
                 if self.ocil or self.ocil_clause:
                     ocil_parent = ET.SubElement(
-                        ocil_parent, "{%s}complex-check" % XCCDF11_NS)
+                        ocil_parent, "{%s}complex-check" % XCCDF12_NS)
                     ocil_parent.set('operator', 'OR')
 
                 check_parent = ET.SubElement(
-                    ocil_parent, "{%s}complex-check" % XCCDF11_NS)
+                    ocil_parent, "{%s}complex-check" % XCCDF12_NS)
                 check_parent.set('operator', self.sce_metadata['complex-check'])
 
             # Now, add the SCE check element to the tree.
-            check = ET.SubElement(check_parent, "{%s}check" % XCCDF11_NS)
+            check = ET.SubElement(check_parent, "{%s}check" % XCCDF12_NS)
             check.set("system", SCE_SYSTEM)
 
             if 'check-import' in self.sce_metadata:
@@ -1648,7 +1664,7 @@ class Rule(XCCDFEntity):
                     self.sce_metadata['check-import'] = [self.sce_metadata['check-import']]
                 for entry in self.sce_metadata['check-import']:
                     check_import = ET.SubElement(
-                        check, '{%s}check-import' % XCCDF11_NS)
+                        check, '{%s}check-import' % XCCDF12_NS)
                     check_import.set('import-name', entry)
                     check_import.text = None
 
@@ -1658,20 +1674,20 @@ class Rule(XCCDFEntity):
                 for entry in self.sce_metadata['check-export']:
                     export, value = entry.split('=')
                     check_export = ET.SubElement(
-                        check, '{%s}check-export' % XCCDF11_NS)
+                        check, '{%s}check-export' % XCCDF12_NS)
                     check_export.set('value-id', value)
                     check_export.set('export-name', export)
                     check_export.text = None
 
             check_ref = ET.SubElement(
-                check, "{%s}check-content-ref" % XCCDF11_NS)
+                check, "{%s}check-content-ref" % XCCDF12_NS)
             href = self.sce_metadata['relative_path']
             check_ref.set("href", href)
 
-        check = ET.SubElement(check_parent, '{%s}check' % XCCDF11_NS)
+        check = ET.SubElement(check_parent, '{%s}check' % XCCDF12_NS)
         check.set("system", oval_namespace)
         check_content_ref = ET.SubElement(
-            check, "{%s}check-content-ref" % XCCDF11_NS)
+            check, "{%s}check-content-ref" % XCCDF12_NS)
         if self.oval_external_content:
             check_content_ref.set("href", self.oval_external_content)
         else:
@@ -1686,10 +1702,10 @@ class Rule(XCCDFEntity):
 
         patches_up_to_date = (self.id_ == "security_patches_up_to_date")
         if (self.ocil or self.ocil_clause) and not patches_up_to_date:
-            ocil_check = ET.SubElement(check_parent, "{%s}check" % XCCDF11_NS)
+            ocil_check = ET.SubElement(check_parent, "{%s}check" % XCCDF12_NS)
             ocil_check.set("system", ocil_cs)
             ocil_check_ref = ET.SubElement(
-                ocil_check, "{%s}check-content-ref" % XCCDF11_NS)
+                ocil_check, "{%s}check-content-ref" % XCCDF12_NS)
             ocil_check_ref.set("href", "ocil-unlinked.xml")
             ocil_check_ref.set("name", self.id_ + "_ocil")
 

--- a/ssg/checks.py
+++ b/ssg/checks.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import os
 
-from .constants import XCCDF11_NS
+from .constants import XCCDF12_NS
 from .oval import parse_affected
 from .utils import read_file_list
 
@@ -17,7 +17,7 @@ def get_content_ref_if_exists_and_not_remote(check):
 
     ..see-also:: is_content_href_remote
     """
-    checkcontentref = check.find("./{%s}check-content-ref" % XCCDF11_NS)
+    checkcontentref = check.find("./{%s}check-content-ref" % XCCDF12_NS)
     if checkcontentref is None:
         return None
     if is_content_href_remote(checkcontentref):

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -100,9 +100,11 @@ ssg_version_uri = \
     "https://github.com/ComplianceAsCode/content/releases/latest"
 OSCAP_VENDOR = "org.ssgproject"
 OSCAP_DS_STRING = "xccdf_%s.content_benchmark_" % OSCAP_VENDOR
+OSCAP_BENCHMARK = "xccdf_%s.content_benchmark_" % OSCAP_VENDOR
 OSCAP_PROFILE = "xccdf_%s.content_profile_" % OSCAP_VENDOR
 OSCAP_GROUP = "xccdf_%s.content_group_" % OSCAP_VENDOR
 OSCAP_RULE = "xccdf_%s.content_rule_" % OSCAP_VENDOR
+OSCAP_VALUE = "xccdf_%s.content_value_" % OSCAP_VENDOR
 OSCAP_GROUP_PCIDSS = "xccdf_%s.content_group_pcidss-req" % OSCAP_VENDOR
 OSCAP_GROUP_VAL = "xccdf_%s.content_group_values" % OSCAP_VENDOR
 OSCAP_GROUP_NON_PCI = "xccdf_%s.content_group_non-pci-dss" % OSCAP_VENDOR


### PR DESCRIPTION
#### Description:
Generate XCCDF 1.2 directly from the resolved YAML files. Stop using interim XCCDF 1.1 build step. The `build/$product/shorthand.xml` becomes a valid XCCDF 1.2 file.

For more details, please read commit messages of every commit.

#### Rationale:
* Reduces build complexity by removing the XCCDF 1.1 build step
* Build no longer depends on the XSLT template converting XCCDF 1.1 to 1.2 provided by openscap RPM package
* Stop using outdated XCCDF 1.1 standard
* Enables improvements in CPE AL in future.
