### PR TITLE
Fix audit_rules_privileged_commands_kmod rule in RHEL7

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/rhel7.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/ansible/rhel7.yml
@@ -31,11 +31,10 @@
     - '"auditd.service" in ansible_facts.services'
     - '"auditctl" in check_rules_scripts_result.stdout'
   register: auditctl_audit_rules_kmod_update_result
-
-- name: Restart auditd.service
-  systemd:
-    name: auditd.service
-    state: restarted
+- name: Restart Auditd
+  command: /usr/sbin/service auditd restart # restarting auditd through systemd doesn't work, see: https://access.redhat.com/solutions/5515011
+  args:
+    warn: false
   when:
     - (augenrules_audit_rules_kmod_update_result.changed or
        auditctl_audit_rules_kmod_update_result.changed)

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/rhel7.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/oval/rhel7.xml
@@ -23,7 +23,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_kmod_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+-k[\s]+module-change[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -32,7 +32,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_kmod_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+-k[\s]+module-change[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-w[\s]+/usr/bin/kmod[\s]+-p[\s]+x[\s]+-F[\s]+auid!=(?:4294967295|unset|-1)[\s]+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -1,4 +1,4 @@
-{{%- if product in ["rhel8"] %}}
+{{%- if product in ["rhel8", "rhel9"] %}}
     {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" %}}
 {{%- elif product in ["rhel7"] %}}
     {{%- set kmod_audit="-w /usr/bin/kmod -p x -F auid!=unset -k module-change" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/correct_value.pass.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_rhel
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+
+{{%- if product == "rhel7" %}}
+echo "-w /usr/bin/kmod -p x -F auid!=unset -k module-change" > /etc/audit/rules.d/module-change.rules
+{{%- else %}}
+echo "-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" > /etc/audit/rules.d/privileged.rules
+{{%- endif %}}
+augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/tests/wrong_value.fail.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_rhel
+# packages = audit
+
+rm -f /etc/audit/rules.d/*
+
+{{%- if product == "rhel7" %}}
+echo "-w /usr/bin/cp -p x -F auid!=unset -k module-change" > /etc/audit/rules.d/module-change.rules
+{{%- else %}}
+echo "-a always,exit -F path=/usr/bin/cp -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" > /etc/audit/rules.d/privileged.rules
+{{%- endif %}}
+augenrules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -47,8 +47,8 @@
     name: auditd.service
     state: restarted
 {{%- else %}} # restarting auditd through systemd doesn't work, see: https://access.redhat.com/solutions/5515011
-- name: Reload Auditd
-  command: /usr/sbin/service auditd reload
+- name: Restart Auditd
+  command: /usr/sbin/service auditd restart
   args:
     warn: false
 {{%- endif %}}

--- a/shared/templates/audit_rules_login_events/oval.template
+++ b/shared/templates/audit_rules_login_events/oval.template
@@ -24,7 +24,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\S+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -33,7 +33,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_arle_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\S+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/audit_rules_usergroup_modification/oval.template
+++ b/shared/templates/audit_rules_usergroup_modification/oval.template
@@ -18,7 +18,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_audit_rules_usergroup_modification_{{{ NAME }}}_augen" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\S+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -27,7 +27,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_audit_rules_usergroup_modification_{{{ NAME }}}_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\w+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-w[\s]+{{{ PATH }}}[\s]+\-p[\s]+\b([rx]*w[rx]*a[rx]*|[rx]*a[rx]*w[rx]*)\b[\s]+(-k[\s]+|-F[\s]+key=)\S+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION

#### Description:
- Fix audit_rules_privileged_commands_kmod rule in RHEL7.
  - Address minor issues in the rule and similar templates, for example the
\w+ doesn't accept the hyphen character which could be a problem when
the key is "module-change" for example, with the \S+ it should correctly
match the whole line. A couple of tests scenario were added for this
rule as well.


#### Rationale:

- Fixes #9434
