### PR TITLE
Fix a few tests in rules used by OL7 

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altcorrect_permissions.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altcorrect_permissions.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# platforms = multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chown root:ssh_keys "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altlenient_permissions.fail.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/altlenient_permissions.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# platforms = multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chown root:ssh_keys "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/supercompliance.pass.sh
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/tests/supercompliance.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# platforms = multi_platform_rhel
+# platform = multi_platform_ol,multi_platform_rhel
 
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chown root:ssh_keys "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/comment.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/comment.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# variables = var_sshd_priv_separation=sandbox
 
 if grep -q "^UsePrivilegeSeparation" /etc/ssh/sshd_config; then
 	sed -i "s/^UsePrivilegeSeparation.*/# UsePrivilegeSeparation sandbox/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/correct_value.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# variables = var_sshd_priv_separation=sandbox
 
 if grep -q "^UsePrivilegeSeparation" /etc/ssh/sshd_config; then
 	sed -i "s/^UsePrivilegeSeparation.*/UsePrivilegeSeparation sandbox/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/line_not_there.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/line_not_there.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# variables = var_sshd_priv_separation=sandbox
 
 sed -i "/^UsePrivilegeSeparation.*/d" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/nothing.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/nothing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# variables = var_sshd_priv_separation=sandbox
 
 true

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/wrong_value_no.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/wrong_value_no.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# variables = var_sshd_priv_separation=sandbox
 
 if grep -q "^UsePrivilegeSeparation" /etc/ssh/sshd_config; then
 	sed -i "s/^UsePrivilegeSeparation.*/UsePrivilegeSeparation no/" /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/wrong_value_yes.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_priv_separation/tests/wrong_value_yes.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# profiles = xccdf_org.ssgproject.content_profile_ospp
+# variables = var_sshd_priv_separation=sandbox
 
 if grep -q "^UsePrivilegeSeparation" /etc/ssh/sshd_config; then
 	sed -i "s/^UsePrivilegeSeparation.*/UsePrivilegeSeparation yes/" /etc/ssh/sshd_config

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/missing.fail.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-sed -i '/^UMASK.*/d' /etc/profile
+sed -i '/^UMASK.*/d' /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_multiple.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-sed -i '/UMASK/d' /etc/bashrc
-echo "UMASK 077" >> /etc/bashrc
-echo "UMASK 077" >> /etc/bashrc
-echo "UMASK 077" >> /etc/bashrc
+sed -i '/UMASK/d' /etc/login.defs
+echo "UMASK 077" >> /etc/login.defs
+echo "UMASK 077" >> /etc/login.defs
+echo "UMASK 077" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_multiple.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/tests/wrong_multiple.fail.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-sed -i '/UMASK/d' /etc/login.defs
-echo "UMASK 077" >> /etc/login.defs
-echo "UMASK 077" >> /etc/login.defs
-echo "UMASK 077" >> /etc/login.defs

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/disabled_wireless_interfaces.pass.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/disabled_wireless_interfaces.pass.sh
@@ -1,5 +1,6 @@
 #/bin/bash
-#
+# platform = Not Applicable
+# This test is not runnable by automatus tool
 
 {{{ bash_package_install("NetworkManager") }}}
 nmcli radio wifi off

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/enabled_wireless_interface.fail.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/tests/enabled_wireless_interface.fail.sh
@@ -1,5 +1,6 @@
 #/bin/bash
-#
+# platform = Not Applicable
+# This test is not runnable by automatus tool
 
 {{{ bash_package_install("NetworkManager") }}}
 nmcli radio wifi on

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -11,6 +11,8 @@ pkg_manager: "yum"
 
 init_system: "systemd"
 
+dconf_gdm_dir: "local.d"
+
 pkg_release: "53619141"
 pkg_version: "ec551f03"
 
@@ -18,6 +20,10 @@ release_key_fingerprint: "42144123FECFC55B9086313D72F97B74EC551F03"
 
 grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 audisp_conf_path: "/etc/audisp"
+
+groups:
+  dedicated_ssh_keyowner:
+    name: ssh_keys
 
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -21,6 +21,10 @@ grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
+groups:
+  dedicated_ssh_keyowner:
+    name: ssh_keys
+
 cpes_root: "../../shared/applicability"
 cpes:
   - ol8:

--- a/products/ol9/product.yml
+++ b/products/ol9/product.yml
@@ -23,6 +23,10 @@ auxiliary_key_fingerprint: "982231759C7467065D0CE9B2A7DD07088B4EFBE6"
 
 oval_feed_url: "https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2"
 
+groups:
+  dedicated_ssh_keyowner:
+    name: ssh_keys
+
 cpes_root: "../../shared/applicability"
 cpes:
   - ol9:

--- a/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform multi_platform_rhel,multi_platform_ol
 
+echo > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf

--- a/shared/templates/service_enabled/tests/service_disabled.fail.sh
+++ b/shared/templates/service_enabled/tests/service_disabled.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{% if SERVICENAME == sshd %}}
+# platform = Not Applicable
+{{% endif%}}
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'

--- a/shared/templates/service_enabled/tests/service_enabled.pass.sh
+++ b/shared/templates/service_enabled/tests/service_enabled.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+{{% if SERVICENAME == sshd %}}
+# platform = Not Applicable
+{{% endif%}}
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'


### PR DESCRIPTION
#### Description:

- Fix tests in `accounts_umask_etc_login_defs`
  - `missing.fail.sh` & `wrong_multiple.fail.sh` were manipulating the wrong file
- Update tests in `sshd_use_priv_separation`
  - Use variables to set values to expect instead of profile selection
- Update platform and fix typo in tests of rule
  - `file_permissions_sshd_private_key`. Add ol platform for these tests
- Update tests in `wireless_disable_interfaces`
  - Make them nonapplicable as they aren't runnable in any of the environments supported by automatus
-  Update test in `kernel_module_disable` template
   - Fix the `missing_blacklist` test to actually ensure that the blacklist conf is missing
- Update tests in `service_enabled` template
  - Make the tests not applicable when the service is sshd since this service is used to run tests, so it can't be disabled during testing
- Update ol products yaml files to align final behavior of rules with STIG requirements

#### Rationale:

- All these tests were giving false negatives during the run of automatus tool. They were found running the scan of the STIG profile in OL7
- In the case of `sshd_use_priv_separation` it is a better approach to set the variable so the test is more generic