### PR TITLE
Add tests to rule dir_perms_world_writable_system_owned_group

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/tests/correct_setting.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/tests/correct_setting.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = None
+
+find / -xdev -type d -perm -0002 -gid +999 -print | xargs -I{} chown root {}

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/tests/wrong_setting.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/tests/wrong_setting.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# remediation = None
+
+groupadd testGrp
+
+mkdir testDir
+
+chgrp testGrp  testDir/
+
+chmod 777 testDir/


### PR DESCRIPTION
#### Description:

- Add tests to rule dir_perms_world_writable_system_owned_group

#### Rationale:

- This rule didn't have tests
