### PR TITLE
Align sysctl rules to RHEL9 STIG

### DIFF
--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/rule.yml
@@ -29,10 +29,16 @@ references:
     stigid@ol8: OL08-00-010374
     stigid@rhel8: RHEL-08-010374
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="fs.protected_hardlinks", value="1") }}}
+ocil: |
+    Verify {{{ full_name }}} is configured to enable DAC on hardlinks.
+
+    {{{ ocil_sysctl_option_value(sysctl="fs.protected_hardlinks", value="1") }}}
+
+ocil_clause: |
+    "fs.protected_hardlinks is not set to 1 or is missing"
 
 fixtext: |-
-    Verify the operating system is configured to enable DAC on hardlinks with the following commands:
+    Verify {{{ full_name }}} is configured to enable DAC on hardlinks with the following commands:
     {{{ fixtext_sysctl("fs.protected_hardlinks", "1") | indent(4) }}}
 
 srg_requirement: '{{{ full_name }}} must enable kernel parameters to enforce discretionary access control on hardlinks.'
@@ -45,3 +51,14 @@ template:
         datatype: int
 
 platform: machine
+
+vuldiscussion: |-
+    Preventing non-privileged users from executing privileged functions mitigates the risk that
+    unauthorized individuals or processes may gain unnecessary access to information or
+    privileges.
+
+    Privileged functions include, for example, establishing accounts, performing system integrity
+    checks, or administering cryptographic key management activities. Non-privileged users are
+    individuals that do not possess appropriate authorizations. Circumventing intrusion detection
+    and prevention mechanisms or malicious code protection mechanisms are examples of privileged
+    functions that require protection from non-privileged users.

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/rule.yml
@@ -31,10 +31,16 @@ references:
     stigid@ol8: OL08-00-010373
     stigid@rhel8: RHEL-08-010373
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="fs.protected_symlinks", value="1") }}}
+ocil: |
+    Verify {{{ full_name }}} is configured to enable DAC on symlinks.
+
+    {{{ ocil_sysctl_option_value(sysctl="fs.protected_symlinks", value="1") }}}
+
+ocil_clause: |
+    "fs.protected_symlinks is not set to 1 or is missing"
 
 fixtext: |-
-    Verify the operating system is configured to enable DAC on symlinks with the following commands:
+    Verify {{{ full_name }}} is configured to enable DAC on symlinks with the following commands:
     {{{ fixtext_sysctl("fs.protected_symlinks", "1") | indent(4) }}}
 
 srg_requirement: '{{{ full_name }}} must enable kernel parameters to enforce discretionary access control on symlinks.'
@@ -47,3 +53,14 @@ template:
         datatype: int
 
 platform: machine
+
+vuldiscussion: |-
+    Preventing non-privileged users from executing privileged functions mitigates the risk that
+    unauthorized individuals or processes may gain unnecessary access to information or
+    privileges.
+
+    Privileged functions include, for example, establishing accounts, performing system integrity
+    checks, or administering cryptographic key management activities. Non-privileged users are
+    individuals that do not possess appropriate authorizations. Circumventing intrusion detection
+    and prevention mechanisms or malicious code protection mechanisms are examples of privileged
+    functions that require protection from non-privileged users.

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/rule.yml
@@ -85,3 +85,14 @@ fixtext: |-
 
     {{{ fixtext_grub2_bootloader_argument_absent("noexec") | indent(4) }}}
     {{%- endif -%}}
+
+srg_requirement: |-
+    {{{ full_name }}} must implement non-executable data to protect its memory from unauthorized
+    code execution.
+
+checktext: |-
+    Verify ExecShield is enabled on 64-bit {{{ full_name }}} systems with the following command:
+    $ dmesg | grep '[NX|DX]*protection'
+    [ 0.000000] NX (Execute Disable) protection: active
+
+    If "dmesg" does not show "NX (Execute Disable) protection" active, this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/rule.yml
@@ -32,34 +32,26 @@ references:
     stigid@sle12: SLES-12-030320
     stigid@sle15: SLES-15-010540
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.kptr_restrict", value="1") }}}
-
 ocil: |-
-    The runtime status of the <code>kernel.kptr_restrict</code> kernel parameter can be queried
-    by running the following command:
+    Verify {{{ full_name }}} restricts exposed kernel pointer addresses access.
+
+    Check the status of the <code>kernel.kptr_restrict</code> kernel parameter with the
+    following commands:
     <pre>$ sysctl kernel.kptr_restrict</pre>
     The output of the command should indicate either:
     <code>kernel.kptr_restrict = 1</code>
     or:
     <code>kernel.kptr_restrict = 2</code>
