### PR TITLE
Remove empty load operation

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -2038,9 +2038,6 @@ class LinearLoader(object):
         filenames = glob.glob(os.path.join(self.resolved_groups_dir, "*.yml"))
         self.load_entities_by_id(filenames, self.groups, Group)
 
-        filenames = glob.glob(os.path.join(self.resolved_profiles_dir, "*.yml"))
-        self.load_entities_by_id(filenames, self.profiles, Profile)
-
         filenames = glob.glob(os.path.join(self.resolved_values_dir, "*.yml"))
         self.load_entities_by_id(filenames, self.values, Value)
 


### PR DESCRIPTION
This commit removes code that doesn't load anything because resolved profiles have `.profile` file name, not `.yml` file name so this glob doesn't match any file. The profiles are loaded using `add_profiles_from_dir` method from the `Benchmark` class instead.


