### PR TITLE
Update auditd_data_retention_max_log_file_action_stig OVAL to accept expected values from RHEL9 STIG profile

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/oval/shared.xml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/oval/shared.xml
@@ -3,19 +3,19 @@
     {{{ oval_metadata("max_log_file_action setting in /etc/audit/auditd.conf is set to a certain action") }}}
 
     <criteria operator="OR">
-        <criterion comment="max_log_file_action setting in auditd.conf" test_ref="test_auditd_data_retention_max_log_file_action_stig_syslog" />
-        <criterion comment="max_log_file_action setting in auditd.conf" test_ref="test_auditd_data_retention_max_log_file_action_stig_keep_logs" />
+        <criterion comment="max_log_file_action setting in auditd.conf" test_ref="test_auditd_data_retention_max_log_file_action_stig_rotate" />
+        <criterion comment="max_log_file_action setting in auditd.conf" test_ref="test_auditd_data_retention_max_log_file_action_stig_single" />
     </criteria>
 
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="admin space left action " id="test_auditd_data_retention_max_log_file_action_stig_syslog" version="1">
+  <ind:textfilecontent54_test check="all" comment="admin space left action " id="test_auditd_data_retention_max_log_file_action_stig_rotate" version="1">
     <ind:object object_ref="object_auditd_data_retention_max_log_file_action_stig" />
-    <ind:state state_ref="state_auditd_data_retention_max_log_file_action_stig_syslog" />
+    <ind:state state_ref="state_auditd_data_retention_max_log_file_action_stig_rotate" />
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_test check="all" comment="admin space left action " id="test_auditd_data_retention_max_log_file_action_stig_keep_logs" version="1">
+  <ind:textfilecontent54_test check="all" comment="admin space left action " id="test_auditd_data_retention_max_log_file_action_stig_single" version="1">
     <ind:object object_ref="object_auditd_data_retention_max_log_file_action_stig" />
-    <ind:state state_ref="state_auditd_data_retention_max_log_file_action_stig_keep_logs" />
+    <ind:state state_ref="state_auditd_data_retention_max_log_file_action_stig_single" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_auditd_data_retention_max_log_file_action_stig" version="2">
@@ -26,11 +26,11 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_auditd_data_retention_max_log_file_action_stig_syslog" version="1">
-    <ind:subexpression operation="case insensitive equals">syslog</ind:subexpression>
+  <ind:textfilecontent54_state id="state_auditd_data_retention_max_log_file_action_stig_rotate" version="1">
+    <ind:subexpression operation="case insensitive equals">rotate</ind:subexpression>
   </ind:textfilecontent54_state>
-    <ind:textfilecontent54_state id="state_auditd_data_retention_max_log_file_action_stig_keep_logs" version="1">
-    <ind:subexpression operation="case insensitive equals">keep_logs</ind:subexpression>
+    <ind:textfilecontent54_state id="state_auditd_data_retention_max_log_file_action_stig_single" version="1">
+    <ind:subexpression operation="case insensitive equals">single</ind:subexpression>
   </ind:textfilecontent54_state>
 
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/rule.yml
@@ -44,7 +44,7 @@ references:
     pcidss: Req-10.7
     srg: SRG-OS-000047-GPOS-00023
 
-ocil_clause: 'the value of the "disk_full_action" option is not "ROTATE", "SINGLE", or the line is commented out, ask the system administrator to indicate how the system takes appropriate action when an audit storage volume is full. If there is no evidence of appropriate action'
+ocil_clause: 'the value of the "max_log_file_action" option is not "ROTATE", "SINGLE", or the line is commented out, ask the system administrator to indicate how the system takes appropriate action when an audit storage volume is full. If there is no evidence of appropriate action'
 
 ocil: |-
     Verify {{{ full_name }}} takes the appropriate action when the audit files have reached maximum size.

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_ignore.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_ignore.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# variables = var_auditd_max_log_file_action=syslog
+# variables = var_auditd_max_log_file_action=rotate
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_keep_logs.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_keep_logs.pass.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# packages = audit
-# variables = var_auditd_max_log_file_action=syslog
-
-. $SHARED/auditd_utils.sh
-prepare_auditd_test_enviroment
-set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "keep_logs"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_not_there.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = audit
-# variables = var_auditd_max_log_file_action=syslog
+# variables = var_auditd_max_log_file_action=rotate
 
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_rotate.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_rotate.pass.sh
@@ -2,7 +2,6 @@
 # packages = audit
 # variables = var_auditd_max_log_file_action=rotate
 
-
 . $SHARED/auditd_utils.sh
 prepare_auditd_test_enviroment
-set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "suspend"
+set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "rotate"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_single.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_single.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_max_log_file_action=single
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "single"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_syslog.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/tests/max_log_file_action_syslog.pass.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-# packages = audit
-# variables = var_auditd_max_log_file_action=syslog
-
-. $SHARED/auditd_utils.sh
-prepare_auditd_test_enviroment
-set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "syslog"


### PR DESCRIPTION
#### Description:
- Update auditd_data_retention_max_log_file_action_stig OVAL to accept expected values from RHEL9 STIG profile.
- Both rotate and single should be accepted.

#### Rationale:

- No failing rule in Centos Stream 9 testing farm STIG profile.
