### PR TITLE
Add bash and ansible remediation for rsyslog_remote_tls

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -10,16 +10,14 @@
   register: include_omfwd_config_output
 
 - name: "Get include files directives"
-  shell: "echo \"{{ include_omfwd_config_output.stdout }}\"|grep  ' StreamDriver=\"gtls\" '"
+  shell: "echo \"{{ include_omfwd_config_output.stdout }}\"|grep  'StreamDriver=\"gtls\"'"
   register: include_omfwd_gtls_config_output
   when: (include_omfwd_config_output.stdout_lines| length > 0)
 
 - name: "Set rsyslog omfwd to use TLS"
   lineinfile:
     dest: /etc/rsyslog.conf
-    line: "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")" 
+    line: "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"
     create: yes
   when: (include_omfwd_gtls_config_output is skipped ) or
         ("gtls" not in include_omfwd_gtls_config_output.stdout)
-
-

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -1,0 +1,25 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
+
+- name: "Get omfwd configuration directive"
+  shell: sed -e '/action\s*(\s*type\s*=\s*"omfwd"/,/)/!d' /etc/rsyslog.conf /etc/rsyslog.d/*.conf
+  register: include_omfwd_config_output
+
+- name: "Get include files directives"
+  shell: "echo \"{{ include_omfwd_config_output.stdout }}\"|grep  ' StreamDriver=\"gtls\" '"
+  register: include_omfwd_gtls_config_output
+  when: (include_omfwd_config_output.stdout_lines| length > 0)
+
+- name: "Set rsyslog omfwd to use TLS"
+  lineinfile:
+    dest: /etc/rsyslog.conf
+    line: "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")" 
+    create: yes
+  when: (include_omfwd_gtls_config_output is skipped ) or
+        ("gtls" not in include_omfwd_gtls_config_output.stdout)
+
+

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -10,7 +10,9 @@
   register: include_omfwd_config_output
 
 - name: "Get include files directives"
-  shell: "echo \"{{ include_omfwd_config_output.stdout }}\"|grep  'StreamDriver=\"gtls\"'"
+  shell: >
+    set -o pipefail
+    echo \"{{ include_omfwd_config_output.stdout }}\"|grep  'StreamDriver=\"gtls\"'
   register: include_omfwd_gtls_config_output
   when: (include_omfwd_config_output.stdout_lines| length > 0)
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
@@ -9,10 +9,10 @@
 # Get omfwd configuration directive
 OMFWD_CONFIG_OUTPUT=`grep -Pzo '(?s)action\s*\(\s*type\s*=\s*"omfwd".*\)' /etc/rsyslog.conf /etc/rsyslog.d/*.conf`
 OMFWD_CONFIG=`echo "$OMFWD_CONFIG_OUTPUT"| awk 'BEGIN {FS=":"; RS=")\n"}; {print $2}'`
-OMFWD_CONFIG_FILE=`echo OMFWD_CONFIG_OUTPUT| awk 'BEGIN {FS=":"; RS=")\n"}; {print $1}'`
-if [! -z "$OMFWD_CONFIG" ]; then
-    OMFWD_TLS_STREAM=`grep  ' StreamDriver="gtls" ' "$OMFWD_CONFIG"`
-    if [! -z "!OMFWD_TLS_STREAM" ]; then
+OMFWD_CONFIG_FILE=`echo "$OMFWD_CONFIG_OUTPUT"| awk 'BEGIN {FS=":"; RS=")\n"}; {print $1}'`
+if ! [ -z "$OMFWD_CONFIG" ]; then
+    OMFWD_TLS_STREAM=`echo "$OMFWD_CONFIG"|grep  'StreamDriver="gtls"'`
+    if ! [ -z "${OMFWD_TLS_STREAM}" ]; then
         exit 0
     else
         # insert TLS stream param

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
@@ -19,5 +19,5 @@ if ! [ -z "$OMFWD_CONFIG" ]; then
         sed -i 's/action\s*(\s*type\s*=\s*"omfwd"/action(type="omfwd"\ StreamDriver="gtls"\ /' $OMFWD_CONFIG_FILE
     fi
 else
-    echo "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"  >> /etc/rsyslog.conf
+    echo "action(type=\"omfwd\" protocol=\"tcp\" Target=\"$rsyslog_remote_loghost_address\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"  >> /etc/rsyslog.conf
 fi

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
@@ -1,0 +1,23 @@
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
+
+{{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
+
+# Get omfwd configuration directive
+OMFWD_CONFIG_OUTPUT=`grep -Pzo '(?s)action\s*\(\s*type\s*=\s*"omfwd".*\)' /etc/rsyslog.conf /etc/rsyslog.d/*.conf`
+OMFWD_CONFIG=`echo "$OMFWD_CONFIG_OUTPUT"| awk 'BEGIN {FS=":"; RS=")\n"}; {print $2}'`
+OMFWD_CONFIG_FILE=`echo OMFWD_CONFIG_OUTPUT| awk 'BEGIN {FS=":"; RS=")\n"}; {print $1}'`
+if [! -z "$OMFWD_CONFIG" ]; then
+    OMFWD_TLS_STREAM=`grep  ' StreamDriver="gtls" ' "$OMFWD_CONFIG"`
+    if [! -z "!OMFWD_TLS_STREAM" ]; then
+        exit 0
+    else
+        # insert TLS stream param
+        sed -i 's/action\s*(\s*type\s*=\s*"omfwd"/action(type="omfwd"\ StreamDriver="gtls"\ /' $OMFWD_CONFIG_FILE
+    fi
+else
+    echo "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"  >> /etc/rsyslog.conf
+fi


### PR DESCRIPTION
#### Description:

Add bash and ansible remediation scripts for rsyslog_remote_tls rule

#### Rationale:

- Scripts make sure the rsyslog config will contain `StreamDriver=gtls`