### PR TITLE
Add  dconf_gnome_disable_user_list to the RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -187,6 +187,7 @@ controls:
             - dconf_gnome_disable_automount_open
             - dconf_gnome_disable_autorun
             - dconf_gnome_disable_ctrlaltdel_reboot
+            - dconf_gnome_disable_user_list
             - dconf_db_up_to_date
 
             # partition

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/policy/stig/shared.yml
@@ -1,0 +1,29 @@
+srg_requirement: |-
+  {{{ full_name }}} must disable the user list at logon for graphical user interfaces.
+
+vuldiscussion: |-
+    Leaving the user list enabled is a security risk since it allows anyone with physical access to the system to enumerate known user accounts without authenticated access to the system.
+
+checktext: |-
+    Verify that {{{ full_name }}} disables the user logon list for graphical user interfaces with the following command:
+    Note: This requirement assumes the use of the {{{ full_name }}} default graphical user interface, Gnome Shell. If the system does not have any graphical user interface installed, this requirement is Not Applicable.
+
+    $ sudo gsettings get org.gnome.login-screen disable-user-list
+    true
+
+    If the setting is "false", this is a finding.
+
+fixtext: |-
+    Configure {{{ full_name }}} to disable the user list at logon for graphical user interfaces.
+
+    Create a database to contain the system-wide screensaver settings (if it does not already exist) with the following command:
+    Note: The example below is using the database "local" for the system, so if the system is using another database in "/etc/dconf/profile/user", the file should be created under the appropriate subdirectory.
+
+    $ sudo touch /etc/dconf/db/local.d/02-login-screen
+
+    [org/gnome/login-screen]
+    disable-user-list=true
+
+    Update the system databases:
+
+    $ sudo dconf update


### PR DESCRIPTION

#### Description:

* Add policy-specific content to `dconf_gnome_disable_user_list`
* Add `dconf_gnome_disable_user_list` to the RHEL 9 STIG

#### Rationale:

This rule should be in the STIG based on the RHEL 8 STIG.