-    The output of the command should not indicate:
-    <code>kernel.kptr_restrict = 0</code>
 
-    The preferable way how to assure the runtime compliance is to have
-    correct persistent configuration, and rebooting the system.
+    If kernel.kptr_restrict is not set to 1 or 2 or is missing, this is a finding.
 
-    The persistent kernel parameter configuration is performed by specifying the appropriate
-    assignment in any file located in the <pre>/etc/sysctl.d</pre> directory.
-    Verify that there is not any existing incorrect configuration by executing the following command:
-    <pre>$ grep -r '^\s*kernel.kptr_restrict\s*=' /etc/sysctl.conf /etc/sysctl.d</pre>
-    The command should not find any assignments other than:
-    kernel.kptr_restrict = 1
+    Check that the configuration files are present to enable this kernel parameter.
+    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel\.kptr_restrict | tail -1
+    <code>kernel.kptr_restrict = 1</code>
     or:
-    kernel.kptr_restrict = 2
+    <code>kernel.kptr_restrict = 2</code>
 
-    Conflicting assignments are not allowed.
-
-ocil_clause: "the kernel.kptr_restrict is not set to 1 or 2 or is configured to be 0"
+ocil_clause: "the kernel.kptr_restrict is not set to 1 or 2 or is missing"
 
 srg_requirement: '{{{ full_name }}} must restrict exposed kernel pointer addresses access.'
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/rule.yml
@@ -45,7 +45,13 @@ references:
     stigid@sle15: SLES-15-010550
     stigid@ubuntu2004: UBTU-20-010448
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.randomize_va_space", value="2") }}}
+ocil: |-
+    Verify {{{ full_name }}} is implementing ASLR with the following command:
+
+    {{{ ocil_sysctl_option_value(sysctl="kernel.randomize_va_space", value="2") }}}
+
+ocil_clause: |-
+    "kernel.randomize_va_space is not set to 2 or is missing"
 
 srg_requirement: '{{{ full_name }}} must implement address space layout randomization (ASLR) to protect its memory from unauthorized code execution.'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/rule.yml
@@ -32,12 +32,21 @@ references:
     stigid@rhel8: RHEL-08-010671
 
 ocil_clause:  |-
-    the returned line does not have a value of "|/bin/false", or a line is not
-    returned and the need for core dumps is not documented with the Information
-    System Security Officer (ISSO) as an operational requirement
+    "kernel.core_pattern" is not set to "|/bin/false" and is not documented with the
+    Information System Security Officer (ISSO) as an operational requirement, or is missing
 
 ocil: |
-    {{{ ocil_sysctl_option_value(sysctl="kernel.core_pattern", value="|/bin/false") }}}
+    Verify {{{ full_name }}} disables storing core dumps with the following commands:
+
+    $ sudo sysctl kernel.core_pattern
+    kernel.core_pattern = |/bin/false
+    If the returned line does not have a value of "|/bin/false", or a line is not returned and
+    the need for core dumps is not documented with the Information System Security Officer (ISSO)
+    as an operational requirement, this is a finding.
+
+    Check that the configuration files are present to disable core dump storage.
+    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.core_pattern | tail -1
+    kernel.core_pattern = |/bin/false
 
 fixtext: |-
     Configure {{{ full_name }}} to disable storing core dumps.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -30,10 +30,16 @@ references:
     stigid@ol8: OL08-00-010375
     stigid@rhel8: RHEL-08-010375
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.dmesg_restrict", value="1") }}}
+ocil: |
+    Verify {{{ full_name }}} is configured to restrict access to the kernel message buffer.
+
+    {{{ ocil_sysctl_option_value(sysctl="kernel.dmesg_restrict", value="1") }}}
+
+ocil_clause: |
+    "kernel.dmesg_restrict is not set to 1 or is missing"
 
 fixtext: |-
-    Configure {{{ full_name }}} to restrict access to the dmesg bus.
+    Configure {{{ full_name }}} to restrict access to the kernel message buffer.
     {{{ fixtext_sysctl("kernel.dmesg_restrict", "1") | indent(4) }}}
 
 srg_requirement: '{{{ full_name }}} must restrict access to the kernel message buffer.'

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/rule.yml
@@ -26,7 +26,13 @@ references:
     stigid@rhel8: RHEL-08-010372
 
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.kexec_load_disabled", value="1") }}}
+ocil: |
+    Verify {{{ full_name }}} is configured to disable kernel image loading.
+
+    {{{ ocil_sysctl_option_value(sysctl="kernel.kexec_load_disabled", value="1") }}}
+
+ocil_clause: |
+    "kernel.kexec_load_disabled is not set to 1 or is missing"
 
 srg_requirement: '{{{ full_name }}} must prevent the loading of a new kernel for later execution.'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
