### PR TITLE
Remove ident_size for .py files from editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indentation_guess = true
 
-[{*.py, *.yml, *.yaml, *.jinja}]
+[*.py]
+indent_style = space
+
+[{*.yml, *.yaml, *.jinja}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
#### Description:

Removes `ident_size` from `.editorconfig` for `.py` files.

#### Rationale:

This was causing issues with Code Climate.
