### PR TITLE
Improve ansible remediation of accounts_umask_etc_login_defs

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_bashrc/ansible/shared.yml
@@ -11,16 +11,27 @@
 {{% set etc_bash_rc = "/etc/bashrc" %}}
 {{% endif %}}
 
-- name: Replace user umask in {{{ etc_bash_rc }}}
-  replace:
+- name: Check if umask in {{{ etc_bash_rc }}} is already set
+  ansible.builtin.lineinfile:
     path: {{{ etc_bash_rc }}}
-    regexp: "umask.*"
-    replace: "umask {{ var_accounts_user_umask }}"
+    regexp: ^(\s*)umask\s+.*
+    state: absent
+  check_mode: true
+  changed_when: false
   register: umask_replace
 
-- name: Append user umask in {{{ etc_bash_rc }}}
-  lineinfile:
-    create: yes
+- name: Replace user umask in {{{ etc_bash_rc }}}
+  ansible.builtin.replace:
     path: {{{ etc_bash_rc }}}
-    line: "umask {{ var_accounts_user_umask }}"
-  when: umask_replace is not changed
+    regexp: ^(\s*)umask(\s+).*
+    replace: \g<1>umask\g<2>{{ var_accounts_user_umask }}
+  when:
+  - umask_replace.found > 0
+
+- name: Ensure the Default umask is Appended Correctly
+  ansible.builtin.lineinfile:
+    create: true
+    path: {{{ etc_bash_rc }}}
+    line: umask {{ var_accounts_user_umask }}
+  when:
+  - umask_replace.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_csh_cshrc/ansible/shared.yml
@@ -5,16 +5,27 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
-- name: Replace user umask in /etc/csh.cshrc
-  replace:
+- name: Check if umask in /etc/csh.cshrc is already set
+  ansible.builtin.lineinfile:
     path: /etc/csh.cshrc
-    regexp: "umask.*"
-    replace: "umask {{ var_accounts_user_umask }}"
+    regexp: ^(\s*)umask\s+.*
+    state: absent
+  check_mode: true
+  changed_when: false
   register: umask_replace
 
-- name: Append user umask in /etc/csh.cshrc
-  lineinfile:
-    create: yes
+- name: Replace user umask in /etc/csh.cshrc
+  ansible.builtin.replace:
     path: /etc/csh.cshrc
-    line: "umask {{ var_accounts_user_umask }}"
-  when: umask_replace is not changed
+    regexp: ^(\s*)umask(\s+).*
+    replace: \g<1>umask\g<2>{{ var_accounts_user_umask }}
+  when:
+  - umask_replace.found > 0
+
+- name: Ensure the Default umask is Appended Correctly
+  ansible.builtin.lineinfile:
+    create: true
+    path: /etc/csh.cshrc
+    line: umask {{ var_accounts_user_umask }}
+  when:
+  - umask_replace.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -5,16 +5,35 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_user_umask") }}}
 
-- name: Ensure the Default UMASK is Set Correctly
-  replace:
+- name: Check if UMASK is already set
+  ansible.builtin.lineinfile:
     path: /etc/login.defs
