### PR TITLE
Add ordering to the `platform` key

### DIFF
--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -169,6 +169,7 @@ Rules sections must be in the following order, if they are present.
 * `ocil_clause`
 * `ocil` (HTML Like)
 * `fixtext` (HTML Like)
+* `checktext` (HTML Like)
 * `srg_requirement`
 * `warnings`
     * All subsections are HTML-Like

--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -270,7 +270,7 @@ Control sections must be in the following order, all sections are required unles
     * `version`
     * `SMEs`
 * `title`
-    * Shall be short and descriptive 
+    * Shall be short and descriptive
 * `description` (HTML-Like)
 * `extends` (Optional)
     * Must be valid id of another profile id

--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -138,7 +138,7 @@ The following elements are not allowed:
 
 ### Rule
 
-This section describes the styleguide around the `rule.yml` files.
+This section describes the style guide around the `rule.yml` files.
 * All the above [YAML](manual/developer/04_style_guide:yaml) rules apply.
 * A rule should only address one configuration item change.
 * A variable should be when a configuration change can be multiple different values.
@@ -186,7 +186,7 @@ Rules sections must be in the following order, if they are present.
 
 ### Group
 
-This section describes the styleguide around the `group.yml` files.
+This section describes the style guide around the `group.yml` files.
 
 * All the above [YAML](manual/developer/04_style_guide:yaml) rules apply
 * A group should only contain rules that effect the same software or service
@@ -203,7 +203,7 @@ Group sections must be in the following order, if present.
 
 ### Benchmark
 
-This section describes the styleguide around the `benchmark.yml` files.
+This section describes the style guide around the `benchmark.yml` files.
 All the above [YAML](manual/developer/04_style_guide:yaml) rules apply.
 
 #### Benchmark Sections

--- a/docs/manual/developer/04_style_guide.md
+++ b/docs/manual/developer/04_style_guide.md
@@ -293,9 +293,14 @@ The header should start on the first line.
 
 #### `platform`
 
-Unless there is a good reason this should be `multi_platform_all`. 
-But if the rule only applies to a specific operating system or family of operating then should be used. 
+Unless there is a good reason this should be `multi_platform_all`.
+But if the rule only applies to a specific operating system or family of operating then should be used.
 The values can be product names or values from `MULTI_PLATFORM_LIST` or `MULTI_PLATFORM_LIST` in [ssg/constants.py](https://github.com/ComplianceAsCode/content/blob/master/ssg/constants.py).
+
+
+The `platform` key should first list specific products, then list the `multi_platform`.
+Products and `multi_platform` shall be placed in alphabetical order.
+For example, Oracle Linux 9, Red Hat Enterprise Linux 9, multi_platform_fedora.
 
 #### `reboot`
 


### PR DESCRIPTION
#### Description:
Add section about the platform key that enforces an order.

#### Rationale:

Formalize the policy around the order and clean up the doc.
