### PR TITLE
Update aide-related rules to align with RHEL9 STIG

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -46,20 +46,20 @@ references:
     stigid@sle15: SLES-15-030630
     stigid@ubuntu2004: UBTU-20-010205
 
-ocil_clause: 'integrity checks of the audit tools are missing or incomplete'
-
 ocil: |-
     Check that AIDE is properly configured to protect the integrity of the
-    audit tools by running the following command:
+    audit tools with the following command:
 
-    <pre># sudo cat {{{ aide_conf_path }}} | grep /usr/sbin/au
+    <pre>$ sudo cat {{{ aide_conf_path }}} | grep /usr/sbin/au
 
     {{{ aide_files() }}}
     </pre>
-    If AIDE is configured properly to protect the integrity of the audit tools,
-    all lines listed above will be returned from the command.
 
-    If one or more lines are missing, this is a finding.
+ocil_clause: |-
+    AIDE is not installed, ask the System Administrator how file integrity checks are performed on the system.
+    If any of the audit tools listed above do not have a corresponding line, ask the System Administrator to indicate what cryptographic mechanisms are being used to protect the integrity of the audit tools.  
+    If there is no evidence of integrity protection
+
 
 fixtext: |-
     Add or update the following lines to "/etc/aide.conf", to protect the integrity of the audit tools.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -70,14 +70,13 @@ references:
     stigid@ubuntu2004: UBTU-20-010074
 
 {{%- if "rhel" in product %}}
-ocil_clause: |-
+ocil_clause: >-
     the file integrity application does not exist, or
     a script file controlling the execution of the file integrity application does not exist, or
     the file integrity application does not notify designated personnel of changes
 
 ocil: |-
-    Verify that {{{ full_name }}} routinely executes a file integrity scan for changes to the system baseline.
-    The command used in the example will use a daily occurrence.
+    Verify that {{{ full_name }}} routinely executes a file integrity scan for changes to the system baseline. The command used in the example will use a daily occurrence.
     Check the cron directories for scripts controlling the execution and notification of results of the file integrity application.
     For example, if AIDE is installed on the system, use the following commands:
     <pre>
@@ -94,9 +93,7 @@ ocil: |-
 ocil_clause: 'AIDE is not configured to scan periodically'
 
 ocil: |-
-    Verify the operating system routinely checks the baseline configuration for unauthorized changes.
-
-    To determine that periodic AIDE execution has been scheduled, run the following command:
+    Verify the operating system routinely checks the baseline configuration for unauthorized changes. To determine that periodic AIDE execution has been scheduled, run the following command:
     <pre>$ grep aide /etc/crontab</pre>
     The output should return something similar to the following:
     <pre>05 4 * * * root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -69,6 +69,28 @@ references:
     stigid@sle15: SLES-15-010570
     stigid@ubuntu2004: UBTU-20-010074
 
+{{%- if "rhel" in product %}}
+ocil_clause: |-
+    the file integrity application does not exist, or
+    a script file controlling the execution of the file integrity application does not exist, or
+    the file integrity application does not notify designated personnel of changes
+
+ocil: |-
+    Verify that {{{ full_name }}} routinely executes a file integrity scan for changes to the system baseline.
+    The command used in the example will use a daily occurrence.
+    Check the cron directories for scripts controlling the execution and notification of results of the file integrity application.
+    For example, if AIDE is installed on the system, use the following commands:
+    <pre>
+    $ ls -al /etc/cron.* | grep aide
+    -rwxr-xr-x 1 root root 29 Nov 22 2015 aide
+    $ grep aide /etc/crontab /var/spool/cron/root
+    /etc/crontab: 30 04 * * * root usr/sbin/aide
+    /var/spool/cron/root: 30 04 * * * root usr/sbin/aide
+    $ sudo more /etc/cron.daily/aide
+    #!/bin/bash
+    /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+    </pre>
+{{%- else %}}
 ocil_clause: 'AIDE is not configured to scan periodically'
 
 ocil: |-
