### PR TITLE
Use variable to remediate rule

### DIFF
--- a/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
@@ -3,6 +3,7 @@
 # strategy = configure
 # complexity = low
 # disruption = medium
+{{{ ansible_instantiate_variables("var_sssd_certificate_verification_digest_function") }}}
 
 - name: Ensure that "certificate_verification" is not set in /etc/sssd/sssd.conf
   ini_file:
@@ -23,5 +24,5 @@
       path: /etc/sssd/conf.d/certificate_verification.conf
       section: sssd
       option: certificate_verification
-      value: "ocsp_dgst = sha1"
+      value: "ocsp_dgst = {{ var_sssd_certificate_verification_digest_function }}"
       state: present

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/tests/wrong_value_not_default.fail.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/tests/wrong_value_not_default.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = sssd-common
+# variables = var_sssd_certificate_verification_digest_function=sha512
+
+mkdir -p /etc/sssd/conf.d
+touch /etc/sssd/sssd.conf
+echo -e "[sssd]\ncertificate_verification = ocsp_dgst=sha256" >> /etc/sssd/sssd.conf
+


### PR DESCRIPTION
#### Description:

- Rule `sssd_certificate_verification should` use value from variable var_sssd_certificate_verification_digest_function to remediate.

#### Rationale:

- Rule is resulting in `fail` when remediating with Ansible
- Bash and Ansible are disaligned.
- Fixes #9585
