### PR TITLE
Do not remove remediation for FIPS related rules in derivatives.

### DIFF
--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -111,8 +111,6 @@ def remove_idents(tree_root, namespace, prod="RHEL"):
                     rule.remove(ref)
 
         for fix in rule.findall(".//{%s}fix" % (namespace)):
-            if "fips" in fix.get("id"):
-                rule.remove(fix)
             sub_elems = fix.findall(".//{%s}sub" % (namespace))
             for sub_elem in sub_elems:
                 sub_elem.tail = re.sub(r"[\s]+- CCE-.*", "", sub_elem.tail)


### PR DESCRIPTION
#### Description:

- Do not remove remediation for FIPS related rules in derivatives.
#### Rationale:

- Since we use Centos Stream for testing, we should have the remediation back so we can test fips rules.
