### PR TITLE
compare_ds.py: Identify new and missing rules while comparing content

### DIFF
--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -326,12 +326,14 @@ class StigContentDiffer(StandardContentDiffer):
                             for rule in rules_in_new_benchmark}
 
         for old_rule in rules_in_old_benchmark:
-            sv_rule_id = new_rule_mapping[self.get_stig_rule_SV(old_rule.get_attr("id"))]
-            new_rule = new_benchmark.find_rule(sv_rule_id)
-            if new_rule is None:
-                missing_rules.append(sv_rule_id)
-                print("%s is missing in new datastream." % (sv_rule_id))
+            old_sv_rule_id = self.get_stig_rule_SV(old_rule.get_attr("id"))
+            try:
+                new_sv_rule_id = new_rule_mapping[old_sv_rule_id]
+            except KeyError:
+                missing_rules.append(old_sv_rule_id)
+                print("%s is missing in new datastream." % (old_rule.get_version_element().text))
                 continue
+            new_rule = new_benchmark.find_rule(new_sv_rule_id)
             if self.only_rules:
                 continue
             stig_id = new_rule.get_version_element()

--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -7,7 +7,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 import ssg.xml
-from ssg.constants import FIX_TYPE_TO_SYSTEM
+from ssg.constants import FIX_TYPE_TO_SYSTEM, XCCDF12_NS
 
 
 class StandardContentDiffer(object):
@@ -304,6 +304,9 @@ class StigContentDiffer(StandardContentDiffer):
 
         self.context_lines = 200
 
+    def _get_stig_id(self, element):
+        return element.get_version_element().text
+
     def get_stig_rule_SV(self, sv_rule_id):
         stig_rule_id = re.search(r'(SV-\d+)r\d+_rule', sv_rule_id)
         if not stig_rule_id:
@@ -329,34 +332,46 @@ class StigContentDiffer(StandardContentDiffer):
         old_rule_mapping = {self.get_stig_rule_SV(rule.get_attr("id")): rule.get_attr("id")
                             for rule in rules_in_old_benchmark}
 
+        self.compare_existing_rules(new_benchmark,
+                                    old_benchmark, rules_in_old_benchmark, new_rule_mapping)
+
+        self.check_for_new_rules(rules_in_new_benchmark, old_rule_mapping)
+
+        if self.rule_diffs:
+            print("Diff files saved at %s." % self.output_dir)
+
+    def compare_existing_rules(self, new_benchmark, old_benchmark,
+                               rules_in_old_benchmark, new_rule_mapping):
         for old_rule in rules_in_old_benchmark:
             old_sv_rule_id = self.get_stig_rule_SV(old_rule.get_attr("id"))
+            old_stig_id = self._get_stig_id(old_rule)
             try:
                 new_sv_rule_id = new_rule_mapping[old_sv_rule_id]
             except KeyError:
                 missing_rules.append(old_sv_rule_id)
-                print("%s is missing in new datastream." % (old_rule.get_version_element().text))
+                print("%s is missing in new datastream." % old_stig_id)
                 continue
-            new_rule = new_benchmark.find_rule(new_sv_rule_id)
             if self.only_rules:
                 continue
-            stig_id = new_rule.get_version_element()
-            self.compare_rule(old_rule, new_rule, stig_id.text)
-            self.compare_platforms(old_rule, new_rule,
-                                   old_benchmark, new_benchmark, stig_id)
 
+            new_rule = new_benchmark.find_rule(new_sv_rule_id)
+            new_stig_id = self._get_stig_id(new_rule)
+
+            self.compare_rule(old_rule, new_rule, new_stig_id)
+            self.compare_platforms(old_rule, new_rule,
+                                   old_benchmark, new_benchmark, new_stig_id)
+
+    def check_for_new_rules(self, rules_in_new_benchmark, old_rule_mapping):
         # Check for rules added in new content
         for new_rule in rules_in_new_benchmark:
-            stig_id = new_rule.get_version_element()
+            new_stig_id = self._get_stig_id(new_rule)
             new_sv_rule_id = self.get_stig_rule_SV(new_rule.get_attr("id"))
             try:
                 old_sv_rule_id = old_rule_mapping[new_sv_rule_id]
             except KeyError:
-                print("%s was added in new datastream." % (stig_id.text))
+                print("%s was added in new datastream." % (new_stig_id))
 
                 # Compare against empty rule so that a diff is generated
-                empty_rule = ssg.xml.XMLRule(ET.Element('{xccdf-1.2}Rule'))
-                self.compare_rule(empty_rule, new_rule, stig_id.text)
+                empty_rule = ssg.xml.XMLRule(ET.Element("{%s}Rule" % XCCDF12_NS))
+                self.compare_rule(empty_rule, new_rule, new_stig_id)
 
-        if self.rule_diffs:
-            print("Diff files saved at %s." % self.output_dir)


### PR DESCRIPTION
#### Description:

- Identify when a rule is removed from the content and print a message about it.
- Identify when a rule is added to the content and generate a diff for the rule.

#### Rationale:

- It is important to track added and removed rules in the content.
- Generating a diff for the added rule facilitates review of the new content.
