### PR TITLE
Ubuntu 20.04: Make sure xatrr audit rules contains a check for root user

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/rule.yml
@@ -104,6 +104,7 @@ template:
         check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        check_root_user@ubuntu2004: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/rule.yml
@@ -99,6 +99,7 @@ template:
         check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        check_root_user@ubuntu2004: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/rule.yml
@@ -104,6 +104,7 @@ template:
         check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        check_root_user@ubuntu2004: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/rule.yml
@@ -99,6 +99,7 @@ template:
         check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        check_root_user@ubuntu2004: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/rule.yml
@@ -103,6 +103,7 @@ template:
         check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        check_root_user@ubuntu2004: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/rule.yml
@@ -99,6 +99,7 @@ template:
         check_root_user@ol8: "true"
         check_root_user@rhel8: "true"
         check_root_user@rhel9: "true"
+        check_root_user@ubuntu2004: "true"
         syscall_grouping:
           - fremovexattr
           - lremovexattr


### PR DESCRIPTION
#### Description:

- On Ubuntu 20.04 STIG V1R1, the items related to xattr (UBTU-20-010142, UBTU-20-010143, UBTU-20-010144, UBTU-20-010145, UBTU-20-010146 and UBTU-20-010147) should have a check for root user. E.g.:
```
-a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=-1 -k perm_mod
-a always,exit -F arch=b32 -S setxattr -F auid=0 -k perm_mod                            <- Check for root
-a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=-1 -k perm_mod
-a always,exit -F arch=b64 -S setxattr -F auid=0 -k perm_mod                            <- Check for root
```

This was missing and can easily be added by setting check_root_user to true.