### PR TITLE
Update some PAM rules for RHEL9 STIG

### DIFF
--- a/controls/srg_gpos.yml
+++ b/controls/srg_gpos.yml
@@ -19,7 +19,6 @@ controls:
             - var_sshd_disable_compression=no
             - var_password_hashing_algorithm=SHA512
             - var_password_pam_dictcheck=1
-            - var_password_pam_retry=3
             - sshd_approved_macs=stig
             - sshd_approved_ciphers=stig
             - sshd_idle_timeout_value=10_minutes

--- a/controls/srg_gpos/SRG-OS-000069-GPOS-00037.yml
+++ b/controls/srg_gpos/SRG-OS-000069-GPOS-00037.yml
@@ -5,6 +5,7 @@ controls:
         title: {{{ full_name }}} must enforce password complexity by requiring that at
             least one upper-case character be used.
         rules:
+            - var_password_pam_retry=3
             - accounts_password_pam_enforce_root
             - accounts_password_pam_retry
             - accounts_password_pam_ucredit

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -50,25 +50,22 @@ references:
     vmmsrg: SRG-OS-000077-VMM-000440
 
 ocil_clause: |-
-     the value of remember is not set equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
+     the line containing "pam_pwhistory.so" does not have the "remember" module argument set,
+     is commented out, or the value of the "remember" module argument is set to less than
+     "{{{ xccdf_value("var_password_pam_remember") }}}"
 
 ocil: |-
-    Check that the operating system prohibits the reuse of a password for
-    a minimum of <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
-    <pre># grep pam_pwhistory.so /etc/pam.d/password-auth
-    password <i>control_flag</i> pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, the returned line is commented out,
-    the line does not contain "remember" value, the value is less than <tt>{{{
-    xccdf_value("var_password_pam_remember") }}}</tt>, the <i>control_flag</i> value isn't one of
-    the next: <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt> this is a
-    finding.
+    Verify {{{ full_name }}} is configured in the password-auth file to prohibit password reuse
+    for a minimum of {{{ xccdf_value("var_password_pam_remember") }}} generations with the following command:
+
+    <pre>$ grep -i remember /etc/pam.d/password-auth
+    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember={{{ xccdf_value("var_password_pam_remember") }}} retry=3</pre>
 
 fixtext: |-
-    To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
-    file <tt>/etc/pam.d/password-auth</tt>, make sure the <tt>remember</tt> parameter is present
-    and it has a value equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
-    For example:
-    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
+    Configure the {{{ full_name }}} password-auth file to prohibit password reuse for a minimum of
+    {{{ xccdf_value("var_password_pam_remember") }}} generations. Add the following line in
+    "/etc/pam.d/password-auth" (or modify the line to have the required value):
+    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember={{{ xccdf_value("var_password_pam_remember") }}} retry=3</pre>
 
 srg_requirement: '{{{ full_name }}} must be configured in the password-auth file to prohibit password reuse for a minimum of five generations.'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -51,25 +51,22 @@ references:
     vmmsrg: SRG-OS-000077-VMM-000440
 
 ocil_clause: |-
-     the value of remember is not set equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
+     the line containing "pam_pwhistory.so" does not have the "remember" module argument set,
+     is commented out, or the value of the "remember" module argument is set to less than
+     "{{{ xccdf_value("var_password_pam_remember") }}}"
 
 ocil: |-
-    Check that the operating system prohibits the reuse of a password for a minimum of
-    <tt>{{{ xccdf_value("var_password_pam_remember") }}}</tt> generations with the following command:
-    <pre># grep pam_pwhistory.so /etc/pam.d/system-auth
-    password <i>control_flag</i> pam_pwhistory.so remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
-    If the command does not return a result, the returned line is commented out,
-    the line does not contain "remember" value, the value is less than <tt>{{{
-    xccdf_value("var_password_pam_remember") }}}</tt>, the <i>control_flag</i> value isn't one of
-    the next: <tt>{{{ xccdf_value("var_password_pam_remember_control_flag") }}}</tt> this is a
-    finding.
+    Verify {{{ full_name }}} is configured in the system-auth file to prohibit password reuse
+    for a minimum of {{{ xccdf_value("var_password_pam_remember") }}} generations with the following command:
+
+    <pre>$ grep -i remember /etc/pam.d/system-auth
+    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember={{{ xccdf_value("var_password_pam_remember") }}} retry=3</pre>
 
 fixtext: |-
