### PR TITLE
Fix issue introduced in commit 1ba11cb

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -63,6 +63,7 @@ template:
             - /lib64/
             - /usr/lib/
             - /usr/lib64/
+        file_regex: ^.*$
         recursive: 'true'
         filegid: '0'
 

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/correct_groupowner.pass.sh
@@ -1,0 +1,9 @@
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+
+for SYSLIBDIRS in /lib /lib64 /usr/lib /usr/lib64
+do
+    if [[ -d $SYSLIBDIRS  ]]
+    then
+        find $SYSLIBDIRS ! -group root -type f -exec chgrp root '{}' \;
+    fi
+done

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/incorrect_groupowner.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/tests/incorrect_groupowner.fail.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_sle,multi_platform_rhel,multi_platform_fedora,multi_platform_ubuntu
+
+groupadd group_test
+for TESTFILE in /lib/test_me /lib64/test_me /usr/lib/test_me /usr/lib64/test_me
+do
+   if [[ ! -f $TESTFILE ]]
+   then
+     touch $TESTFILE
+   fi
+   chgrp group_test $TESTFILE
+done


### PR DESCRIPTION
#### Description:

root_permissions_syslibrary_files: Re-add file_regex otherwise remediation will fix directories instead of files, which is what this rule is about. This issue was introduced in commit 1ba11cb