### PR TITLE
OCP4: Add 4.12-specific test manifests

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_v1beta1_flowschema_catch_all/tests/ocp4/4.12.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta1_flowschema_catch_all/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: NOT-APPLICABLE
+

--- a/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
@@ -27,7 +27,7 @@ identifiers:
   cce@ocp4: CCE-86390-2
 
 platforms:
-  - ocp4.11
+  - ocp4.11 or ocp4.12
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/tests/ocp4/4.12.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/api-server/api_server_insecure_port/tests/ocp4/4.12.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: NOT-APPLICABLE
+

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -33,7 +33,7 @@ identifiers:
   cce@ocp4: CCE-84080-1
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/tests/ocp4/4.12.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -33,7 +33,7 @@ identifiers:
   cce@ocp4: CCE-83591-8
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key/tests/ocp4/4.12.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@ocp4: CCE-83396-2
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
 
 references:
     cis@ocp4: 4.2.10

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/tests/ocp4/4.12.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@ocp4: CCE-90614-9
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
 
 references:
     cis@ocp4: 4.2.10

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/tests/ocp4/4.12.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/tests/ocp4/4.12.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+


### PR DESCRIPTION

#### Description:

Adds platform versions to rules as well as the default test results for
the upcoming OCP release.

#### Rationale:

New OCP version means that we need to add the new version to the
manifests.
