### PR TITLE
OCP: Add var_access_token_inactivity_timeout_seconds

### DIFF
--- a/applications/openshift/authentication/oauthclient_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauthclient_inactivity_timeout/rule.yml
@@ -65,4 +65,4 @@ template:
         yamlpath: ".items[:].accessTokenInactivityTimeoutSeconds"
         check_existence: "all_exist"
         entity_check: "all"
-        xccdf_variable: var_oauth_inactivity_timeout
+        xccdf_variable: var_access_token_inactivity_timeout_seconds

--- a/applications/openshift/authentication/oauthclient_inactivity_timeout/tests/correct.pass.sh
+++ b/applications/openshift/authentication/oauthclient_inactivity_timeout/tests/correct.pass.sh
@@ -39,7 +39,7 @@ cat << EOF > /kubernetes-api-resources/apis/oauth.openshift.io/v1/oauthclients
             "apiVersion": "oauth.openshift.io/v1",
             "grantMethod": "auto",
             "kind": "OAuthClient",
-            "accessTokenInactivityTimeoutSeconds": "10m0s",
+            "accessTokenInactivityTimeoutSeconds": "600",
             "metadata": {
                 "creationTimestamp": "2022-06-20T15:52:50Z",
                 "name": "openshift-browser-client",

--- a/applications/openshift/authentication/var_access_token_inactivity_timeout_seconds.var
+++ b/applications/openshift/authentication/var_access_token_inactivity_timeout_seconds.var
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'OAuth Clients Token Inactivity Timeout'
+
+description: 'Enter OAuth Clients Token Inactivity Timeout in Seconds'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    600s: "600"
+    default: "600"


### PR DESCRIPTION
We need to add var_access_token_inactivity_timeout_seconds variable for rule `oauthclient_inactivity_timeout`
