### PR TITLE
Ubuntu 20.04 CIS Level1 profile: add package_pam_pwquality_installed

### DIFF
--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -701,6 +701,7 @@ selections:
 
     ## 5.3 Configure PAM ##
     ### 5.3.1 Ensure password creation requirements are configured (Automated)
+    - package_pam_pwquality_installed
     - var_password_pam_minlen=14
     - accounts_password_pam_minlen
     - var_password_pam_minclass=4


### PR DESCRIPTION
#### Description:

- This is needed for the case where that package is not installed, resulting in failure for the subsequent rules.