### PR TITLE
Use string type in `var_event_record_qps` OpenShift Variable

### DIFF
--- a/applications/openshift/kubelet/var_event_record_qps.var
+++ b/applications/openshift/kubelet/var_event_record_qps.var
@@ -4,7 +4,7 @@ title: 'Configure Kubelet Event Limit'
 
 description: 'Maximum event creations per second.'
 
-type: number
+type: string
 
 operator: equals
 


### PR DESCRIPTION

#### Description:

- Use string type in `var_event_record_qps` OpenShift Variable
  - As of now, all variables in yamlfile_value template are considered to be a string and the variables must match that type.

#### Rationale:

- Related to https://github.com/ComplianceAsCode/content/issues/9564

- Should fix: https://github.com/ComplianceAsCode/content/actions/runs/3120974231/jobs/5061972106
