### PR TITLE
Fix OL documentation links

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/group.yml
+++ b/linux_os/guide/services/ldap/openldap_client/group.yml
@@ -15,7 +15,7 @@ description: |-
     {{% if product == "rhel7" %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/openldap") }}}.
     {{% elif product == "ol7" %}}
-        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/ol7-auth.html#ol7-s9-auth") }}}.
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/userauth-AuthenticationConfiguration.html#ol7-s7-auth") }}}.
     {{% endif %}}
 
 warnings:

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -53,6 +53,8 @@ description: |-
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/network/ol7-nettime.html") }}}
     {{% elif product == "ol8" %}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/network/network-ConfiguringNetworkTime.html#ol-nettime") }}}
+    {{% elif product == "ol9" %}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/9/network/network-ConfiguringNetworkTime.html#ol-nettime") }}}
     {{% elif product == "rhel7" %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
     {{% elif "ubuntu" in product  %}}

--- a/linux_os/guide/services/sssd/group.yml
+++ b/linux_os/guide/services/sssd/group.yml
@@ -17,9 +17,11 @@ description: |-
     {{%- elif product == "rhel9" -%}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/installing_identity_management/index#assembly_installing-an-idm-client_installing-identity-management") }}}
     {{%- elif product == "ol7" -%}}
-        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/ol7-auth.html#ol7-sssd-auth") }}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/userauth/userauth-AuthenticationConfiguration.html#ol7-sssd-auth") }}}
     {{%- elif product == "ol8" -%}}
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/userauth/userauth-UsingtheSystemSecurityServicesDaemon.html#sssd-auth") }}}
+    {{%- elif product == "ol9" -%}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/9/userauth/userauth-UsingtheSystemSecurityServicesDaemon.html") }}}
     {{%- endif %}}
 
 platform: sssd

--- a/linux_os/guide/system/selinux/group.yml
+++ b/linux_os/guide/system/selinux/group.yml
@@ -29,7 +29,7 @@ description: |-
     {{% elif product == "rhel8" %}}
     <br /><br />
     For more information on SELinux, see <b>{{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/using_selinux") }}}</b>.
-    {{% elif product == "ol7" %}}
+    {{% elif "ol" in product %}}
     For more information on SELinux, see <b>{{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/selinux/") }}}</b>.
     {{% endif %}}
 

--- a/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
+++ b/linux_os/guide/system/software/disk_partitioning/encrypt_partitions/rule.yml
@@ -32,9 +32,11 @@ description: |-
     Detailed information on encrypting partitions using LUKS or LUKS ciphers can be found on
     the {{{ full_name }}} Documentation web site:<br />
     {{% if product == "ol7" %}}
-        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/security/ol7-install-sec.html") }}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/7/security/security-SecureInstallationandConfiguration.html#ol7-instcsdp-sec") }}}
     {{% elif product == "ol8" %}}
-        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/install/install-InstallingOracleLinuxManually.html#install-storage-network") }}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/8/install/install-InstallingOracleLinuxManually.html#system-options") }}}
+    {{% elif product == "ol9" %}}
+        {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/9/install/install-InstallingOracleLinuxManually.html#system-options") }}}
     {{% elif product in ["sle12", "sle15"] %}}
         {{{ weblink(link="https://www.suse.com/documentation/sled-12/book_security/data/sec_security_cryptofs_y2.html") }}}
     {{% elif product == "rhel7" %}}


### PR DESCRIPTION
#### Description:

- Fix broken OL7 documentation links.
- Also add documentation links for OL9 where applicable.

#### Rationale:

- Some of the documentation links for OL7 were broken and some for OL9 were missing

- Fixes #9696 
