### PR TITLE
bugfix: service_sssd_enabled: fix tests

### DIFF
--- a/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8
+prodtype: fedora,ol7,ol8,rhel7,rhel8
 
 title: 'Enable the SSSD Service'
 

--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/common.sh
@@ -1,0 +1,21 @@
+# sssd.service needs /etc/sssd/sssd.conf to start
+if [ ! -f /etc/sssd/sssd.conf ]; then
+	cat << EOF > /etc/sssd/sssd.conf
+[sssd]
+config_file_version = 2
+services = nss, pam
+domains = example.com
+
+[domain/example.com]
+id_provider = files
+access_provider = simple
+simple_allow_users = user1, user2
+
+[nss]
+filter_groups = root
+filter_users = root
+
+[pam]
+EOF
+	chmod 0600 /etc/sssd/sssd.conf
+fi

--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_disabled.fail.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_disabled.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = sssd
+
+source common.sh
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" stop 'sssd.service'
+"$SYSTEMCTL_EXEC" disable 'sssd.service'

--- a/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_enabled.pass.sh
+++ b/linux_os/guide/services/sssd/service_sssd_enabled/tests/service_enabled.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = sssd
+
+source common.sh
+
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" unmask 'sssd.service'
+"$SYSTEMCTL_EXEC" start 'sssd.service'
+"$SYSTEMCTL_EXEC" enable 'sssd.service'


### PR DESCRIPTION
### Description:

Mock `/etc/sssd/sssd.conf` if none exists yet when testing `service_sssd_enabled`.

#### Rationale:

In Fedora 36 `sssd.service` has this:
```
	ConditionPathExists=|/etc/sssd/sssd.conf
```
So test fails because service is not able to start.

sssd requires `/etc/sssd/sssd.conf` to have perms 0600 or it refuses to start.

Rule is about SSSD Service, not about config. So decided not to test config or perms in any way.

Under Fedora 36 there is  no default  config.