### PR TITLE
Make groups inherit platforms from parent groups

### DIFF
--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -42,6 +42,19 @@ TEST_TEMPLATE_DICT = {
 }
 
 
+def test_rule_platforms_inheritance():
+    group1 = ssg.build_yaml.Group('gr1_id')
+    group1.platforms = {'pl0', 'pl1'}
+    group2 = ssg.build_yaml.Group('gr2_id')
+    group2.platforms = {'pl1', 'pl2'}
+    rule = ssg.build_yaml.Rule('rul_id')
+    rule.platforms = {'plX'}
+    group1.add_group(group2)
+    group2.add_rule(rule)
+    assert rule.inherited_platforms == {'pl0', 'pl1', 'pl2'}
+    assert rule.platforms == {'plX'}
+
+
 def test_make_items_product_specific():
     rule = ssg.build_yaml.Rule("something")
 


### PR DESCRIPTION
This is a creative revert of the revert (#6807) of the fix (#6772).

#### Description:

Rules will now inherit platforms from the whole group hierarchy not only the direct parent.

#### Rationale:

Previous implementation propagated group platforms to rules only from the closest group in hierarchy. This fixes it. you can see a good example with rule file_groupowner_efi_grub2_cfg. Before this PR, the rule inherited only platform "uefi". After this PR, it inherits also "grub2". This manifests in the rule remediation. Before this PR the remediation was actually not checking if grub2 package is installed.