### PR TITLE
Add variable for auditd freq

### DIFF
--- a/controls/srg_gpos/SRG-OS-000051-GPOS-00024.yml
+++ b/controls/srg_gpos/SRG-OS-000051-GPOS-00024.yml
@@ -5,6 +5,7 @@ controls:
         title: {{{ full_name }}} must provide the capability to centrally review and
             analyze audit records from multiple components within the system.
         rules:
+            - var_auditd_freq=100
             - auditd_freq
             - service_auditd_enabled
             - package_audit_installed

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_freq/rule.yml
@@ -4,11 +4,11 @@ title: 'Set number of records to cause an explicit flush to audit logs'
 
 description: |-
     To configure Audit daemon to issue an explicit flush to disk command
-    after writing 50 records, set <tt>freq</tt> to <tt>50</tt>
+    after writing {{{ xccdf_value("var_auditd_freq") }}} records, set <tt>freq</tt> to <tt>{{{ xccdf_value("var_auditd_freq") }}}</tt>
     in <tt>/etc/audit/auditd.conf</tt>.
 
 rationale: |-
-    If option <tt>freq</tt> isn't set to <tt>50</tt>, the flush to disk
+    If option <tt>freq</tt> isn't set to <tt>{{{ xccdf_value("var_auditd_freq") }}}</tt>, the flush to disk
     may happen after higher number of records, increasing the danger
     of audit loss.
 
@@ -25,17 +25,17 @@ references:
     ospp: FAU_GEN.1
     srg: SRG-OS-000051-GPOS-00024
 
-ocil_clause: freq isn't set to 50
+ocil_clause: freq isn't set to {{{ xccdf_value("var_auditd_freq") }}}
 
 ocil: |-
     To verify that Audit Daemon is configured to flush to disk after
-    every 50 records, run the following command:
+    every {{{ xccdf_value("var_auditd_freq") }}} records, run the following command:
     <pre>$ sudo grep freq /etc/audit/auditd.conf</pre>
     The output should return the following:
-    <pre>freq = 50</pre>
+    <pre>freq = {{{ xccdf_value("var_auditd_freq") }}}</pre>
 
 fixtext: |-
-    {{{ fixtext_audit_configuration(param="freq", value="50") | indent(4) }}}
+    {{{ fixtext_audit_configuration(param="freq", value=xccdf_value("var_auditd_freq")) | indent(4) }}}
 
 srg_requirement: |-
     {{{ full_name }}} must periodically flush audit records to disk to ensure that audit records are not lost.

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_freq.var
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/var_auditd_freq.var
@@ -1,0 +1,15 @@
+documentation_complete: true
+
+title: 'Number of Record to Retain Before Flushing to Disk'
+
+description: 'The setting for freq in /etc/audit/auditd.conf'
+
+type: number
+
+interactive: true
+
+
+options:
+    50: 50
+    100: 100
+    default: 50


### PR DESCRIPTION
#### Description:

Make the value for auditd_freq not hard coded.

#### Rationale:
RHEL 9 STIG is proposed to use a new value.
