### PR TITLE
Use variable for ocp version detection

### DIFF
--- a/applications/openshift/general/version_detect_in_hypershift/rule.yml
+++ b/applications/openshift/general/version_detect_in_hypershift/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'This is a helper rule to fetch the required api resource for detecting HyperShift OCP version'
+
+{{% set custom_jqfilter = '[.status.version.history[].version]' %}}
+{{% set custom_api_path = '/apis/hypershift.openshift.io/v1alpha1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set default_api_path = '/hypershift/version' %}}
+{{% set dump_path = default_api_path ~ ',' ~ custom_jqfilter %}}
+
+description: |-
+    no description
+
+rationale: |-
+    no rationale
+
+severity: medium
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_version({custom_api_path: dump_path}) | indent(4) }}}

--- a/applications/openshift/general/version_detect_in_ocp/rule.yml
+++ b/applications/openshift/general/version_detect_in_ocp/rule.yml
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+prodtype: ocp4
+
+title: 'This is a helper rule to fetch the required api resource for detecting OCP version'
+
+{{% set custom_jqfilter = '{{.ocp_version_yaml_path}}' %}}
+{{% set custom_api_path = '{{.ocp_version_api_path}}' %}}
+{{% set default_api_path = '/ocp/version' %}}
+{{% set dump_path = default_api_path ~ ',' ~ custom_jqfilter %}}
+
+description: |-
+    no description
+
+rationale: |-
+    no rationale
+
+severity: medium
+
+warnings:
+- general: |-
+    {{{ openshift_filtered_version({custom_api_path: dump_path}) | indent(4) }}}

--- a/applications/openshift/hypershift_cluster.var
+++ b/applications/openshift/hypershift_cluster.var
@@ -1,0 +1,16 @@
+documentation_complete: true
+
+title: 'HyperShift Cluster Name'
+
+description: |-
+    When this parameter is set, we will assume the cluster is a HyperShift cluster,
+    and we will fetch the OCP version api resource for HyperShift cluster
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: 

--- a/applications/openshift/ocp_version_api_path.var
+++ b/applications/openshift/ocp_version_api_path.var
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'OCP version api path'
+
+description: |-
+    When scanning OpenShift clusters, not all type of cluster has same api
+    resource path for ocp version, ex. HyperShift OCP version api resource path
+    is different than a regular OpenShift Cluster.
+    This variable determines which api resource to fetch to detect ocp version,
+    the default value is for a regular OpenShift Cluster.
+    This variable should be used in conjunction with ocp_version_yaml_path.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: /apis/config.openshift.io/v1/clusteroperators/openshift-apiserver

--- a/applications/openshift/ocp_version_yaml_path.var
+++ b/applications/openshift/ocp_version_yaml_path.var
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+title: 'OCP version yaml path'
+
+description: |-
+    When scanning OpenShift clusters, not all type of cluster has same api
+    resource path for ocp version, ex. HyperShift OCP version api resource path
+    is different than a regular OpenShift Cluster.
+    This variable determines what yaml api filter to apply to the fetched api resource
+    defined by ocp_version_api_path variable.
+    The default value is for a regular OpenShift Cluster. this variable should be used
+    in conjunction with ocp_version_api_path.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "[.status.versions[].version]"

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -22,6 +22,10 @@ description: |-
 
     This profile is applicable to OpenShift versions 4.6 and greater.
 selections:
+  ### Helper Rules
+  ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift
   ### 1 Control Plane Components
   ###
   #### 1.2 API Server

--- a/products/ocp4/profiles/e8.profile
+++ b/products/ocp4/profiles/e8.profile
@@ -32,3 +32,7 @@ selections:
     - rbac_limit_cluster_admin
     - api_server_tls_cipher_suites
     - api_server_encryption_provider_cipher
+  ### Helper Rules
+  ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/products/ocp4/profiles/high.profile
+++ b/products/ocp4/profiles/high.profile
@@ -45,3 +45,7 @@ extends: cis
 
 selections:
     - nist_ocp4:all:high
