### PR TITLE
Pass product 'platforms' and 'cpe_items' directory to `ssg.template.Builder()` when loading test scenarios in Automatus

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -34,6 +34,10 @@ Scenario_conditions = namedtuple(
     ("backend", "scanning_mode", "remediated_by", "datastream"))
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
+DEFAULT_BUILD_DIR = os.path.abspath(os.path.join(SSG_ROOT, "build"))
+
+PROD_PLATFORMS_DIR = "/{}/platforms"
+PROD_CPE_ITEMS_DIR = "/{}/cpe_items"
 
 _BENCHMARK_DIRS = [
         os.path.abspath(os.path.join(SSG_ROOT, 'linux_os', 'guide')),
@@ -43,9 +47,6 @@ _BENCHMARK_DIRS = [
 _SHARED_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../shared'))
 
 _SHARED_TEMPLATES = os.path.abspath(os.path.join(SSG_ROOT, 'shared/templates'))
-
-_PLATFORMS_DIR = "/platforms"
-_CPE_ITEMS_DIR = "/cpe_items"
 
 TEST_SUITE_NAME="ssgts"
 TEST_SUITE_PREFIX = "_{}".format(TEST_SUITE_NAME)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -44,6 +44,9 @@ _SHARED_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../shared
 
 _SHARED_TEMPLATES = os.path.abspath(os.path.join(SSG_ROOT, 'shared/templates'))
 
+_PLATFORMS_DIR = "/platforms"
+_CPE_ITEMS_DIR = "/cpe_items"
+
 TEST_SUITE_NAME="ssgts"
 TEST_SUITE_PREFIX = "_{}".format(TEST_SUITE_NAME)
 REMOTE_USER = "root"

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -391,10 +391,10 @@ class RuleChecker(oscap.Checker):
         product_yaml = common.get_product_context(self.test_env.product)
         # Initialize a mock template_builder.
         empty = "/ssgts/empty/placeholder"
-        product_build_dir = os.path.join(common.SSG_ROOT, "build", product_yaml["product"])
         template_builder = ssg.templates.Builder(
             product_yaml, empty, common._SHARED_TEMPLATES, empty, empty,
-            product_build_dir + common._PLATFORMS_DIR, product_build_dir + common._CPE_ITEMS_DIR)
+            common.DEFAULT_BUILD_DIR + common.PROD_PLATFORMS_DIR.format(product_yaml["product"]),
+            common.DEFAULT_BUILD_DIR + common.PROD_CPE_ITEMS_DIR.format(product_yaml["product"]))
 
         templated_tests_paths, local_tests_paths = self._find_tests_paths(
             rule, template_builder, product_yaml)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -394,7 +394,7 @@ class RuleChecker(oscap.Checker):
         product_build_dir = os.path.join(common.SSG_ROOT, "build", product_yaml["product"])
         template_builder = ssg.templates.Builder(
             product_yaml, empty, common._SHARED_TEMPLATES, empty, empty,
-            product_build_dir + "/platforms", product_build_dir + "/cpe_items")
+            product_build_dir + common._PLATFORMS_DIR, product_build_dir + common._CPE_ITEMS_DIR)
 
         templated_tests_paths, local_tests_paths = self._find_tests_paths(
             rule, template_builder, product_yaml)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -391,8 +391,10 @@ class RuleChecker(oscap.Checker):
         product_yaml = common.get_product_context(self.test_env.product)
         # Initialize a mock template_builder.
         empty = "/ssgts/empty/placeholder"
+        product_build_dir = os.path.join(common.SSG_ROOT, "build", product_yaml["product"])
         template_builder = ssg.templates.Builder(
-            product_yaml, empty, common._SHARED_TEMPLATES, empty, empty)
+            product_yaml, empty, common._SHARED_TEMPLATES, empty, empty,
+            product_build_dir + "/platforms", product_build_dir + "/cpe_items")
 
         templated_tests_paths, local_tests_paths = self._find_tests_paths(
             rule, template_builder, product_yaml)


### PR DESCRIPTION
#### Description:

- Pass the product specific `platforms` and `cpe_items` directories to `ssg.templates.Builder()`.

#### Rationale:

- The Builder class requires the `platforms` and `cpe_items` directories to list all test scenarios.

- Fixes #9752

#### Review Hints:

-  Try to test a rule in a container or VM with and without this patch.
- Related:
  - https://github.com/ComplianceAsCode/content/actions/runs/3372700322/jobs/5596508651
  - https://github.com/ComplianceAsCode/content/actions/runs/3370997294/jobs/5592710001