### PR TITLE
CIS: Update etcd encryption provider rationale

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -18,8 +18,11 @@ description: |-
                 text="the relevant documentation") }}}.
 
 rationale: |-
-    <tt>aescbc</tt> is currently the strongest encryption provider, it should
-    be preferred over other providers.
+    Where etcd encryption is used, it is important to ensure that the
+    appropriate set of encryption providers is used. Currently, aescbc, kms
+    and secretbox are likely to be appropriate options.
+
+    <tt>aescbc</tt> is the only type supported by OCP.
 
 severity: medium
 


### PR DESCRIPTION
The Kubernetes docs at https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/ state that aescbc is not recommended. However, it's the only supported option for OCP, and the CIS benchmark states that it's a suitable option. So this PR updates the rationale text to help clarify the choice of aescbc. 

https://issues.redhat.com/browse/OCPBUGS-2312