### PR TITLE
Fix config file and interpreter check control flow

### DIFF
--- a/shared/templates/firefox_policy-setting/bash.template
+++ b/shared/templates/firefox_policy-setting/bash.template
@@ -14,20 +14,21 @@ if [ -f ${__FIREFOX_DISTRIBUTION}/policies.json ]; then
 fi
 # Check the possible Firefox install directories
 for firefox_dir in ${firefox_dirs}; do
-    if [ -d "${firefox_dir}" ]; then
+    if ! [ -d "${firefox_dir}" ]; then
         mkdir -p "${firefox_dir}"
         chmod 755 "${firefox_dir}"
-        # Make sure the Firefox .cfg file exists and has the appropriate permissions
-        if ! [ -f "${firefox_dir}/${firefox_cfg}" ] ; then
-            echo "{" > "${firefox_dir}/${firefox_cfg}"
-            echo "    \"policies\": {" >> "${firefox_dir}/${firefox_cfg}"
-            echo "    }" >> "${firefox_dir}/${firefox_cfg}"
-            echo "}" >> "${firefox_dir}/${firefox_cfg}"
-            chmod ${permissions} "${firefox_dir}/${firefox_cfg}"
-        fi
-        # If the key exists, change it. Otherwise, add it to the config_file.
-        if [ -x ${__REMEDIATE_PYTHON} ]; then
-            echo """
+    fi
+    # Make sure the Firefox .cfg file exists and has the appropriate permissions
+    if ! [ -f "${firefox_dir}/${firefox_cfg}" ] ; then
+        echo "{" > "${firefox_dir}/${firefox_cfg}"
+        echo "    \"policies\": {" >> "${firefox_dir}/${firefox_cfg}"
+        echo "    }" >> "${firefox_dir}/${firefox_cfg}"
+        echo "}" >> "${firefox_dir}/${firefox_cfg}"
+        chmod ${permissions} "${firefox_dir}/${firefox_cfg}"
+    fi
+    # If the key exists, change it. Otherwise, add it to the config_file.
+    if [ -x ${__REMEDIATE_PYTHON} ]; then
+        echo """
 import json
 _file=open('${firefox_dir}/${firefox_cfg}', 'r')
 _tree=json.load(_file)
@@ -45,7 +46,6 @@ _file=open('${firefox_dir}/${firefox_cfg}', 'w')
 json.dump(_tree, _file, indent=4, sort_keys=True)
 _file.close()
 """ | ${__REMEDIATE_PYTHON}
-        fi
         chmod ${permissions} "${firefox_dir}/${firefox_cfg}"
     fi
 done


### PR DESCRIPTION
#### Description:

There is an issue with the Bash remediation script template for Firefox. The conditionals for verifying existence of the Firefox configuration directory and file are incorrectly nested, preventing completion of the remediation steps.

![Screenshot from 2022-10-15 18-30-51](https://user-images.githubusercontent.com/96031332/196013681-044d604e-9037-4585-bd34-614837646190.png)

[DEBUG Log: out.log](https://github.com/ComplianceAsCode/content/files/9793428/out.log)

