### PR TITLE
Add tests to accounts_password template

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/tests/disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/tests/disabled.fail.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "dictcheck=0" > /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/tests/enable.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/tests/enable.pass.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-echo "dictcheck=1" > /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/tests/not_defined.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/tests/not_defined.fail.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sed -i s/dictcheck.+//g /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
-	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 4/' /etc/security/pwquality.conf
-else
-	echo "maxclassrepeat = 4" >> /etc/security/pwquality.conf
-fi
-

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value_less_than_variable.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/correct_value_less_than_variable.pass.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
-	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 2/' /etc/security/pwquality.conf
-else
-	echo "maxclassrepeat = 2" >> /etc/security/pwquality.conf
-fi
-

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/negative_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/negative_value.fail.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
-	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = -1/' /etc/security/pwquality.conf
-else
-	echo "maxclassrepeat = -1" >> /etc/security/pwquality.conf
-fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
-	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 5/' /etc/security/pwquality.conf
-else
-	echo "maxclassrepeat = 5" >> /etc/security/pwquality.conf
-fi
-

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value_0.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/tests/wrong_value_0.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if grep -q 'maxclassrepeat' /etc/security/pwquality.conf; then
-	sed -i 's/.*maxclassrepeat.*/maxclassrepeat = 0/' /etc/security/pwquality.conf
-else
-	echo "maxclassrepeat = 0" >> /etc/security/pwquality.conf
-fi
-

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/correct.pass.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf
-echo "minclass = 4" >> /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/line_not_there.fail.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/wrong.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minclass/tests/wrong.fail.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-sed -i '/\s*minclass\s*=/d' /etc/security/pwquality.conf
-echo "minclass = 0" >> /etc/security/pwquality.conf

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/commented.fail.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-CONF_FILE="/etc/security/pwquality.conf"
-
-if grep -q "^.*minlen\s*=" "$CONF_FILE"; then
-	sed -i "s/^.*minlen\s*=.*/# minlen = 15/" "$CONF_FILE"
-else
-	echo "# minlen = 15" >> "$CONF_FILE"
-fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/correct.pass.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-CONF_FILE="/etc/security/pwquality.conf"
-
-if grep -q "^.*minlen\s*=" "$CONF_FILE"; then
-	sed -i "s/^.*minlen\s*=.*/minlen = 15/" "$CONF_FILE"
-else
-	echo "minlen = 15" >> "$CONF_FILE"
-fi

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/missing.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-CONF_FILE="/etc/security/pwquality.conf"
-
-sed -i "/^.*minlen\s*=.*/d" "$CONF_FILE"

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/short.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/tests/short.fail.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-CONF_FILE="/etc/security/pwquality.conf"
-
-if grep -q "^.*minlen\s*=" "$CONF_FILE"; then
-	sed -i "s/^.*minlen\s*=.*/minlen = 1/" "$CONF_FILE"
-else
-	echo "minlen = 1" >> "$CONF_FILE"
-fi

--- a/shared/templates/accounts_password/template.py
+++ b/shared/templates/accounts_password/template.py
@@ -2,4 +2,43 @@ from ssg.utils import parse_template_boolean_value
 
 def preprocess(data, lang):
     data["zero_comparison_operation"] = data.get("zero_comparison_operation", None)
+
+    if "greater" in data["operation"]:
+        if data["zero_comparison_operation"]:
+            if "greater" in data["zero_comparison_operation"]:
+                data["test_var_value"] = "-2"
+                data["test_correct_value"] = "1"
+                data["test_wrong_value"] = "-3"
+                data["test_wrong_vs_zero_value"] = "-1"
+            elif "less" in data["zero_comparison_operation"]:
+                data["test_var_value"] = "-2"
+                data["test_correct_value"] = "-1"
+                data["test_wrong_value"] = "-3"
+                data["test_wrong_vs_zero_value"] = "1"
+        else:
+            data["test_var_value"] = "0"
+            data["test_correct_value"] = "1"
+            data["test_wrong_value"] = "-1"
+
+    elif "less" in data["operation"]:
+        if data["zero_comparison_operation"]:
+            if "greater" in data["zero_comparison_operation"]:
+                data["test_var_value"] = "2"
+                data["test_correct_value"] = "1"
+                data["test_wrong_value"] = "3"
+                data["test_wrong_vs_zero_value"] = "-1"
+            elif "less" in data["zero_comparison_operation"]:
+                data["test_var_value"] = "2"
+                data["test_correct_value"] = "-1"
+                data["test_wrong_value"] = "3"
+                data["test_wrong_vs_zero_value"] = "1"
+        else:
+            data["test_var_value"] = "0"
+            data["test_correct_value"] = "-1"
+            data["test_wrong_value"] = "1"
+    else:
+        data["test_var_value"] = "0"
+        data["test_correct_value"] = "0"
+        data["test_wrong_value"] = "1"
+
     return data

--- a/shared/templates/accounts_password/tests/commented.fail.sh
+++ b/shared/templates/accounts_password/tests/commented.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "#{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf

--- a/shared/templates/accounts_password/tests/conflicting_values.fail.sh
+++ b/shared/templates/accounts_password/tests/conflicting_values.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This test only applies to platforms that check the pwquality.conf.d directory
+# platform = Oracle Linux 8
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" \
+>> /etc/security/pwquality.conf.d/test_file.conf

--- a/shared/templates/accounts_password/tests/correct_value.pass.sh
+++ b/shared/templates/accounts_password/tests/correct_value.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf

--- a/shared/templates/accounts_password/tests/correct_value_directory.pass.sh
+++ b/shared/templates/accounts_password/tests/correct_value_directory.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This test only applies to platforms that check the pwquality.conf.d directory
+# platform = Oracle Linux 8
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+# This test will ensure that OVAL also checks the configuration in 
+# /etc/security/pwquality.conf.d/*.conf files
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" \
+>> /etc/security/pwquality.conf.d/test_file.conf

--- a/shared/templates/accounts_password/tests/multiple_correct_value.pass.sh
+++ b/shared/templates/accounts_password/tests/multiple_correct_value.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This test only applies to platforms that check the pwquality.conf.d directory
+# platform = Oracle Linux 8
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" \
+>> /etc/security/pwquality.conf.d/test_file.conf

--- a/shared/templates/accounts_password/tests/wrong_value.fail.sh
+++ b/shared/templates/accounts_password/tests/wrong_value.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" >> /etc/security/pwquality.conf

--- a/shared/templates/accounts_password/tests/wrong_value_directory.fail.sh
+++ b/shared/templates/accounts_password/tests/wrong_value_directory.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+
+# This test will ensure that the remediation also applies the configuration in 
+# /etc/security/pwquality.conf.d/*.conf files
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" \
+>> /etc/security/pwquality.conf.d/test_file.conf

--- a/shared/templates/accounts_password/tests/wrong_value_vs_zero.fail.sh
+++ b/shared/templates/accounts_password/tests/wrong_value_vs_zero.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+{{% if ZERO_COMPARISON_OPERATION is none %}}
+# platform = Not Applicable
+{{% endif %}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VS_ZERO_VALUE }}}" >> /etc/security/pwquality.conf


### PR DESCRIPTION
#### Description:

- Add tests to `accounts_password` template
- Also removed tests that resulted duplicated because of this

#### Rationale:

- This template didn't have tests. so many of the rules using the template didn't have them

#### Review Hints:

- As this is only an update on tests, the automatus run should be sufficient, and look at the logic in the introduced tests