### PR TITLE
Clarify instructions for implementing SCCs

### DIFF
--- a/applications/openshift/general/general_apply_scc/rule.yml
+++ b/applications/openshift/general/general_apply_scc/rule.yml
@@ -21,11 +21,11 @@ severity: medium
 ocil_clause: 'SCCs in Pod definitions need review'
 
 ocil: |-
-   Review the pod definitions in your cluster and verify that you have security
-   contexts defined as appropriate.  OpenShift's Security Context Constraint
-   feature is on by default in OpenShift 4 and applied to all pods deployed. SCC
-   selection is determined by a combination of the values in the securityContext
-   and the rolebindings for the account deploying the pod.
+   Review the pod definitions in your cluster and verify they have appropriate
+   security contexts. OpenShift comes configured with default security context
+   constraints you can use immediately to secure pods in your cluster. For more
+   information on security context constraints, how to use them, and how to
+   build your own, please refer to the {{{ weblink(link="https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html", text="OpenShift security constraints documentation") }}}.
 
 references:
     cis@ocp4: 5.6.3


### PR DESCRIPTION
We advise users to deploy security context constraints to secure pods. This is especially important with OpenShift 4, which comes with default security context constraints enabled and ready to use.

Previously, the documentation for using security context constraints was vague. This is somewhat understandable since using security context constrains is open-ended, and really depends on application and pods running within a cluster.

This commit tries to clarify the instructions by briefly introducing security context constraints, and leaving the educational heavy lifting to another OpenShift document that's dedicated to describing that feature and how to use it effectively.

Jira: https://issues.redhat.com/browse/OCPBUGS-698