### PR TITLE
Add PCI-DSS Rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_warn_age_login_defs/rule.yml
@@ -21,6 +21,8 @@ identifiers:
     cce@rhel7: CCE-82016-7
     cce@rhel8: CCE-80671-1
     cce@rhel9: CCE-83609-8
+    cce@sle12: CCE-92205-4
+    cce@sle15: CCE-91335-0
 
 references:
     cis-csc: 1,12,13,14,15,16,18,3,5,7,8

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 
 # uncomment the option if commented
   sed '/^[[:space:]]*#[[:space:]]*auth[[:space:]]\+required[[:space:]]\+pam_wheel\.so[[:space:]]\+use_uid$/s/^[[:space:]]*#//' -i /etc/pam.d/su

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
+prodtype: alinux2,alinux3,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle15,ubuntu2004,ubuntu2204
 
 title: 'Enforce usage of pam_wheel for su authentication'
 
@@ -21,6 +21,8 @@ identifiers:
     cce@rhel7: CCE-85855-5
     cce@rhel8: CCE-83318-6
     cce@rhel9: CCE-90085-2
+    cce@sle12: CCE-91633-8
+    cce@sle15: CCE-91336-8
 
 references:
     cis@alinux2: "5.6"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
@@ -34,6 +34,7 @@ identifiers:
     cce@rhel8: CCE-80682-8
     cce@rhel9: CCE-83701-3
     cce@sle15: CCE-85778-9
+    cce@sle12: CCE-91632-0
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
@@ -33,8 +33,8 @@ identifiers:
     cce@rhel7: CCE-27231-0
     cce@rhel8: CCE-80682-8
     cce@rhel9: CCE-83701-3
-    cce@sle15: CCE-85778-9
     cce@sle12: CCE-91632-0
+    cce@sle15: CCE-85778-9
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -35,7 +35,11 @@ selections:
     - accounts_password_pam_unix_remember
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_unlock_time
+    - accounts_password_warn_age_login_defs
     - accounts_tmout
+    - accounts_umask_etc_bashrc
+    - accounts_umask_etc_login_defs
+    - accounts_umask_etc_profile
     - aide_build_database
     - aide_periodic_cron_checking
     - auditd_audispd_syslog_plugin_activated
@@ -98,12 +102,18 @@ selections:
     - chronyd_or_ntpd_specify_multiple_servers
     - chronyd_specify_remote_server
     - configure_opensc_card_drivers
-    - dconf_gnome_screensaver_idle_activation_enabled
-    - dconf_gnome_screensaver_mode_blank
-    - display_login_attempts
     - configure_libreswan_crypto_policy
     - configure_openssl_crypto_policy
     - configure_ssh_crypto_policy
+    - cracklib_accounts_password_pam_dcredit
+    - cracklib_accounts_password_pam_ucredit
+    - cracklib_accounts_password_pam_lcredit
+    - cracklib_accounts_password_pam_ocredit
+    - cracklib_accounts_password_pam_minlen
+    - cracklib_accounts_password_pam_retry
+    - dconf_gnome_screensaver_idle_activation_enabled
+    - dconf_gnome_screensaver_mode_blank
+    - display_login_attempts
     - ensure_logrotate_activated
     - ensure_gpgcheck_globally_activated
     - ensure_gpgcheck_never_disabled
@@ -125,10 +135,12 @@ selections:
     - grub2_audit_argument
     - install_hids
     - install_smartcard_packages
+    - no_direct_root_logins
     - no_empty_passwords
     - package_aide_installed
     - package_audit-audispd-plugins_installed
     - package_audit_installed
+    - package_chrony_installed
     - package_openldap-clients_removed
     - package_strongswan_installed
     - package_sudo_installed
@@ -142,6 +154,7 @@ selections:
     - rsyslog_files_ownership
     - rsyslog_files_permissions
     - security_patches_up_to_date
+    - securetty_root_login_console_only
     - service_auditd_enabled
     - service_chronyd_or_ntpd_enabled
     - service_pcscd_enabled


### PR DESCRIPTION
#### Description:

    - accounts_password_warn_age_login_defs
    - accounts_umask_etc_bashrc
    - accounts_umask_etc_login_defs
    - accounts_umask_etc_profile
    - cracklib_accounts_password_pam_dcredit
    - cracklib_accounts_password_pam_ucredit
    - cracklib_accounts_password_pam_lcredit
    - cracklib_accounts_password_pam_ocredit
    - cracklib_accounts_password_pam_minlen
    - cracklib_accounts_password_pam_retry
    - dconf_gnome_screensaver_idle_activation_enabled
    - dconf_gnome_screensaver_mode_blank
    - display_login_attempts
    - no_direct_root_logins
    - package_audit_installed
    - package_chrony_installed
    - securetty_root_login_console_only

#### Rationale:
