### PR TITLE
Fix var_auditd_max_log_file_action for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000047-GPOS-00023.yml
+++ b/controls/srg_gpos/SRG-OS-000047-GPOS-00023.yml
@@ -11,5 +11,5 @@ controls:
             - auditd_data_disk_full_action_stig
             - var_auditd_disk_full_action=halt
             - auditd_data_retention_max_log_file_action_stig
-            - var_auditd_max_log_file_action=syslog
+            - var_auditd_max_log_file_action=rotate
         status: automated


### PR DESCRIPTION
#### Description:

Backports the reset of d541c51b912 to fix the RHEL 9 STIG.

#### Rationale:
Closes #9584 
