### PR TITLE
Add tests to dconf_gnome_session_idle_user_locks

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/comented_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/comented_value.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_lock "# org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/correct_value.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "local.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/missing_value.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+
+dconf update


### PR DESCRIPTION
#### Description:

- Add tests to `dconf_gnome_session_idle_user_locks`

#### Rationale:

- This rule didn't have tests
