### PR TITLE
Add audit_rules_kernel_module_loading_create to RHEL7 STIG profile

### DIFF
--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -332,3 +332,4 @@ selections:
     - sudoers_default_includedir
     - package_aide_installed
     - selinux_context_elevation_for_sudo
+    - audit_rules_kernel_module_loading_create


### PR DESCRIPTION
#### Description:

- Add audit_rules_kernel_module_loading_create to RHEL7 STIG profile.

#### Rationale:

- Fixes #9425 (or at least improve the results of it because we were not selecting the rule)
