### PR TITLE
Re add `kernel_module_dccp_disabled` to RHEL9 data stream

### DIFF
--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,fedora,ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,alinux3,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Disable DCCP Support'
 


### PR DESCRIPTION

#### Description:

- Re add the rule to RHEL9 data stream.

#### Rationale:

- Although the dccp module is not available for RHEL9, we should not remove the rule. There was a release containing the rule and removing it may break tailorings.

- Fixes #9579 