### PR TITLE
[stabilization] Use string type in var_event_record_qps OpenShift Variable

### DIFF
--- a/applications/openshift/kubelet/var_event_record_qps.var
+++ b/applications/openshift/kubelet/var_event_record_qps.var
@@ -4,7 +4,7 @@ title: 'Configure Kubelet Event Limit'
 
 description: 'Maximum event creations per second.'
 
-type: number
+type: string
 
 operator: equals
 


### PR DESCRIPTION
#### Description:

- Backport of https://github.com/ComplianceAsCode/content/pull/9565
