### PR TITLE
rsyslog_files_permissions: Consider the last field in the config line the log file path

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/bash/shared.sh
@@ -57,7 +57,7 @@ do
 	then
 		NORMALIZED_CONFIG_FILE_LINES=$(sed -e "/^[#|$]/d" "${LOG_FILE}")
 		LINES_WITH_PATHS=$(grep '[^/]*\s\+\S*/\S\+$' <<< "${NORMALIZED_CONFIG_FILE_LINES}")
-		FILTERED_PATHS=$(awk '{if(NF>=2&&($2~/^\//||$2~/^-\//)){sub(/^-\//,"/",$2);print $2}}' <<< "${LINES_WITH_PATHS}")
+		FILTERED_PATHS=$(awk '{if(NF>=2&&($NF~/^\//||$NF~/^-\//)){sub(/^-\//,"/",$NF);print $NF}}' <<< "${LINES_WITH_PATHS}")
 		CLEANED_PATHS=$(sed -e "s/[\"')]//g; /\\/etc.*\.conf/d; /\\/dev\\//d" <<< "${FILTERED_PATHS}")
 		MATCHED_ITEMS=$(sed -e "/^$/d" <<< "${CLEANED_PATHS}")
 		# Since above sed command might return more than one item (delimited by newline), split the particular

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_cloudinit.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0600_cloudinit.pass.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8,multi_platform_sle
+
+source $SHARED/rsyslog_log_utils.sh
+
+PERMS=0600
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod $PERMS ${RSYSLOG_TEST_LOGS[@]}
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+:syslogtag, isequal, "[CLOUDINIT]" ${RSYSLOG_TEST_LOGS[1]}
+EOF
+

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0601_cloudinit.fail.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/tests/include_perms_0601_cloudinit.fail.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# platform = Red Hat Enterprise Linux 8,multi_platform_fedora,Oracle Linux 8,multi_platform_sle
+
+source $SHARED/rsyslog_log_utils.sh
+
+# setup test data
+create_rsyslog_test_logs 2
+
+# setup test log files and permissions
+chmod 0600 ${RSYSLOG_TEST_LOGS[0]}
+chmod 0601 ${RSYSLOG_TEST_LOGS[1]}
+
+# create rsyslog.conf configuration file
+cat << EOF > $RSYSLOG_CONF
+# rsyslog configuration file
+
+#### RULES ####
+
+*.*     ${RSYSLOG_TEST_LOGS[0]}
+:syslogtag, isequal, "[CLOUDINIT]" ${RSYSLOG_TEST_LOGS[1]}
+EOF
+


### PR DESCRIPTION
#### Description:

- Fix path filtering in the Bash remediation.
  - It was assuming that the log file path is always the second field in the config line. But this assumption breaks when there are conditionals.
  - The log file path is always the last field in the config line.

#### Rationale:

- Should fix errors in `testing-farm:centos-stream-9-x86_64` test on https://github.com/ComplianceAsCode/content/pull/9738
