### PR TITLE
Complete tests to validate Ol9 pci dss profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/tests/correct_value.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = opensc
+# variables = var_smartcard_drivers=default
+
+cat  <<EOF  > /etc/opensc.conf
+app default {
+	# debug = 3;
+	# debug_file = opensc-debug.txt;
+	framework pkcs15 {
+		use_file_caching = true;
+	}
+	reader_driver pcsc {
+		# The pinpad is disabled by default,
+		# because of many broken readers out there
+		enable_pinpad = false;
+	}
+	card_drivers = default;
+}
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/tests/missing_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = opensc
+# variables = var_smartcard_drivers=default
+
+cat  <<EOF  > /etc/opensc.conf
+app default {
+	# debug = 3;
+	# debug_file = opensc-debug.txt;
+	framework pkcs15 {
+		use_file_caching = true;
+	}
+	reader_driver pcsc {
+		# The pinpad is disabled by default,
+		# because of many broken readers out there
+		enable_pinpad = false;
+	}
+}
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/tests/wrong_value.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = opensc
+# variables = var_smartcard_drivers=default
+
+cat  <<EOF  > /etc/opensc.conf
+app default {
+	# debug = 3;
+	# debug_file = opensc-debug.txt;
+	framework pkcs15 {
+		use_file_caching = true;
+	}
+	reader_driver pcsc {
+		# The pinpad is disabled by default,
+		# because of many broken readers out there
+		enable_pinpad = false;
+	}
+	card_drivers = cac;
+}
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/tests/correct_value.pass.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = opensc
+# variables = var_smartcard_drivers=default
+
+cat  <<EOF  > /etc/opensc.conf
+app default {
+	# debug = 3;
+	# debug_file = opensc-debug.txt;
+	framework pkcs15 {
+		use_file_caching = true;
+	}
+	reader_driver pcsc {
+		# The pinpad is disabled by default,
+		# because of many broken readers out there
+		enable_pinpad = false;
+	}
+	force_card_driver = default;
+}
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/tests/missing_value.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# packages = opensc
+# variables = var_smartcard_drivers=default
+
+cat  <<EOF  > /etc/opensc.conf
+app default {
+	# debug = 3;
+	# debug_file = opensc-debug.txt;
+	framework pkcs15 {
+		use_file_caching = true;
+	}
+	reader_driver pcsc {
+		# The pinpad is disabled by default,
+		# because of many broken readers out there
+		enable_pinpad = false;
+	}
+}
+EOF

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/force_opensc_card_drivers/tests/wrong_value.fail.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# packages = opensc
+# variables = var_smartcard_drivers=default
+
+cat  <<EOF  > /etc/opensc.conf
+app default {
+	# debug = 3;
+	# debug_file = opensc-debug.txt;
+	framework pkcs15 {
+		use_file_caching = true;
+	}
+	reader_driver pcsc {
+		# The pinpad is disabled by default,
+		# because of many broken readers out there
+		enable_pinpad = false;
+	}
+	force_card_driver = cac;
+}
+EOF

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/tests/correct_value.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# packages = audit
+
+touch "/var/log/audit/audit.log"
+chown root  "/var/log/audit/audit.log"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_ownership_var_log_audit/tests/wrong_value.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+
+useradd testuser_123
+
+touch "/var/log/audit/audit.log"
+chown testuser_123 "/var/log/audit/audit.log"

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/tests/correct_value.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = audit
+# variables = var_auditd_max_log_file_action=rotate
+
+. $SHARED/auditd_utils.sh
+prepare_auditd_test_enviroment
+set_parameters_value /etc/audit/auditd.conf "max_log_file_action" "rotate"


### PR DESCRIPTION
#### Description:

- Add tests for automatus used during the PCI-DSS profile validation in OL9
- Now all rules in OL9 PCI-DSS profile have some tests

#### Rationale:

- These rules didn't have tests

#### Review Hints:

- Since this only introduce tests, it is expected to have the Automatus tests passed