### PR TITLE
Improve remediation of dir_perms_world_writable_sticky_bits

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 df --local -P | awk '{if (NR!=1) print $6}' \
-| xargs -I '{}' find '{}' -xdev -type d \
+| xargs -I '$6' find '$6' -xdev -type d \
 \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \
-| xargs chmod a+t
+-exec chmod a+t {} +

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = Red Hat Virtualization 4,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
 df --local -P | awk '{if (NR!=1) print $6}' \
 | xargs -I '{}' find '{}' -xdev -type d \
 \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
@@ -2,9 +2,9 @@
 
 # Perform remediation
 df --local -P | awk '{if (NR!=1) print $6}' \
-| xargs -I '{}' find '{}' -xdev -type d \
+| xargs -I '$6' find '$6' -xdev -type d \
 \( -perm -0002 -a ! -perm -1000 \) 2>/dev/null \
-| xargs chmod a+t
+-exec chmod a+t {} +
 
 # Create a new dir that has sticky bit but is not word-writable
 mkdir /test_dir_1


### PR DESCRIPTION
#### Description:

- The remediation script of dir_perms_world_writable_sticky_bits was throwing a warning on `chmod: missing operand after a+t`
- I've also added the ubuntu platform to the remediation as it was weirdly missing