### PR TITLE
Remove superfluous XML namespaces from HTML tables

### DIFF
--- a/utils/tables/tables_template_common.html
+++ b/utils/tables/tables_template_common.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cdf="http://checklists.nist.gov/xccdf/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+<html>
 <head lang="en">
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 <title>{{{ title }}}</title>


### PR DESCRIPTION
The root element defines some XML namespaces that aren't used in any child element so we don't have to declare them.

