### PR TITLE
Add pci-ds rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_root_gid_zero/rule.yml
@@ -14,6 +14,8 @@ identifiers:
     cce@rhel7: CCE-86296-1
     cce@rhel8: CCE-86297-9
     cce@rhel9: CCE-86298-7
+    cce@sle12: CCE-91635-3
+    cce@sle15: CCE-91289-9
 
 references:
     cis@alinux2: 5.4.3
@@ -21,6 +23,7 @@ references:
     cis@rhel7: 5.5.3
     cis@rhel8: 5.6.4
     cis@sle15: 5.4.3
+    pcidss: Req-8.2.1
 
 ocil_clause: 'root has a primary gid not equal to zero'
 

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
@@ -23,6 +23,8 @@ severity: medium
 identifiers:
     cce@rhel8: CCE-85965-2
     cce@rhel9: CCE-85966-0
+    cce@sle12: CCE-91648-6
+    cce@sle15: CCE-91342-6
 
 references:
     cis-csc: 11,14,3,9
@@ -36,6 +38,7 @@ references:
     nerc-cip: CIP-003-8 R4,CIP-003-8 R5,CIP-004-6 R3
     nist: AC-4,CM-7(b),CA-3(5),SC-7(21),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
+    pcidss: Req-1.4.1
 
 ocil_clause: 'the default policy for the INPUT chain is not set to DROP'
 

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -17,6 +17,7 @@ selections:
     -  accounts_minimum_age_login_defs
     -  accounts_no_uid_except_zero
     -  accounts_password_warn_age_login_defs
+    -  accounts_root_gid_zero
     -  accounts_tmout
     -  accounts_umask_etc_bashrc
     -  accounts_umask_etc_login_defs


### PR DESCRIPTION
#### Description:

Add rules to PCI-DSS-4 profile
- accounts_root_gid_zero
- set_ip6tables_default_rule

#### Rationale:
