### PR TITLE
Fix Ansible for rsyslog_remote_tls

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -6,7 +6,7 @@
 {{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
 - name: "Get omfwd configuration directive"
-  shell: sed -e '/action\s*(\s*type\s*=\s*"omfwd"/,/)/!d' /etc/rsyslog.conf /etc/rsyslog.d/*.conf
+  shell: sed -e '/action\s*(\s*type\s*=\s*"omfwd"/,/)/!d' /etc/rsyslog.conf /etc/rsyslog.d/*.conf || true
   register: include_omfwd_config_output
 
 - name: "Get include files directives"


### PR DESCRIPTION
#### Description:

Instead of erroring out on the `sed` command in rsyslog_remote_tls, return true. This should not be an issue, as this should cause the script to see that `gtls` is not in the output.

#### Rationale:

Fix some Ansible playbooks.

Fixes #9625
