### PR TITLE
Remove "note" superfluous field from the controls file format

### DIFF
--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -879,7 +879,7 @@ controls:
       The features configured at the level of launched services
       should be limited to the strict minimum.
     status: supported
-    note: |-
+    notes: |-
       This is individual depending on the system workload
       therefore needs to be audited manually.
     related_rules:
@@ -939,7 +939,7 @@ controls:
       The features configured at the level of launched services
       should be limited to the strict minimum.
     status: supported
-    note: |-
+    notes: |-
       This is individual depending on the system workload
       therefore needs to be audited manually.
     related_rules:
@@ -1094,7 +1094,6 @@ controls: a list of controls (required key)
     notes: a short paragraph of text
     rules: a list of rule IDs that cover this control
     related_rules: a list of related rules
-    note: a short paragraph of text
     controls: a nested list of controls
     status: a keyword that reflects the current status of the implementation of this control
     tickets: a list of URLs reflecting the work that still needs to be done to address this control
@@ -1135,7 +1134,7 @@ controls:
     rationale: >-
         Minimization of configuration helps to reduce attack surface.
     status: supported
-    note: >-
+    notes: >-
       This is individual depending on the system workload
       therefore needs to be audited manually.
     related_rules:

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -126,7 +126,6 @@ class Control(ssg.build_yaml.SelectionHandler):
         control.selections = selections
 
         control.related_rules = control_dict.get("related_rules", [])
-        control.note = control_dict.get("note")
         return control
 
 

--- a/tests/unit/ssg-module/data/controls_dir/abcd.yml
+++ b/tests/unit/ssg-module/data/controls_dir/abcd.yml
@@ -25,7 +25,7 @@ controls:
     rationale: >-
       Minimization of configuration helps to reduce attack surface.
     automated: no
-    note: >-
+    notes: >-
       This is individual depending on the system workload
       therefore needs to be audited manually.
     related_rules:

--- a/tests/unit/ssg-module/data/controls_dir/jklm.yml
+++ b/tests/unit/ssg-module/data/controls_dir/jklm.yml
@@ -12,7 +12,7 @@ controls:
     rationale: >-
         Minimization of configuration helps to reduce attack surface.
     automated: no
-    note: >-
+    notes: >-
       This is individual depending on the system workload
       therefore needs to be audited manually.
     related_rules:

--- a/tests/unit/ssg-module/data/controls_dir/nopq.yml
+++ b/tests/unit/ssg-module/data/controls_dir/nopq.yml
@@ -13,7 +13,7 @@ controls:
     rationale: >-
         Minimization of configuration helps to reduce attack surface.
     automated: no
-    note: >-
+    notes: >-
       This is individual depending on the system workload
       therefore needs to be audited manually.
     related_rules:

--- a/tests/unit/ssg-module/data/controls_dir/qrst/r2_r3.yml
+++ b/tests/unit/ssg-module/data/controls_dir/qrst/r2_r3.yml
@@ -7,7 +7,7 @@ controls:
         rationale: >-
             Minimization of configuration helps to reduce attack surface.
         automated: no
-        note: >-
+        notes: >-
             This is individual depending on the system workload
             therefore needs to be audited manually.
         related_rules:

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -35,11 +35,9 @@ def _load_test(profile):
     assert "vague" in c_r1.notes
     c_r2 = controls_manager.get_control(profile, "R2")
     assert c_r2.automated == "no"
-    assert c_r2.note == "This is individual depending on the system " \
+    assert c_r2.notes == "This is individual depending on the system " \
                         "workload therefore needs to be audited manually."
     assert c_r2.rationale == "Minimization of configuration helps to reduce attack surface."
-    assert len(c_r2.selected) == 0
-    assert not c_r2.notes
     c_r4 = controls_manager.get_control(profile, "R4")
     assert len(c_r4.selected) == 3
     c_r4_rules = c_r4.selected


### PR DESCRIPTION
#### Description:

- This field has been replaced by "notes" field and it actually the one being in use.

#### Rationale:

- No unnecessary fields in the controls format. 
