### PR TITLE
Disable anaconda remediation of mount_option_boot_efi_nosuid

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -37,6 +37,8 @@ template:
         mountpoint: /boot/efi
         mountoption: nosuid
         mount_has_to_exist: "no"
+    backends:
+        anaconda: "off"
 
 fixtext: |-
     {{{ fixtext_mount_option("/boot/efi", "nosuid") }}}


### PR DESCRIPTION
#### Description:
- Disable anaconda remediation of mount_option_boot_efi_nosuid.
- Oscap Anaconda Addon is treating this rule as a required separate partition even on a non-uefi machine, causing the installation to abort if the separate partition is not present on a kickstart installation.

#### Rationale:

- Fixes https://github.com/ComplianceAsCode/content/issues/9528
