### PR TITLE
bugfix: accounts_password_all_shadowed_sha512: add !* as locked

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -18,7 +18,7 @@
     <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
   </unix:shadow_object>
   <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
-      <unix:password operation="pattern match">^(!|!!|\*|!locked)$</unix:password>
+      <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked)$</unix:password>
   </unix:shadow_state>
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
       <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-echo 'test1:$6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/:18793:0:99999:7:::' >> /etc/shadow
+{
+echo 'test1:$6$kcOnRq/5$NUEYPuyL.wghQwWssXRcLRFiiru7f5JPV6GaJhNC2aK5F3PZpE/BCCtwrxRc/AInKMNX3CdMw11m9STiql12f/:18793:0:99999:7:::'
+echo 'locked1:!:18793:0:99999:7:::'
+echo 'locked2:!!:18793:0:99999:7:::'
+echo 'locked3:!*:18793:0:99999:7:::'
+echo 'locked4:*:18793:0:99999:7:::'
+echo 'locked5:!locked:18793:0:99999:7:::'
+} >> /etc/shadow


### PR DESCRIPTION
#### Description:

Add one more locked format, `!*`. Seen in Fedora 36.

#### Rationale:

At Fedora 36 test container  there is:

	systemd-network:!*:19236::::::
	systemd-oom:!*:19236::::::

Add locked formats to test.