### PR TITLE
Add tests to rule dconf_gnome_screensaver_idle_activation_enabled

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/comment.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/comment.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "#idle-activation-enabled" "true" \
+                  "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "idle-activation-enabled" "local.d" \
+               "00-security-settings-lock"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/correct_value.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "idle-activation-enabled" "true" \
+                  "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "idle-activation-enabled" "local.d" \
+               "00-security-settings-lock"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/missing_lock.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/missing_lock.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "idle-activation-enabled" "true" \
+                  "local.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/setting_not_there.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/setting_not_there.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_enabled/tests/wrong_value.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "idle-activation-enabled" "false" \
+                  "local.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "idle-activation-enabled" "local.d" \
+               "00-security-settings-lock"


### PR DESCRIPTION
#### Description:

- Add tests to rule `dconf_gnome_screensaver_idle_activation_enabled`

#### Rationale:

- This rule didn't have tests