+  ### Helper Rules
+  ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/products/ocp4/profiles/moderate.profile
+++ b/products/ocp4/profiles/moderate.profile
@@ -44,3 +44,7 @@ extends: cis
 
 selections:
     - nist_ocp4:all:moderate
+  ### Helper Rules
+  ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/products/ocp4/profiles/pci-dss.profile
+++ b/products/ocp4/profiles/pci-dss.profile
@@ -22,3 +22,7 @@ extends: cis
 
 selections:
     - pcidss_ocp4:all:base
+  ### Helper Rules
+  ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/products/ocp4/profiles/stig.profile
+++ b/products/ocp4/profiles/stig.profile
@@ -24,3 +24,7 @@ filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platfo
 
 selections:
     - srg_ctr:all
+  ### Helper Rules
+  ### This is a helper rule to fetch the required api resource for detecting OCP version
+    - version_detect_in_ocp
+    - version_detect_in_hypershift

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -21,12 +21,30 @@
   </ind:yamlfilecontent_test>
 
   <local_variable id="ocp4_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
-      <literal_component>/kubernetes-api-resources/apis/config.openshift.io/v1/clusteroperators/openshift-apiserver</literal_component>
+      <literal_component>/kubernetes-api-resources/ocp/version</literal_component>
+  </local_variable>
+
+  <local_variable id="ocp4_hypershift_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
+      <literal_component>/kubernetes-api-resources/hypershift/version</literal_component>
   </local_variable>
 
   <unix:file_test id="test_file_for_ocp4" check="only one" comment="Find the actual file to be scanned." version="1">
       <unix:object object_ref="object_file_for_ocp4"/>
   </unix:file_test>
+
+  <unix:file_test id="test_hypershift_file_for_ocp4" check="only one" comment="Find the actual file to be scanned for hypershift." version="1">
+      <unix:object object_ref="object_hypershift_file_for_ocp4"/>
+  </unix:file_test>
+
+  <unix:file_object id="object_hypershift_file_for_ocp4" version="1">
+      <unix:filepath var_ref="ocp4_hypershift_dump_location"/>
+  </unix:file_object>
+
+  <ind:yamlfilecontent_object id="object_hypershift_ocp4" version="1">
+      <ind:filepath var_ref="ocp4_hypershift_dump_location"/>
+      <ind:yamlpath>[:]</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
 
   <unix:file_object id="object_file_for_ocp4" version="1">
       <unix:filepath var_ref="ocp4_dump_location"/>
@@ -34,7 +52,7 @@
 
   <ind:yamlfilecontent_object id="object_ocp4" version="1">
       <ind:filepath var_ref="ocp4_dump_location"/>
-      <ind:yamlpath>.status.versions[:].version</ind:yamlpath>
+      <ind:yamlpath>[:]</ind:yamlpath>
   </ind:yamlfilecontent_object>
 
   <ind:yamlfilecontent_state id="state_ocp4" version="1">
@@ -54,9 +72,16 @@
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.{{{ minorversion }}}" source="CPE" />
       <description>The application installed installed on the system is OpenShift version 4.{{{ minorversion }}}.</description>
     </metadata>
-    <criteria operator="AND">
-      <criterion comment="cluster is OpenShift 4.{{{ minorversion }}}" test_ref="test_ocp4_{{{ minorversion }}}" />
-      <criterion comment="Make sure OCP4 clusteroperators file is present" test_ref="test_file_for_ocp4"/>
+    <criteria operator="OR">
+      <criteria operator="AND">
+        <criterion comment="cluster is OpenShift 4.{{{ minorversion }}}" test_ref="test_ocp4_{{{ minorversion }}}" />
+        <criterion comment="Make sure OCP4 clusteroperators file is present" test_ref="test_file_for_ocp4"/>
+        <criterion negate="true" comment="Make sure HyperShift OCP4 clusteroperators file is not present" test_ref="test_hypershift_file_for_ocp4"/>
+      </criteria>
+      <criteria operator="AND">
+        <criterion comment="cluster is OpenShift 4.{{{ minorversion }}}" test_ref="test_hypershift_ocp4_{{{ minorversion }}}" />
+        <criterion comment="Make sure HyperShift OCP4 clusteroperators file is present" test_ref="test_hypershift_file_for_ocp4"/>
+      </criteria>
     </criteria>
   </definition>
 
