### PR TITLE
bugfix: package_gdm_removed: package name is gdm, not quagga

### DIFF
--- a/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
@@ -57,9 +57,9 @@ ocil: |-
     <pre>dpkg-query: no packages found matching gdm3</pre>
 {{% endif %}}
 
-fixtext: '{{{ fixtext_package_removed("quagga") }}}'
+fixtext: '{{{ fixtext_package_removed("gdm") }}}'
 
-srg_requirement: '{{{ srg_requirement_package_removed("quagga") }}}'
+srg_requirement: '{{{ srg_requirement_package_removed("gdm") }}}'
 
 template:
     name: package_removed


### PR DESCRIPTION
#### Description:

Copy-paste error in rule text.

#### Rationale:

More consistent look now.