### PR TITLE
Fix incorrect variable reference

### DIFF
--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -429,7 +429,7 @@ class RoleGithubUpdater(object):
         """
         content = self.remote_repo.get_contents(path_name, ref=branch)
         if content.content:
-            return (remote.decoded_content.decode("utf-8"), remote.sha)
+            return (content.decoded_content.decode("utf-8"), content.sha)
 
         blob = self._get_blob_content(branch, path_name)
         if blob is None:


### PR DESCRIPTION
#### Description:

Fix bug in playbook to role conversion utility

#### Rationale:

- existing code references a variable that does not exist and the program terminates

- Fixes #9639 
