### PR TITLE
[stabilization] Fix OL7 URL documentation link.

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/rule.yml
@@ -10,7 +10,7 @@ description: |-
     {{% if product == "rhel7" %}}
     <li><b>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/smartcards#authconfig-smartcards") }}}</b></li>
     {{% elif product == "ol7" %}}
-    <li><b>{{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/ol7-auth.html#ol7-s4-auth") }}}</b></li>
+    <li><b>{{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/userauth-AuthenticationConfiguration.html#ol7-s4-auth") }}}</b></li>
     {{% endif %}}
     </ul>
 


### PR DESCRIPTION
#### Description:

- Fix OL7 URL documentation link.

#### Rationale:

- Relates to: https://github.com/ComplianceAsCode/content/pull/9562
- 
https://github.com/ComplianceAsCode/content/actions/runs/3075946876/jobs/4969755761#step:11:57
