### PR TITLE
Ubuntu 20.04: fix grub2 password related rules

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/ubuntu.xml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/grub2_uefi_password/oval/ubuntu.xml
@@ -1,0 +1,28 @@
+<def-group>
+  <definition class="compliance" id="grub2_uefi_password" version="1">
+    {{{ oval_metadata("The UEFI grub2 boot loader should have password protection enabled.") }}}
+
+    <criteria operator="AND">
+      <criterion comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_grub2_uefi_password_grubcfg" />
+      <criterion comment="make sure a superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" test_ref="test_bootloader_uefi_superuser"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" id="test_bootloader_uefi_superuser" version="2">
+    <ind:object object_ref="object_bootloader_uefi_superuser" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_bootloader_uefi_superuser" version="2">
+    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*set[\s]+superusers=("?)[a-zA-Z_]+\1$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_uefi_boot_path }}}/grub.cfg" id="test_grub2_uefi_password_grubcfg" version="1">
+    <ind:object object_ref="object_grub2_uefi_password_grubcfg" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_grub2_uefi_password_grubcfg" version="1">
+    <ind:filepath>{{{ grub2_uefi_boot_path }}}/grub.cfg</ind:filepath>
+    <ind:pattern operation="pattern match">^[\s]*password_pbkdf2[\s]+.*[\s]+grub\.pbkdf2\.sha512.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -13,7 +13,7 @@ init_system: "systemd"
 oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml"
 
 grub2_boot_path: "/boot/grub"
-grub2_uefi_boot_path: "/boot/efi/EFI/ubuntu"
+grub2_uefi_boot_path: "/boot/grub"
 
 aide_bin_path: "/usr/bin/aide.wrapper"
 aide_conf_path: "/etc/aide/aide.conf"

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -130,6 +130,7 @@ selections:
     ## 1.5 Secure Boot Settings ##
     ### 1.5.1 Ensure bootloader password is set (Automated)
     - grub2_password
+    - grub2_uefi_password
 
     ### 1.5.2 Ensure permissions on bootloader config are configured (Automated)
     - file_owner_grub2_cfg

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -38,7 +38,7 @@ selections:
 
     # UBTU-20-010009 Ubuntu operating systems when booted must require authentication upon booting into single-user and maintenance modes.
     - grub2_uefi_password
-    - '!grub2_password'
+    - grub2_password
 
     # UBTU-20-010010 The Ubuntu operating system must uniquely identify interactive users.
     - no_duplicate_uids


### PR DESCRIPTION
#### Description:

- This fixes th grub2_uefi_boot_path for Ubuntu 20.04 as well as the profiles for CIS and STIG
- Also added a Ubuntu specific OVAL for grub2_uefi as we differ from other distros.
