### PR TITLE
Dconf macros update to align them with OVAL expectation

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value.pass.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "{{{ dconf_db }}}" "00-security-settings"
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "{{{ dconf_gdm_dir }}}" "00-security-settings"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+source $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "true" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "dummy.d" "00-security-settings"
+
+dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_banner_enabled/tests/wrong_value.fail.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "{{{ dconf_db }}}" "00-security-settings"
+add_dconf_setting "org/gnome/login-screen" "banner-message-enable" "false" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-enable" "{{{ dconf_gdm_dir }}}" "00-security-settings"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value.pass.sh
@@ -3,11 +3,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_ncp
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -16,7 +11,7 @@ login_banner_text="--[\s\n]+WARNING[\s\n]+--[\s\n]*This[\s\n]+system[\s\n]+is[\s
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig_wrong_db.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/correct_value_stig_wrong_db.fail.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# profiles = xccdf_org.ssgproject.content_profile_stig
+# packages = dconf,gdm
+
+source $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+
+login_banner_text="(^You[\s\n]+are[\s\n]+accessing[\s\n]+a[\s\n]+U.S.[\s\n]+Government[\s\n]+\(USG\)[\s\n]+Information[\s\n]+System[\s\n]+\(IS\)[\s\n]+that[\s\n]+is[\s\n]+provided[\s\n]+for[\s\n]+USG-authorized[\s\n]+use[\s\n]+only.[\s\n]*By[\s\n]+using[\s\n]+this[\s\n]+IS[\s\n]+\(which[\s\n]+includes[\s\n]+any[\s\n]+device[\s\n]+attached[\s\n]+to[\s\n]+this[\s\n]+IS\),[\s\n]+you[\s\n]+consent[\s\n]+to[\s\n]+the[\s\n]+following[\s\n]+conditions\:(\\n)*(\n)*-The[\s\n]+USG[\s\n]+routinely[\s\n]+intercepts[\s\n]+and[\s\n]+monitors[\s\n]+communications[\s\n]+on[\s\n]+this[\s\n]+IS[\s\n]+for[\s\n]+purposes[\s\n]+including,[\s\n]+but[\s\n]+not[\s\n]+limited[\s\n]+to,[\s\n]+penetration[\s\n]+testing,[\s\n]+COMSEC[\s\n]+monitoring,[\s\n]+network[\s\n]+operations[\s\n]+and[\s\n]+defense,[\s\n]+personnel[\s\n]+misconduct[\s\n]+\(PM\),[\s\n]+law[\s\n]+enforcement[\s\n]+\(LE\),[\s\n]+and[\s\n]+counterintelligence[\s\n]+\(CI\)[\s\n]+investigations.(\\n)*(\n)*-At[\s\n]+any[\s\n]+time,[\s\n]+the[\s\n]+USG[\s\n]+may[\s\n]+inspect[\s\n]+and[\s\n]+seize[\s\n]+data[\s\n]+stored[\s\n]+on[\s\n]+this[\s\n]+IS.(\\n)*(\n)*-Communications[\s\n]+using,[\s\n]+or[\s\n]+data[\s\n]+stored[\s\n]+on,[\s\n]+this[\s\n]+IS[\s\n]+are[\s\n]+not[\s\n]+private,[\s\n]+are[\s\n]+subject[\s\n]+to[\s\n]+routine[\s\n]+monitoring,[\s\n]+interception,[\s\n]+and[\s\n]+search,[\s\n]+and[\s\n]+may[\s\n]+be[\s\n]+disclosed[\s\n]+or[\s\n]+used[\s\n]+for[\s\n]+any[\s\n]+USG-authorized[\s\n]+purpose.(\\n)*(\n)*-This[\s\n]+IS[\s\n]+includes[\s\n]+security[\s\n]+measures[\s\n]+\(e.g.,[\s\n]+authentication[\s\n]+and[\s\n]+access[\s\n]+controls\)[\s\n]+to[\s\n]+protect[\s\n]+USG[\s\n]+interests--not[\s\n]+for[\s\n]+your[\s\n]+personal[\s\n]+benefit[\s\n]+or[\s\n]+privacy.(\\n)*(\n)*-Notwithstanding[\s\n]+the[\s\n]+above,[\s\n]+using[\s\n]+this[\s\n]+IS[\s\n]+does[\s\n]+not[\s\n]+constitute[\s\n]+consent[\s\n]+to[\s\n]+PM,[\s\n]+LE[\s\n]+or[\s\n]+CI[\s\n]+investigative[\s\n]+searching[\s\n]+or[\s\n]+monitoring[\s\n]+of[\s\n]+the[\s\n]+content[\s\n]+of[\s\n]+privileged[\s\n]+communications,[\s\n]+or[\s\n]+work[\s\n]+product,[\s\n]+related[\s\n]+to[\s\n]+personal[\s\n]+representation[\s\n]+or[\s\n]+services[\s\n]+by[\s\n]+attorneys,[\s\n]+psychotherapists,[\s\n]+or[\s\n]+clergy,[\s\n]+and[\s\n]+their[\s\n]+assistants.[\s\n]+Such[\s\n]+communications[\s\n]+and[\s\n]+work[\s\n]+product[\s\n]+are[\s\n]+private[\s\n]+and[\s\n]+confidential.[\s\n]+See[\s\n]+User[\s\n]+Agreement[\s\n]+for[\s\n]+details.$|^I\'ve[\s\n]+read[\s\n]+\&[\s\n]+consent[\s\n]+to[\s\n]+terms[\s\n]+in[\s\n]+IS[\s\n]+user[\s\n]+agreem\'t$)"
+expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "dummy.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrapped_banner.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrapped_banner.fail.sh
@@ -3,11 +3,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_ncp
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -16,7 +11,7 @@ login_banner_text="Some text before --[\s\n]+WARNING[\s\n]+--[\s\n]*This[\s\n]+s
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/gui_login_banner/dconf_gnome_login_banner_text/tests/wrong_value.fail.sh
@@ -3,11 +3,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_ncp
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 source $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
@@ -16,7 +11,7 @@ login_banner_text="Wrong Banner Text"
 expanded=$(echo "$login_banner_text" | sed 's/(\\\\\x27)\*/\\\x27/g;s/(\\\x27)\*//g;s/(\\\\\x27)/tamere/g;s/(\^\(.*\)\$|.*$/\1/g;s/\[\\s\\n\][+*]/ /g;s/\\//g;s/(n)\*/\\n/g;s/\x27/\\\x27/g;')
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "banner-message-text" "'${expanded}'" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "banner-message-text" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/correct_value.pass.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 . $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "true" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "true" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "true" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "dummy.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/tests/wrong_value.fail.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 . $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "false" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "disable-restart-buttons" "false" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-restart-buttons" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_user_list/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "disable-user-list" "true" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "disable-user-list" "dummy.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/correct_value.pass.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 . $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "true" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "true" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "true" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "dummy.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_enable_smartcard_auth/tests/wrong_value.fail.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 . $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "false" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "enable-smartcard-authentication" "false" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "enable-smartcard-authentication" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/correct_value.pass.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 . $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "allowed-failures" "3" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "allowed-failures" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "allowed-failures" "3" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "allowed-failures" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/login-screen" "allowed-failures" "3" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "allowed-failures" "dummy.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_login_retries/tests/wrong_value.fail.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 # packages = dconf,gdm
 
