### PR TITLE
Remove fapolicyd prevent home folder access from the RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00230.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00230.yml
@@ -8,5 +8,3 @@ controls:
         rules:
             - package_fapolicyd_installed
             - service_fapolicyd_enabled
-            - fapolicyd_prevent_home_folder_access
-

--- a/linux_os/guide/services/fapolicyd/fapolicyd_prevent_home_folder_access/rule.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicyd_prevent_home_folder_access/rule.yml
@@ -21,21 +21,7 @@ references:
     nist: CM-6 b
     srg: SRG-OS-000480-GPOS-00230
 
-ocil_clause: 'fapolicyd allows non-privileged users to grant other users direct access to the contents of their home directories/folders'
-
-ocil: |-
-    Verify that fapolicyd on {{{ full_name }}} prevents ability of non-privileged users to grant other users direct access to the contents of their home directories/folders.
-
-    Run the following command:
-
-    grep -r "deny_audit perm=chmod path=/home" /etc/fapolicyd/rules.d
-
-fixtext: |-
-    Configure fapolicyd to ability of non-privileged users to grant other users direct access to the contents of their home directories/folders.
-    Add or edit the following lines in /etc/fapolicyd/rules.d/90-deny-home.
-
-    deny_audit perm=chmod path=/home all : all
-
-    Note: That fapolicyd must have correctly configured rules. All configurations will be based on the actual system setup and organizational polices and practices.
-
-srg_requirement: '{{{ full_name }}} must limit the ability of non-privileged users to grant other users direct access to the contents of their home directories/folders.'
+warnings:
+    - general: |-
+          This rule is deprecated and there is no replacement at this time.
+          Previous versions of this rule provided fixtext that would cause fapolicyd not to start.


### PR DESCRIPTION

#### Description:

- Remove fapolicyd_prevent_home_folder_access from the RHEL 9 STIG
- Remove the harmful text from fapolicyd_prevent_home_folder_access


#### Rationale
Remove bad advice from the project.