### PR TITLE
Require a Github account for gitpod.io workshops

### DIFF
--- a/docs/workshop/README.adoc
+++ b/docs/workshop/README.adoc
@@ -4,7 +4,7 @@ This workshop contains many exercises that will get you familiar with OpenSCAP a
 
 Go ahead and experiment them using an online free to use environment directly in your browser.
 
-Note: A GitHub, GitLab, or Bitbucket account is required to spin up the lab environment.
+Note: A GitHub account is required to spin up the lab environment, authenticating via Gitlab or BitBucket will cause an error.
 
 == Table of Contents
 * link:lab1_introduction.adoc[Lab Exercise 1: Say Hello to ComplianceAsCode^]


### PR DESCRIPTION
#### Description:

- The online workshops use gitpod.io and that service doesn't seem to work with a Github repository (such as this one) being accessed after authenticating via a non-Github site.
- After authenticating to gitpod.io via my Gitlab login, I get: ![image](https://user-images.githubusercontent.com/1620988/194577360-2eb5a2d2-2034-49df-b91d-74d8441b6774.png)

#### Rationale:

- From a cursory look, there doesn't seem to be an easy configuration that would allow this, so just alter the README to warn users about this.