@@ -80,11 +102,26 @@ ocil: |-
     <pre>05 4 * * * root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>
 
     NOTE: The usage of special cron times, such as @daily or @weekly, is acceptable.
+{{%- endif %}}
 
 fixtext: |-
+    Configure the file integrity tool to run automatically on the system at least weekly and to
+    notify designated personnel if baseline configurations are changed in an unauthorized manner.
+    {{%- if "rhel" in product %}}
+    The AIDE tool can be configured to email designated personnel with the use of the cron system.
+    The following example output is generic.
+    It will set cron to run AIDE daily and to send email at the completion of the analysis.
+
+    <pre>
+    $ sudo more /etc/cron.daily/aide
+    #!/bin/bash
+    {{{ aide_bin_path }}} --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+    </pre>
+    {{%- else %}}
     Configure the file integrity to run at least weekly.
     Edit "/etc/crontab" and add or edit the following line:
 
     <pre>05 4 * * * root {{{ aide_bin_path }}} {{{ config_command_line }}}--check</pre>
+    {{%- endif %}}
 
-srg_requirement: '{{{ full_name }}} must notify the system administrator when Advanced Intrusion Detection Environment (AIDE) discovers anomalies in the operation of any security functions.'
+srg_requirement: {{{ full_name }}} must routinely check the baseline configuration for unauthorized changes and notify the system administrator when anomalies in the operation of any security functions are discovered.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
@@ -25,6 +25,18 @@ rationale: |-
     Security Officer (ISSO) and System Administrators (SAs) must be notified via email and/or
     monitoring system trap when there is an unauthorized modification of a configuration item.
 
+vuldiscussion: |
+    If anomalies are not acted upon, security functions may fail to secure the system.
+    Security function is defined as the hardware, software, and/or firmware of the information system responsible for
+    enforcing the system security policy and supporting the isolation of code and data on which the protection is based.
+    Security functionality includes, but is not limited to, establishing system accounts,
+    configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and
+    setting intrusion detection parameters.
+    Notifications provided by information systems include messages to local computer consoles,
+    and/or hardware indications, such as lights.
+    This capability must take into account operational requirements for availability for selecting an appropriate response.
+    The organization may choose to shut down or restart the information system upon security function anomaly detection.
+
 severity: medium
 
 identifiers:
@@ -75,4 +87,4 @@ fixtext: |-
     /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
 
 srg_requirement: |-
-    The {{{ full_name }}} file integrity tool must notify the system administrator when changes to the baseline configuration or anomalies in the operation of any security functions are discovered within an organizationally defined frequency.
+    {{{ full_name }}} Must Shut Down The Information System, Restart The Information System, And/Or Notify The System Administrator When Anomalies In The Operation Of Any Security Functions Are Discovered.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/rule.yml
@@ -47,16 +47,21 @@ references:
     stigid@sle12: SLES-12-010520
     stigid@sle15: SLES-15-040040
 
-ocil_clause: 'the acl option is missing or not added to the correct ruleset'
+ocil_clause: |-
+    the "acl" rule is not being used on all uncommented selection lines in the "/etc/aide.conf" file, or
+    ACLs are not being checked by another file integrity tool
 
 ocil: |-
-    To determine that AIDE is verifying ACLs, run the following command:
-    <pre>$ grep acl /etc/aide.conf</pre>
-    Verify that the <tt>acl</tt> option is added to the correct ruleset.
+    Verify that that AIDE is verifying ACLs with the following command:
+    <pre>
+    $ grep acl /etc/aide.conf
+
+    All= p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux
+    </pre>
 
 fixtext: |-
     Configure the file integrity tool to check file and directory ACLs.
 
-    If AIDE is installed, ensure the "acl" rule is present on all file and directory selection lists.
+    If AIDE is installed, ensure the "acl" rule is present on all uncommented file and directory selection lists.
 
-srg_requirement: 'The {{{ full_name }}} file integrity tool must be configured to verify Access Control Lists (ACLs).'
+srg_requirement: {{{ full_name }}} must be configured so that the file integrity tool verifies Access Control Lists (ACLs).

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
@@ -47,16 +47,18 @@ references:
     stigid@sle12: SLES-12-010530
     stigid@sle15: SLES-15-040050
 
