### PR TITLE
Unselect configure_gnutls_tls_crypto_policy in RHEL9 STIG.

### DIFF
--- a/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
+++ b/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
@@ -5,7 +5,8 @@ controls:
         title: {{{ full_name }}} must implement cryptography to protect the integrity
             of remote access sessions.
         rules:
-            - configure_gnutls_tls_crypto_policy
+            # https://github.com/ComplianceAsCode/content/issues/9385
+            # - configure_gnutls_tls_crypto_policy
             - configure_openssl_crypto_policy
             - configure_openssl_tls_crypto_policy
             - configure_ssh_crypto_policy

--- a/controls/srg_gpos/SRG-OS-000423-GPOS-00187.yml
+++ b/controls/srg_gpos/SRG-OS-000423-GPOS-00187.yml
@@ -8,6 +8,7 @@ controls:
             - package_openssh-server_installed
             - service_sshd_enabled
             - configure_bind_crypto_policy
-            - configure_gnutls_tls_crypto_policy
+            # https://github.com/ComplianceAsCode/content/issues/9385
+            # - configure_gnutls_tls_crypto_policy
             - sysctl_crypto_fips_enabled
         status: automated


### PR DESCRIPTION
#### Description:

- The module has changed the format of the configuration file and thus doesn't work with current rule. The rule is going to be temporarily disabled from the profile and a new rule should be created to support the new format. Check the issue above for more details.

#### Rationale:

- The rule is broken in RHEL9 and should not be used at this moment.

- Related to: https://github.com/ComplianceAsCode/content/issues/9385
