### PR TITLE
Check NM profiles use interace's altnames

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -55,6 +55,8 @@ done
 fi
 {{% endif %}}
 
+ip link show
+
 if [ $nic_bound = false ];then
     # Add first Network profile to SSH enabled zone
     interface="${available_nmconfig_profiles[0]}"

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -23,19 +23,39 @@ if ! grep -q 'service name="ssh"' "/etc/firewalld/zones/${firewalld_sshd_zone}.x
   <service name="ssh"/>' "/etc/firewalld/zones/${firewalld_sshd_zone}.xml"
 fi
 
+available_nmconfig_profiles=()
 # Check if any eth interface is bounded to the zone with SSH service enabled
 nic_bound=false
-readarray -t eth_interface_list < <(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
-for interface in "${eth_interface_list[@]}"; do
+readarray -t dev_interface_list < <(ip link show up | cut -d ' ' -f2 | cut -d ':' -s -f1 | grep -E '^(en|eth)')
+for interface in "${dev_interface_list[@]}"; do
+    if [ -f {{{ network_config_path }}} ]; then
+      available_nmconfig_profiles+=("$interface")
+    fi
     if grep -qi "ZONE=$firewalld_sshd_zone" "{{{ network_config_path }}}"; then
         nic_bound=true
         break;
     fi
 done
 
+{{% if product in ['rhel9'] %}}
+# Check NetworkManager profiles by looking at interface's altnames
+if [ $nic_bound = false ]; then
+  readarray -t altname_interface_list < <(ip link show up | grep -oP '(?<=altname )(.*)')
+  for interface in "${altname_interface_list[@]}"; do
+    if [ -f {{{ network_config_path }}} ]; then
+      available_nmconfig_profiles+=("$interface")
+    fi
+    if grep -qi "ZONE=$firewalld_sshd_zone" "{{{ network_config_path }}}"; then
+        nic_bound=true
+        break;
+    fi
+done
+fi
+{{% endif %}}
+
 if [ $nic_bound = false ];then
-    # Add first NIC to SSH enabled zone
-    interface="${eth_interface_list[0]}"
+    # Add first Network profile to SSH enabled zone
+    interface="${available_nmconfig_profiles[0]}"
 
     if ! firewall-cmd --state -q; then
         {{% if product in ['rhel9'] %}}
@@ -47,7 +67,7 @@ if [ $nic_bound = false ];then
         # If firewalld service is running, we need to do this step with firewall-cmd
         # Otherwise firewalld will communicate with NetworkManage and will revert assigned zone
         # of NetworkManager managed interfaces upon reload
-        firewall-cmd --permanent --zone="$firewalld_sshd_zone" --add-interface="${eth_interface_list[0]}"
+        firewall-cmd --permanent --zone="$firewalld_sshd_zone" --add-interface="$interface"
         firewall-cmd --reload
     fi
 fi

--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/bash/shared.sh
@@ -56,6 +56,7 @@ fi
 {{% endif %}}
 
 ip link show
+ls /etc/NetworkManager/system-connections/
 
 if [ $nic_bound = false ];then
     # Add first Network profile to SSH enabled zone


### PR DESCRIPTION
#### Description:

- Improve remediation so that it checks the NM profiles by `altname`s.

#### Rationale:

- The NM profiles can be named after an interface's `altname` rather than its `device` name.

- Fixes #9495
