### PR TITLE
Add tests to file_ownership_binary_dirs

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/right_owner.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+find /bin/ \
+/usr/bin/ \
+/usr/local/bin/ \
+/sbin/ \
+/usr/sbin/ \
+/usr/local/sbin/ \
+/usr/libexec \
+\! -user root -execdir chown root {} \;

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/wrong_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_binary_dirs/tests/wrong_owner.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+useradd testUser
+
+dirs=("/bin" "/sbin" "/usr/bin" "/usr/sbin" "/usr/libexec" "/usr/local/bin" "/usr/local/sbin")
+
+for directory in "${dirs[@]}"; do
+
+    file="${directory}/emptyfile"
+
+    touch "$file"
+
+    chown testUser "$file"
+done


### PR DESCRIPTION
#### Description:

- Add tests to file_ownership_binary_dirs

#### Rationale:

- This rule didn't have tests
