### PR TITLE
Update SLE 15 SAP hardening profile

### DIFF
--- a/products/sle15/profiles/pcs-hardening-sap.profile
+++ b/products/sle15/profiles/pcs-hardening-sap.profile
@@ -7,15 +7,25 @@ metadata:
 
 reference: 
 
-title: 'Public Cloud SAP Hardening for SUSE Linux Enterprise 15'
+title: 'Hardening for Public Cloud Image of SUSE Linux Enterprise Server (SLES) for SAP Applications 15'
 
 description: |-
-    This profile contains configuration checks to be used to harden
-    SUSE Linux Enterprise 15 SAP Images for use with public cloud providers.
+    This profile contains configuration rules to be used to harden the images
+    of SUSE Linux Enterprise Server (SLES) for SAP Applications 15 including
+    all Service Packs, for Public Cloud providers, currently AWS, Microsoft
+    Azure, and Google Cloud.
 
 extends: pcs-hardening
 
 selections:
+    # Install rules for we want for SAP
+    - install_smartcard_packages
+    - package_aide_installed
+    - package_audit-audispd-plugins_installed
+    - package_audit_installed
+    - package_chrony_installed
+    - package_iptables_installed
+    - package_rsyslog_installed
     # remove some rules in pcs-hardening
     - '!accounts_umask_etc_login_defs'
     - '!accounts_umask_etc_profile'


### PR DESCRIPTION
Update the profile title and description to more closely match published documents on product.

Add package install rules. Testing with minimal installs showed that some of the assumptions we made about what was installed by default was incorrect.

#### Description:

- The original title was slightly off from the SUSE documentation "SUSE Linux Enterprise Server for SAP Applications 15"
see: https://blogs.sap.com/2020/11/20/sles-for-sap-applications-15-is-now-certified-for-sap-s-4hana-and-netweaver-ha-interface-certification/
That it was thought that it might be confusing for users.

- rules for installing packages were omitted from the first commit, because the internal build process uses kiwi to specify the packages. Since then we have had requests to make the profile self contained and testing. 

#### Rationale:

- reduce user confusion
- enable use of the profile with remediation outside of the image build process
