### PR TITLE
Add an unit test for the to_ocil() method

### DIFF
--- a/tests/unit/ssg-module/data/accounts_tmout_action.xml
+++ b/tests/unit/ssg-module/data/accounts_tmout_action.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<ns0:boolean_question_test_action xmlns:ns0="http://scap.nist.gov/schema/ocil/2.0" id="accounts_tmout_action" question_ref="accounts_tmout_question">
+  <ns0:when_true>
+    <ns0:result>PASS</ns0:result>
+  </ns0:when_true>
+  <ns0:when_false>
+    <ns0:result>FAIL</ns0:result>
+  </ns0:when_false>
+</ns0:boolean_question_test_action>

--- a/tests/unit/ssg-module/data/accounts_tmout_boolean_question.xml
+++ b/tests/unit/ssg-module/data/accounts_tmout_boolean_question.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<ns0:boolean_question xmlns:ns0="http://scap.nist.gov/schema/ocil/2.0" id="accounts_tmout_question">
+  <ns0:question_text>Run the following command to ensure the TMOUT value is configured for all users
+on the system:
+
+$ sudo grep TMOUT /etc/profile /etc/profile.d/*.sh
+
+The output should return the following:
+TMOUT=
+      Is it the case that value of TMOUT is not less than or equal to expected setting?
+      </ns0:question_text>
+</ns0:boolean_question>

--- a/tests/unit/ssg-module/data/accounts_tmout_questionnaire.xml
+++ b/tests/unit/ssg-module/data/accounts_tmout_questionnaire.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<ns0:questionnaire xmlns:ns0="http://scap.nist.gov/schema/ocil/2.0" id="accounts_tmout_ocil">
+  <ns0:title>Set Interactive Session Timeout</ns0:title>
+  <ns0:actions>
+    <ns0:test_action_ref>accounts_tmout_action</ns0:test_action_ref>
+  </ns0:actions>
+</ns0:questionnaire>

--- a/tests/unit/ssg-module/data/accounts_tmout_without_ocil.yml
+++ b/tests/unit/ssg-module/data/accounts_tmout_without_ocil.yml
@@ -1,0 +1,70 @@
+prodtype: alinux2,alinux3,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+title: Set Interactive Session Timeout
+description: 'Setting the <tt>TMOUT</tt> option in <tt>/etc/profile</tt> ensures that
+
+    all user sessions will terminate based on inactivity.
+
+    The value of TMOUT should be exported and read only.
+
+    The <tt>TMOUT</tt>
+
+
+    setting in a file loaded by <tt>/etc/profile</tt>, e.g.
+
+    <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
+
+    <pre>declare -xr TMOUT=<sub idref="var_accounts_tmout" /></pre>'
+rationale: 'Terminating an idle session within a short time period reduces
+
+    the window of opportunity for unauthorized personnel to take control of a
+
+    management session enabled on the console or console port that has been
+
+    left unattended.'
+severity: medium
+references:
+    anssi: BP28(R29)
+    cis-csc: 1,12,15,16
+    cobit5: DSS05.04,DSS05.10,DSS06.10
+    cui: 3.1.11
+    disa: CCI-000057,CCI-001133,CCI-002361
+    isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
+    isa-62443-2013: SR 1.1,SR 1.10,SR 1.2,SR 1.5,SR 1.7,SR 1.8,SR 1.9
+    iso27001-2013: A.18.1.4,A.9.2.1,A.9.2.4,A.9.3.1,A.9.4.2,A.9.4.3
+    nerc-cip: CIP-004-6 R2.2.3,CIP-007-3 R5.1,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3
+        R5.3.2,CIP-007-3 R5.3.3
+    nist: AC-12,SC-10,AC-2(5),CM-6(a)
+    nist-csf: PR.AC-7
+    ospp: FMT_MOF_EXT.1
+    srg: SRG-OS-000163-GPOS-00072,SRG-OS-000029-GPOS-00010
+    vmmsrg: SRG-OS-000163-VMM-000700,SRG-OS-000279-VMM-001010
+identifiers:
+    cce: CCE-83633-8
+
+oval_external_content: null
+fixtext: 'Configure Red Hat Enterprise Linux 9 to terminate user sessions after <sub
+    idref="var_accounts_tmout" /> seconds of inactivity.
+
+
+    Add or edit the following line in "/etc/profile.d/tmout.sh":
+
+    TMOUT=<sub idref="var_accounts_tmout" />'
+checktext: ''
+vuldiscussion: ''
+srg_requirement: ''
+warnings: []
+conflicts: []
+requires: []
+policy_specific_content: {}
+platform: machine
+platforms: !!set
+    machine: null
+sce_metadata: {}
+inherited_platforms: !!set {}
+template: null
+cpe_platform_names: !!set
+    machine: null
+inherited_cpe_platform_names: !!set {}
+bash_conditional: null
+fixes: {}
+documentation_complete: true

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 
 from ssg.build_cpe import ProductCPEs
 import ssg.build_yaml
-from ssg.constants import cpe_language_namespace, ocil_namespace
+from ssg.constants import cpe_language_namespace
 from ssg.yaml import open_raw
 
 

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 
 from ssg.build_cpe import ProductCPEs
 import ssg.build_yaml
-from ssg.constants import cpe_language_namespace
+from ssg.constants import cpe_language_namespace, ocil_namespace
 from ssg.yaml import open_raw
 
 
@@ -397,3 +397,31 @@ def test_profile_to_xml_element_extends(profile_ospp_with_extends):
     profile_el = profile_ospp_with_extends.to_xml_element()
     assert profile_el.get("extends") == \
         "xccdf_org.ssgproject.content_profile_standard"
+
+
+@pytest.fixture
+def rule_without_ocil():
+    rule_file = os.path.join(DATADIR, "accounts_tmout_without_ocil.yml")
+    return ssg.build_yaml.Rule.from_yaml(rule_file)
+
+
+def test_rule_to_ocil_without_ocil(rule_without_ocil):
+    with pytest.raises(ValueError) as e:
+        rule_without_ocil.to_ocil()
+    assert "Rule accounts_tmout_without_ocil doesn't have OCIL" in str(e)
+
+
+def test_rule_to_ocil(rule_accounts_tmout):
+    xmldiff_main = pytest.importorskip("xmldiff.main")
+    questionnaire, action, boolean_question = rule_accounts_tmout.to_ocil()
+    testables = {
+        questionnaire: "accounts_tmout_questionnaire.xml",
+        action: "accounts_tmout_action.xml",
+        boolean_question: "accounts_tmout_boolean_question.xml"
+    }
+    for element, expected_filename in testables.items():
+        with temporary_filename() as real_file_path:
+            ET.ElementTree(element).write(real_file_path)
+            expected_file_path = os.path.join(DATADIR, expected_filename)
+            diff = xmldiff_main.diff_files(real_file_path, expected_file_path)
+            assert diff == []


### PR DESCRIPTION
#### Description:
This commit adds an unit test for the ssg.build_yaml.Rule.to_ocil()
method and test whether it generates correct OCIL elements.

#### Rationale:

This PR is blocked by #9548 and #9617 and will be rebased on the top of master after they will be merged.
