### PR TITLE
Add support for regulated fields

### DIFF
--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1280,7 +1280,7 @@ class Rule(XCCDFEntity):
         warnings=lambda: list(),
         conflicts=lambda: list(),
         requires=lambda: list(),
-        regulated_prose=lambda: dict(),
+        policy_specific_content=lambda: dict(),
         platform=lambda: None,
         platforms=lambda: set(),
         sce_metadata=lambda: dict(),
@@ -1353,7 +1353,7 @@ class Rule(XCCDFEntity):
                 cpe_platform = add_platform_if_not_defined(cpe_platform, product_cpes)
                 rule.cpe_platform_names.add(cpe_platform.id_)
 
-        rule.load_regulated_content(yaml_file, env_yaml)
+        rule.load_policy_specific_content(yaml_file, env_yaml)
 
         if sce_metadata and rule.id_ in sce_metadata:
             rule.sce_metadata = sce_metadata[rule.id_]
@@ -1414,32 +1414,47 @@ class Rule(XCCDFEntity):
                     product_references[gref] = gval
         return product_references
 
-    def find_regulated_content(self, rule_root):
-        regulated_dir = os.path.join(rule_root, "regulated")
-        files = glob.glob(os.path.join(regulated_dir, "*.yml"))
-        return files
+    def find_policy_specific_content(self, rule_root):
+        policy_specific_dir = os.path.join(rule_root, "policy")
+        policy_directories = glob.glob(os.path.join(policy_specific_dir, "*"))
+        filenames = set()
+        for pdir in policy_directories:
+            policy_files = glob.glob(os.path.join(pdir, "*.yml"))
+            filenames.update(set(policy_files))
+        return filenames
 
-    def read_regulated_content_file(self, env_yaml, filename):
+    def triage_policy_specific_content(self, product_name, filenames):
+        product_dot_yml = product_name + ".yml"
+        filename_by_policy = dict()
+        for fname in filenames:
+            policy = os.path.basename(os.path.dirname(fname))
+            filename_appropriate_for_storage = (
+                fname.endswith(product_dot_yml)
+                or fname.endswith("shared.yml") and policy not in filename_by_policy)
+            if (filename_appropriate_for_storage):
+                filename_by_policy[policy] = fname
+        return filename_by_policy
+
+    def read_policy_specific_content_file(self, env_yaml, filename):
         yaml_data = open_and_macro_expand(filename, env_yaml)
         return yaml_data
 
-    def read_regulated_content(self, env_yaml, files):
+    def read_policy_specific_content(self, env_yaml, files):
         keys = dict()
-        for f in files:
-            yaml_data = self.read_regulated_content_file(env_yaml, f)
-            keys.update(yaml_data)
-
-        product_suffix = "@{0}".format(env_yaml.get("product"))
-        keys = self._make_items_product_specific(keys, product_suffix)
+        filename_by_policy = self.triage_policy_specific_content(env_yaml["product"], files)
+        for p, f in filename_by_policy.items():
+            yaml_data = self.read_policy_specific_content_file(env_yaml, f)
+            keys[p] = yaml_data
         return keys
 
-    def load_regulated_content(self, rule_filename, env_yaml):
+    def load_policy_specific_content(self, rule_filename, env_yaml):
         rule_root = os.path.dirname(rule_filename)
-        regulated_content_files = self.find_regulated_content(rule_root)
-        regulated_prose = dict()
-        if regulated_content_files:
-            regulated_prose = self.read_regulated_content(env_yaml, regulated_content_files)
-        self.regulated_prose = regulated_prose
+        policy_specific_content_files = self.find_policy_specific_content(rule_root)
+        policy_specific_content = dict()
+        if policy_specific_content_files:
+            policy_specific_content = self.read_policy_specific_content(
+                env_yaml, policy_specific_content_files)
+        self.policy_specific_content = policy_specific_content
 
     def make_template_product_specific(self, product):
         product_suffix = "@{0}".format(product)

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -279,3 +279,20 @@ def test_derive_id_from_file_name():
     assert ssg.build_yaml.derive_id_from_file_name("rule.yml") == "rule"
     assert ssg.build_yaml.derive_id_from_file_name("id.with.dots.yaml") == "id.with.dots"
     assert ssg.build_yaml.derive_id_from_file_name("my_id") == "my_id"
+
+
+def test_rule_triage_policy_files():
+    product = "example"
+    filenames = [
+        "policy/po/shared.yml",
+        "policy/po/example.yml",
+        "policy/li/sample.yml",
+        "policy/li/shared.yml",
+        "policy/cy/sample.yml",
+    ]
+    rule = ssg.build_yaml.Rule("id")
+    triaged = rule.triage_policy_specific_content(product, filenames)
+    number_of_applicable_policies = 2
+    assert len(triaged) == number_of_applicable_policies
+    assert triaged["po"].endswith(product + ".yml")
+    assert triaged["li"].endswith("shared" + ".yml")


### PR DESCRIPTION
#### Description:

This change allows definition of such rule fields in separate files in a free-form schema.
Those fields are accessible in compiled rules under a dedicated key, but they don't appear anywhere else.

#### Rationale:

Allow the content rules to relate to policies in a non-disruptive way. Some policies may be very picky when it comes to implementation of configuration requirements - the wording can be prescribed in a literal way that could interfere with the otherwise neutral and general description/rationale.

#### How to test:

Create a yaml file, e.g. `linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/policy/stig/shared.yml` with e.g. following contents:

```
fixtext: |-
    Configure {{{ full_name }}} to securely compare internal information system clocks at a regular interval with an NTP server by adding/modifying the following line in the /etc/chrony.conf file.
    server [ntp.server.name] iburst maxpoll 10
```

After compiling the datastream, check out the compiled rule at `build/rhel9/rules/chronyd_or_ntpd_set_maxpoll.yml` - keys defined in that file will appear as a subkey of a key `policy_specific_content`.

#### Interesting questions:

- Naming.
- Should there be a deeper folder structure?
- Should individual filenames propagate to e.g. key names?