### PR TITLE
Add ol8 platform to existing required tests

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_empty.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # remediation = none
 
 echo "" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/file_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # remediation = none
 
 rm -f {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/line_missing.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/line_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # remediation = none
 
 echo "some line" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/multiple_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/multiple_servers.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # remediation = none
 
 sed -i "^pool.*" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_pool.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_pool.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # remediation = none
 
 sed -i "^server.*" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_server.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/tests/only_server.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = chrony
-# platform = multi_platform_fedora,multi_platform_rhel
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 sed -i "^pool.*" {{{ chrony_conf_path }}}
 echo "server 0.pool.ntp.org" > {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/rhel8_ospp_ok.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/rhel8_ospp_ok.pass.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 # profiles = xccdf_org.ssgproject.content_profile_ospp
 
 mkdir -p /etc/ssh/sshd_config.d

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_rhv,multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
 
 systemctl set-default multi-user.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target_under_lib.pass.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/correct_target_under_lib.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_rhv,multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
 
 ln -sf /lib/systemd/system/multi-user.target /etc/systemd/system/default.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_rhv,multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
 
 systemctl set-default graphical.target

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target_under_lib.fail.sh
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/tests/wrong_target_under_lib.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_sle,multi_platform_rhv,multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
 
 ln -sf /lib/systemd/system/graphical.target /etc/systemd/system/default.target

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_ncp
 # packages = dconf,gdm
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # packages = dconf,gdm
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig.pass.sh
@@ -3,11 +3,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -16,7 +11,7 @@ login_banner_text="(^You[\s\n]+are[\s\n]+accessing[\s\n]+a[\s\n]+U.S.[\s\n]+Gove
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/missing_value_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/missing_value_stig.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # packages = dconf,gdm
 

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/missing_value_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/missing_value_stig.fail.sh
@@ -3,12 +3,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # packages = dconf,gdm
 
-
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -17,7 +11,7 @@ install_dconf_and_gdm_if_needed
 # expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-enabled" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "banner-message-enabled" "true" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enabled" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value_stig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value_stig.fail.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 login_banner_text="Wrong Banner Text"
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
@@ -16,8 +11,8 @@ install_dconf_and_gdm_if_needed
 
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 {{% else %}}
     apt update

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/argument_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 for auth_file in system-auth password-auth; do
     config_file=/etc/pam.d/${auth_file}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_remember=5
 
 remember_cnt=5

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_argument.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_remember=5
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_line.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_remember=5
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_modified_pam.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = none
 
 SYSTEM_AUTH_FILE="/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_remember=5
 
 remember_cnt=3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_unix_remember=5
 
 remember_cnt=5

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_unix_remember=5
 
 remember_cnt=3

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/masked.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/not_masked.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/tests/not_masked.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_ubuntu
 
 systemctl unmask ctrl-alt-del.target

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo 'set -g lock-command vlock' >> '/etc/tmux.conf'
 chmod 0644 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/file_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/file_empty.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo > '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/line_commented.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo '# set -g lock-command vlock' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_permissions.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo 'set -g lock-command vlock' >> '/etc/tmux.conf'
 chmod 0600 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/tests/wrong_value.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo 'set -g lock-command locker' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_10.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_10.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 if grep -q "^PASS_MIN_LEN" /etc/login.defs; then
 	sed -i "s/^PASS_MIN_LEN.*/PASS_MIN_LEN 10/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_12.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_12.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 if grep -q "^PASS_MIN_LEN" /etc/login.defs; then
 	sed -i "s/^PASS_MIN_LEN.*/PASS_MIN_LEN 12/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_15.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_15.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 if grep -q "^PASS_MIN_LEN" /etc/login.defs; then
 	sed -i "s/^PASS_MIN_LEN.*/PASS_MIN_LEN 15/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_commented.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 sed -i "s/.*PASS_MIN_LEN.*/#PASS_MIN_LEN 12/" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_minlen_login_defs/tests/password_minlen_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
 # profiles = xccdf_org.ssgproject.content_profile_ospp
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 sed -i "/^PASS_MIN_LEN.*/d" /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_argument_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_modified_pam.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = none
 # variables = var_password_pam_unix_rounds=65536
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_control.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/authselect_wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=4000

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/default_rounds.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/default_rounds.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
 
 pamFile="/etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/explicit_rounds.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/explicit_rounds.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
 
 pamFile="/etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/less_rounds.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/less_rounds.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
 # variables = var_password_pam_unix_rounds=5000
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/tests/wrong_control.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_argument_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_argument_missing.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 authselect create-profile hardening -b sssd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_modified_pam.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_modified_pam.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = none
 # variables = var_password_pam_unix_rounds=65536
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_control.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/authselect_wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = authselect
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=4000

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/default_rounds.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/default_rounds.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
 
 pamFile="/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/explicit_rounds.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/explicit_rounds.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/less_rounds.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/less_rounds.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
 # variables = var_password_pam_unix_rounds=5000
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/tests/wrong_control.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # variables = var_password_pam_unix_rounds=65536
 
 ROUNDS=65536

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/tests/stig_correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_stig
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 sed -i '/umask/d' /etc/bashrc
 echo "umask 077" >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/tests/stig_correct.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # profiles = xccdf_org.ssgproject.content_profile_stig
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 sed -i '/umask/d' /etc/csh.cshrc
 echo "umask 077" >> /etc/csh.cshrc

--- a/linux_os/guide/system/accounts/enable_authselect/tests/not_remediable.fail.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/not_remediable.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # packages = authselect,pam
 # remediation = none
 

--- a/linux_os/guide/system/accounts/enable_authselect/tests/profile.pass.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/profile.pass.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # packages = authselect,pam
 
 authselect select minimal --force

--- a/linux_os/guide/system/accounts/enable_authselect/tests/remediable.fail.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/remediable.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # packages = authselect,pam
 
 rm -f /etc/pam.d/{fingerprint-auth,password-auth,postlogin,smartcard-auth,system-auth}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i '/newgrp/d' /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_with_perm_x.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 # augenrules is default for rhel7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -2,7 +2,7 @@
 # packages = audit
 # Remediation for this rule cannot remove the duplicates
 # remediation = none
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /tmp/privileged.rules
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
 sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
 echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
 echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
 # remediation = bash
-# platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 own_key /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_activated_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/tests/audit_syslog_plugin_not_activated.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
 # remediation = bash
 
 . $SHARED/auditd_utils.sh

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/blank_grubenv_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/blank_grubenv_rhel8.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # remediation = none
 
 # Removes audit argument from kernel command line in /boot/grub2/grubenv

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/double_value_rhel8.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 # Break the audit argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_argument/tests/wrong_value_rhel8.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 # Break the audit argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/correct_grubenv.pass.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/correct_grubenv.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 grub2-editenv - set "$(grub2-editenv - list | grep kernelopts) audit_backlog_limit=8192"

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_etcdefaultgrub.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_etcdefaultgrub.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7
 
 # Break the audit_backlog_limit argument in kernel command line in /etc/default/grub
 if grep -q '^GRUB_CMDLINE_LINUX=.*audit_backlog_limit=.*"'  '/etc/default/grub' ; then

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_rhel8.fail.sh
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/tests/wrong_value_rhel8.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 # Break the audit_backlog_limit argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Based on shared/templates/grub2_bootloader_argument/tests/arg_not_there.fail.sh
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 # Removes audit argument from kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there_grubenv.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/arg_not_there_grubenv.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # Based on shared/templates/grub2_bootloader_argument/tests/arg_not_there_grubenv.fail.sh
 
 # Fake the kernel compile config, this is necessary when the distro's kernel is already compiled

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled.pass.sh
@@ -6,8 +6,8 @@ if grep -q '^.*random\.trust_cpu=.*'  "$file" ; then
 	sed -i 's/\(^.*\)random.trust_cpu=[^[:space:]]*\(.*\)/\1 \2/'  "$file"
 fi
 
-if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
-    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=y\2/' /boot/config-`uname -r`
+if grep -Pq "^[^#]*CONFIG_RANDOM_TRUST_CPU" /boot/config-`uname -r`; then
+    sed -Ei 's/^([^#]*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=y\2/' /boot/config-`uname -r`
 else
     echo "CONFIG_RANDOM_TRUST_CPU=y" >> /boot/config-`uname -r`
 fi

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/compiled_uppercase.pass.sh
@@ -10,8 +10,8 @@ fi
 grubby --update-kernel=ALL --remove-args="random.trust_cpu"
 {{% endif %}}
 
-if grep -q CONFIG_RANDOM_TRUST_CPU /boot/config-`uname -r`; then
-    sed -Ei 's/(.*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=Y\2/' /boot/config-`uname -r`
+if grep -Pq "^[^#]*CONFIG_RANDOM_TRUST_CPU" /boot/config-`uname -r`; then
+    sed -Ei 's/^([^#]*)CONFIG_RANDOM_TRUST_CPU=.(.*)/\1CONFIG_RANDOM_TRUST_CPU=Y\2/' /boot/config-`uname -r`
 else
     echo "CONFIG_RANDOM_TRUST_CPU=Y" >> /boot/config-`uname -r`
 fi

--- a/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/bootloader-grub2/grub2_kernel_trust_cpu_rng/tests/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Based on shared/templates/grub2_bootloader_argument/tests/wrong_value.fail.sh
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 # Break the argument in kernel command line in /boot/grub2/grubenv
 file="/boot/grub2/grubenv"

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_configured.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Oracle Linux 7,Red Hat Enterprise Linux 7
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7
 
 # fix logrotate config
 sed -i "s/\(weekly\|monthly\|yearly\)/daily/" /etc/logrotate.conf

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/correct_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/correct_owner.pass.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	find "$dirPath" -type d -exec chown root '{}' \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_ownership_library_dirs/tests/incorrect_owner.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle
 groupadd nogroup
 DIRS="/lib /lib64"
 for dirPath in $DIRS; do

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/all_dirs_ok.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/all_dirs_ok.pass.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu,multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	find "$dirPath" -perm /022 -type d -exec chmod go-w '{}' \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/owner_only_writable_dir.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/owner_only_writable_dir.pass.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu,multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 DIRS="/lib /lib64 /usr/lib /usr/lib64"
 for dirPath in $DIRS; do
     chmod -R 755 "$dirPath"

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/world_writable_dir_on_lib.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/world_writable_dir_on_lib.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu,multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 DIRS="/lib /lib64"
 for dirPath in $DIRS; do
 	mkdir -p "$dirPath/testme" && chmod 777  "$dirPath/testme"

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/world_writable_dir_on_usr_lib.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/tests/world_writable_dir_on_usr_lib.fail.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu,multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 DIRS="/usr/lib /usr/lib64"
 for dirPath in $DIRS; do
 	mkdir -p "$dirPath/testme" && chmod 777 "$dirPath/testme"

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_gnutls_tls_crypto_policy/tests/missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 configfile=/etc/crypto-policies/back-ends/gnutls.config
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 incorrect_sshd_approved_ciphers=aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes256-ctr,aes256-cbc

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_ciphers=aes256-ctr,aes192-ctr,aes128-ctr

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/tests/rhel8_stig_missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_correct_followed_by_incorrect_commented.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_followed_by_correct_commented.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/tests/stig_missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/openssh.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 sshd_approved_macs=hmac-sha2-512,hmac-sha2-256

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_empty_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_empty_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_incorrect_policy.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_incorrect_policy.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_missing_file.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/tests/rhel8_stig_missing_file.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
 configfile=/etc/crypto-policies/back-ends/opensshserver.config

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 cat > /etc/profile.d/openssl-rand.sh <<- 'EOM'
 # provide a default -rand /dev/random option to openssl commands that

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_missing.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_missing.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 rm -f /etc/profile.d/openssl-rand.sh

--- a/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_modified.fail.sh
+++ b/linux_os/guide/system/software/integrity/crypto/openssl_use_strong_entropy/tests/file_modified.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 
 echo "wrong data" > /etc/profile.d/openssl-rand.sh

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 
 yum -y install aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 yum -y install aide
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_rhel,multi_platform_fedora
+# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 
 yum -y install aide

--- a/shared/templates/grub2_bootloader_argument/tests/arg_not_there_grubenv.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/arg_not_there_grubenv.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 
 source common.sh

--- a/shared/templates/grub2_bootloader_argument/tests/wrong_value.fail.sh
+++ b/shared/templates/grub2_bootloader_argument/tests/wrong_value.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# platform = Red Hat Enterprise Linux 8
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8
 # packages = grub2,grubby
 
 source common.sh


### PR DESCRIPTION
#### Description:

- Add ol8 platform to existing required tests
- Update tests in rule `dconf_gnome_login_banner_text` to use `dconf_gdm_dir` variable as in OVAL and remediations, so they are more generic
- Update tests in rule `grub2_kernel_trust_cpu_rng` to handle commented lines correctly

#### Rationale:

- This enables a more complete test of OL8 using automatus