### PR TITLE
Update regex in OVAL for harden_sshd_ciphers_opensshserver_conf_crypto_policy rule

### DIFF
--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/oval/shared.xml
@@ -16,7 +16,7 @@
 
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
     <ind:filepath>{{{ PATH }}}</ind:filepath>
-    <ind:pattern operation="pattern match">^(?!#).*(-oCiphers=\S+).*$</ind:pattern>
+    <ind:pattern operation="pattern match">^(?!#).*(-oCiphers=[^\s']+).*$</ind:pattern>
     <ind:instance operation="equals" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

- Update OVAL in `harden_sshd_ciphers_opensshserver_conf_crypto_policy` to align it with generated conf by remediation

#### Rationale:

- Existing tests are failing because existing regex captures the string with the `'` character set during remediation, and compares it against expected string without that character
