### PR TITLE
Prefer platform_package_overrides

### DIFF
--- a/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
+++ b/linux_os/guide/services/avahi/disable_avahi_group/service_avahi-daemon_disabled/rule.yml
@@ -51,6 +51,3 @@ template:
     vars:
         servicename: avahi-daemon
         packagename: avahi
-        packagename@ubuntu1604: avahi-daemon
-        packagename@ubuntu1804: avahi-daemon
-        packagename@ubuntu2004: avahi-daemon

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -1,3 +1,5 @@
+{{%- set package = "dhcp" -%}}
+
 documentation_complete: true
 
 prodtype: ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
@@ -7,13 +9,7 @@ title: 'Uninstall DHCP Server Package'
 description: |-
     If the system does not need to act as a DHCP server,
     the dhcp package can be uninstalled.
-    {{% if 'ubuntu' in product %}}
-    {{{ describe_package_remove(package="isc-dhcp-server") }}}
-    {{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
-    {{{ describe_package_remove(package="dhcp-server") }}}
-    {{% else %}}
-    {{{ describe_package_remove(package="dhcp") }}}
-    {{% endif %}}
+    {{{ describe_package_remove(package=package) }}}
 
 rationale: |-
     Removing the DHCP server ensures that it cannot be easily or
@@ -27,7 +23,7 @@ identifiers:
     cce@rhel9: CCE-84240-1
     cce@sle12: CCE-91453-1
     cce@sle15: CCE-85759-9
-    
+
 references:
     anssi: BP28(R1)
     cis-csc: 11,14,3,9
@@ -44,20 +40,9 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
 
-{{% if 'ubuntu' in product %}}
-{{{ complete_ocil_entry_package(package="isc-dhcp-server") }}}
-{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
-{{{ complete_ocil_entry_package(package="dhcp-server") }}}
-{{% else %}}
-{{{ complete_ocil_entry_package(package="dhcp") }}}
-{{% endif %}}
+{{{ complete_ocil_entry_package(package=package) }}}
 
 template:
     name: package_removed
     vars:
-        pkgname: dhcp
-        pkgname@rhel8: dhcp-server
-        pkgname@rhel9: dhcp-server
-        pkgname@ubuntu1604: isc-dhcp-server
-        pkgname@ubuntu1804: isc-dhcp-server
-        pkgname@ubuntu2004: isc-dhcp-server
+        pkgname: {{{ package }}}

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/rule.yml
@@ -49,5 +49,3 @@ template:
     vars:
         servicename: dhcpd
         packagename: dhcp
-        packagename@rhel8: dhcp-server
-        packagename@rhel9: dhcp-server

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/service_enabled.fail.sh
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/service_dhcpd_disabled/tests/service_enabled.fail.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
-{{% if product in ['rhel7', 'sle15'] %}}
-    {{% set pkp_name="dhcp" %}}
-{{% else %}}
-    {{% set pkp_name="dhcp-server" %}}
-{{% endif %}}
-# packages = {{{ pkp_name }}}
+# packages = dhcp
 
 # Simple configuration for dhcp so we can start the service
 cat << EOF >> /etc/dhcp/dhcpd.conf

--- a/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/service_rsh_disabled/rule.yml
@@ -45,3 +45,4 @@ template:
     name: service_disabled
     vars:
         servicename: rsh
+        packagename: rsh-server

--- a/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/service_rsyncd_disabled/rule.yml
@@ -38,6 +38,3 @@ template:
     vars:
         servicename: rsyncd
         packagename: rsync-daemon
-        packagename@rhel7: rsync
-        packagename@ol7: rsync
-        packagename@sle15: rsync

--- a/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
+++ b/linux_os/guide/services/obsolete/telnet/service_telnet_disabled/rule.yml
@@ -65,3 +65,4 @@ template:
     name: service_disabled
     vars:
         servicename: telnet
+        packagename: telnet-server

--- a/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/service_snmpd_disabled/rule.yml
@@ -38,7 +38,4 @@ template:
     name: service_disabled
     vars:
         servicename: snmpd
-        packagename@debian9: snmpd
-        packagename@debian10: snmpd
-        packagename@debian11: snmpd
         packagename: net-snmp

--- a/linux_os/guide/services/ssh/service_sshd_disabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_disabled/rule.yml
@@ -28,8 +28,6 @@ template:
     vars:
         servicename: sshd
         packagename: openssh-server
-        packagename@opensuse: openssh
-        packagename@sle12: openssh
         daemonname@debian9: ssh
         daemonname@debian10: ssh
         daemonname@debian11: ssh

--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -59,8 +59,6 @@ template:
         servicename@ubuntu1804: ssh
         servicename@ubuntu2004: ssh
         packagename: openssh-server
-        packagename@sle12: openssh
-        packagename@sle15: openssh
 
 fixtext: |-
     {{{ fixtext_service_enabled("sshd") }}}

--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -59,8 +59,5 @@ template:
     vars:
         servicename: apparmor
         packagename: apparmor-parser
-        packagename@ubuntu1604: apparmor
-        packagename@ubuntu1804: apparmor
-        packagename@ubuntu2004: apparmor
 
 platform: machine

--- a/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
+++ b/linux_os/guide/system/auditing/service_auditd_enabled/rule.yml
@@ -86,9 +86,3 @@ template:
     vars:
         servicename: auditd
         packagename: audit
-        packagename@debian9: auditd
-        packagename@debian10: auditd
-        packagename@debian11: auditd
-        packagename@ubuntu1604: auditd
-        packagename@ubuntu1804: auditd
-        packagename@ubuntu2004: auditd

--- a/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
+++ b/linux_os/guide/system/software/gnome/package_gdm_removed/rule.yml
@@ -1,3 +1,5 @@
+{{%- set package = "gdm" -%}}
+
 documentation_complete: true
 
 prodtype: fedora,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
@@ -5,19 +7,11 @@ prodtype: fedora,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 title: 'Remove the GDM Package Group'
 
 description: |-
-    {{% if 'ubuntu' not in product %}}
-    By removing the <tt>gdm</tt> package, the system no longer has GNOME installed
-    {{% else %}}
-    By removing the <tt>gdm3</tt> package, the system no longer has GNOME installed
-    {{% endif %}}
+    By removing the <tt>{{{ package }}}</tt> package, the system no longer has GNOME installed
     installed. If X Windows is not installed then the system cannot boot into graphical user mode.
     This prevents the system from being accidentally or maliciously booted into a <tt>graphical.target</tt>
     mode. To do so, run the following command:
-    {{% if 'ubuntu' not in product %}}
-    <pre>$ sudo yum remove gdm</pre>
-    {{% else %}}
-    <pre>$ sudo apt remove gdm3</pre>
-    {{% endif %}}
+    {{{ describe_package_remove(package=package) }}}
 
 rationale: |-
     Unnecessary service packages must not be installed to decrease the attack surface of the system.
@@ -37,34 +31,13 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a)
     srg: SRG-OS-000480-GPOS-00227
 
-{{% if 'ubuntu' not in product %}}
-ocil_clause: 'gdm has not been removed'
+{{{ complete_ocil_entry_package(package=package) }}}
 
-ocil: |-
-    To ensure the gdm package group is removed, run the following command:
-    <pre>$ rpm -qi gdm</pre>
-    The output should be:
-    <pre>package gdm is not installed</pre>
-{{% else %}}
-ocil_clause: 'gdm3 has not been removed'
+fixtext: '{{{ fixtext_package_removed(package) }}}'
 
-ocil: |-
-    To ensure the gdm3 package group is removed, run the following command:
-    <pre>$ dpkg -l gdm3</pre>
-    The output should begin with:
-    <pre>rc gdm3</pre>
-    Or
-    <pre>dpkg-query: no packages found matching gdm3</pre>
-{{% endif %}}
-
-fixtext: '{{{ fixtext_package_removed("gdm") }}}'
-
-srg_requirement: '{{{ srg_requirement_package_removed("gdm") }}}'
+srg_requirement: '{{{ srg_requirement_package_removed(package) }}}'
 
 template:
     name: package_removed
     vars:
-        pkgname: gdm
-        pkgname@ubuntu1604: gdm3
-        pkgname@ubuntu1804: gdm3
-        pkgname@ubuntu2004: gdm3
+        pkgname: {{{ package }}}

--- a/products/debian10/product.yml
+++ b/products/debian10/product.yml
@@ -24,6 +24,7 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
+  audit: auditd
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/debian10/product.yml
+++ b/products/debian10/product.yml
@@ -28,7 +28,7 @@ platform_package_overrides:
   avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/debian10/product.yml
+++ b/products/debian10/product.yml
@@ -25,6 +25,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/debian11/product.yml
+++ b/products/debian11/product.yml
@@ -22,6 +22,7 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
+  audit: auditd
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/debian11/product.yml
+++ b/products/debian11/product.yml
@@ -26,7 +26,7 @@ platform_package_overrides:
   avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/debian11/product.yml
+++ b/products/debian11/product.yml
@@ -23,6 +23,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/debian9/product.yml
+++ b/products/debian9/product.yml
@@ -24,6 +24,7 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
+  audit: auditd
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/debian9/product.yml
+++ b/products/debian9/product.yml
@@ -28,7 +28,7 @@ platform_package_overrides:
   avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/debian9/product.yml
+++ b/products/debian9/product.yml
@@ -25,6 +25,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -79,4 +79,5 @@ previous_pkg_release: "601c49ca"
 
 # Mapping of CPE platform to package
 platform_package_overrides:
+  dhcp: "dhcp-server"
   login_defs: "shadow-utils"

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -31,6 +31,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"
+  rsync-daemon: rsync
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/oracle_linux/'

--- a/products/opensuse/product.yml
+++ b/products/opensuse/product.yml
@@ -11,6 +11,9 @@ pkg_manager: "zypper"
 
 init_system: "systemd"
 
+platform_package_overrides:
+  openssh-server: openssh
+
 cpes_root: "../../shared/applicability"
 cpes:
   - opensuse-42.1:

--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -58,6 +58,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"
+  rsync-daemon: rsync
 
 centos_pkg_release: "53a7ff4b"
 centos_pkg_version: "f4a80eb5"

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -92,6 +92,7 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
+  dhcp: "dhcp-server"
   login_defs: "shadow-utils"
 
 centos_pkg_release: "5ccc5b19"

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -42,6 +42,7 @@ cpes:
 
 # Mapping of CPE platform to package
 platform_package_overrides:
+  dhcp: "dhcp-server"
   login_defs: "shadow-utils"
 
 reference_uris:

--- a/products/sle12/product.yml
+++ b/products/sle12/product.yml
@@ -31,6 +31,7 @@ cpes:
 platform_package_overrides:
   login_defs: "shadow"
   grub2: "grub2"
+  openssh-server: openssh
   sssd: "sssd"
 
 auid: 1000

--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -36,6 +36,7 @@ cpes:
 platform_package_overrides:
   login_defs: "shadow"
   grub2: "grub2"
+  rsync-daemon: rsync
   sssd: "sssd"
 
 auid: 1000

--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -36,6 +36,7 @@ cpes:
 platform_package_overrides:
   login_defs: "shadow"
   grub2: "grub2"
+  openssh-server: openssh
   rsync-daemon: rsync
   sssd: "sssd"
 

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -28,6 +28,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  apparmor-parser: apparmor
   audit: auditd
   avahi: avahi-daemon
   dhcp: isc-dhcp-server

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -28,6 +28,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  audit: auditd
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -33,7 +33,7 @@ platform_package_overrides:
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -28,6 +28,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -29,6 +29,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -27,6 +27,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  audit: auditd
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -32,7 +32,7 @@ platform_package_overrides:
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -28,6 +28,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -27,6 +27,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  apparmor-parser: apparmor
   audit: auditd
   avahi: avahi-daemon
   dhcp: isc-dhcp-server

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -27,6 +27,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -32,7 +32,7 @@ platform_package_overrides:
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -28,6 +28,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -28,6 +28,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -27,6 +27,7 @@ cpes:
       check_id: installed_OS_is_ubuntu2004
 
 platform_package_overrides:
+  apparmor-parser: apparmor
   audit: auditd
   avahi: avahi-daemon
   dhcp: isc-dhcp-server

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -32,7 +32,7 @@ platform_package_overrides:
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
-  net-snmp: snmp
+  net-snmp: snmpd
   nss-pam-ldapd: libpam-ldap
   pam: libpam-runtime
   shadow: login

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -27,6 +27,7 @@ cpes:
       check_id: installed_OS_is_ubuntu2204
 
 platform_package_overrides:
+  apparmor-parser: apparmor
   audit: auditd
   avahi: avahi-daemon
   dhcp: isc-dhcp-server

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -28,6 +28,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  avahi: avahi-daemon
   dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -28,6 +28,7 @@ cpes:
 
 platform_package_overrides:
   audit: auditd
+  dhcp: isc-dhcp-server
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -529,6 +529,22 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 
 
 {{#
+Do platform_package_overrides replacement if needed
+
+:param package: name of package
+:type package: str
+
+#}}
+{{%- macro apply_platform_package_overrides(package) -%}}
+{{%- if package in platform_package_overrides and platform_package_overrides[package] is not none -%}}
+{{{- platform_package_overrides[package] -}}}
+{{%- else -%}}
+{{{- package -}}}
+{{%- endif -%}}
+{{%- endmacro -%}}
+
+
+{{#
     Show how to install a package with apt-get.
 
     Example output::
@@ -665,6 +681,7 @@ management software.
 
 #}}
 {{%- macro package_install(package) -%}}
+  {{%- set package = apply_platform_package_overrides(package) -%}}
   {{% if pkg_manager is defined %}}
     {{%- if pkg_manager == "apt_get" -%}}
         {{{ apt_get_package_install(package) }}}
@@ -690,6 +707,7 @@ substituting the correct package management software.
 
 #}}
 {{%- macro describe_package_install(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
     The <code>{{{ package }}}</code> package can be installed with the following command:
     <pre>{{{ package_install(package) }}}</pre>
 {{%- endmacro %}}
@@ -700,6 +718,7 @@ Outputs a command for removing a package, substituting the correct package
 management software.
 #}}
 {{%- macro package_remove(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
   {{% if pkg_manager is defined %}}
     {{%- if pkg_manager == "apt_get" -%}}
         {{{ apt_get_package_remove(package) }}}
@@ -725,6 +744,7 @@ substituting the correct package management software.
 
 #}}
 {{%- macro describe_package_remove(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
     The <code>{{{ package }}}</code> package can be removed with the following command:
     <pre>{{{ package_remove(package) }}}</pre>
 {{%- endmacro %}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -702,9 +702,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   The macro respects `platform_package_overrides` variable.
 #}}
 {{%- macro ansible_pkg_conditional(package) -%}}
-{{%- if package in platform_package_overrides -%}}
-  {{%- set package = platform_package_overrides[package] -%}}
-{{%- endif -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 '"{{{ package }}}" in ansible_facts.packages'
 {{%- endmacro -%}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -568,12 +568,14 @@ done
     Install a package
 
     Uses the right command based on pkg_manager property defined in product.yml.
+    The macro respects `platform_package_overrides` variable.
 
 :param package: name of the package
 :type package: str
 
 #}}
 {{%- macro bash_package_install(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 {{%- if pkg_manager is defined -%}}
 {{%- if pkg_manager == "yum" or pkg_manager == "dnf" -%}}
 if ! rpm -q --quiet "{{{ package }}}" ; then
@@ -597,12 +599,14 @@ zypper install -y "{{{ package }}}"
 
     Uses the right command based on pkg_manager property defined in product.yml.
     When used in a test scenario, the macro will remove even protected packages.
+    The macro respects `platform_package_overrides` variable.
 
 :param package: name of the package
 :type package: str
 
 #}}
 {{%- macro bash_package_remove(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 {{%- if pkg_manager is defined -%}}
 {{%- if pkg_manager == "yum" or pkg_manager == "dnf" -%}}
 if rpm -q --quiet "{{{ package }}}" ; then
@@ -1021,7 +1025,7 @@ fi
 
 :param option: faillock option eg. deny, unlock_time, fail_interval
 :param value: value of option
-:param authfail: check the pam_faillock.so conf line with authfail 
+:param authfail: check the pam_faillock.so conf line with authfail
 
 #}}
 {{%- macro bash_pam_faillock_parameter_value(option, value='', authfail=True) -%}}
@@ -1302,8 +1306,10 @@ fi
 
 {{#
   # Check whether or not a package is installed.
+  # The macro respects `platform_package_overrides` variable.
   #}}
 {{%- macro bash_package_installed(pkgname) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 {{%- if pkg_manager == "apt_get" -%}}
 dpkg-query --show --showformat='${db:Status-Status}\n' "{{{ pkgname }}}" 2>/dev/null | grep -q installed
 {{%- else -%}}
@@ -1751,9 +1757,7 @@ Part of the grub2_bootloader_argument_absent template.
   The macro respects `platform_package_overrides` variable.
 #}}
 {{%- macro bash_pkg_conditional(package) -%}}
-{{%- if package in platform_package_overrides -%}}
-  {{%- set package = platform_package_overrides[package] -%}}
-{{%- endif -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
   {{% if pkg_system is defined %}}
     {{%- if pkg_system == "rpm" -%}}
         {{{ bash_pkg_conditional_rpm(package) }}}

--- a/shared/macros/10-fixtext.jinja
+++ b/shared/macros/10-fixtext.jinja
@@ -397,11 +397,14 @@ The audit daemon must be restarted for the changes to take effect.
 {{#
 Fixtext for removing a package
 
+The macro respects `platform_package_overrides` variable.
+
 :param package: The package to remove
 :type package: str
 
 #}}
 {{% macro fixtext_package_removed(package) %}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 To remove the {{{ full_name }}} package {{{ package }}} run the following command:
 
 {{{ package_remove(package) }}}
@@ -410,11 +413,14 @@ To remove the {{{ full_name }}} package {{{ package }}} run the following comman
 {{#
 Fixtext for installing a package
 
+The macro respects `platform_package_overrides` variable.
+
 :param package: The package to install
 :type package: str
 
 #}}
 {{% macro fixtext_package_installed(package) %}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 To install the {{{ full_name }}} package {{{ package }}} run the following command:
 
 {{{ package_install(package) }}}

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -196,6 +196,7 @@ ocil: |
 
 #}}
 {{% macro ocil_package(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
   {{% if pkg_system is defined %}}
     {{%- if pkg_system == "rpm" -%}}
         {{{ rpm_ocil_package(package) }}}
@@ -246,6 +247,7 @@ ocil_clause: "the package is installed"
 
 #}}
 {{% macro complete_ocil_entry_package(package) -%}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
   {{% if pkg_system is defined %}}
     {{%- if pkg_system == "rpm" %}}
         {{{ rpm_complete_ocil_entry_package(package) }}}

--- a/shared/macros/10-srg_requirement.jinja
+++ b/shared/macros/10-srg_requirement.jinja
@@ -45,11 +45,14 @@ Successful/unsuccessful uses of the {{{ command }}} command in {{{ full_name }}}
 {{#
     Generate a SRG requirement text for package removal.
 
+    The macro respects `platform_package_overrides` variable.
+
 :param package: Name of the package to be removed
 :type package: str
 
 #}}
 {{% macro srg_requirement_package_removed(package) %}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 The package {{{ package }}} must be removed in {{{ full_name }}}.
 {{%- endmacro %}}
 
@@ -67,11 +70,14 @@ The kernel module {{{ module }}} must be disabled in {{{ full_name }}}.
 {{#
     Generate a SRG requirement text for package installed.
 
+    The macro respects `platform_package_overrides` variable.
+
 :param package: Name of the package to be installed
 :type package: str
 
 #}}
 {{% macro srg_requirement_package_installed(package) %}}
+{{%- set package = apply_platform_package_overrides(package) -%}}
 The {{{ full_name }}} package {{{ package }}} must be installed.
 {{%- endmacro %}}
 

--- a/shared/templates/package_installed/template.py
+++ b/shared/templates/package_installed/template.py
@@ -2,6 +2,9 @@ import re
 
 
 def preprocess(data, lang):
+    package = data["platform_package_overrides"].get(data["pkgname"], data["pkgname"])
+    if package is not None:
+        data["pkgname"] = package
     if "evr" in data:
         evr = data["evr"]
         if evr and not re.match(r'\d:\d[\d\w+.]*-\d[\d\w+.]*', evr, 0):

--- a/shared/templates/package_removed/template.py
+++ b/shared/templates/package_removed/template.py
@@ -1,0 +1,5 @@
+def preprocess(data, lang):
+    package = data["platform_package_overrides"].get(data["pkgname"], data["pkgname"])
+    if package is not None:
+        data["pkgname"] = package
+    return data

--- a/shared/templates/service_disabled/template.py
+++ b/shared/templates/service_disabled/template.py
@@ -1,6 +1,9 @@
 def preprocess(data, lang):
     if "packagename" not in data:
         data["packagename"] = data["servicename"]
+    package = data["platform_package_overrides"].get(data["packagename"], data["packagename"])
+    if package is not None:
+        data["packagename"] = package
     if "daemonname" not in data:
         data["daemonname"] = data["servicename"]
     if "mask_service" not in data:

--- a/shared/templates/service_enabled/template.py
+++ b/shared/templates/service_enabled/template.py
@@ -1,6 +1,9 @@
 def preprocess(data, lang):
     if "packagename" not in data:
         data["packagename"] = data["servicename"]
+    package = data["platform_package_overrides"].get(data["packagename"], data["packagename"])
+    if package is not None:
+        data["packagename"] = package
     if "daemonname" not in data:
         data["daemonname"] = data["servicename"]
     return data

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -530,6 +530,17 @@ def install_packages(test_env, packages):
         platform_cpe = get_cpe_of_tested_os(test_env, log_file)
     platform = cpes_to_platform([platform_cpe])
 
+    fixed_packages = []
+    product = test_env.product
+    product_yaml = get_product_context(product)
+    platform_package_overrides = product_yaml["platform_package_overrides"]
+    for package in packages:
+        package = platform_package_overrides.get(package, package)
+        if package is None:
+            continue
+        fixed_packages.append(package)
+    packages = set(fixed_packages)
+
     command_str = " ".join(INSTALL_COMMANDS[platform] + tuple(packages))
 
     with open(log_file_name, 'a') as log_file:


### PR DESCRIPTION
#### Description:

Add platform_package_overrides handling all over. Replace other methods to use it.

#### Rationale:

There is 3 ways to handle package names differing between products.

There is one exception where we need other way to handle package names and that is when default has only one package to handle a service and another product has multiple packages. And there is no possibility to se up platform_package_overrides.

First way is to use if block, see `package_gdm_removed` and `package_dhcp_removed` as an example. Endless lists of products that change and where ever there is possibility that some rule has a different set, there  probably is. I don't like this and it just seems totally unmaintainable.

Second way is template vars '@<product>' naming. Maintaining multiple lists is still hard,  `openssh-server` in `service_sshd_enabled` is named `openssh` in products `sle12` and `sle15`, but in rule `service_sshd_disabled`, same is only true with `opensuse` and `sle12`.

Third, and my selected way is to use per product dict `platform_package_overrides`. You need to make only one change when you notice package name mismatch. No maintenance needed after that.

There was already some support for `platform_package_overrides` in tests but it was not wholly used. See `service_dhcpd_disabled`.

My implementation uses one new jinja macro to procide transformation `apply_platform_package_overrides`. Each macro with package parameter is changed to use this. For each template  with various package name parameter there is transformation in `template.py` `preprocess`.

All other ways I could find are changed.

Some changes on package names as I noticed mistakes.

Because this is change over multiple products and multiple rules it might need some deliberation how to proceed.