-{{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
-{{% set dconf_db = "gdm.d" %}}
-{{% endif %}}
-
 . $SHARED/dconf_test_functions.sh
 
 install_dconf_and_gdm_if_needed
 
 clean_dconf_settings
-add_dconf_setting "org/gnome/login-screen" "allowed-failures" "99" "{{{ dconf_db }}}" "00-security-settings"
-add_dconf_lock "org/gnome/login-screen" "allowed-failures" "{{{ dconf_db }}}" "00-security-settings-lock"
+add_dconf_setting "org/gnome/login-screen" "allowed-failures" "99" "{{{ dconf_gdm_dir }}}" "00-security-settings"
+add_dconf_lock "org/gnome/login-screen" "allowed-failures" "{{{ dconf_gdm_dir }}}" "00-security-settings-lock"
 
 dconf update

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+
+add_dconf_setting "org/gnome/desktop/media-handling" "automount" "false" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/media-handling" "automount" "dummy.d" "00-security-settings"
+

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_automount_open/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+
+add_dconf_setting "org/gnome/desktop/media-handling" "automount-open" "false" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/media-handling" "automount-open" "dummy.d" "00-security-settings"
+
+

--- a/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_media_settings/dconf_gnome_disable_autorun/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# profiles = xccdf_org.ssgproject.content_profile_stig
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+
+add_dconf_setting "org/gnome/desktop/media-handling" "autorun-never" "true" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/media-handling" "autorun-never" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_activation_locked/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+add_dconf_lock "org/gnome/desktop/screensaver" "idle-activation-enabled" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_idle_delay/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = inactivity_timeout_value=900
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/session" "idle-delay" "uint32 900" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = var_screensaver_lock_delay=5
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "lock-delay" "uint32 5" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_enabled/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+{{% if 'sle' in product %}}
+add_dconf_settings "org/gnome/desktop/lockdown", "disable-lock-screen", "false", "dummy.d", "00-security-settings"
+add_dconf_lock "org/gnome/desktop/lockdown", "disable-lock-screen", "dummy.d", "00-security-settings-lock"
+{{% else %}}
+add_dconf_setting "org/gnome/desktop/screensaver" "lock-enabled" "true" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "lock-enabled" "dummy.d" "00-security-settings"
+{{% endif %}}

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_lock "org/gnome/desktop/screensaver" "lock-enabled" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_mode_blank/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = dconf,gdm
+# variables = inactivity_timeout_value=900
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_setting "org/gnome/desktop/screensaver" "picture-uri" "string ''" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/desktop/screensaver" "picture-uri" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_lock "org/gnome/desktop/screensaver" "lock-delay" "dummy.d" "00-security-settings"

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# packages = dconf,gdm
+
+. $SHARED/dconf_test_functions.sh
+
+clean_dconf_settings
+add_dconf_lock "org/gnome/desktop/session" "idle-delay" "dummy.d" "00-security-settings-lock"
+
+dconf update

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_wrong_db.fail.sh
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/tests/correct_value_wrong_db.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+. $SHARED/dconf_test_functions.sh
+
+install_dconf_and_gdm_if_needed
+clean_dconf_settings
+add_dconf_setting "org/gnome/settings-daemon/plugins/media-keys" "logout" "''" "dummy.d" "00-security-settings"
+add_dconf_lock "org/gnome/settings-daemon/plugins/media-keys" "logout" "dummy.d" "00-security-settings"

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -700,28 +700,38 @@ fi
 # Check for setting in any of the DConf db directories
 # If files contain ibus or distro, ignore them.
 # The assignment assumes that individual filenames don't contain :
-readarray -t SETTINGSFILES < <(grep -r "\\[{{{ path }}}\\]" "/etc/dconf/db/" | grep -v 'distro\|ibus' | cut -d":" -f1)
+readarray -t SETTINGSFILES < <(grep -r "\\[{{{ path }}}\\]" "/etc/dconf/db/" \
+                                | grep -v 'distro\|ibus\|{{{ db }}}' | cut -d":" -f1)
 DCONFFILE="/etc/dconf/db/{{{ db }}}/{{{ setting_file }}}"
 DBDIR="/etc/dconf/db/{{{ db }}}"
 
 mkdir -p "${DBDIR}"
 
-if [ "${#SETTINGSFILES[@]}" -eq 0 ]
+# Comment out the configurations in databases different from the target one
+if [ "${#SETTINGSFILES[@]}" -ne 0 ]
 then
-    [ ! -z ${DCONFFILE} ] || echo "" >> ${DCONFFILE}
-    printf '%s\n' "[{{{ path }}}]" >> ${DCONFFILE}
-    printf '%s=%s\n' "{{{ key }}}" "{{{ value }}}" >> ${DCONFFILE}
-else
-    escaped_value="$(sed -e 's/\\/\\\\/g' <<< "{{{ value }}}")"
     if grep -q "^\\s*{{{ key }}}\\s*=" "${SETTINGSFILES[@]}"
     then
         {{% if '/' in key %}}
         {{{ raise("Key (" + key + ") uses sed path separator (/) in " + rule_id) }}}
         {{% endif %}}
-        sed -i "s/\\s*{{{ key }}}\\s*=\\s*.*/{{{ key }}}=${escaped_value}/g" "${SETTINGSFILES[@]}"
-    else
-        sed -i "\\|\\[{{{ path }}}\\]|a\\{{{ key }}}=${escaped_value}" "${SETTINGSFILES[@]}"
+        sed -Ei "s/(^\s*){{{ key }}}(\s*=)/#\1{{{ key }}}\2/g" "${SETTINGSFILES[@]}"
     fi
+fi
+
+
+[ ! -z "${DCONFFILE}" ] && echo "" >> "${DCONFFILE}"
+if ! grep -q "\\[{{{ path }}}\\]" "${DCONFFILE}"
+then
+    printf '%s\n' "[{{{ path }}}]" >> ${DCONFFILE}
+fi
+
+escaped_value="$(sed -e 's/\\/\\\\/g' <<< "{{{ value }}}")"
+if grep -q "^\\s*{{{ key }}}\\s*=" "${DCONFFILE}"
+then
+        sed -i "s/\\s*{{{ key }}}\\s*=\\s*.*/{{{ key }}}=${escaped_value}/g" "${DCONFFILE}"
+    else
+        sed -i "\\|\\[{{{ path }}}\\]|a\\{{{ key }}}=${escaped_value}" "${DCONFFILE}"
 fi
 
 dconf update
@@ -734,12 +744,19 @@ dconf update
 #}}
 {{%- macro bash_dconf_lock(key, setting, db, lock_file) -%}}
 # Check for setting in any of the DConf db directories
-LOCKFILES=$(grep -r "^/{{{ key }}}/{{{ setting }}}$" "/etc/dconf/db/" | grep -v 'distro\|ibus' | cut -d":" -f1)
+LOCKFILES=$(grep -r "^/{{{ key }}}/{{{ setting }}}$" "/etc/dconf/db/" \
+            | grep -v 'distro\|ibus\|{{{ db }}}' | grep ":" | cut -d":" -f1)
 LOCKSFOLDER="/etc/dconf/db/{{{ db }}}/locks"
 
 mkdir -p "${LOCKSFOLDER}"
 
-if [[ -z "${LOCKFILES}" ]]
+# Comment out the configurations in databases different from the target one
+if [[ ! -z "${LOCKFILES}" ]]
+then
+    sed -i -E "s|^/{{{ key }}}/{{{ setting }}}$|#&|" "${LOCKFILES[@]}"
+fi
+
+if ! grep -qr "^/{{{ key }}}/{{{ setting }}}$" /etc/dconf/db/{{{ db }}}/
 then
     echo "/{{{ key }}}/{{{ setting }}}" >> "/etc/dconf/db/{{{ db }}}/locks/{{{ lock_file }}}"
 fi


### PR DESCRIPTION
#### Description:

- Update dconf macros so they ensure the expected content is present in the expected db
- Update dconf tests to use `dconf_gdm_dir` when OVAL uses it
- Add dconf tests to validate changes in macros

#### Rationale:

- The bash macro wasn't compatible with OVAL. Bash could accept the value on any db, but OVAL expected it in one specific
- Once touching dconf tests, updated the `dconf_gdm_dir` 

#### Review Hints:

- Ensure the built bash comments configurations out of the expected db. The tests will ensure that they set it in the right place
- The tests where `dconf_gdm_dir` is used, should only be present where OVAL also uses it