### PR TITLE
2 SLES-15/12 CCE codes added to the rule sshd_set_max_sessions

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_maxstartups/rule.yml
@@ -24,6 +24,8 @@ identifiers:
     cce@rhel7: CCE-90714-7
     cce@rhel8: CCE-90718-8
     cce@rhel9: CCE-87872-8
+    cce@sle12: CCE-91679-1
+    cce@sle15: CCE-91309-5
 
 references:
     cis@rhel7: 5.3.21


### PR DESCRIPTION
#### Description:

- _Two CCE SLES-15/12 codes were added to 'Set SSH MaxSessions limit'  _

#### Rationale:

- The rule will be used in new profile(s)


