### PR TITLE
Added SLES 15/12 codes to rules ..._backup_etc_passwd

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -15,6 +15,8 @@ identifiers:
     cce@rhel7: CCE-83323-6
     cce@rhel8: CCE-83324-4
     cce@rhel9: CCE-83933-2
+    cce@sle12: CCE-91693-2
+    cce@sle15: CCE-91323-6
 
 references:
     cis@alinux2: 6.1.6

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/rule.yml
@@ -15,6 +15,8 @@ identifiers:
     cce@rhel7: CCE-83325-1
     cce@rhel8: CCE-83326-9
     cce@rhel9: CCE-83947-2
+    cce@sle12: CCE-91694-0
+    cce@sle15: CCE-91324-4
 
 references:
     cis@alinux2: 6.1.6

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/rule.yml
@@ -16,6 +16,8 @@ identifiers:
     cce@rhel7: CCE-83331-9
     cce@rhel8: CCE-83332-7
     cce@rhel9: CCE-83940-7
+    cce@sle12: CCE-91695-7
+    cce@sle15: CCE-91325-1
 
 references:
     cis@alinux2: 6.1.6


### PR DESCRIPTION
#### Description:

- _Added 6 SLES-15/12 CCE codes to the rules file_groupowner_backup_etc_passwd, file_owner_backup_etc_passwd and file_permissions_backup_etc_passwd  _

#### Rationale:

- The rules will be used in new profile(s)


