### PR TITLE
Refactor and speed up combine_ovals.py

### DIFF
--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -345,7 +345,11 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
             if not filename.endswith(".xml"):
                 continue
             oval_file_path = os.path.join(oval_dir, filename)
-            xml_content = process_file_with_macros(oval_file_path, env_yaml)
+            if "checks_from_templates" in oval_dir:
+                with open(oval_file_path, "r") as f:
+                    xml_content = f.read()
+            else:
+                xml_content = process_file_with_macros(oval_file_path, env_yaml)
 
             if not _check_is_applicable_for_product(xml_content, product):
                 continue

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -338,23 +338,24 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
             already_loaded[filename] = oval_version
 
     for oval_dir in reversed_dirs:
-        if os.path.isdir(oval_dir):
-            # sort the files to make output deterministic
-            for filename in sorted(os.listdir(oval_dir)):
-                if filename.endswith(".xml"):
-                    xml_content = process_file_with_macros(
-                        os.path.join(oval_dir, filename), env_yaml
-                    )
+        if not os.path.isdir(oval_dir):
+            continue
+        # sort the files to make output deterministic
+        for filename in sorted(os.listdir(oval_dir)):
+            if filename.endswith(".xml"):
+                xml_content = process_file_with_macros(
+                    os.path.join(oval_dir, filename), env_yaml
+                )
 
-                    if not _check_is_applicable_for_product(xml_content, product):
-                        continue
-                    if _check_is_loaded(already_loaded, filename, oval_version):
-                        continue
-                    oval_file_tree = _create_oval_tree_from_string(xml_content)
-                    if not _check_oval_version_from_oval(oval_file_tree, oval_version):
-                        continue
-                    body.append(xml_content)
-                    included_checks_count += 1
-                    already_loaded[filename] = oval_version
+                if not _check_is_applicable_for_product(xml_content, product):
+                    continue
+                if _check_is_loaded(already_loaded, filename, oval_version):
+                    continue
+                oval_file_tree = _create_oval_tree_from_string(xml_content)
+                if not _check_oval_version_from_oval(oval_file_tree, oval_version):
+                    continue
+                body.append(xml_content)
+                included_checks_count += 1
+                already_loaded[filename] = oval_version
 
     return "".join(body)

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -344,9 +344,8 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
         for filename in sorted(os.listdir(oval_dir)):
             if not filename.endswith(".xml"):
                 continue
-            xml_content = process_file_with_macros(
-                os.path.join(oval_dir, filename), env_yaml
-            )
+            oval_file_path = os.path.join(oval_dir, filename)
+            xml_content = process_file_with_macros(oval_file_path, env_yaml)
 
             if not _check_is_applicable_for_product(xml_content, product):
                 continue

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -342,20 +342,21 @@ def checks(env_yaml, yaml_path, oval_version, oval_dirs, build_ovals_dir=None):
             continue
         # sort the files to make output deterministic
         for filename in sorted(os.listdir(oval_dir)):
-            if filename.endswith(".xml"):
-                xml_content = process_file_with_macros(
-                    os.path.join(oval_dir, filename), env_yaml
-                )
+            if not filename.endswith(".xml"):
+                continue
+            xml_content = process_file_with_macros(
+                os.path.join(oval_dir, filename), env_yaml
+            )
 
-                if not _check_is_applicable_for_product(xml_content, product):
-                    continue
-                if _check_is_loaded(already_loaded, filename, oval_version):
-                    continue
-                oval_file_tree = _create_oval_tree_from_string(xml_content)
-                if not _check_oval_version_from_oval(oval_file_tree, oval_version):
-                    continue
-                body.append(xml_content)
-                included_checks_count += 1
-                already_loaded[filename] = oval_version
+            if not _check_is_applicable_for_product(xml_content, product):
+                continue
+            if _check_is_loaded(already_loaded, filename, oval_version):
+                continue
+            oval_file_tree = _create_oval_tree_from_string(xml_content)
+            if not _check_oval_version_from_oval(oval_file_tree, oval_version):
+                continue
+            body.append(xml_content)
+            included_checks_count += 1
+            already_loaded[filename] = oval_version
 
     return "".join(body)


### PR DESCRIPTION
#### Description:

This contains some refactoring and a change in behavior that the templated OVAL checks won't be processed by Jinja when loaded by combine_ovals.py scripts because they already are processed by Jinja so we don't have to process them twice.

For more details, please read commit messages of every commit.

#### Rationale:

Refactoring helps readability.

The change in the behavior speeds up the script - on RHEL 9 content it goes down from 17 to 12 seconds.