-ocil_clause: 'the xattrs option is missing or not added to the correct ruleset'
+ocil_clause: |-
+    the "xattrs" rule is not being used on all uncommented selection lines in the "/etc/aide.conf" file, or
+    extended attributes are not being checked by another file integrity tool
 
 ocil: |-
-    To determine that AIDE is verifying extended file attributes, run the following command:
-    <pre>$ grep xattrs /etc/aide.conf</pre>
-    Verify that the <tt>xattrs</tt> option is added to the correct ruleset.
+    Verify that that AIDE is verify extended attributes with the following command:
+    <pre>$ grep xattrs /etc/aide.conf
+    All= p+i+n+u+g+s+m+S+sha512+acl+xattrs+selinux</pre>
 
 fixtext: |-
     Configure the file integrity tool to check file and directory extended attributes.
 
     If AIDE is installed, ensure the "xattrs" rule is present on all uncommented file and directory selection lists.
 
-srg_requirement: 'The {{{ full_name }}} file integrity tool must be configured to verify extended attributes.'
+srg_requirement: {{{ full_name }}} must be configured so that the file integrity tool verifies extended attributes.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/rule.yml
@@ -47,7 +47,7 @@ references:
     stigid@sle12: SLES-12-010530
     stigid@sle15: SLES-15-040050
 
-ocil_clause: |-
+ocil_clause: >-
     the "xattrs" rule is not being used on all uncommented selection lines in the "/etc/aide.conf" file, or
     extended attributes are not being checked by another file integrity tool
 

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1034,7 +1034,7 @@ Configure the default Grub2 kernel command line to contain {{{ arg_name_value }}
 p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
 {{%- else -%}}
 p+i+n+u+g+s+b+acl+xattrs+sha512
-{{% endif %}}
+{{%- endif -%}}
 {{%- endmacro -%}}
 
 {{#
@@ -1047,11 +1047,17 @@ p+i+n+u+g+s+b+acl+xattrs+sha512
     /usr/sbin/ausearch {{{ aide_string() }}}
     /usr/sbin/aureport {{{ aide_string() }}}
     /usr/sbin/autrace {{{ aide_string() }}}
-    {{% if 'rhel' not in product and product != 'ol8' %}}/usr/sbin/audispd {{{ aide_string() }}}{{% endif %}}
-    {{% if product == 'ol8' %}}/usr/sbin/rsyslogd {{{ aide_string() }}}{{% endif %}}
-    {{% if product == 'rhel9' %}}/usr/sbin/autrace {{{ aide_string() }}}{{% endif %}}
+{{%- if 'rhel' not in product and product != 'ol8' %}}
+    /usr/sbin/audispd {{{ aide_string() }}}
+{{%- endif %}}
+{{%- if product == 'ol8' %}}
+    /usr/sbin/rsyslogd {{{ aide_string() }}}
+{{%- endif %}}
+{{%- if product == 'rhel9' %}}
+    /usr/sbin/autrace {{{ aide_string() }}}
+{{%- endif %}}
     /usr/sbin/augenrules {{{ aide_string() }}}
-{{% endmacro %}}
+{{%- endmacro %}}
 
 
 {{#


### PR DESCRIPTION
Easy changes:

- `aide_verify_acls`
- `aide_verify_ext_attributes`

Slightly problematic changes:

- `aide_check_audit_tools` - whitespace-fixing multi-product macro edit)
- `aide_periodic_cron_checking` - avoided clash with other products at the cost of adding jinja if statements

Tricky:
`aide_scan_notification` - the new srg_requirement says that "RHEL... Must Shut Down The Information System, Restart The Information System, **And/Or** Notify The System Administrator When Anomalies In The Operation Of Any Security Functions Are Discovered". Previously, the rule was solely about notifications, now it got this shutdown/restart part, but maybe it's optional? That's unclear, in any way the rule's associated content is solely about the notification. 