### PR TITLE
change parameter of findmnt used in bash partition conditional

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2080,7 +2080,7 @@ fi
 
 
 {{%- macro bash_partition_conditional(path) -%}}
-'findmnt --mountpoint "{{{ path }}}" > /dev/null'
+'findmnt --kernel "{{{ path }}}" > /dev/null'
 {{%- endmacro -%}}
 
 


### PR DESCRIPTION
#### Description:

- in the bash partition conditional, change `findmnt --mountpoint` for `findmnt --kernel`.

#### Rationale:

- in RHEL7, the findmnt commant does not support the --mountpoint option. I chose the kernel option because we are interested in partitions which are mounted at the time of remediation.
- Fixes #9445 