### PR TITLE
Add tests to rule no_tmux_in_shells

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/tests/tmux_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/tests/tmux_absent.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if grep -q 'tmux\s*$' /etc/shells ; then
+	sed -i '/tmux\s*$/d' /etc/shells
+fi

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/tests/tmux_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/no_tmux_in_shells/tests/tmux_present.fail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+echo "/usr/bin/tmux" >> /etc/shells


### PR DESCRIPTION
#### Description:

- Add tests to rule `no_tmux_in_shell`

#### Rationale:

- This rule didn't have tests
