### PR TITLE
Added 2 SLES-15/12' CCE codes for the rule package_net-snmp-removed

### DIFF
--- a/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
+++ b/linux_os/guide/services/snmp/disabling_snmp_service/package_net-snmp_removed/rule.yml
@@ -24,6 +24,8 @@ identifiers:
     cce@rhel7: CCE-80275-1
     cce@rhel8: CCE-85980-1
     cce@rhel9: CCE-85981-9
+    cce@sle12: CCE-91645-2
+    cce@sle15: CCE-91288-1
 
 references:
     cis@rhel7: 2.2.13


### PR DESCRIPTION
#### Description:

- _Added 2 CCE codes in rule package_net-snmp_removed_

#### Rationale:

- At the moment the rule does not have SLES-15/12 CCE codes. It will be included into new profiles 


