### PR TITLE
Added 2 SLES-15/12' CCE codes to the rule package_samba_removed

### DIFF
--- a/linux_os/guide/services/smb/disabling_samba/package_samba_removed/rule.yml
+++ b/linux_os/guide/services/smb/disabling_samba/package_samba_removed/rule.yml
@@ -16,6 +16,8 @@ identifiers:
     cce@rhel7: CCE-80278-5
     cce@rhel8: CCE-85978-5
     cce@rhel9: CCE-85979-3
+    cce@sle12: CCE-91644-5
+    cce@sle15: CCE-91287-3
 
 references:
     cis@rhel7: 2.2.11


### PR DESCRIPTION
#### Description:

- Added 2 SLES-12/15 CCE codes to the rule package_samba_removed 

#### Rationale:

- At the moment the rule does not have such codes. The rule will be included into new profiles 


