### PR TITLE
[stabilization] Disable anaconda remediation of mount_option_boot_efi_nosuid.

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_efi_nosuid/rule.yml
@@ -37,6 +37,8 @@ template:
         mountpoint: /boot/efi
         mountoption: nosuid
         mount_has_to_exist: "no"
+    backends:
+        anaconda: "off"
 
 fixtext: |-
     {{{ fixtext_mount_option("/boot/efi", "nosuid") }}}


### PR DESCRIPTION
#### Description:

- Backport of https://github.com/ComplianceAsCode/content/pull/9552