@@ -29,9 +29,15 @@ references:
     stigid@rhel8: RHEL-08-010376
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.perf_event_paranoid", value="2") }}}
+ocil: |-
+    Verify {{{ full_name }}} is configured to prevent kernel profiling by unprivileged users.
+    {{{ ocil_sysctl_option_value(sysctl="kernel.perf_event_paranoid", value="2") }}}
+
+ocil_clause: |-
+    "kernel.perf_event_paranoid is not set to 2 or is missing"
 
 fixtext: |-
-    Configure {{{ full_name }}} to only allow root to do kernel profiling.
+    Configure {{{ full_name }}} to prevent profiling by unprivileged users.
     {{{ fixtext_sysctl(sysctl="kernel.perf_event_paranoid", value="2") | indent(4) }}}
 
 srg_requirement: '{{{ full_name }}} must prevent kernel profiling by unprivileged users.'

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/rule.yml
@@ -26,10 +26,17 @@ references:
     stigid@ol8: OL08-00-040281
     stigid@rhel8: RHEL-08-040281
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.unprivileged_bpf_disabled", value="1") }}}
+ocil: |
+    Verify {{{ full_name }}} prevents privilege escalation thru the kernel by disabling access to the bpf syscall.
+
+    {{{ ocil_sysctl_option_value(sysctl="kernel.unprivileged_bpf_disabled", value="1") }}}
+
+ocil_clause: |
+    "kernel.unprivileged_bpf_disabled is not set to 1 or is missing"
 
 fixtext: |-
     Configure {{{ full_name }}} to prevent privilege escalation thru the kernel by disabling access to the bpf syscall.
+    {{{ fixtext_sysctl("kernel.unprivileged_bpf_disabled", "1") | indent(4) }}}
 
 srg_requirement: '{{{ full_name }}} must disable access to network bpf syscall from unprivileged processes.'
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/rule.yml
@@ -30,7 +30,12 @@ references:
     stigid@ol8: OL08-00-040282
     stigid@rhel8: RHEL-08-040282
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.yama.ptrace_scope", value="1") }}}
+ocil: |-
+    Verify {{{ full_name }}} restricts usage of ptrace to descendant processes.
+    {{{ ocil_sysctl_option_value(sysctl="kernel.yama.ptrace_scope", value="1") }}}
+
+ocil_clause: |-
+    "kernel.yama.ptrace_scope is not set to 1 or is missing"
 
 fixtext: |-
     Configure {{{ full_name }}} to restrict usage of ptrace to descendant processes.

--- a/shared/macros/10-fixtext.jinja
+++ b/shared/macros/10-fixtext.jinja
@@ -283,6 +283,7 @@ $ sudo systemctl mask --now {{{ service }}}
 Add or edit the following line in a system configuration file in the "/etc/sysctl.d/" directory:
 {{{ sysctl }}} = {{{ value }}}
 
+The system configuration files need to be reloaded for the changes to take effect.
 Load settings from all system configuration files with the following command:
 
 $ sudo sysctl --system

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -975,10 +975,14 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 
 #}}
 {{% macro ocil_sysctl_option_value(sysctl, value) -%}}
-    The runtime status of the <code>{{{ sysctl }}}</code> kernel parameter can be queried
-    by running the following command:
-    <pre>$ sysctl {{{ sysctl }}}</pre>
-    <code>{{{ value }}}</code>.
+    Check the status of the <code>{{{ sysctl }}}</code> kernel parameter with the following commands:
+    $ sudo sysctl {{{ sysctl }}}
+    {{{ sysctl }}} = {{{ value }}}
+    If {{{ sysctl }}} is not set to {{{ value }}} or is missing, this is a finding.
+
+    Check that the configuration files are present to enable this kernel parameter.
+    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F {{{ sysctl }}} | tail -1
+    {{{ sysctl }}} = {{{ value }}}
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
#### Description:

- Update sysctls rules to align with RHEL9 STIG.
- These rules had move away from using `complete_ocil_entry_sysctl_option_value()`, as each OCIL has a specific sentence particular to the rule.
- Update the check commands in OCIL macro `ocil_sysctl_option_value()`.

#### Rationale:

- STIG alignment

