### PR TITLE
bugfix: sudoers_validate_passwd/tests: /etc/sudoers.d can be empty

### DIFF
--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_passwd.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_passwd.fail.sh
@@ -1,7 +1,8 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,SUSE Linux Enterprise 15
 # packages = sudo
 
+touch /etc/sudoers.d/empty
 if [ $(grep -Ei '(!rootpw|!targetpw|!runaspw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#' | wc -l) -ne 0 ]
 then
-     sed -i '/Defaults !targetpw/{:a;N;/Defaults !runaspw/!ba};/Defaults !rootpw/d' /etc/sudoers
+     sed -i '/Defaults !targetpw/{:a;N;/Defaults !runaspw/!ba};/Defaults !rootpw/d' /etc/sudoers /etc/sudoers.d/*
 fi

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_rootpw.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_rootpw.fail.sh
@@ -1,7 +1,8 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,SUSE Linux Enterprise 15
 # packages = sudo
 
+touch /etc/sudoers.d/empty
 if [ $(grep -Ei '(!rootpw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#' | wc -l) -ne 0 ]
 then
-     sed -i '/Defaults !rootpw/d' /etc/sudoers
+     sed -i '/Defaults !rootpw/d' /etc/sudoers /etc/sudoers.d/*
 fi

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_runaspw.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_runaspw.fail.sh
@@ -1,7 +1,8 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,SUSE Linux Enterprise 15
 # packages = sudo
 
+touch /etc/sudoers.d/empty
 if [ $(grep -Ei '(!runaspw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#' | wc -l) -ne 0 ]
 then
-     sed -i '/Defaults !runaspw/d' /etc/sudoers
+     sed -i '/Defaults !runaspw/d' /etc/sudoers /etc/sudoers.d/*
 fi

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_targetpw.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/tests/sudoers_validate_targetpw.fail.sh
@@ -1,7 +1,8 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,SUSE Linux Enterprise 15
 # packages = sudo
 
+touch /etc/sudoers.d/empty
 if [ $(grep -Ei '(!targetpw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#' | wc -l) -ne 0 ]
 then
-     sed -i '/Defaults !targetpw/d' /etc/sudoers
+     sed -i '/Defaults !targetpw/d' /etc/sudoers /etc/sudoers.d/*
 fi


### PR DESCRIPTION
#### Description:

Under minimal containers when test scripts uses glob and then directory is empty, tests fail. Simplest way to handle situation is to create empty file under the directory.

#### Rationale:

Add a file, so /etc/sudoers.d is not empty and glob does not fail.

Also handle situation where there is already other file under
/etc/sudoers.d where there is the directive under test.

Another possibility could be to use
```
shopt -s nullglob
```
Or use any other way to work around the star glob.

But I think empty file is just fine in these test scripts.