### PR TITLE
Added 2 SLES15/12' CCE codes to the rule package_httpd_removed

### DIFF
--- a/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
+++ b/linux_os/guide/services/http/disabling_httpd/package_httpd_removed/rule.yml
@@ -21,6 +21,8 @@ identifiers:
     cce@rhel7: CCE-80301-5
     cce@rhel8: CCE-85970-2
     cce@rhel9: CCE-85974-4
+    cce@sle12: CCE-91643-7
+    cce@sle15: CCE-91286-5
 
 references:
     cis-csc: 11,14,3,9


### PR DESCRIPTION
#### Description:

- _Added 2 SLES_12/15 CCE codes to the rule package_httpd_removed_

#### Rationale:

- The rule will be integrated in new profile(s) and at the moment it does not have these codes


