### PR TITLE
OCP4: Install FIO from the right catalog

### DIFF
--- a/ocp-resources/e2e/file-integrity-install.yaml
+++ b/ocp-resources/e2e/file-integrity-install.yaml
@@ -8,7 +8,7 @@ spec:
   displayName: File Integrity Operator
   publisher: github.com/openshift/file-integrity-operator
   sourceType: grpc
-  image: quay.io/file-integrity-operator/file-integrity-operator-index:latest
+  image: quay.io/file-integrity-operator/file-integrity-operator-catalog:latest
 ---
 apiVersion: v1
 kind: Namespace


### PR DESCRIPTION

#### Description:

The file integrity operator changes the name of the OPM catalog image
and our e2e manifests kept installing the old one. This was causing
issues with 4.12+ OCP clusters.

#### Rationale:

I'm trying to upgrade our CI to 4.12 and this was causing issues

