### PR TITLE
Update account_password_selinux_faillock_dir rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -59,4 +59,5 @@ fixtext: |-
 
     $ sudo restorecon -R -v /var/log/faillock
 
-srg_requirement: '{{{ full_name }}} must configure SELinux context type to allow the use of a non-default pam_faillock.so tally directory.'
+srg_requirement: |-
+    {{{ full_name }}} must configure SELinux context type to allow the use of a non-default faillock tally directory.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -45,17 +45,17 @@ ocil: |-
     unconfined_u:object_r:faillog_t:s0 /var/log/faillock
 
 fixtext: |-
-    Configure {{{ full_name }}} to allow the use of a non-default pam_faillock.so tally directory while SELinux enforces a targeted policy.
+    Configure {{{ full_name }}} to allow the use of a non-default faillock tally directory while SELinux enforces a targeted policy.
 
-    Create a non-default pam_faillock.so tally directory (if it does not already exist) with the following example:
+    Create a non-default faillock tally directory (if it does not already exist) with the following example:
 
     $ sudo mkdir /var/log/faillock
 
-    Update the /etc/selinux/targeted/contexts/files/file_contexts.local with "faillog_t" context type for the non-default pam_faillock.so tally directory with the following command:
+    Update the /etc/selinux/targeted/contexts/files/file_contexts.local with "faillog_t" context type for the non-default faillock tally directory with the following command:
 
     $ sudo semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
 
-    Next, update the context type of the non-default pam_faillock.so directory/subdirectories and files with the following command:
+    Next, update the context type of the non-default faillock directory/subdirectories and files with the following command:
 
     $ sudo restorecon -R -v /var/log/faillock
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/rule.yml
@@ -30,9 +30,11 @@ platform: machine
 ocil_clause: 'the security context type of the non-default tally directory is not "faillog_t"'
 
 ocil: |-
-    If the system does not have SELinux enabled and enforcing a targeted policy, or if the pam_faillock.so module is not configured for use, this requirement is not applicable.
+    If the system does not have SELinux enabled and enforcing a targeted policy, or if the
+    pam_faillock.so module is not configured for use, this requirement is not applicable.
 
-    Verify the location of the non-default tally directory for the pam_faillock module with the following command:
+    Verify the location of the non-default tally directory for the pam_faillock.so module with
+    the following command:
 
     $ sudo grep -w dir /etc/security/faillock.conf
 


### PR DESCRIPTION
#### Description:

Update ocil, fixtext and srg_requirement in alignment to STIG.

#### Rationale:

STIG alignment
