### PR TITLE
CMake Improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ else()
     message(STATUS "jinja2 cache: disabled")
 endif()
 message(STATUS "STIG Delta Taloring files: ${SSG_BUILD_DISA_DELTA_FILES}")
+message(STATUS "Build SCE Content: " ${SSG_SCE_ENABLED})
 message(STATUS " ")
 
 message(STATUS "Products:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 
 # Inspired and referenced from https://blog.kitware.com/cmake-and-the-default-build-type
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)


### PR DESCRIPTION
#### Description:

* Update `cmake_minimum_required` to 2.8.12 to silence a deprecation warning
* Add a status for SCE content

#### Rationale:

* Clean up output
* Help inform developers