### PR TITLE
correct inheritance of platforms by rules from groups

### DIFF
--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -42,13 +42,11 @@ def main():
 def check_product(build_dir, product, rules_dirs):
     input_groups, input_rules = scan_rules_groups(rules_dirs, False)
     ds_path = os.path.join(build_dir, "ssg-" + product + "-ds.xml")
-    if machine_platform_missing_in_rules(ds_path, input_rules):
-        return False
-    return True
+    return not machine_platform_missing_in_rules(ds_path, input_rules)
 
 
 def shorten_id(full_id):
-    id_prefix = "xccdf_org.ssgproject.content_rule_"
+    id_prefix = ssg.constants.OSCAP_RULE
     return full_id.replace(id_prefix, "")
 
 

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -10,11 +10,15 @@ import io
 import re
 
 
-BASH_MACHINE_CONDITIONAL = re.compile('^.*\[ ! -f /.dockerenv \] && \[ ! -f /run/.containerenv \].*$', re.M)
-ANSIBLE_MACHINE_CONDITIONAL = re.compile(r'ansible_virtualization_type not in \["docker", "lxc", "openvz", "podman", "container"\]', re.M)
-MACHINE_PLATFORM_ONE_LINE = re.compile(r'^\s*platform:\s+machine\s*$', re.M)
-MACHINE_PLATFORM_MULTILINE = re.compile(r'^\s*platforms:\s*\n(\s+-\s+.*machine.*)+', re.M)
-
+BASH_MACHINE_CONDITIONAL = re.compile(
+    r'^.*\[ ! -f /.dockerenv \] && \[ ! -f /run/.containerenv \].*$', re.M)
+ANSIBLE_MACHINE_CONDITIONAL = re.compile(
+    r'ansible_virtualization_type not in \["docker", "lxc", "openvz", "podman", "container"\]',
+    re.M)
+MACHINE_PLATFORM_ONE_LINE = re.compile(
+    r'^\s*platform:\s+machine\s*$', re.M)
+MACHINE_PLATFORM_MULTILINE = re.compile(
+    r'^\s*platforms:\s*\n(\s+-\s+.*machine.*)+', re.M)
 
 
 def main():
@@ -27,11 +31,13 @@ def main():
         guide_dir = os.path.abspath(
             os.path.join(product_dir, product_yaml['benchmark_root']))
         additional_content_directories = product_yaml.get("additional_content_directories", [])
-        add_content_dirs = [os.path.abspath(os.path.join(product_dir, rd)) for rd in additional_content_directories]
+        add_content_dirs = [os.path.abspath(
+            os.path.join(product_dir, rd)) for rd in additional_content_directories]
         if not check_product(args.build_dir, product, [guide_dir] + add_content_dirs):
             test_result = 1
     if test_result:
         sys.exit(1)
+
 
 def check_product(build_dir, product, rules_dirs):
     input_groups, input_rules = scan_rules_groups(rules_dirs, False)
@@ -44,16 +50,13 @@ def check_product(build_dir, product, rules_dirs):
 def check_ds(ds_path, input_elems):
     try:
         tree = ET.parse(ds_path)
-    except IOError as e:
+    except IOError:
         sys.stderr.write("The product datastream '%s' hasn't been build, "
                          "skipping the test.\n" % (ds_path))
         return True
 
     platform_missing = False
     root = tree.getroot()
-    # if what == "Group":
-        # replacement = "xccdf_org.ssgproject.content_group_"
-        # xpath_query = ".//{%s}Group" % ssg.constants.XCCDF12_NS
     replacement = "xccdf_org.ssgproject.content_rule_"
     xpath_query = ".//{%s}Rule" % ssg.constants.XCCDF12_NS
     benchmark = root.find(".//{%s}Benchmark" % ssg.constants.XCCDF12_NS)
@@ -79,12 +82,14 @@ def check_ds(ds_path, input_elems):
                     bash_fix_has_machine_conditional = True
 
         if ansible_fix_present and not ansible_fix_has_machine_conditional:
-            sys.stderr.write("Rule %s in %s is missing a machine conditional in Ansible remediation\n" %
-                             (elem_short_id, ds_path))
+            sys.stderr.write(
+                "Rule %s in %s is missing a machine conditional in Ansible remediation\n" %
+                (elem_short_id, ds_path))
             platform_missing = True
         if bash_fix_present and not bash_fix_has_machine_conditional:
