### PR TITLE
Added 4 rules to SLES 12/15 PCI DSS 4.0 profiles

### DIFF
--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -17,18 +17,22 @@ selections:
     -  coredump_disable_backtraces
     -  coredump_disable_storage
     -  disable_host_auth
+    -  disable_prelink
     -  disable_users_coredumps
     -  file_at_deny_not_exist
     -  file_cron_deny_not_exist
     -  file_groupowner_at_allow
+    -  file_groupowner_backup_etc_group
     -  file_groupowner_backup_etc_passwd
     -  file_groupowner_backup_etc_shadow
     -  file_groupowner_cron_allow
     -  file_owner_at_allow
+    -  file_owner_backup_etc_group
     -  file_owner_backup_etc_passwd
     -  file_owner_backup_etc_shadow
     -  file_owner_cron_allow
     -  file_permissions_at_allo
+    -  file_permissions_backup_etc_group
     -  file_permissions_backup_etc_passwd
     -  file_permissions_backup_etc_shadow
     -  file_permissions_cron_allow

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -31,18 +31,22 @@ selections:
     -  cracklib_accounts_password_pam_retry
     -  cracklib_accounts_password_pam_ucredit
     -  disable_host_auth
+    -  disable_prelink
     -  disable_users_coredumps
     -  file_at_deny_not_exist
     -  file_cron_deny_not_exist
     -  file_groupowner_at_allow
+    -  file_groupowner_backup_etc_group
     -  file_groupowner_backup_etc_passwd
     -  file_groupowner_backup_etc_shadow
     -  file_groupowner_cron_allow
     -  file_owner_at_allow
+    -  file_owner_backup_etc_group
     -  file_owner_backup_etc_passwd
     -  file_owner_backup_etc_shadow
     -  file_owner_cron_allow
     -  file_permissions_at_allow
+    -  file_permissions_backup_etc_group
     -  file_permissions_backup_etc_passwd
     -  file_permissions_backup_etc_shadow
     -  file_permissions_cron_allow


### PR DESCRIPTION
#### Description:

- _Added the rules  disable_prelink, file_groupowner_backup_etc_group, file_owner_backup_etc_group and  file_permissions_backup_etc_group to the SLES 12/15 PCI DSS 4.0 profiles_

#### Rationale:

- Update of PCI DSS 4.0 profiles



#### Review Hints:

- _Review hints here. Replace this text. Don't use the italics format!_

- _Use this optional section to give any relevant information which could help the reviewer to more quickly and assertively understand and test the changes._

- _Good examples are useful commands, if it is better to review all commits together or in a suggested sequence, any relevant discussion in other PRs or issues, etc._