### PR TITLE
Added SLES 15/12 CCE codes related to the rules ...backup_etc_group

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -15,6 +15,8 @@ identifiers:
     cce@rhel7: CCE-83474-7
     cce@rhel8: CCE-83475-4
     cce@rhel9: CCE-83928-2
+    cce@sle12: CCE-91699-9
+    cce@sle15: CCE-91329-3
 
 references:
     cis@alinux2: 6.1.8

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/rule.yml
@@ -15,6 +15,8 @@ identifiers:
     cce@rhel7: CCE-83472-1
     cce@rhel8: CCE-83473-9
     cce@rhel9: CCE-83944-9
+    cce@sle12: CCE-91700-5
+    cce@sle15: CCE-91330-1
 
 references:
     cis@alinux2: 6.1.8

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/rule.yml
@@ -16,6 +16,8 @@ identifiers:
     cce@rhel7: CCE-83482-0
     cce@rhel8: CCE-83483-8
     cce@rhel9: CCE-83939-9
+    cce@sle12: CCE-92201-3
+    cce@sle15: CCE-91331-9
 
 references:
     cis@alinux2: 6.1.8


### PR DESCRIPTION
#### Description:

- _Added 6 SLES-15/12 CCE numbers to the rules file_groupowner_backup_etc_group, file_owner_backup_etc_group, and file_permissions_backup_etc_group_

#### Rationale:

- The rules will be used in new profile(s)