-    To configure the <tt>remember</tt> option for the <tt>pam_pwhistory</tt> PAM module, in the
-    file <tt>/etc/pam.d/system-auth</tt>, make sure the <tt>remember</tt> parameter is present
-    and it has a value equal to or greater than {{{ xccdf_value("var_password_pam_remember") }}}
-    For example:
-    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so <i>...existing_options...</i> remember={{{ xccdf_value("var_password_pam_remember") }}} use_authtok</pre>
+    Configure the {{{ full_name }}} system-auth file to prohibit password reuse for a minimum of
+    {{{ xccdf_value("var_password_pam_remember") }}} generations. Add the following line in
+    "/etc/pam.d/system-auth" (or modify the line to have the required value):
+    <pre>password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember={{{ xccdf_value("var_password_pam_remember") }}} retry=3</pre>
 
 srg_requirement: '{{{ full_name }}} must be configured in the system-auth file to prohibit password reuse for a minimum of five generations.'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
@@ -29,6 +29,12 @@ references:
 
 ocil_clause: 'pam_pwquality.so is not enabled in password-auth'
 
+ocil: |-
+    To check if pam_pwhistory.so is enabled in password-auth, run the following command:
+    <pre>$ grep pam_pwquality /etc/pam.d/password-auth</pre>
+    The output should be similar to the following:
+    <pre>password requisite pam_pwquality.so</pre>
+
 fixtext: |-
     Configure {{{ full_name }}} to use "pwquality" to enforce password complexity rules.
 
@@ -37,12 +43,5 @@ fixtext: |-
     password required pam_pwquality.so
 
 srg_requirement: '{{{ full_name }}} must ensure the password complexity module is enabled in the password-auth file.'
-
-
-ocil: |-
-    To check if pam_pwhistory.so is enabled in password-auth, run the following command:
-    <pre>$ grep pam_pwquality /etc/pam.d/password-auth</pre></pre>
-    The output should be similar to the following:
-    <pre>password    requisite                                    pam_pwquality.so</pre>
 
 platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/rule.yml
@@ -30,7 +30,7 @@ references:
 ocil_clause: 'pam_pwquality.so is not enabled in password-auth'
 
 ocil: |-
-    To check if pam_pwhistory.so is enabled in password-auth, run the following command:
+    To check if pam_pwquality.so is enabled in password-auth, run the following command:
     <pre>$ grep pam_pwquality /etc/pam.d/password-auth</pre>
     The output should be similar to the following:
     <pre>password requisite pam_pwquality.so</pre>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
@@ -29,6 +29,12 @@ references:
 
 ocil_clause: 'pam_pwquality.so is not enabled in system-auth'
 
+ocil: |-
+    To check if pam_pwhistory.so is enabled in system-auth, run the following command:
+    <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre>
+    The output should be similar to the following:
+    <pre>password requisite pam_pwquality.so</pre>
+
 fixtext: |-
     Configure {{{ full_name }}} to use "pwquality" to enforce password complexity rules.
 
@@ -37,11 +43,5 @@ fixtext: |-
     password required pam_pwquality.so
 
 srg_requirement: '{{{ full_name }}} must ensure the password complexity module is enabled in the system-auth file.'
-
-ocil: |-
-    To check if pam_pwhistory.so is enabled in system-auth, run the following command:
-    <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre></pre>
-    The output should be similar to the following:
-    <pre>password    requisite                                    pam_pwquality.so</pre>
 
 platform: pam

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/rule.yml
@@ -30,7 +30,7 @@ references:
 ocil_clause: 'pam_pwquality.so is not enabled in system-auth'
 
 ocil: |-
-    To check if pam_pwhistory.so is enabled in system-auth, run the following command:
+    To check if pam_pwquality.so is enabled in system-auth, run the following command:
     <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre>
     The output should be similar to the following:
     <pre>password requisite pam_pwquality.so</pre>

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -56,29 +56,42 @@ references:
     stigid@rhel8: RHEL-08-020104
     stigid@ubuntu2004: UBTU-20-010057
 
-ocil_clause: 'it is not the required value'
+ocil_clause: 'the value of "retry" is set to "0" or greater than "{{{ xccdf_value("var_password_pam_retry") }}}", or is missing'
 
 ocil: |-
