### PR TITLE
Refactor json output function in controleval.py

### DIFF
--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -161,6 +161,10 @@ def print_specific_stat(status, current, total):
             total=total))
 
 
+def sort_controls_by_id(control_list):
+    return sorted([(str(c.id), c.title) for c in control_list])
+
+
 def print_controls(status_count, control_list, args):
     status = args.status
     if status not in status_count:
@@ -171,8 +175,9 @@ def print_controls(status_count, control_list, args):
     if status_count[status] > 0:
         print("\nList of the {status} ({total}) controls:".format(
             total=status_count[status], status=status))
-        for ctrl in control_list[status]:
-            print("{id:>16} - {title}".format(id=ctrl.id, title=ctrl.title))
+
+        for ctrl in sort_controls_by_id(control_list[status]):
+            print("{id:>16} - {title}".format(id=ctrl[0], title=ctrl[1]))
     else:
         print("There is no controls with {status} status.".format(status=status))
 

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -210,7 +210,8 @@ def print_stats_json(product, id, level, control_list):
 
     for status in sorted(control_list.keys()):
         json_key_name = get_formatted_name(status)
-        data["addressed_controls"][json_key_name] = [str(c.id) for c in (control_list[status])]
+        data["addressed_controls"][json_key_name] = [
+            sorted(str(c.id) for c in (control_list[status]))]
     print(json.dumps(data))
 
 

--- a/utils/controleval.py
+++ b/utils/controleval.py
@@ -188,7 +188,7 @@ def print_stats(status_count, control_list, args):
 
     print("General stats:")
     for status in sorted(explicit_status):
-        print_specific_stat(status, status_count[status], status_count['applicable'])
+        print_specific_stat(status, status_count[status], status_count['all'])
 
     print("\nStats grouped by status:")
     for status in sorted(implicit_status):


### PR DESCRIPTION
#### Description:

The function has been refactored to reduce code and no longer calculate statistics, but use already calculated statistics.

**IMPORTANT**: This refactoring also standardized the json object keys, so it is necessary to adjust any
automation that uses this json output.

The changes to the json output keys are basically in their names:

- Functions that calculate statistics use the status names as they are defined.
- Some status names are defined using spaces.
- `json` object keys are easier to be processed when key names do not have spaces.
- So spaces have been replaced by underscores in key names. 
- This only affects the `json` output.

#### Rationale:

Make the tool more robust and scalable by centralizing the stats calculations.
Make it easier to consume outputs when the controls are listed.