-            sys.stderr.write("Rule %s in %s is missing a machine conditional in Bash remediation\n" %
-                             (elem_short_id, ds_path))
+            sys.stderr.write(
+                "Rule %s in %s is missing a machine conditional in Bash remediation\n" %
+                (elem_short_id, ds_path))
             platform_missing = True
     return not platform_missing
 

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -12,6 +12,8 @@ import re
 
 BASH_MACHINE_CONDITIONAL = re.compile('^.*\[ ! -f /.dockerenv \] && \[ ! -f /run/.containerenv \].*$', re.M)
 ANSIBLE_MACHINE_CONDITIONAL = re.compile(r'ansible_virtualization_type not in \["docker", "lxc", "openvz", "podman", "container"\]', re.M)
+MACHINE_PLATFORM_ONE_LINE = re.compile(r'^\s*platform:\s+machine\s*$', re.M)
+MACHINE_PLATFORM_MULTILINE = re.compile(r'^\s*platforms:\s*\n(\s+-\s+.*machine.*)+', re.M)
 
 
 
@@ -106,7 +108,9 @@ def check_if_machine_only(dirpath, name, is_machine_only_group):
         yml_path = os.path.join(dirpath, name)
         with io.open(yml_path, "r", encoding="utf-8") as yml_file:
             yml_file_contents = yml_file.read()
-            if "platform: machine" in yml_file_contents:
+            single_line_platform_found = MACHINE_PLATFORM_ONE_LINE.search(yml_file_contents)
+            multiline_platform_found = MACHINE_PLATFORM_MULTILINE.search(yml_file_contents)
+            if single_line_platform_found or multiline_platform_found:
                 return True
     return False
 

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -45,7 +45,7 @@ def main():
 
 
 def check_product(ds_path, rules_dirs):
-    input_groups, input_rules = scan_rules_groups(rules_dirs, False)
+    input_rules = scan_rules_groups(rules_dirs, False)
     return not machine_platform_missing_in_rules(ds_path, input_rules)
 
 
@@ -146,8 +146,8 @@ def scan_rules_groups(dir_paths, parent_machine_only):
     groups = set()
     rules = set()
     for dir_path in dir_paths:
-        groups, rules = scan_rules_group(dir_path, parent_machine_only, groups, rules)
-    return groups, rules
+        _, rules = scan_rules_group(dir_path, parent_machine_only, groups, rules)
+    return rules
 
 
 def scan_rules_group(dir_path, parent_machine_only, groups, rules):

--- a/tests/test_machine_only_rules.py
+++ b/tests/test_machine_only_rules.py
@@ -71,12 +71,14 @@ def get_element_fix_text_by_system(element):
 
 
 def machine_platform_missing_in_rules(ds_path, short_ids_to_check):
+    machine_platform_missing = False
+
     try:
         tree = ET.parse(ds_path)
     except IOError:
         sys.stderr.write("The product datastream '%s' hasn't been build, "
                          "skipping the test.\n" % (ds_path))
-        return False
+        return machine_platform_missing
 
     root = tree.getroot()
     only_rules_query = ".//{%s}Rule" % ssg.constants.XCCDF12_NS
@@ -105,7 +107,6 @@ def machine_platform_missing_in_rules(ds_path, short_ids_to_check):
             ansible_fix_has_machine_conditional = ANSIBLE_MACHINE_CONDITIONAL.search(
                     maybe_ansible_fix_text)
 
-        machine_platform_missing = False
         elem_short_id = shorten_id(elem.get("id"))
         if ansible_fix_present and not ansible_fix_has_machine_conditional:
             sys.stderr.write(


### PR DESCRIPTION
#### Description:

- correct the process of passing on platforms so that they do not appear in multiple places in the datastream
- update the tests_machine_only_rules tests which ensures that machine-only applicability propagates correctly from groups to rules. This has to be changed because now when checking, we rely on XCCDF processing to apply platforms correctly, while when remediating we rely on generated remediations containing correct conditionals.


#### Rationale:

Fixes #9482 