### PR TITLE
Added CCE number for SLES_15 in the rule sshd_use_approved_ciphers

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -50,12 +50,13 @@ identifiers:
     cce@rhel7: CCE-27295-5
     cce@rhel8: CCE-81032-5
     cce@sle12: CCE-83181-8
+    cce@sle15: CCE-91337-6
 
 references:
     cis-csc: 1,11,12,14,15,16,18,3,5,6,8,9
     cis@alinux2: 5.2.17
     cis@rhel7: 5.3.13
-    cis@sle12: 5.3.14
+    cis@sle12: 5.2.13
     cis@sle15: 5.2.13
     cis@ubuntu2004: 5.2.12
     cis@ubuntu2204: 5.2.12
@@ -71,6 +72,7 @@ references:
     nist-csf: PR.AC-1,PR.AC-3,PR.AC-4,PR.AC-6,PR.AC-7,PR.IP-1,PR.PT-1,PR.PT-3,PR.PT-4
     srg: SRG-OS-000033-GPOS-00014,SRG-OS-000120-GPOS-00061,SRG-OS-000125-GPOS-00065,SRG-OS-000250-GPOS-00093,SRG-OS-000393-GPOS-00173,SRG-OS-000394-GPOS-00174
     stigid@sle12: SLES-12-030170
+    stigid@sle15: SLES-15-010160
     vmmsrg: SRG-OS-000033-VMM-000140,SRG-OS-000120-VMM-000600,SRG-OS-000478-VMM-001980,SRG-OS-000396-VMM-001590
 
 ocil_clause: 'FIPS ciphers are not configured or the enabled ciphers are not FIPS-approved'


### PR DESCRIPTION
#### Description:

- _Added CCE/STIGID code for SLES 15 into the rule sshd_use_approved_ciphers. multi_platform_sle included in bash/shared.sh file  _

#### Rationale:

- Rule has to be available for SLES 12 and 15. The rule will be used in new profile(s) 

 