-    regexp: "^UMASK"
-    replace: "UMASK {{ var_accounts_user_umask }}"
-  register: umask_replace
+    regexp: ^(?!#)(\s*)UMASK\s+.*
+    state: absent
+  check_mode: yes
+  changed_when: false
+  register: result_umask_is_set
+
+- name: Check if UMASK is already correctly set
+  ansible.builtin.lineinfile:
+    path: /etc/login.defs
+    regexp: '^(?!#)(\s*)UMASK\s+{{ var_accounts_user_umask }}\s*$'
+    state: absent
+  check_mode: yes
+  changed_when: false
+  when: result_umask_is_set.found == 1
+  register: result_umask_is_correctly_set
+
+- name: Replace user UMASK in /etc/login.defs
+  ansible.builtin.replace:
+    path: /etc/login.defs
+    regexp: ^(?!#)(\s*)UMASK(\s+).*
+    replace: '\g<1>UMASK\g<2>{{ var_accounts_user_umask }}'
+  when: result_umask_is_correctly_set.found is defined and result_umask_is_correctly_set.found == 0
 
 - name: Ensure the Default UMASK is Appended Correctly
   lineinfile:
     create: yes
     path: /etc/login.defs
     line: "UMASK {{ var_accounts_user_umask }}"
-  when: umask_replace is not changed
+  when: result_umask_is_set.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -10,30 +10,22 @@
     path: /etc/login.defs
     regexp: ^(\s*)UMASK\s+.*
     state: absent
-  check_mode: yes
+  check_mode: true
   changed_when: false
   register: result_umask_is_set
-
-- name: Check if UMASK is already correctly set
-  ansible.builtin.lineinfile:
-    path: /etc/login.defs
-    regexp: '^(\s*)UMASK\s+{{ var_accounts_user_umask }}\s*$'
-    state: absent
-  check_mode: yes
-  changed_when: false
-  when: result_umask_is_set.found == 1
-  register: result_umask_is_correctly_set
 
 - name: Replace user UMASK in /etc/login.defs
   ansible.builtin.replace:
     path: /etc/login.defs
     regexp: ^(\s*)UMASK(\s+).*
-    replace: '\g<1>UMASK\g<2>{{ var_accounts_user_umask }}'
-  when: result_umask_is_correctly_set.found is defined and result_umask_is_correctly_set.found == 0
+    replace: \g<1>UMASK\g<2>{{ var_accounts_user_umask }}
+  when:
+  - result_umask_is_set.found > 0
 
 - name: Ensure the Default UMASK is Appended Correctly
   ansible.builtin.lineinfile:
-    create: yes
+    create: true
     path: /etc/login.defs
-    line: "UMASK {{ var_accounts_user_umask }}"
-  when: result_umask_is_set.found == 0
+    line: UMASK {{ var_accounts_user_umask }}
+  when:
+  - result_umask_is_set.found == 0

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -8,7 +8,7 @@
 - name: Check if UMASK is already set
   ansible.builtin.lineinfile:
     path: /etc/login.defs
-    regexp: ^(?!#)(\s*)UMASK\s+.*
+    regexp: ^(\s*)UMASK\s+.*
     state: absent
   check_mode: yes
   changed_when: false
@@ -17,7 +17,7 @@
 - name: Check if UMASK is already correctly set
   ansible.builtin.lineinfile:
     path: /etc/login.defs
-    regexp: '^(?!#)(\s*)UMASK\s+{{ var_accounts_user_umask }}\s*$'
+    regexp: '^(\s*)UMASK\s+{{ var_accounts_user_umask }}\s*$'
     state: absent
   check_mode: yes
   changed_when: false
@@ -27,7 +27,7 @@
 - name: Replace user UMASK in /etc/login.defs
   ansible.builtin.replace:
     path: /etc/login.defs
-    regexp: ^(?!#)(\s*)UMASK(\s+).*
+    regexp: ^(\s*)UMASK(\s+).*
     replace: '\g<1>UMASK\g<2>{{ var_accounts_user_umask }}'
   when: result_umask_is_correctly_set.found is defined and result_umask_is_correctly_set.found == 0
 

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/ansible/shared.yml
@@ -32,7 +32,7 @@
   when: result_umask_is_correctly_set.found is defined and result_umask_is_correctly_set.found == 0
 
 - name: Ensure the Default UMASK is Appended Correctly
-  lineinfile:
+  ansible.builtin.lineinfile:
     create: yes
     path: /etc/login.defs
     line: "UMASK {{ var_accounts_user_umask }}"

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -159,7 +159,7 @@ def run_stage_remediation_ansible(run_type, test_env, formatting, verbose_path):
                            '/' + formatting['output_file']):
         return False
     command = (
-        'ansible-playbook', '-v', '-i', '{0},'.format(formatting['domain_ip']),
+        'ansible-playbook', '-vvv', '-i', '{0},'.format(formatting['domain_ip']),
         '-u' 'root', '--ssh-common-args={0}'.format(' '.join(test_env.ssh_additional_options)),
         formatting['playbook'])
     command_string = ' '.join(command)


### PR DESCRIPTION
#### Description:

- Improve ansible remediation of accounts_umask_etc_login_defs.
  - Correctly replace wrong values
  - Do not attempt to change a file that already has a valid configuration

#### Rationale:

- Regex 101 Example: https://regex101.com/r/T0xVnu/1

- Fixes: #9456

This PR can inspire fixes for other similar rules as well. https://github.com/ComplianceAsCode/content/issues/9456#issuecomment-1239355682
