### PR TITLE
fix: service_disabled/tests: handle socket actication services

### DIFF
--- a/shared/templates/service_disabled/tests/service_disabled.pass.sh
+++ b/shared/templates/service_disabled/tests/service_disabled.pass.sh
@@ -2,11 +2,15 @@
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
-"$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.service' | grep -q '^{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+fi
 # Disable socket activation if we have a unit file for it
-if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.socket' | grep -q '^{{{ DAEMONNAME }}}.socket'; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
     "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
 fi

--- a/shared/templates/service_disabled/tests/service_enabled.fail.sh
+++ b/shared/templates/service_disabled/tests/service_enabled.fail.sh
@@ -2,9 +2,18 @@
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
-"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.service' | grep -q '^{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+fi
+# Disable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.socket' | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.socket'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.socket'
+fi
 
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.


### PR DESCRIPTION
#### Description:

Some systemd services use only socket activation. Like  `telnet-server` under Fedora. Fix their tests.

#### Rationale:

They have service like: `<name>@.service` and are only meant to be used
via socket activation via `<name>.socket`.

Also there is considerable speed difference between slow:
	systemctl list-unit-files
and fast:
	systemctl list-unit-files <name>.<type>

Use fast solution here.

Without this patch rules using these templates fail when tested under default test container when there is socket activation used. There is some package name mismatches too, but more on that in another PR.