### PR TITLE
Make rule applicable only to uefi systems mount_option_boot_efi_nosuid.

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -29,7 +29,7 @@ references:
     stigid@ol8: OL08-00-010572
     stigid@rhel8: RHEL-08-010572
 
-platform: machine
+platform: machine and uefi
 
 template:
     name: mount_option


### PR DESCRIPTION
#### Description:

- Make rule applicable only to uefi systems mount_option_boot_efi_nosuid.

#### Rationale:

- Fixes #9523