### PR TITLE
Use custom content for auditd_name_format because of different path in EL7

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/ansible/shared.yml
@@ -1,0 +1,19 @@
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set auditd_conf_path=audisp_conf_path + "/audispd.conf" %}}
+{{%- else %}}
+  {{%- set auditd_conf_path=audisp_conf_path + "/auditd.conf" %}}
+{{%- endif %}}
+
+{{{ ansible_set_config_file(file=auditd_conf_path,
+                  parameter="name_format",
+                  value="hostname",
+                  create=true,
+                  separator=" = ",
+                  separator_regex="\s*=\s*",
+                  prefix_regex="(?i)^\s*") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/bash/shared.sh
@@ -1,0 +1,22 @@
+# platform = multi_platform_fedora,multi_platform_rhel,multi_platform_ol
+# reboot = true
+# strategy = restrict
+# complexity = low
+# disruption = low
+
+{{%- if product in ["rhel7", "ol7"] %}}
+  {{%- set auditd_conf_path=audisp_conf_path + "/audispd.conf" %}}
+{{%- else %}}
+  {{%- set auditd_conf_path=audisp_conf_path + "/auditd.conf" %}}
+{{%- endif %}}
+
+{{{set_config_file(path=auditd_conf_path,
+                  parameter="name_format",
+                  value="hostname",
+                  create=true,
+                  insensitive=true,
+                  separator=" = ",
+                  separator_regex="\s*=\s*",
+                  prefix_regex="^\s*")}}}
+
+

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/oval/shared.xml
@@ -1,0 +1,12 @@
+{{% if product in ["rhel7", "ol7"] %}}
+{{% set audisp_conf_file = "/audispd.conf" %}}
+{{% else %}}
+{{% set audisp_conf_file = "/auditd.conf" %}}
+{{% endif %}}
+
+{{{ oval_check_config_file(
+    path=audisp_conf_path + audisp_conf_file,
+    prefix_regex="^[ \\t]*(?i)",
+    parameter="name_format",
+    value="(?i)hostname(?-i)",
+    separator_regex="(?-i)[ \\t]*=[ \\t]*") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/rule.yml
@@ -45,11 +45,3 @@ fixtext: |-
 
 srg_requirement: |-
     {{{ full_name }}} must label all off-loaded audit logs before sending them to the central log server.
-
-template:
-    name: auditd_lineinfile
-    vars:
-        missing_parameter_pass: 'false'
-        parameter: name_format
-        rule_id: auditd_name_format
-        value: hostname

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/commented_out.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/commented_out.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# packages = audit
+# Ensure test system has proper directories/files for test scenario
+bash -x setup.sh
+
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*name_format.*$//" $config_file
+# put commented out occurrence
+echo "# name_format = hostname" >> "$config_file"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/correct_value.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# packages = audit
+# Ensure test system has proper directories/files for test scenario
+bash -x setup.sh
+
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+# remove any occurrence
+sed -i "s/^.*name_format.*$//" $config_file
+echo "name_format = hostname" >> $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/empty.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/empty.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# packages = audit
+# Ensure test system has proper directories/files for test scenario
+
+bash -x setup.sh
+
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+if [[ -f $config_file ]]; then
+    echo '' > ${config_file}
+fi

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/file_not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/file_not_present.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = audit
+
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+if [[ -f $config_file ]]; then
+    rm -f $config_file
+fi

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/not_present.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/not_present.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = audit
+# Ensure test system has proper directories/files for test scenario
+bash -x setup.sh
+
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+{{%- endif %}}
+
+sed -i "s/^.*name_format.*$//" $config_file

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/setup.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_name_format/tests/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Use this script to ensure the audit directory structure and audit conf file
+# exist in the test env.
+{{%- if product in ["rhel7", "ol7"] %}}
+config_file="/etc/audisp/audispd.conf"
+# Ensure directory structure exists (useful for container based testing)
+test -d /etc/audisp/ || mkdir -p /etc/audisp/
+{{%- else %}}
+config_file="/etc/audit/auditd.conf"
+# Ensure directory structure exists (useful for container based testing)
+test -d /etc/audit/ || mkdir -p /etc/audit/
+{{%- endif %}}
+
+test -f $config_file || touch $config_file


### PR DESCRIPTION
#### Description:

- Use custom content for auditd_name_format because of different path in EL7.

#### Rationale:

- Fixes https://github.com/ComplianceAsCode/content/issues/9429
