### PR TITLE
Add tests to sebool template

### DIFF
--- a/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_policyload/tests/test_config.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/sebool_secure_mode_policyload/tests/test_config.yml
@@ -1,0 +1,2 @@
+allow_templated_scenarios:
+  - none

--- a/shared/templates/sebool/template.py
+++ b/shared/templates/sebool/template.py
@@ -5,4 +5,8 @@ def preprocess(data, lang):
             "ERROR: key sebool_bool in rule {0} contains forbidden "
             "value '{1}'.".format(data["_rule_id"], sebool_bool)
         )
+
+    if sebool_bool:
+        data["wrong_sebool"] = "true" if sebool_bool == "false" else "false"
+
     return data

--- a/shared/templates/sebool/tests/correct_value.pass.sh
+++ b/shared/templates/sebool/tests/correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+{{% if not SEBOOL_BOOL %}}
+# variables = var_{{{ SEBOOLID }}}=true
+{{% set SEBOOL_BOOL="true" %}}
+{{% endif %}}
+
+setsebool -P {{{ SEBOOLID }}} {{{ SEBOOL_BOOL }}}

--- a/shared/templates/sebool/tests/wrong_value.fail.sh
+++ b/shared/templates/sebool/tests/wrong_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+{{% if not SEBOOL_BOOL %}}
+# variables = var_{{{ SEBOOLID }}}=true
+{{% set WRONG_SEBOOL="false" %}}
+{{% endif %}}
+
+setsebool -P {{{ SEBOOLID }}} {{{ WRONG_SEBOOL }}}


### PR DESCRIPTION
#### Description:

- Add tests to sebool template
- Use `test_config.yml` to exclude `sebool_secure_mode_policyload` from these tests. This because the tests were failing to execute due to some extra steps needed to change that boolean to off, like reboot.

#### Rationale:

- None of the rules about sebooleans had tests
