### PR TITLE
Remove duplicated CCE

### DIFF
--- a/linux_os/guide/services/cron_and_at/service_cron_enabled/rule.yml
+++ b/linux_os/guide/services/cron_and_at/service_cron_enabled/rule.yml
@@ -15,7 +15,7 @@ rationale: |-
 severity: medium
 
 identifiers:
-    cce@sle12: CCE-91667-6
+    cce@sle12: CCE-91680-9
     cce@sle15: CCE-91437-4
 
 references:


### PR DESCRIPTION
A new CCE should be assigned by the responsible people.

#### Description:
- Remove duplicated CCE
- A new CCE should be assigned by the responsible people.

#### Rationale:

- Fix our CI while we wait for a new CCE to be added by SLE maintainers.
