### PR TITLE
Remove audit_rules_execution_restorecon from SRG control files.

### DIFF
--- a/controls/srg_gpos/SRG-OS-000392-GPOS-00172.yml
+++ b/controls/srg_gpos/SRG-OS-000392-GPOS-00172.yml
@@ -23,7 +23,6 @@ controls:
             - audit_rules_execution_chacl
             - audit_rules_execution_setfacl
             - audit_rules_execution_chcon
-            - audit_rules_execution_restorecon
             - audit_rules_execution_semanage
             - audit_rules_execution_setfiles
             - audit_rules_execution_setsebool

--- a/controls/srg_gpos/SRG-OS-000463-GPOS-00207.yml
+++ b/controls/srg_gpos/SRG-OS-000463-GPOS-00207.yml
@@ -11,7 +11,6 @@ controls:
             - audit_rules_dac_modification_lsetxattr
             - audit_rules_dac_modification_removexattr
             - audit_rules_execution_chcon
-            - audit_rules_execution_restorecon
             - audit_rules_execution_semanage
             - audit_rules_execution_setfiles
             - audit_rules_execution_setsebool

--- a/controls/srg_gpos/SRG-OS-000465-GPOS-00209.yml
+++ b/controls/srg_gpos/SRG-OS-000465-GPOS-00209.yml
@@ -6,7 +6,6 @@ controls:
             attempts to modify categories of information (e.g., classification levels) occur.
         rules:
             - audit_rules_execution_chcon
-            - audit_rules_execution_restorecon
             - audit_rules_execution_semanage
             - audit_rules_execution_setfiles
             - audit_rules_execution_setsebool


### PR DESCRIPTION


#### Description:
- Remove audit_rules_execution_restorecon from SRG control files.

#### Rationale:

 - It's basically the same as audit_rules_execution_setfiles and this one should be enough to cover the SRG requirement.
