### PR TITLE
Update macros to use more STIG like language

### DIFF
--- a/shared/macros/10-fixtext.jinja
+++ b/shared/macros/10-fixtext.jinja
@@ -524,7 +524,7 @@ Fixtext for setting the permissions on a file.
 
 #}}
 {{% macro fixtext_file_permissions(file, mode) %}}
-Change the permissions of the file "{{{ file }}}" to "{{{ mode }}}" by running the following command:
+Configure the "{{{ file }}}" file to "{{{ mode }}}" by running the following command:
 
 $ sudo chmod {{{ mode }}} {{{ file }}}
 {{%- endmacro %}}

--- a/shared/macros/10-srg_requirement.jinja
+++ b/shared/macros/10-srg_requirement.jinja
@@ -50,7 +50,7 @@ Successful/unsuccessful uses of the {{{ command }}} command in {{{ full_name }}}
 
 #}}
 {{% macro srg_requirement_package_removed(package) %}}
-{{{ full_name }}} must have the {{{ package }}} installed.
+{{{ full_name }}} must have the {{{ package }}} removed.
 {{%- endmacro %}}
 
 {{#

--- a/shared/macros/10-srg_requirement.jinja
+++ b/shared/macros/10-srg_requirement.jinja
@@ -50,7 +50,7 @@ Successful/unsuccessful uses of the {{{ command }}} command in {{{ full_name }}}
 
 #}}
 {{% macro srg_requirement_package_removed(package) %}}
-The package {{{ package }}} must be removed in {{{ full_name }}}.
+{{{ full_name }}} must have the {{{ package }}} installed.
 {{%- endmacro %}}
 
 {{#
@@ -72,7 +72,7 @@ The kernel module {{{ module }}} must be disabled in {{{ full_name }}}.
 
 #}}
 {{% macro srg_requirement_package_installed(package) %}}
-The {{{ full_name }}} package {{{ package }}} must be installed.
+{{{ full_name }}} must have the {{{ package }}} package installed.
 {{%- endmacro %}}
 
 {{#
@@ -153,7 +153,7 @@ SRG requirement for setting permissions on a file
 
 #}}
 {{% macro srg_requirement_file_permission(file, mode) %}}
-The {{{ full_name }}} {{{ file }}} file must have {{{ mode }}} or less permissive to prevent unauthorized access.
+The {{{ full_name }}} {{{ file }}} file must have mode {{{ mode }}} or less permissive to prevent unauthorized access.
 {{%- endmacro %}}
 
 
@@ -167,7 +167,7 @@ SRG requirement for setting permissions on a directory
 
 #}}
 {{% macro srg_requirement_directory_permission(file, mode) %}}
-The {{{ full_name }}} {{{ file }}} directory must have {{{ mode }}} or less permissive to prevent unauthorized access.
+The {{{ full_name }}} {{{ file }}} directory must have mode {{{ mode }}} or less permissive.
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
#### Description:
Change the wording in the SRG Requirement and Fix text macros.

#### Rationale:

To help better sync the RHEL 9 STIG.