@@ -64,6 +89,12 @@
       <ind:object object_ref="object_ocp4"/>
       <ind:state state_ref="state_ocp4_{{{ minorversion }}}"/>
   </ind:yamlfilecontent_test>
+
+  <ind:yamlfilecontent_test id="test_hypershift_ocp4_{{{ minorversion }}}" check="at least one" comment="Find one match" version="1">
+      <ind:object object_ref="object_hypershift_ocp4"/>
+      <ind:state state_ref="state_ocp4_{{{ minorversion }}}"/>
+  </ind:yamlfilecontent_test>
+
 
   <ind:yamlfilecontent_state id="state_ocp4_{{{ minorversion }}}" version="1">
       <ind:value datatype="record">

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -91,6 +91,36 @@ Therefore, you need to use a tool that can query the OCP API, retrieve the follo
 </ul>
 {{%- endmacro %}}
 
+{{#
+  Macro which generates a unique identifier for Compliance Operator, this will hide the rule from ComplianceCheckResult
+#}}
+{{% macro hide_rule() -%}}
+This rule will be a hidden rule 
+<code class="ocp-hide-rule" id="ocp-hide-rule">true</code>
+{{%- endmacro %}}
+
+{{% macro openshift_filtered_version(path_filter_pairs) -%}}
+This rule's check operates on the cluster configuration dump.
+Therefore, you need to use a tool that can query the OCP API, retrieve the following:
+<ul>
+{{% for obj_path, v in path_filter_pairs.items() %}}
+  {{% set vars = v.split(',') %}}
+    {{% set dump_path = vars[0] %}}
+    {{% set default_filter = vars[1] %}}
+  <li>
+    <code class="ocp-api-endpoint" id="{{{ (dump_path+default_filter)|sha256 }}}">{{{ obj_path }}}</code>
+    API endpoint, filter with with the <code>jq</code> utility using the following filter
+    <code class="ocp-api-filter" id="filter-{{{ (dump_path+default_filter)|sha256 }}}">{{{ default_filter }}}</code>
+    and persist it to the local
+    <code class="ocp-dump-location" id="dump-{{{ (dump_path+default_filter)|sha256 }}}">{{{ xccdf_value("ocp_data_root") }}}/{{{ dump_path.lstrip("/") }}}</code>
+    file.
+    {{{ hide_rule() }}}
+  </li>
+{{% endfor %}}
+</ul>
+{{%- endmacro %}}
+
+
 
 {{#
   Macro which generates a unique path for a filtered Kubernetes


### PR DESCRIPTION
In order to use OCP version detection on HyperShift we need to introduce variables to specify the API path.

We have introduced the rule [version_detect/rule.yml](https://github.com/ComplianceAsCode/content/pull/9726/files#diff-dafef22e37ea492d6725a6c29ab6db99dd0941322150768063f6fd3d9c241164), this rule is used to fetch ocp version api resource, user can set [ocp_version_yaml_path.var](https://github.com/ComplianceAsCode/content/pull/9726/files#diff-f739a3aaf4cb3269532a94bfb8c73532be05dbaa9fa2c376c3a87c8f0c9ebfd8) and [applications/openshift/ocp_version_api_path.var](https://github.com/ComplianceAsCode/content/pull/9726/files#diff-612fb661ba294f5a0823e7b09d814ce672d6582c3d666ffab7c2f727bc57b6fb) to set custom api path for a HyperShift cluster.

Example on how you can you can set HyperShift cluster name in a tailoredProfile so that the version detection will detect the OCP version of HyperShift cluster correctly.

```yaml
apiVersion: compliance.openshift.io/v1alpha1
kind: TailoredProfile
metadata:
  name: hypershift-cis
spec:
  description: scan a hypershift cluster
  setValues:
  - name: upstream-ocp4-hypershift-cluster
    rationale: Scan this cluster
    value: example-guest-cluster
  extends: upstream-ocp4-cis
  title: CIS
```