### PR TITLE
service_ntp_enabled: Fix description as service name is ntp

### DIFF
--- a/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
@@ -3,10 +3,10 @@ documentation_complete: true
 title: 'Enable the NTP Daemon'
 
 description: |-
-    {{{ describe_service_enable(service="ntpd") }}}
+    {{{ describe_service_enable(service="ntp") }}}
 
 rationale: |-
-    Enabling the <tt>ntpd</tt> service ensures that the <tt>ntpd</tt>
+    Enabling the <tt>ntp</tt> service ensures that the <tt>ntp</tt>
     service will be running and that the system will synchronize its time to
     any servers specified. This is important whether the system is configured to be
     a client (and synchronize only its own clock) or it is also acting as an NTP


### PR DESCRIPTION
#### Description:

- Simple fix in rule description.