-    To check how many retry attempts are permitted on a per-session basis, run the following command:
+    Verify {{{ full_name }}} is configured to limit the "pwquality" retry option to {{{ xccdf_value("var_password_pam_retry") }}}.
+
     {{% if product in ['rhel8', 'rhel9'] %}}
+    Check for the use of the "pwquality" retry option in the pwquality.conf file with the following command:
     <pre>$ grep retry /etc/security/pwquality.conf</pre>
     {{% else %}}
+    Check for the use of the "pwquality" retry option in the PAM files with the following command:
     {{% if 'ubuntu' in product %}}
     <pre>$ grep pam_pwquality /etc/pam.d/common-password</pre>
     {{% else %}}
     <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre>
     {{% endif %}}
+
+    <pre>password required pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}</pre>
     {{% endif %}}
-    The <tt>retry</tt> parameter will indicate how many attempts are permitted.
-    The DoD required value is less than or equal to 3.
-    This would appear as <tt>retry={{{ xccdf_value("var_password_pam_retry") }}}</tt>, or a lower value.
 
 platform: pam
 
 fixtext: |-
-    Configure {{{ full_name }}} to allow at most {{{ xccdf_value("var_password_pam_retry") }}} password prompts per-session.
-    Add or edit the following line in "/etc/security/pwquality.conf":
+    Configure {{{ full_name }}} to limit the "pwquality" retry option to {{{ xccdf_value("var_password_pam_retry") }}}.
+
+    {{% if product in ['rhel8', 'rhel9'] %}}
+    Add the following line to the "/etc/security/pwquality.conf" file (or modify the line to have the required value):
 
     retry={{{ xccdf_value("var_password_pam_retry") }}}
+    {{% else %}}
+    {{% if 'ubuntu' in product %}}
+    Add the following line to the "/etc/pam.d/common-password" file (or modify the line to have the required value):
+    {{% else %}}
+    Add the following line to the "/etc/pam.d/system-auth" file (or modify the line to have the required value):
+    {{% endif %}}
+    password required pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}
+    {{% endif %}}
 
-srg_requirement: '{{{ full_name }}} must ensure the password complexity module is configured for three retries or less.'
+srg_requirement: |-
+    '{{{ full_name }}} must ensure the password complexity module in the system-auth file is configured for three retries or less.'

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/rule.yml
@@ -18,9 +18,9 @@ description: |-
     this is a finding.
 
 rationale: |-
-    The system must use a strong hashing algorithm to store the password. The
-    system must use a sufficient number of hashing rounds to ensure the required
-    level of entropy.
+    Passwords need to be protected at all times, and encryption is the standard method for
+    protecting passwords. If passwords are not encrypted, they can be plainly read
+    (i.e., clear text) and easily compromised.
 
 severity: medium
 
@@ -43,10 +43,10 @@ references:
     stigid@sle15: SLES-15-020180
 
 
-ocil_clause: 'passwords hashed with an unauthorized algorithm are found in /etc/shadow'
+ocil_clause: 'any interactive user password hash does not begin with "$6"'
 
 ocil: |-
-    Check that the interactive user account passwords are using a strong
+    Verify that the interactive user account passwords are using a strong
     password hash with the following command:
 
     <pre>$ sudo cut -d: -f2 /etc/shadow
@@ -56,15 +56,8 @@ ocil: |-
     Password hashes <tt>!</tt> or <tt>*</tt> indicate inactive accounts not
     available for logon and are not evaluated.
 
-    If any interactive user password hash does not begin with <tt>$6</tt>,
-    this is a finding.
-
 fixtext: |-
     Lock all interactive user accounts not using SHA-512 hashing until the passwords can be regenerated with SHA-512.
 
 srg_requirement: |-
-    {{% if product in ['rhel9'] %}}
     {{{ full_name }}} must employ FIPS 140-3 approved cryptographic hashing algorithms for all stored passwords.
-    {{% else %}}
-    {{{ full_name }}} must employ FIPS 140-2 approved cryptographic hashing algorithms for all stored passwords.
-    {{% endif %}}


### PR DESCRIPTION
#### Description:

Some PAM related rules had their ocil, ocil_clause, srg_requirement and fixtext updated to align with STIG.

#### Rationale:

RHEL9 STIG
