### PR TITLE
Remove RPM verify rules from RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000278-GPOS-00108.yml
+++ b/controls/srg_gpos/SRG-OS-000278-GPOS-00108.yml
@@ -6,6 +6,4 @@ controls:
             of audit tools.
         rules:
             - aide_check_audit_tools
-            - rpm_verify_ownership
-            - rpm_verify_permissions
         status: automated

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -233,7 +233,6 @@ controls:
             - tftpd_uses_secure_mode
             - display_login_attempts
             - installed_OS_is_vendor_supported
-            - rpm_verify_hashes
             - security_patches_up_to_date
             - grub2_kernel_trust_cpu_rng
 


### PR DESCRIPTION
#### Description:

This PR removes RPM verify rules from the RHEL 9 STIG.

#### Rationale:
Due to high failure rates, this rule is being removed.

Closes #9588
Closes #9587 
Closes #9586