### PR TITLE
Added 2 SLES15/12 CCE codes to the rule file_permissions_crontab

### DIFF
--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/rule.yml
@@ -18,6 +18,8 @@ identifiers:
     cce@rhel7: CCE-82205-6
     cce@rhel8: CCE-82206-4
     cce@rhel9: CCE-84176-7
+    cce@sle12: CCE-91667-6
+    cce@sle15: CCE-91299-8
 
 references:
     cis-csc: 12,13,14,15,16,18,3,5


### PR DESCRIPTION
#### Description:

- _Two CCE SLES15/12' codes were added to 'Verify Permissions on crontab' rule  _

#### Rationale:

- The rule will be used in new profile(s)


