### PR TITLE
Include the status tag in SRG-OS-000163-GPOS-00072

### DIFF
--- a/controls/srg_gpos/SRG-OS-000163-GPOS-00072.yml
+++ b/controls/srg_gpos/SRG-OS-000163-GPOS-00072.yml
@@ -29,3 +29,4 @@ controls:
             seconds.
         mitigation: |-
             There is no mitigation.
+        status: automated


### PR DESCRIPTION
#### Description:

The control is already automated but since the status tag was missing there, it was reported as pending.

#### Rationale:

Status accuracy