### PR TITLE
Introduce support for parametrized CPE items

### DIFF
--- a/build-scripts/collect_remediations.py
+++ b/build-scripts/collect_remediations.py
@@ -129,7 +129,8 @@ def main():
     for platform_file in os.listdir(args.platforms_dir):
         platform_path = os.path.join(args.platforms_dir, platform_file)
         try:
-            platform = ssg.build_yaml.Platform.from_yaml(platform_path, env_yaml, product_cpes)
+            platform = ssg.build_yaml.Platform.from_yaml(platform_path, env_yaml, product_cpes,
+                                                         args.fixes_from_templates_dir)
         except ssg.build_yaml.DocumentationNotComplete:
             # Happens on non-debug build when a platform is
             # "documentation-incomplete"

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -258,7 +258,7 @@ endmacro()
 
 macro(ssg_build_oval_unlinked PRODUCT)
     set(BUILD_CHECKS_DIR "${CMAKE_CURRENT_BINARY_DIR}/checks_from_templates")
-    set(OVAL_COMBINE_PATHS "${BUILD_CHECKS_DIR}/shared/oval" "${SSG_SHARED}/checks/oval" "${BUILD_CHECKS_DIR}/oval" "${CMAKE_CURRENT_SOURCE_DIR}/checks/oval")
+    set(OVAL_COMBINE_PATHS "${BUILD_CHECKS_DIR}/shared/oval" "${SSG_SHARED}/checks/oval" "${BUILD_CHECKS_DIR}/oval" "${CMAKE_CURRENT_SOURCE_DIR}/checks/oval" "${BUILD_CHECKS_DIR}/oval_platform")
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/combine_ovals.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --output "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml" --build-ovals-dir "${CMAKE_CURRENT_BINARY_DIR}/checks/oval" ${OVAL_COMBINE_PATHS}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_time_service_set_maxpoll") }}}
 

--- a/products/chromium/product.yml
+++ b/products/chromium/product.yml
@@ -12,4 +12,5 @@ cpes:
   - chromium:
       name: "cpe:/a:google:chromium-browser"
       title: "Google Chromium Browser"
-      check_id: installed_app_is_chromium
+      conditional:
+        oval_id: installed_app_is_chromium

--- a/products/debian10/product.yml
+++ b/products/debian10/product.yml
@@ -20,7 +20,8 @@ cpes:
   - debian10:
       name: "cpe:/o:debian:debian_linux:10"
       title: "Debian Linux 10"
-      check_id: installed_OS_is_debian10
+      conditional:
+        oval_id: installed_OS_is_debian10
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/debian11/product.yml
+++ b/products/debian11/product.yml
@@ -18,7 +18,8 @@ cpes:
   - debian11:
       name: "cpe:/o:debian:debian_linux:11"
       title: "Debian Linux 11"
-      check_id: installed_OS_is_debian11
+      conditional:
+        oval_id: installed_OS_is_debian11
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/eks/product.yml
+++ b/products/eks/product.yml
@@ -19,15 +19,18 @@ cpes:
   - eks:
       name: "cpe:/a:amazon:elastic_kubernetes_service:1"
       title: "Amazon Elastic Kubernetes Service"
-      check_id: installed_app_is_eks
+      conditional:
+        oval_id: installed_app_is_eks
   - eks-node:
       name: "cpe:/o:amazon:elastic_kubernetes_service_node:1"
       title: "Amazon Elastic Kubernetes Service Node"
-      check_id: installed_app_is_eks_node
+      conditional:
+        oval_id: installed_app_is_eks_node
   - eks-1.21:
       name: "cpe:/a:amazon:elastic_kubernetes_service_node:1.21"
       title: "Amazon Elastic Kubernetes Service 1.21"
-      check_id: installed_app_is_eks_1_21
+      conditional:
+        oval_id: installed_app_is_eks_1_21
 
 # Requirement string, see: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing
 # requires: "openscap>=1.3.4"

--- a/products/example/product.yml
+++ b/products/example/product.yml
@@ -16,4 +16,5 @@ cpes:
   - example:
       name: "cpe:/o:example"
       title: "Example"
-      check_id: installed_OS_is_part_of_Unix_family
+      conditional:
+        oval_id: installed_OS_is_part_of_Unix_family

--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -38,12 +38,14 @@ cpes:
   - fedora_36:
       name: "cpe:/o:fedoraproject:fedora:36"
       title: "Fedora 36"
-      check_id: installed_OS_is_fedora
+      conditional:
+        oval_id: installed_OS_is_fedora
 
   - fedora_35:
       name: "cpe:/o:fedoraproject:fedora:35"
       title: "Fedora 35"
-      check_id: installed_OS_is_fedora
+      conditional:
+        oval_id: installed_OS_is_fedora
 
 # Retrieve the fingerprint as follows:
 #   gpg --show-keys --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-primary" | grep '^fpr' | cut -d ":" -f 10

--- a/products/firefox/product.yml
+++ b/products/firefox/product.yml
@@ -12,4 +12,5 @@ cpes:
   - firefox:
       name: "cpe:/a:mozilla:firefox"
       title: "Mozilla Firefox"
-      check_id: installed_app_is_firefox
+      conditional:
+        oval_id: installed_app_is_firefox

--- a/products/macos1015/product.yml
+++ b/products/macos1015/product.yml
@@ -12,4 +12,5 @@ cpes:
   - macos15:
       name: "cpe:/o:apple:macos:10.15"
       title: "Apple macOS 10.15"
-      check_id: installed_OS_is_macos1015
+      conditional:
+        oval_id: installed_OS_is_macos1015

--- a/products/ocp4/product.yml
+++ b/products/ocp4/product.yml
@@ -19,117 +19,140 @@ cpes:
   - ocp4:
       name: "cpe:/a:redhat:openshift_container_platform:4.1"
       title: "Red Hat OpenShift Container Platform 4"
-      check_id: installed_app_is_ocp4
+      conditional:
+        oval_id: installed_app_is_ocp4
 
   - ocp4-node:
       name: "cpe:/o:redhat:openshift_container_platform_node:4"
       title: "Red Hat OpenShift Container Platform 4 Node"
-      check_id: installed_app_is_ocp4_node
+      conditional:
+        oval_id: installed_app_is_ocp4_node
 
   - ocp4-node-on-ovn:
       name: "cpe:/a:redhat:openshift_container_platform_node_on_ovn:4"
       title: "Red Hat OpenShift Container Platform 4 Node on OVN"
-      check_id: installed_app_is_ocp4_node_on_openshift-ovn
+      conditional:
+        oval_id: installed_app_is_ocp4_node_on_openshift-ovn
 
   - ocp4-node-on-sdn:
       name: "cpe:/a:redhat:openshift_container_platform_node_on_sdn:4"
       title: "Red Hat OpenShift Container Platform 4 Node on SDN"
-      check_id: installed_app_is_ocp4_node_on_openshift-sdn
+      conditional:
+        oval_id: installed_app_is_ocp4_node_on_openshift-sdn
 
   - ocp4.6:
       name: "cpe:/a:redhat:openshift_container_platform:4.6"
       title: "Red Hat OpenShift Container Platform 4.6"
-      check_id: installed_app_is_ocp4_6
+      conditional:
+        oval_id: installed_app_is_ocp4_6
 
   - ocp4.7:
       name: "cpe:/a:redhat:openshift_container_platform:4.7"
       title: "Red Hat OpenShift Container Platform 4.7"
-      check_id: installed_app_is_ocp4_7
+      conditional:
+        oval_id: installed_app_is_ocp4_7
 
   - ocp4.8:
       name: "cpe:/a:redhat:openshift_container_platform:4.8"
       title: "Red Hat OpenShift Container Platform 4.8"
-      check_id: installed_app_is_ocp4_8
+      conditional:
+        oval_id: installed_app_is_ocp4_8
 
   - ocp4.9:
       name: "cpe:/a:redhat:openshift_container_platform:4.9"
       title: "Red Hat OpenShift Container Platform 4.9"
-      check_id: installed_app_is_ocp4_9
+      conditional:
+        oval_id: installed_app_is_ocp4_9
 
   - ocp4.10:
       name: "cpe:/a:redhat:openshift_container_platform:4.10"
       title: "Red Hat OpenShift Container Platform 4.10"
-      check_id: installed_app_is_ocp4_10
+      conditional:
+        oval_id: installed_app_is_ocp4_10
 
   - ocp4.11:
       name: "cpe:/a:redhat:openshift_container_platform:4.11"
       title: "Red Hat OpenShift Container Platform 4.11"
-      check_id: installed_app_is_ocp4_11
+      conditional:
+        oval_id: installed_app_is_ocp4_11
 
   - ocp4.12:
       name: "cpe:/a:redhat:openshift_container_platform:4.12"
       title: "Red Hat OpenShift Container Platform 4.12"
-      check_id: installed_app_is_ocp4_12
+      conditional:
+        oval_id: installed_app_is_ocp4_12
 
   - ocp4.13:
       name: "cpe:/a:redhat:openshift_container_platform:4.13"
       title: "Red Hat OpenShift Container Platform 4.13"
-      check_id: installed_app_is_ocp4_13
+      conditional:
+        oval_id: installed_app_is_ocp4_13
 
   - ocp4.14:
       name: "cpe:/a:redhat:openshift_container_platform:4.14"
       title: "Red Hat OpenShift Container Platform 4.14"
-      check_id: installed_app_is_ocp4_14
+      conditional:
+        oval_id: installed_app_is_ocp4_14
 
   - ocp4.15:
       name: "cpe:/a:redhat:openshift_container_platform:4.15"
       title: "Red Hat OpenShift Container Platform 4.15"
-      check_id: installed_app_is_ocp4_15
+      conditional:
+        oval_id: installed_app_is_ocp4_15
 
   - ocp4.16:
       name: "cpe:/a:redhat:openshift_container_platform:4.16"
       title: "Red Hat OpenShift Container Platform 4.16"
-      check_id: installed_app_is_ocp4_16
+      conditional:
+        oval_id: installed_app_is_ocp4_16
 
   - ocp4.17:
       name: "cpe:/a:redhat:openshift_container_platform:4.17"
       title: "Red Hat OpenShift Container Platform 4.17"
-      check_id: installed_app_is_ocp4_17
+      conditional:
+        oval_id: installed_app_is_ocp4_17
 
   - ocp4.18:
       name: "cpe:/a:redhat:openshift_container_platform:4.18"
       title: "Red Hat OpenShift Container Platform 4.18"
-      check_id: installed_app_is_ocp4_18
+      conditional:
+        oval_id: installed_app_is_ocp4_18
 
   - ocp4-on-aws:
       name: "cpe:/a:redhat:openshift_container_platform_on_aws:4"
       title: "Red Hat OpenShift Container Platform 4 on AWS"
-      check_id: installed_app_is_ocp4_on_aws
+      conditional:
+        oval_id: installed_app_is_ocp4_on_aws
 
   - ocp4-on-azure:
       name: "cpe:/a:redhat:openshift_container_platform_on_azure:4"
       title: "Red Hat OpenShift Container Platform 4 on Azure"
-      check_id: installed_app_is_ocp4_on_azure
+      conditional:
+        oval_id: installed_app_is_ocp4_on_azure
 
   - ocp4-on-gcp:
       name: "cpe:/a:redhat:openshift_container_platform_on_gcp:4"
       title: "Red Hat OpenShift Container Platform 4 on GCP"
-      check_id: installed_app_is_ocp4_on_gcp
+      conditional:
+        oval_id: installed_app_is_ocp4_on_gcp
 
   - ocp4-on-ovn:
       name: "cpe:/a:redhat:openshift_container_platform_on_ovn:4"
       title: "Red Hat OpenShift Container Platform 4 on OVN"
-      check_id: installed_app_is_ocp4_on_openshiftovn
+      conditional:
+        oval_id: installed_app_is_ocp4_on_openshiftovn
 
   - ocp4-on-sdn:
       name: "cpe:/a:redhat:openshift_container_platform_on_sdn:4"
       title: "Red Hat OpenShift Container Platform 4 on SDN"
-      check_id: installed_app_is_ocp4_on_openshiftsdn
+      conditional:
+        oval_id: installed_app_is_ocp4_on_openshiftsdn
 
   - ocp4-on-hypershift:
       name: "cpe:/a:redhat:openshift_container_platform_on_hypershift:4"
       title: "Red Hat OpenShift Container Platform 4 on HyperShift"
-      check_id: installed_app_is_ocp4_on_hypershift
+      conditional:
+        oval_id: installed_app_is_ocp4_on_hypershift
 
 # Requirement string, see: https://setuptools.readthedocs.io/en/latest/pkg_resources.html#requirements-parsing
 # requires: "openscap>=1.3.4"

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -32,7 +32,8 @@ cpes:
   - ol7:
       name: "cpe:/o:oracle:linux:7"
       title: "Oracle Linux 7"
-      check_id: installed_OS_is_ol7_family
+      conditional:
+        oval_id: installed_OS_is_ol7_family
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/ol8/product.yml
+++ b/products/ol8/product.yml
@@ -30,7 +30,8 @@ cpes:
   - ol8:
       name: "cpe:/o:oracle:linux:8"
       title: "Oracle Linux 8"
-      check_id: installed_OS_is_ol8_family
+      conditional:
+        oval_id: installed_OS_is_ol8_family
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/ol9/product.yml
+++ b/products/ol9/product.yml
@@ -32,7 +32,8 @@ cpes:
   - ol9:
       name: "cpe:/o:oracle:linux:9"
       title: "Oracle Linux 9"
-      check_id: installed_OS_is_ol9_family
+      conditional:
+        oval_id: installed_OS_is_ol9_family
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/opensuse/product.yml
+++ b/products/opensuse/product.yml
@@ -16,19 +16,23 @@ cpes:
   - opensuse-42.1:
       name: "cpe:/o:opensuse:leap:42.1"
       title: "openSUSE Leap 42.1"
-      check_id: installed_OS_is_opensuse_leap42
+      conditional:
+        oval_id: installed_OS_is_opensuse_leap42
 
   - opensuse-42.2:
       name: "cpe:/o:opensuse:leap:42.2"
       title: "openSUSE Leap 42.2"
-      check_id: installed_OS_is_opensuse_leap42
+      conditional:
+        oval_id: installed_OS_is_opensuse_leap42
 
   - opensuse-42.3:
       name: "cpe:/o:opensuse:leap:42.3"
       title: "openSUSE Leap 42.3"
-      check_id: installed_OS_is_opensuse_leap42
+      conditional:
+        oval_id: installed_OS_is_opensuse_leap42
 
   - opensuse-15:
       name: "cpe:/o:opensuse:leap:15.0"
       title: "openSUSE Leap 15.0"
-      check_id: installed_OS_is_opensuse_leap15
+      conditional:
+        oval_id: installed_OS_is_opensuse_leap15

--- a/products/rhcos4/product.yml
+++ b/products/rhcos4/product.yml
@@ -20,7 +20,8 @@ cpes:
   - rhcos4:
       name: "cpe:/o:redhat:enterprise_linux_coreos:4"
       title: "Red Hat Enterprise Linux CoreOS 4"
-      check_id: installed_OS_is_rhcos4
+      conditional:
+        oval_id: installed_OS_is_rhcos4
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -33,27 +33,32 @@ cpes:
   - rhel7:
       name: "cpe:/o:redhat:enterprise_linux:7"
       title: "Red Hat Enterprise Linux 7"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-server:
       name: "cpe:/o:redhat:enterprise_linux:7::server"
       title: "Red Hat Enterprise Linux 7 Server"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-client:
       name: "cpe:/o:redhat:enterprise_linux:7::client"
       title: "Red Hat Enterprise Linux 7 Client"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-computenode:
       name: "cpe:/o:redhat:enterprise_linux:7::computenode"
       title: "Red Hat Enterprise Linux 7 ComputeNode"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-workstation:
       name: "cpe:/o:redhat:enterprise_linux:7::workstation"
       title: "red hat enterprise linux 7 workstation"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -33,62 +33,74 @@ cpes:
   - rhel8:
       name: "cpe:/o:redhat:enterprise_linux:8"
       title: "Red Hat Enterprise Linux 8"
-      check_id: installed_OS_is_rhel8
+      conditional:
+        oval_id: installed_OS_is_rhel8
 
   - rhel8.0:
       name: "cpe:/o:redhat:enterprise_linux:8.0"
       title: "Red Hat Enterprise Linux 8.0"
-      check_id: installed_OS_is_rhel8_0
+      conditional:
+        oval_id: installed_OS_is_rhel8_0
 
   - rhel8.1:
       name: "cpe:/o:redhat:enterprise_linux:8.1"
       title: "Red Hat Enterprise Linux 8.1"
-      check_id: installed_OS_is_rhel8_1
+      conditional:
+        oval_id: installed_OS_is_rhel8_1
 
   - rhel8.2:
       name: "cpe:/o:redhat:enterprise_linux:8.2"
       title: "Red Hat Enterprise Linux 8.2"
-      check_id: installed_OS_is_rhel8_2
+      conditional:
+        oval_id: installed_OS_is_rhel8_2
 
   - rhel8.3:
       name: "cpe:/o:redhat:enterprise_linux:8.3"
       title: "Red Hat Enterprise Linux 8.3"
-      check_id: installed_OS_is_rhel8_3
+      conditional:
+        oval_id: installed_OS_is_rhel8_3
 
   - rhel8.4:
       name: "cpe:/o:redhat:enterprise_linux:8.4"
       title: "Red Hat Enterprise Linux 8.4"
-      check_id: installed_OS_is_rhel8_4
+      conditional:
+        oval_id: installed_OS_is_rhel8_4
 
   - rhel8.5:
       name: "cpe:/o:redhat:enterprise_linux:8.5"
       title: "Red Hat Enterprise Linux 8.5"
-      check_id: installed_OS_is_rhel8_5
+      conditional:
+        oval_id: installed_OS_is_rhel8_5
 
   - rhel8.6:
       name: "cpe:/o:redhat:enterprise_linux:8.6"
       title: "Red Hat Enterprise Linux 8.6"
-      check_id: installed_OS_is_rhel8_6
+      conditional:
+        oval_id: installed_OS_is_rhel8_6
 
   - rhel8.7:
       name: "cpe:/o:redhat:enterprise_linux:8.7"
       title: "Red Hat Enterprise Linux 8.7"
-      check_id: installed_OS_is_rhel8_7
+      conditional:
+        oval_id: installed_OS_is_rhel8_7
 
   - rhel8.8:
       name: "cpe:/o:redhat:enterprise_linux:8.8"
       title: "Red Hat Enterprise Linux 8.8"
-      check_id: installed_OS_is_rhel8_8
+      conditional:
+        oval_id: installed_OS_is_rhel8_8
 
   - rhel8.9:
       name: "cpe:/o:redhat:enterprise_linux:8.9"
       title: "Red Hat Enterprise Linux 8.9"
-      check_id: installed_OS_is_rhel8_9
+      conditional:
+        oval_id: installed_OS_is_rhel8_9
 
   - rhel8.10:
       name: "cpe:/o:redhat:enterprise_linux:8.10"
       title: "Red Hat Enterprise Linux 8.10"
-      check_id: installed_OS_is_rhel8_10
+      conditional:
+        oval_id: installed_OS_is_rhel8_10
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -38,7 +38,8 @@ cpes:
   - rhel9:
       name: "cpe:/o:redhat:enterprise_linux:9"
       title: "Red Hat Enterprise Linux 9"
-      check_id: installed_OS_is_rhel9
+      conditional:
+        oval_id: installed_OS_is_rhel9
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/rhv4/product.yml
+++ b/products/rhv4/product.yml
@@ -25,12 +25,14 @@ cpes:
   - rhel8-host:
       name: "cpe:/o:redhat:enterprise_linux:8::hypervisor"
       title: "Red Hat Virtualization 4 Host"
-      check_id: installed_OS_is_rhv4
+      conditional:
+        oval_id: installed_OS_is_rhv4
 
   - rhvm4:
       name: "cpe:/a:redhat:enterprise_virtualization_manager:4"
       title: "Red Hat Virtualization 4 Manager"
-      check_id: installed_app_is_rhv4
+      conditional:
+        oval_id: installed_app_is_rhv4
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/products/sle12/product.yml
+++ b/products/sle12/product.yml
@@ -21,12 +21,14 @@ cpes:
   - sle12-server:
       name: "cpe:/o:suse:linux_enterprise_server:12"
       title: "SUSE Linux Enterprise Server 12"
-      check_id: installed_OS_is_sle12
+      conditional:
+        oval_id: installed_OS_is_sle12
 
   - sle12-desktop:
       name: "cpe:/o:suse:linux_enterprise_desktop:12"
       title: "SUSE Linux Enterprise Desktop 12"
-      check_id: installed_OS_is_sle12
+      conditional:
+        oval_id: installed_OS_is_sle12
 
 platform_package_overrides:
   login_defs: "shadow"

--- a/products/sle15/product.yml
+++ b/products/sle15/product.yml
@@ -26,12 +26,14 @@ cpes:
   - sle15-server:
       name: "cpe:/o:suse:linux_enterprise_server:15"
       title: "SUSE Linux Enterprise Server 15"
-      check_id: installed_OS_is_sle15
+      conditional:
+        oval_id: installed_OS_is_sle15
 
   - sle15-desktop:
       name: "cpe:/o:suse:linux_enterprise_desktop:15"
       title: "SUSE Linux Enterprise Desktop 15"
-      check_id: installed_OS_is_sle15
+      conditional:
+        oval_id: installed_OS_is_sle15
 
 platform_package_overrides:
   login_defs: "shadow"

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -25,7 +25,8 @@ cpes:
   - ubuntu1604:
       name: "cpe:/o:canonical:ubuntu_linux:16.04::~~lts~~~"
       title: "Ubuntu release 16.04 (Xenial)"
-      check_id: installed_OS_is_ubuntu1604
+      conditional:
+        oval_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
   gdm: gdm3

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -24,7 +24,8 @@ cpes:
   - ubuntu1804:
       name: "cpe:/o:canonical:ubuntu_linux:18.04::~~lts~~~"
       title: "Ubuntu release 18.04 (Bionic Beaver)"
-      check_id: installed_OS_is_ubuntu1804
+      conditional:
+        oval_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
   gdm: gdm3

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -24,7 +24,8 @@ cpes:
   - ubuntu2004:
       name: "cpe:/o:canonical:ubuntu_linux:20.04::~~lts~~~"
       title: "Ubuntu release 20.04 (Focal Fossa)"
-      check_id: installed_OS_is_ubuntu2004
+      conditional:
+        oval_id: installed_OS_is_ubuntu2004
 
 platform_package_overrides:
   audit: auditd

--- a/shared/applicability/aarch64_arch.yml
+++ b/shared/applicability/aarch64_arch.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:aarch64_arch
 title: System architecture is AARCH64
-check_id: proc_sys_kernel_osrelease_arch_aarch64
-bash_conditional: 'grep -q aarch64 /proc/sys/kernel/osrelease'
-ansible_conditional: 'ansible_architecture == "aarch64"'
+conditional:
+    bash: 'grep -q aarch64 /proc/sys/kernel/osrelease'
+    oval_id: proc_sys_kernel_osrelease_arch_aarch64
+    ansible: 'ansible_architecture == "aarch64"'

--- a/shared/applicability/arch.yml
+++ b/shared/applicability/arch.yml
@@ -1,0 +1,9 @@
+name: 'cpe:/a:{arg}'
+title: 'The architecture is {arg}'
+template:
+    name: cond_arch
+args:
+    aarch64:
+        arch_name: "AArch64"
+    s390x:
+        arch_name: "S390x"

--- a/shared/applicability/audit.yml
+++ b/shared/applicability/audit.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:audit"
 title: "Package audit is installed"
-check_id: installed_env_has_audit_package
-bash_conditional: {{{ bash_pkg_conditional("audit") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("audit") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("audit") }}}
+    ansible: {{{ ansible_pkg_conditional("audit") }}}
+    oval_id: installed_env_has_audit_package

--- a/shared/applicability/centos7.yml
+++ b/shared/applicability/centos7.yml
@@ -1,3 +1,4 @@
 name: cpe:/o:centos:centos:7
 title: CentOS 7
-check_id: installed_OS_is_centos7
+conditional:
+    oval_id: installed_OS_is_centos7

--- a/shared/applicability/centos8.yml
+++ b/shared/applicability/centos8.yml
@@ -1,3 +1,4 @@
 name: cpe:/o:centos:centos:8
 title: CentOS 8
-check_id: installed_OS_is_centos8
+conditional:
+    oval_id: installed_OS_is_centos8

--- a/shared/applicability/chrony.yml
+++ b/shared/applicability/chrony.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:chrony"
 title: "Package chrony is installed"
-check_id: installed_env_has_chrony_package
-bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("chrony") }}}
+    ansible: {{{ ansible_pkg_conditional("chrony") }}}
+    oval_id: installed_env_has_chrony_package

--- a/shared/applicability/container.yml
+++ b/shared/applicability/container.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:container
 title: Container
-check_id: installed_env_is_a_container
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
-ansible_conditional: 'ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]'
+conditional:
+    bash: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+    oval_id: installed_env_is_a_container
+    ansible: 'ansible_virtualization_type in ["docker", "lxc", "openvz", "podman", "container"]'

--- a/shared/applicability/cs9.yml
+++ b/shared/applicability/cs9.yml
@@ -1,3 +1,4 @@
 name: cpe:/o:centos:centos:9
 title: CentOS Stream 9
-check_id: installed_OS_is_centos9
+conditional:
+    oval_id: installed_OS_is_centos9

--- a/shared/applicability/gdm.yml
+++ b/shared/applicability/gdm.yml
@@ -1,5 +1,9 @@
 name: "cpe:/a:gdm"
 title: "Package gdm is installed"
-check_id: installed_env_has_gdm_package
-bash_conditional: {{{ bash_pkg_conditional("gdm") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("gdm") }}}
+conditional:
+    bash: |-
+        # include = bash_pkg_compare
+        {{{ bash_pkg_conditional("gdm") }}}
+
+    ansible: {{{ ansible_pkg_conditional("gdm") }}}
+    oval_id: installed_env_has_gdm_package

--- a/shared/applicability/grub2.yml
+++ b/shared/applicability/grub2.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:grub2"
 title: "Package grub2 is installed"
-check_id: installed_env_has_grub2_package
-bash_conditional: {{{ bash_pkg_conditional("grub2") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("grub2") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("grub2") }}}
+    ansible: {{{ ansible_pkg_conditional("grub2") }}}
+    oval_id: installed_env_has_grub2_package

--- a/shared/applicability/krb5_server_older_than_1_17-18.yml
+++ b/shared/applicability/krb5_server_older_than_1_17-18.yml
@@ -1,3 +1,4 @@
 name: "cpe:/a:krb5_server_older_than_1_17-18"
 title: "Package krb5 server is installed and version is lesser than 1.17-18"
-check_id: krb5_server_older_than_1_17_18
+conditional:
+    oval_id: krb5_server_older_than_1_17_18

--- a/shared/applicability/krb5_workstation_older_than_1_17-18.yml
+++ b/shared/applicability/krb5_workstation_older_than_1_17-18.yml
@@ -1,3 +1,4 @@
 name: "cpe:/a:krb5_workstation_older_than_1_17-18"
 title: "Package krb5 workstation is installed and version is lesser than 1.17-18"
-check_id: krb5_workstation_older_than_1_17_18
+conditional:
+    oval_id: krb5_workstation_older_than_1_17_18

--- a/shared/applicability/libuser.yml
+++ b/shared/applicability/libuser.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:libuser"
 title: "Package libuser is installed"
-check_id: installed_env_has_libuser_package
-bash_conditional: {{{ bash_pkg_conditional("libuser") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("libuser") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("libuser") }}}
+    ansible: {{{ ansible_pkg_conditional("libuser") }}}
+    oval_id: installed_env_has_libuser_package

--- a/shared/applicability/login_defs.yml
+++ b/shared/applicability/login_defs.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:login_defs"
 title: "Package providing /etc/login.defs is installed"
-check_id: installed_env_has_login_defs
-bash_conditional: {{{ bash_pkg_conditional("login_defs") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("login_defs") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("login_defs") }}}
+    ansible: {{{ ansible_pkg_conditional("login_defs") }}}
+    oval_id: installed_env_has_login_defs

--- a/shared/applicability/machine.yml
+++ b/shared/applicability/machine.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:machine
 title: Bare-metal or Virtual Machine
-check_id: installed_env_is_a_machine
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
-ansible_conditional: 'ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]'
+conditional:
+    bash: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+    ansible: ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]
+    oval_id: installed_env_is_a_machine

--- a/shared/applicability/net-snmp.yml
+++ b/shared/applicability/net-snmp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:net-snmp"
 title: "Package net-snmp is installed"
-check_id: installed_env_has_net-snmp_package
-bash_conditional: {{{ bash_pkg_conditional("net-snmp") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("net-snmp") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("net-snmp") }}}
+    ansible: {{{ ansible_pkg_conditional("net-snmp") }}}
+    oval_id: installed_env_has_net-snmp_package

--- a/shared/applicability/no_ovirt.yml
+++ b/shared/applicability/no_ovirt.yml
@@ -1,3 +1,4 @@
 name: cpe:/a:no_ovirt
 title: oVirt is not installed (no Host nor Manager)
-check_id: installed_env_has_no_ovirt
+conditional:
+    oval_id: installed_env_has_no_ovirt

--- a/shared/applicability/non-uefi.yml
+++ b/shared/applicability/non-uefi.yml
@@ -1,5 +1,7 @@
 name: cpe:/a:non-uefi
 title: System boot mode is non-UEFI
-check_id: system_boot_mode_is_non_uefi
-bash_conditional: '[ ! -f /sys/firmware/efi ]'
-ansible_conditional: '"/boot/efi" not in ansible_mounts | map(attribute="mount") | list'
+conditional:
+    oval_id: system_boot_mode_is_non_uefi
+
+    bash: '[ ! -f /sys/firmware/efi ]'
+    ansible: '"/boot/efi" not in ansible_mounts | map(attribute="mount") | list'

--- a/shared/applicability/not_aarch64_arch.yml
+++ b/shared/applicability/not_aarch64_arch.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:not_aarch64_arch
 title: System architecture is not AARCH64
-check_id: proc_sys_kernel_osrelease_arch_not_aarch64
-bash_conditional: '! grep -q aarch64 /proc/sys/kernel/osrelease'
-ansible_conditional: 'ansible_architecture != "aarch64"'
+conditional:
+    bash: '! grep -q aarch64 /proc/sys/kernel/osrelease'
+    oval_id: proc_sys_kernel_osrelease_arch_not_aarch64
+    ansible: 'ansible_architecture != "aarch64"'

--- a/shared/applicability/not_s390x_arch.yml
+++ b/shared/applicability/not_s390x_arch.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:not_s390x_arch
 title: System architecture is not S390X
-check_id: proc_sys_kernel_osrelease_arch_not_s390x
-bash_conditional: '! grep -q s390x /proc/sys/kernel/osrelease'
-ansible_conditional: 'ansible_architecture != "s390x"'
+conditional:
+    bash: '! grep -q s390x /proc/sys/kernel/osrelease'
+    oval_id: proc_sys_kernel_osrelease_arch_not_s390x
+    ansible: 'ansible_architecture != "s390x"'

--- a/shared/applicability/nss-pam-ldapd.yml
+++ b/shared/applicability/nss-pam-ldapd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:nss-pam-ldapd"
 title: "Package nss-pam-ldapd is installed"
-check_id: installed_env_has_nss-pam-ldapd_package
-bash_conditional: {{{ bash_pkg_conditional("nss-pam-ldapd") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("nss-pam-ldapd") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("nss-pam-ldapd") }}}
+    ansible: {{{ ansible_pkg_conditional("nss-pam-ldapd") }}}
+    oval_id: installed_env_has_nss-pam-ldapd_package

--- a/shared/applicability/ntp.yml
+++ b/shared/applicability/ntp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:ntp"
 title: "Package ntp is installed"
-check_id: installed_env_has_ntp_package
-bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("ntp") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("ntp") }}}
+    ansible: {{{ ansible_pkg_conditional("ntp") }}}
+    oval_id: installed_env_has_ntp_package

--- a/shared/applicability/ocp4-master-node.yml
+++ b/shared/applicability/ocp4-master-node.yml
@@ -1,3 +1,4 @@
 name: cpe:/a:ocp4-master-node
 title: Node is an OpenShift 4 master node
-check_id: node_is_ocp4_master_node
+conditional:
+    oval_id: node_is_ocp4_master_node

--- a/shared/applicability/os_linux.yml
+++ b/shared/applicability/os_linux.yml
@@ -1,0 +1,13 @@
+name: "cpe:/o:{arg}:{ver_cpe}"
+title: "Operating System is {arg} {ver_str}"
+template:
+    name: cond_os_release
+args:
+    rhel:
+        os_name: "Red Hat Enterprise Linux"
+        os_id: 'rhel'
+        os_id_ansible: "RedHat"
+    fedora:
+        os_name: "Fedora"
+        os_id: 'fedora'
+        os_id_ansible: "Fedora"

--- a/shared/applicability/ovirt.yml
+++ b/shared/applicability/ovirt.yml
@@ -1,3 +1,4 @@
 name: cpe:/a:ovirt
 title: oVirt is installed (Host or Manager)
-check_id: installed_env_has_ovirt
+conditional:
+    oval_id: installed_env_has_ovirt

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -1,0 +1,12 @@
+name: 'cpe:/a:{arg}:{ver_cpe}'
+title: 'Package {arg} {ver_str} is installed'
+template:
+    name: cond_package
+args:
+    chronytest:
+        title: "Chrony Server Test"
+        pkgname: chrony
+        pkgname@debian10: chrony
+    ntptest:
+        title: "NTP Server Test"
+        pkgname: ntp

--- a/shared/applicability/pam.yml
+++ b/shared/applicability/pam.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:pam"
 title: "Package pam is installed"
-check_id: installed_env_has_pam_package
-bash_conditional: {{{ bash_pkg_conditional("pam") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("pam") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("pam") }}}
+    ansible: {{{ ansible_pkg_conditional("pam") }}}
+    oval_id: installed_env_has_pam_package

--- a/shared/applicability/partition-tmp.yml
+++ b/shared/applicability/partition-tmp.yml
@@ -1,5 +1,7 @@
 name: "cpe:/a:partition-tmp"
 title: "There is a /tmp partition"
-check_id: installed_env_mounts_tmp
-bash_conditional: {{{ bash_partition_conditional("/tmp") }}}
-ansible_conditional: {{{ ansible_partition_conditional("/tmp") }}}
+conditional:
+    oval_id: installed_env_mounts_tmp
+
+    bash: {{{ bash_partition_conditional("/tmp") }}}
+    ansible: {{{ ansible_partition_conditional("/tmp") }}}

--- a/shared/applicability/partition-var-tmp.yml
+++ b/shared/applicability/partition-var-tmp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:partition-var-tmp"
 title: "There is a /var/tmp partition"
-check_id: installed_env_mounts_var_tmp
-bash_conditional: {{{ bash_partition_conditional("/var/tmp") }}}
-ansible_conditional: {{{ ansible_partition_conditional("/var/tmp") }}}
+conditional:
+    oval_id: installed_env_mounts_var_tmp
+    bash: {{{ bash_partition_conditional("/var/tmp") }}}
+    ansible: {{{ ansible_partition_conditional("/var/tmp") }}}

--- a/shared/applicability/polkit.yml
+++ b/shared/applicability/polkit.yml
@@ -1,3 +1,4 @@
 name: cpe:/a:polkit
 title: Package polkit is installed
-check_id: installed_env_has_polkit_package
+conditional:
+    oval_id: installed_env_has_polkit_package

--- a/shared/applicability/postfix.yml
+++ b/shared/applicability/postfix.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:postfix"
 title: "Package postfix is installed"
-check_id: installed_env_has_postfix_package
-bash_conditional: {{{ bash_pkg_conditional("postfix") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("postfix") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("postfix") }}}
+    ansible: {{{ ansible_pkg_conditional("postfix") }}}
+    oval_id: installed_env_has_postfix_package

--- a/shared/applicability/ppc64le_arch.yml
+++ b/shared/applicability/ppc64le_arch.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:ppc64le_arch"
 title: "System architecture is ppc64le"
-check_id: proc_sys_kernel_osrelease_arch_ppc64le
-bash_conditional: 'grep -q ppc64le /proc/sys/kernel/osrelease'
-ansible_conditional: 'ansible_architecture == "ppc64le"'
+conditional:
+    oval_id: proc_sys_kernel_osrelease_arch_ppc64le
+    bash: 'grep -q ppc64le /proc/sys/kernel/osrelease'
+    ansible: 'ansible_architecture == "ppc64le"'

--- a/shared/applicability/s390x_arch.yml
+++ b/shared/applicability/s390x_arch.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:s390x_arch
 title: System architecture is S390X
-check_id: proc_sys_kernel_osrelease_arch_s390x
-bash_conditional: 'grep -q s390x /proc/sys/kernel/osrelease'
-ansible_conditional: 'ansible_architecture == "s390x"'
+conditional:
+    bash: 'grep -q s390x /proc/sys/kernel/osrelease'
+    oval_id: proc_sys_kernel_osrelease_arch_s390x
+    ansible: 'ansible_architecture == "s390x"'

--- a/shared/applicability/sl7.yml
+++ b/shared/applicability/sl7.yml
@@ -1,3 +1,4 @@
 name: cpe:/o:scientificlinux:scientificlinux:7
 title: Scientific Linux 7
-check_id: installed_OS_is_sl7
+conditional:
+    oval_id: installed_OS_is_sl7

--- a/shared/applicability/sssd-ldap.yml
+++ b/shared/applicability/sssd-ldap.yml
@@ -1,3 +1,4 @@
 name: cpe:/a:sssd-ldap
 title: SSSD is configured to use LDAP
-check_id: sssd_conf_uses_ldap
+conditional:
+    oval_id: sssd_conf_uses_ldap

--- a/shared/applicability/sssd.yml
+++ b/shared/applicability/sssd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:sssd"
 title: "Package sssd-common is installed"
-check_id: installed_env_has_sssd-common_package
-bash_conditional: {{{ bash_pkg_conditional("sssd") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("sssd") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("sssd") }}}
+    ansible: {{{ ansible_pkg_conditional("sssd") }}}
+    oval_id: installed_env_has_sssd-common_package

--- a/shared/applicability/sudo.yml
+++ b/shared/applicability/sudo.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:sudo"
 title: "Package sudo is installed"
-check_id: installed_env_has_sudo_package
-bash_conditional: {{{ bash_pkg_conditional("sudo") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("sudo") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("sudo") }}}
+    ansible: {{{ ansible_pkg_conditional("sudo") }}}
+    oval_id: installed_env_has_sudo_package

--- a/shared/applicability/systemd.yml
+++ b/shared/applicability/systemd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:systemd"
 title: "Package systemd is installed"
-check_id: installed_env_has_systemd_package
-bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("systemd") }}}
+    ansible: {{{ ansible_pkg_conditional("systemd") }}}
+    oval_id: installed_env_has_systemd_package

--- a/shared/applicability/tftp-server.yml
+++ b/shared/applicability/tftp-server.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:tftp-server"
 title: "Package tftp-server is installed"
-check_id: installed_env_has_tftp_server_package
-bash_conditional: {{{ bash_pkg_conditional("tftp-server") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("tftp-server") }}}
+conditional:
+    oval_id: installed_env_has_tftp_server_package
+    bash: {{{ bash_pkg_conditional("tftp-server") }}}
+    ansible: {{{ ansible_pkg_conditional("tftp-server") }}}

--- a/shared/applicability/tmux.yml
+++ b/shared/applicability/tmux.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:tmux"
 title: "Package tmux is installed"
-check_id: installed_env_has_tmux_package
-bash_conditional: {{{ bash_pkg_conditional("tmux") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("tmux") }}}
+conditional:
+    oval_id: installed_env_has_tmux_package
+    bash: {{{ bash_pkg_conditional("tmux") }}}
+    ansible: {{{ ansible_pkg_conditional("tmux") }}}

--- a/shared/applicability/uefi.yml
+++ b/shared/applicability/uefi.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:uefi
 title: System boot mode is UEFI
-check_id: system_boot_mode_is_uefi
-bash_conditional: '[ -f /sys/firmware/efi ]'
-ansible_conditional: '"/boot/efi" in ansible_mounts | map(attribute="mount") | list'
+conditional:
+    oval_id: system_boot_mode_is_uefi
+    bash: '[ -f /sys/firmware/efi ]'
+    ansible: '"/boot/efi" in ansible_mounts | map(attribute="mount") | list'

--- a/shared/applicability/usbguard.yml
+++ b/shared/applicability/usbguard.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:usbguard"
 title: "Package usbguard is installed"
-check_id: installed_env_has_usbguard_package
-bash_conditional: {{{ bash_pkg_conditional("usbguard") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("usbguard") }}}
+conditional:
+    oval_id: installed_env_has_usbguard_package
+    bash: {{{ bash_pkg_conditional("usbguard") }}}
+    ansible: {{{ ansible_pkg_conditional("usbguard") }}}

--- a/shared/applicability/wifi-iface.yml
+++ b/shared/applicability/wifi-iface.yml
@@ -1,3 +1,4 @@
 name: cpe:/a:wifi-iface
 title: WiFi interface is present
-check_id: installed_env_has_wifi_interface
+conditional:
+    oval_id: installed_env_has_wifi_interface

--- a/shared/applicability/yum.yml
+++ b/shared/applicability/yum.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:yum"
 title: "Package yum is installed"
-check_id: installed_env_has_yum_package
-bash_conditional: {{{ bash_pkg_conditional("yum") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("yum") }}}
+    ansible: {{{ ansible_pkg_conditional("yum") }}}
+    oval_id: installed_env_has_yum_package

--- a/shared/applicability/zypper.yml
+++ b/shared/applicability/zypper.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:zypper"
 title: "Package zypper is installed"
-check_id: installed_env_has_zypper_package
-bash_conditional: {{{ bash_pkg_conditional("zypper") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("zypper") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("zypper") }}}
+    ansible: {{{ ansible_pkg_conditional("zypper") }}}
+    oval_id: installed_env_has_zypper_package

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1738,6 +1738,16 @@ Part of the grub2_bootloader_argument_absent template.
 
 {{#
   This macro creates a bash conditional which is used to determine if a remediation is applicable.
+  The macro takes OS id as an argument and matches it against ID field from /etc/os-release.
+  If id are the same, the Bash remediation will be applied.
+#}}
+{{%- macro bash_os_release_conditional(os_id) -%}}
+grep ID /etc/os-release | grep "{{{ os_id }}}"
+{{%- endmacro -%}}
+
+
+{{#
+  This macro creates a bash conditional which is used to determine if a remediation is applicable.
   The macro takes package as an argument and chooses appropriate package manager.
   If the package is installed, the Bash remediation will be applied.
   The macro respects `platform_package_overrides` variable.

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -644,45 +644,47 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type package: str
 :param evr: Optional, version or newer version to check
 :type evr: str
+:param evr_op: Optional, operation: 'equals', 'not equal', 'greater than', 'greater than or equal', 'less than', and 'less than or equal', default is 'greater than or equal'
+:type evr_op: str
 :param test_id: Suffix of the Ids in test, obj, and state elements
 :type test_id: str
 
 #}}
-{{%- macro oval_test_package_installed(package='', evr='', test_id='') -%}}
+{{%- macro oval_test_package_installed(package='', evr='', evr_op='greater than or equal', test_id='') -%}}
 {{% if pkg_system == "rpm" %}}
   <linux:rpminfo_test check="all" check_existence="all_exist"
   id="{{{ test_id }}}" version="1"
   comment="package {{{ package }}} is installed">
     <linux:object object_ref="obj_{{{ test_id }}}" />
-    {{% if evr %}}
-      <linux:state state_ref="ste_{{{ test_id }}}" />
-    {{% endif %}}
+    {{%- if evr %}}
+    <linux:state state_ref="ste_{{{ test_id }}}" />
+    {{%- endif %}}
   </linux:rpminfo_test>
   <linux:rpminfo_object id="obj_{{{ test_id }}}" version="1">
     <linux:name>{{{ package }}}</linux:name>
   </linux:rpminfo_object>
-  {{% if evr %}}
-    <linux:rpminfo_state id="ste_{{{ test_id }}}" version="1">
-      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ evr }}}</linux:evr>
-    </linux:rpminfo_state>
-  {{% endif %}}
+  {{%- if evr %}}
+  <linux:rpminfo_state id="ste_{{{ test_id }}}" version="1">
+    <linux:evr datatype="evr_string" operation="{{{ evr_op }}}">{{{ evr }}}</linux:evr>
+  </linux:rpminfo_state>
+  {{%- endif %}}
 {{% elif pkg_system == "dpkg" %}}
   <linux:dpkginfo_test check="all" check_existence="all_exist"
   id="{{{ test_id }}}" version="1"
   comment="package {{{ package }}} is installed">
     <linux:object object_ref="obj_{{{ test_id }}}" />
-    {{% if evr %}}
-      <linux:state state_ref="ste_{{{ test_id }}}" />
-    {{% endif %}}
+    {{%- if evr %}}
+    <linux:state state_ref="ste_{{{ test_id }}}" />
+    {{%- endif %}}
   </linux:dpkginfo_test>
   <linux:dpkginfo_object id="obj_{{{ test_id }}}" version="1">
     <linux:name>{{{ package }}}</linux:name>
   </linux:dpkginfo_object>
-  {{% if evr %}}
-    <linux:dpkginfo_state id="ste_{{{ test_id }}}" version="1">
-      <linux:evr datatype="evr_string" operation="greater than or equal">{{{ evr }}}</linux:evr>
-    </linux:dpkginfo_state>
-  {{% endif %}}
+  {{%- if evr %}}
+  <linux:dpkginfo_state id="ste_{{{ test_id }}}" version="1">
+    <linux:evr datatype="evr_string" operation="{{{ evr_op }}}">{{{ evr }}}</linux:evr>
+  </linux:dpkginfo_state>
+  {{%- endif %}}
 {{% endif %}}
 {{%- endmacro -%}}
 

--- a/shared/templates/cond_arch/ansible.template
+++ b/shared/templates/cond_arch/ansible.template
@@ -1,0 +1,1 @@
+ansible_architecture == "{{{ ARG }}}"

--- a/shared/templates/cond_arch/oval.template
+++ b/shared/templates/cond_arch/oval.template
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="inventory" id="{{{ _RULE_ID }}}"
+  version="1">
+    {{{ oval_metadata("Check that architecture of kernel in /proc/sys/kernel/osrelease is " + ARG, affected_platforms=["multi_platform_all"]) }}}
+    <criteria>
+      <criterion comment="Architecture is {{{ ARG }}}"
+      test_ref="test_{{{ _RULE_ID }}}" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="all_exist"
+      comment="The proc_sys_kernel has {{{ ARG }}} architecture"
+      id="test_{{{ _RULE_ID }}}"
+  version="1">
+    <ind:object object_ref="object_{{{ _RULE_ID }}}" />
+    <ind:state state_ref="state_{{{ _RULE_ID }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_{{{ _RULE_ID }}}" version="1">
+    <ind:filepath>/proc/sys/kernel/osrelease</ind:filepath>
+    <ind:pattern operation="pattern match">^.*\.(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ _RULE_ID }}}" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^{{{ ARG }}}$</ind:subexpression>
+  </ind:textfilecontent54_state>
+</def-group>

--- a/shared/templates/cond_arch/template.yml
+++ b/shared/templates/cond_arch/template.yml
@@ -1,0 +1,3 @@
+supported_languages:
+  - oval
+  - ansible

--- a/shared/templates/cond_os_release/ansible.template
+++ b/shared/templates/cond_os_release/ansible.template
@@ -1,0 +1,12 @@
+{{%- set ansible_os_release_name_cond = 'ansible_distribution == "' + OS_ID_ANSIBLE + '"' -%}}
+{{%- macro ansible_os_release_conditional(specs) -%}}
+  {{%- for spec in specs -%}}
+    ansible_distribution_version is version("{{{ spec.ver }}}", "{{{ spec.op }}}")
+  {{% endfor %}}
+{{%- endmacro -%}}
+{{%- if SPECS|length() >= 1 -%}}
+  {{%- set cond = ansible_os_release_conditional(SPECS).strip() +" and " + ansible_os_release_name_cond -%}}
+  {{{ cond.strip().split("\n")|join(" and ") }}}
+{{%- else -%}}
+  {{{ ansible_os_release_name_cond.strip() }}}
+{{%- endif -%}}

--- a/shared/templates/cond_os_release/bash.template
+++ b/shared/templates/cond_os_release/bash.template
@@ -1,0 +1,3 @@
+# include = bash_os_compare
+
+{{{ bash_os_release_conditional(OS_ID) }}}

--- a/shared/templates/cond_os_release/oval.template
+++ b/shared/templates/cond_os_release/oval.template
@@ -1,0 +1,42 @@
+<def-group>
+  <definition class="inventory" id="{{{ _RULE_ID }}}" version="1">
+    {{{ oval_metadata(OS_NAME, affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <criterion comment="The operating system installed on the system is {{{ OS_NAME }}}"
+      test_ref="test_os_id_is_{{{ OS_ID }}}" />
+      {{% for spec in SPECS %}}
+      <criterion comment="The version of operating system {{{ OS_NAME }}} is {{{ spec.evr_op }}} {{{ spec.ver }}}"
+      test_ref="test_{{{ _RULE_ID }}}_version_id_is_{{{ spec.id }}}" />
+      {{% endfor %}}
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="ID in os-release is {{{ OS_ID }}}" id="test_os_id_is_{{{ OS_ID }}}" version="1">
+    <ind:object object_ref="obj_os_id_is_{{{ OS_ID }}}" />
+    <ind:state state_ref="state_os_id_is_{{{ OS_ID }}}" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_os_id_is_{{{ OS_ID }}}" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^ID=&quot;(\w+)&quot;$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_os_id_is_{{{ OS_ID }}}" version="1">
+    <ind:subexpression operation="pattern match">{{{ OS_ID }}}</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  {{% for spec in SPECS %}}
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is {{{ spec.ver }}}" id="test_{{{ _RULE_ID }}}_version_id_is_{{{ spec.id }}}" version="1">
+    <ind:object object_ref="obj_{{{ _RULE_ID }}}_version_id_is_{{{ spec.id }}}" />
+    <ind:state state_ref="state_{{{ _RULE_ID }}}_version_id_is_{{{ spec.id }}}" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_{{{ _RULE_ID }}}_version_id_is_{{{ spec.id }}}" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=&quot;(\d)\.\d+&quot;$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_{{{ _RULE_ID }}}_version_id_is_{{{ spec.id }}}" version="1">
+    <ind:subexpression datatype="evr_string" operation="{{{ spec.evr_op|default("equals") }}}">{{{ spec.ver }}}</ind:subexpression>
+  </ind:textfilecontent54_state>
+{{% endfor %}}
+
+</def-group>

--- a/shared/templates/cond_os_release/template.yml
+++ b/shared/templates/cond_os_release/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - oval
+  - bash
+  - ansible

--- a/shared/templates/cond_package/ansible.template
+++ b/shared/templates/cond_package/ansible.template
@@ -1,0 +1,8 @@
+{{%- macro ansible_package_conditionals(pkgname, specs) %}}
+  {{%- for spec in specs %}}
+    ansible_facts.packages["{{{ pkgname }}}"][0]["version"] is version("{{{ spec.ver }}}", "{{{ spec.op }}}")
+  {{%- else %}}
+    {{{ ansible_pkg_conditional(pigname) }}}
+  {{% endfor %}}
+{{% endmacro %}}
+{{{ ansible_package_conditionals(PKGNAME, SPECS).strip().split("\n")|join(" and ") }}}

--- a/shared/templates/cond_package/ansible.template
+++ b/shared/templates/cond_package/ansible.template
@@ -2,7 +2,7 @@
   {{%- for spec in specs %}}
     ansible_facts.packages["{{{ pkgname }}}"][0]["version"] is version("{{{ spec.ver }}}", "{{{ spec.op }}}")
   {{%- else %}}
-    {{{ ansible_pkg_conditional(pigname) }}}
+    {{{ ansible_pkg_conditional(pkgname) }}}
   {{% endfor %}}
 {{% endmacro %}}
 {{{ ansible_package_conditionals(PKGNAME, SPECS).strip().split("\n")|join(" and ") }}}

--- a/shared/templates/cond_package/bash.template
+++ b/shared/templates/cond_package/bash.template
@@ -1,0 +1,3 @@
+# include = bash_pkg_compare
+
+{{{ bash_pkg_conditional(PKGNAME) }}}

--- a/shared/templates/cond_package/oval.template
+++ b/shared/templates/cond_package/oval.template
@@ -1,0 +1,20 @@
+<def-group>
+  <definition class="inventory" id="{{{ _RULE_ID }}}"
+  version="1">
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_all"]) }}}
+    <criteria>
+    {{% for spec in SPECS %}}
+      <criterion comment="Conditional package {{{ PKGNAME }}} of version {{{ spec.evr_op }}} {{{ spec.ver }}} is installed"
+      test_ref="test_{{{ _RULE_ID }}}_{{{ spec.id }}}_installed" />
+    {{% else %}}
+      <criterion comment="Conditional package {{{ PKGNAME }}} is installed"
+      test_ref="test_{{{ _RULE_ID }}}_installed" />
+    {{% endfor %}}
+    </criteria>
+  </definition>
+{{% for spec in SPECS %}}
+{{{ oval_test_package_installed(package=PKGNAME, evr=spec.evr_ver, evr_op=spec.evr_op, test_id="test_" + _RULE_ID + "_" + spec.id + "_installed") }}}
+{{% else %}}
+{{{ oval_test_package_installed(package=PKGNAME, test_id="test_" + _RULE_ID + "_installed") }}}
+{{% endfor %}}
+</def-group>

--- a/shared/templates/cond_package/template.py
+++ b/shared/templates/cond_package/template.py
@@ -1,0 +1,12 @@
+import re
+
+
+def preprocess(data, lang):
+    if "evr" in data:
+        evr = data["evr"]
+        if evr and not re.match(r'\d:\d[\d\w+.]*-\d[\d\w+.]*', evr, 0):
+            raise RuntimeError(
+                "ERROR: input violation: evr key should be in "
+                "epoch:version-release format, but package {0} has set "
+                "evr to {1}".format(data["pkgname"], evr))
+    return data

--- a/shared/templates/cond_package/template.yml
+++ b/shared/templates/cond_package/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - oval
+  - bash
+  - ansible

--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -4,13 +4,14 @@ from .ext.boolean import boolean
 # Setuptools recognize the issue: https://github.com/pypa/setuptools/issues/2522
 import pkg_resources
 import re
+import uuid
 pkg_resources.safe_name = lambda name: re.sub('[^A-Za-z0-9_.]+', '-', name)
 
 
 # We don't support ~= to avoid confusion with boolean operator NOT (~)
 SPEC_SYMBOLS = ['<', '>', '=', '!', ',', '[', ']']
 
-VERSION_SYMBOLS = ['.', '-', '_', '*']
+VERSION_SYMBOLS = ['.', '-', '_', ':']
 
 SPEC_OP_ID_TRANSLATION = {
     '==': 'eq',
@@ -19,6 +20,15 @@ SPEC_OP_ID_TRANSLATION = {
     '<': 'le',
     '>=': 'gt_or_eq',
     '<=': 'le_or_eq',
+}
+
+SPEC_OP_OVAL_EVR_STRING_TRANSLATION = {
+    '==': 'equal',
+    '!=': 'not equal',
+    '>': 'greater than',
+    '<': 'less than',
+    '>=': 'greater than or equal',
+    '<=': 'less than or equal',
 }
 
 
@@ -55,12 +65,15 @@ class Function(boolean.Function):
             op = 'or'
         return '_{0}_'.format(op).join([arg.as_id() for arg in self.args])
 
+    def as_uuid(self):
+        return str(uuid.uuid5(uuid.NAMESPACE_X500, self.as_id()))
+
 
 class Symbol(boolean.Symbol):
     """
     Base class for boolean symbols
 
-    Sub-class it and pass to the `Algebra` as `symbol_cls` to enrich
+    Subclass it and pass to the `Algebra` as `symbol_cls` to enrich
     expression elements with domain-specific methods.
 
     The `as_id` method will generate an unique string identifier usable as
@@ -69,11 +82,14 @@ class Symbol(boolean.Symbol):
 
     def __init__(self, obj):
         super(Symbol, self).__init__(obj)
-        self.spec = pkg_resources.Requirement.parse(obj)
+        self.spec = pkg_resources.Requirement.parse(obj.replace(':', '!'))
         self.obj = self.spec
 
     def __call__(self, **kwargs):
-        val = kwargs.get(self.name, False)
+        full_name = self.name
+        if self.spec.extras:
+            full_name += '[' + self.spec.extras[0] + ']'
+        val = kwargs.get(full_name, False)
         if len(self.spec.specs):
             if type(val) is str:
                 return val in self.spec
@@ -85,17 +101,28 @@ class Symbol(boolean.Symbol):
 
     def as_id(self):
         id_str = self.name
+        if self.spec.extras:
+            id_str += '_' + self.spec.extras[0]
         for (op, ver) in self.spec.specs:
             id_str += '_{0}_{1}'.format(SPEC_OP_ID_TRANSLATION.get(op, 'unknown_spec_op'), ver)
         return id_str
 
+    def as_uuid(self):
+        return str(uuid.uuid5(uuid.NAMESPACE_X500, self.as_id()))
+
+    def as_dict(self):
+        res = {'id': self.as_id(), 'name': self.name, 'arg': '', 'ver_str': '', 'ver_cpe': '', 'specs': []}
+        if self.spec.extras:
+            res['arg'] = self.spec.extras[0]
+        return res
+
+    @property
+    def arg(self):
+        return self.spec.extras[0] if self.spec.extras else None
+
     @property
     def name(self):
         return self.spec.project_name
-
-    @property
-    def specs(self):
-        return self.spec.specs
 
 
 class Algebra(boolean.BooleanAlgebra):
@@ -109,9 +136,9 @@ class Algebra(boolean.BooleanAlgebra):
 
     Limitations:
     - no white space is allowed inside specifier expressions;
-    - ~= specifier operator is not supported.
+    - ~= specifier operator is not supported (along with '*' as a part of the version).
 
-    For example: "(oranges>=2.0.8,<=5 | banana) and ~apple + !pie"
+    For example: "(oranges>=2.0.8,<=5 | banana) and ~apple + !pie[beef]"
     """
 
     def __init__(self, symbol_cls, function_cls):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -203,7 +203,7 @@ class CPEALLogicalTest(Function):
         for arg in self.args:
             arg.add_enriched_cpe_items(product_cpes)
 
-    def get_conditional(self, language, product_cpes, conditionals_path, env_yaml):
+    def get_remediation_conditional(self, language, product_cpes, conditionals_path, env_yaml):
         contents = ''
         config = defaultdict(lambda: None)
         op = " "
@@ -212,12 +212,7 @@ class CPEALLogicalTest(Function):
         contents += "( "
         child_condlines = []
         for a in self.args:
-            if language == "bash":
-                r = a.get_bash_conditional(product_cpes, conditionals_path, env_yaml)
-            elif language == "ansible":
-                r = a.get_ansible_conditional(product_cpes, conditionals_path, env_yaml)
-            else:
-                raise Exception("Conditionals for {0} are not supported.".format(language))
+            r = a.get_remediation_conditional(language, product_cpes, conditionals_path, env_yaml)
             if r is not None:
                 cont = r.contents.strip()
                 if cont:
@@ -230,14 +225,8 @@ class CPEALLogicalTest(Function):
         contents += " )"
         return namedtuple('remediation', ['contents', 'config'])(contents=contents, config=config)
 
-    def get_bash_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("bash", product_cpes, conditionals_path, env_yaml)
 
-    def get_ansible_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("ansible", product_cpes, conditionals_path, env_yaml)
-
-
-class CPEALFactRef (Symbol):
+class CPEALFactRef(Symbol):
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
@@ -263,7 +252,7 @@ class CPEALFactRef (Symbol):
 
         return cpe_factref
 
-    def get_conditional(self, language, product_cpes, conditionals_path, env_yaml):
+    def get_remediation_conditional(self, language, product_cpes, conditionals_path, env_yaml):
         cpe = product_cpes.get_cpe(self.as_id())
         cond = cpe.conditional.get(language, "")
         if cond:
@@ -276,13 +265,6 @@ class CPEALFactRef (Symbol):
             if os.path.exists(templated_conditional_file):
                 return remediations.parse_from_file_without_jinja(templated_conditional_file)
         return None
-
-    def get_bash_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("bash", product_cpes, conditionals_path, env_yaml)
-
-    def get_ansible_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("ansible", product_cpes, conditionals_path, env_yaml)
-
 
 def extract_subelement(objects, sub_elem_type):
     """

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import sys
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 
 from .constants import oval_namespace
 from .constants import PREFIX_TO_NS
@@ -14,7 +14,7 @@ from .constants import CONDITIONAL_OPERATORS
 from .utils import required_key
 from .xml import ElementTree as ET
 from .boolean_expression import Algebra, Symbol, Function
-from .entities.common import XCCDFEntity
+from .entities.common import XCCDFEntity, RemediationObject
 from .yaml import convert_string_to_bool
 
 from . import remediations
@@ -223,7 +223,7 @@ class CPEALLogicalTest(Function):
             op = " " + CONDITIONAL_OPERATORS[language]["and"] + " "
         contents += op.join(child_condlines)
         contents += " )"
-        return namedtuple('remediation', ['contents', 'config'])(contents=contents, config=config)
+        return RemediationObject(contents=contents, config=config)
 
 
 class CPEALFactRef(Symbol):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -207,9 +207,6 @@ class CPEALLogicalTest(Function):
         contents = ''
         config = defaultdict(lambda: None)
         op = " "
-        if self.is_not():
-            contents += CONDITIONAL_OPERATORS[language]["not"] + " "
-        contents += "( "
         child_condlines = []
         for a in self.args:
             r = a.get_remediation_conditional(language, product_cpes, conditionals_path, env_yaml)
@@ -217,12 +214,16 @@ class CPEALLogicalTest(Function):
                 cont = r.contents.strip()
                 if cont:
                     child_condlines.append(cont)
-        if self.is_or():
-            op = " " + CONDITIONAL_OPERATORS[language]["or"] + " "
-        elif self.is_and():
-            op = " " + CONDITIONAL_OPERATORS[language]["and"] + " "
-        contents += op.join(child_condlines)
-        contents += " )"
+        if child_condlines:
+            if self.is_not():
+                contents += CONDITIONAL_OPERATORS[language]["not"] + " "
+            contents += "( "
+            if self.is_or():
+                op = " " + CONDITIONAL_OPERATORS[language]["or"] + " "
+            elif self.is_and():
+                op = " " + CONDITIONAL_OPERATORS[language]["and"] + " "
+            contents += op.join(child_condlines)
+            contents += " )"
         return RemediationObject(contents=contents, config=config)
 
 

--- a/ssg/build_derivatives.py
+++ b/ssg/build_derivatives.py
@@ -52,7 +52,10 @@ def add_cpe_item_to_dictionary(tree_root, product_yaml_path, cpe_ref, id_name, c
         product_cpes.load_cpes_from_directory_tree(cpe_items_dir, product_yaml)
         cpe_item = product_cpes.get_cpe(cpe_ref)
         translator = IDTranslator(id_name)
-        cpe_item.check_id = translator.generate_id("{" + oval_namespace + "}definition", cpe_item.check_id)
+        cpe_item.conditional[
+                             "oval_id"] = translator.generate_id(
+                             "{" + oval_namespace + "}definition",
+                             cpe_item.conditional["oval_id"])
         cpe_list.append(cpe_item.to_xml_element("ssg-%s-cpe-oval.xml" % product_yaml.get("product")))
 
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -159,8 +159,7 @@ class BashRemediation(Remediation):
                                            self).get_rule_specific_conditionals(
                                            "bash", cpe_platforms)
         if inherited_conditionals or rule_specific_conditionals:
-            wrapped_fix_text = ["# Remediation is applicable only in certain platforms",
-                                "do_something_magical"]
+            wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
             all_conditions = ""
             if inherited_conditionals:
                 all_conditions += " && ".join(inherited_conditionals)

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -123,7 +123,7 @@ class BashRemediation(Remediation):
 
         inherited_conditionals = []
         for p in inherited_cpe_platform_names:
-            r = cpe_platforms[p].get_bash_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("bash")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
@@ -131,7 +131,7 @@ class BashRemediation(Remediation):
 
         rule_specific_conditionals = []
         for p in rule_specific_cpe_platform_names:
-            r = cpe_platforms[p].get_bash_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("bash")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
@@ -288,7 +288,7 @@ class AnsibleRemediation(Remediation):
 
         inherited_conditionals = []
         for p in inherited_cpe_platform_names:
-            r = cpe_platforms[p].get_ansible_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("ansible")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
@@ -296,13 +296,13 @@ class AnsibleRemediation(Remediation):
 
         rule_specific_conditionals = []
         for p in rule_specific_cpe_platform_names:
-            r = cpe_platforms[p].get_ansible_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("ansible")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
                     rule_specific_conditionals.append(stripped)
 
-            cpe_platforms[p].get_ansible_conditional()
+            cpe_platforms[p].get_remediation_conditional("ansible")
 
         # Remove conditionals related to package CPEs if the updated task collects package facts
         if "package_facts" in to_update:

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -60,6 +60,43 @@ class Remediation(object):
     def parse_from_file_with_jinja(self, env_yaml, cpe_platforms):
         return parse_from_file_with_jinja(self.file_path, env_yaml)
 
+    def get_inherited_cpe_platform_names(self):
+        inherited_cpe_platform_names = set()
+        if self.associated_rule:
+            # There can be repeated inherited platforms and rule platforms
+            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
+        return inherited_cpe_platform_names
+
+    def get_rule_specific_cpe_platform_names(self):
+        rule_specific_cpe_platform_names = set()
+        inherited_cpe_platform_names = self.get_inherited_cpe_platform_names()
+        if self.associated_rule:
+            if self.associated_rule.cpe_platform_names is not None:
+                rule_specific_cpe_platform_names = {
+                    p for p in self.associated_rule.cpe_platform_names
+                    if p not in inherited_cpe_platform_names}
+        return rule_specific_cpe_platform_names
+
+    def get_rule_specific_conditionals(self, language, cpe_platforms):
+        rule_specific_conditionals = []
+        for p in self.get_rule_specific_cpe_platform_names():
+            r = cpe_platforms[p].get_remediation_conditional(language)
+            if r is not None:
+                stripped = r.contents.strip()
+                if stripped:
+                    rule_specific_conditionals.append(stripped)
+        return rule_specific_conditionals
+
+    def get_inherited_conditionals(self, language, cpe_platforms):
+        inherited_conditionals = []
+        for p in self.get_inherited_cpe_platform_names():
+            r = cpe_platforms[p].get_remediation_conditional(language)
+            if r is not None:
+                stripped = r.contents.strip()
+                if stripped:
+                    inherited_conditionals.append(stripped)
+        return inherited_conditionals
+
 
 def process(remediation, env_yaml, cpe_platforms):
     """
@@ -111,32 +148,14 @@ class BashRemediation(Remediation):
         if stripped_fix_text == "":
             return result
 
-        rule_specific_cpe_platform_names = set()
-        inherited_cpe_platform_names = set()
-        if self.associated_rule:
-            # There can be repeated inherited platforms and rule platforms
-            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
-            if self.associated_rule.cpe_platform_names is not None:
-                rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names
-                    if p not in inherited_cpe_platform_names}
-
-        inherited_conditionals = []
-        for p in inherited_cpe_platform_names:
-            r = cpe_platforms[p].get_remediation_conditional("bash")
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    inherited_conditionals.append(stripped)
-
-        rule_specific_conditionals = []
-        for p in rule_specific_cpe_platform_names:
-            r = cpe_platforms[p].get_remediation_conditional("bash")
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    rule_specific_conditionals.append(stripped)
-
+        inherited_conditionals = super(
+                                       BashRemediation,
+                                       self).get_inherited_conditionals(
+                                       "bash", cpe_platforms)
+        rule_specific_conditionals = super(
+                                           BashRemediation,
+                                           self).get_rule_specific_conditionals(
+                                           "bash", cpe_platforms)
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms",
                                 "do_something_magical"]
@@ -276,34 +295,14 @@ class AnsibleRemediation(Remediation):
 
     def update_when_from_rule(self, to_update, cpe_platforms):
         additional_when = []
-        rule_specific_cpe_platform_names = set()
-        inherited_cpe_platform_names = set()
-        if self.associated_rule:
-            # There can be repeated inherited platforms and rule platforms
-            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
-            if self.associated_rule.cpe_platform_names is not None:
-                rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names
-                    if p not in inherited_cpe_platform_names}
-
-        inherited_conditionals = []
-        for p in inherited_cpe_platform_names:
-            r = cpe_platforms[p].get_remediation_conditional("ansible")
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    inherited_conditionals.append(stripped)
-
-        rule_specific_conditionals = []
-        for p in rule_specific_cpe_platform_names:
-            r = cpe_platforms[p].get_remediation_conditional("ansible")
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    rule_specific_conditionals.append(stripped)
-
-            cpe_platforms[p].get_remediation_conditional("ansible")
-
+        inherited_conditionals = super(
+                                       AnsibleRemediation,
+                                       self).get_inherited_conditionals(
+                                       "ansible", cpe_platforms)
+        rule_specific_conditionals = super(
+                                           AnsibleRemediation,
+                                           self).get_rule_specific_conditionals(
+                                           "ansible", cpe_platforms)
         # Remove conditionals related to package CPEs if the updated task collects package facts
         if "package_facts" in to_update:
             inherited_conditionals = filter(lambda c: "in ansible_facts.packages" not in c,

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -5,7 +5,7 @@ import sys
 import os
 import os.path
 import re
-from collections import defaultdict, namedtuple, OrderedDict
+from collections import defaultdict, OrderedDict
 
 import ssg.yaml
 import ssg.build_yaml
@@ -13,10 +13,12 @@ from . import rules
 from . import utils
 from . import constants
 
-from .remediations import parse_from_file_with_jinja, parse_from_file_without_jinja, REMEDIATION_TO_EXT_MAP
-
+from .remediations import parse_from_file_with_jinja, parse_from_file_without_jinja
+from .remediations import REMEDIATION_TO_EXT_MAP
+from .entities.common import RemediationObject
 from .xml import ElementTree
 from .constants import XCCDF12_NS
+
 
 REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
 
@@ -180,8 +182,7 @@ class BashRemediation(Remediation):
                 "    >&2 echo 'Remediation is not applicable, nothing was done'")
             wrapped_fix_text.append("fi")
 
-            result = namedtuple('remediation', ['contents', 'config'])(contents="\n".join(wrapped_fix_text),
-                                                                       config=result.config)
+            result = RemediationObject(contents="\n".join(wrapped_fix_text), config=result.config)
         return result
 
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -11,28 +11,13 @@ import ssg.yaml
 import ssg.build_yaml
 from . import rules
 from . import utils
-
 from . import constants
-from .jinja import process_file_with_macros as jinja_process_file
+
+from .remediations import parse_from_file_with_jinja, parse_from_file_without_jinja, REMEDIATION_TO_EXT_MAP
 
 from .xml import ElementTree
 from .constants import XCCDF12_NS
 
-REMEDIATION_TO_EXT_MAP = {
-    'anaconda': '.anaconda',
-    'ansible': '.yml',
-    'bash': '.sh',
-    'puppet': '.pp',
-    'ignition': '.yml',
-    'kubernetes': '.yml',
-    'blueprint': '.toml'
-}
-
-
-FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
-
-REMEDIATION_CONFIG_KEYS = ['complexity', 'disruption', 'platform', 'reboot',
-                           'strategy']
 REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
 
 
@@ -48,59 +33,6 @@ def is_supported_filename(remediation_type, filename):
     sys.stderr.write("ERROR: Unknown remediation type '%s'!\n"
                      % (remediation_type))
     sys.exit(1)
-
-
-def split_remediation_content_and_metadata(fix_file):
-    remediation_contents = []
-    config = defaultdict(lambda: None)
-
-    # Assignment automatically escapes shell characters for XML
-    for line in fix_file.splitlines():
-        if line.startswith(FILE_GENERATED_HASH_COMMENT):
-            continue
-
-        if line.startswith('#') and line.count('=') == 1:
-            (key, value) = line.strip('#').split('=')
-            if key.strip() in REMEDIATION_CONFIG_KEYS:
-                config[key.strip()] = value.strip()
-                continue
-
-        # If our parsed line wasn't a config item, add it to the
-        # returned file contents. This includes when the line
-        # begins with a '#' and contains an equals sign, but
-        # the "key" isn't one of the known keys from
-        # REMEDIATION_CONFIG_KEYS.
-        remediation_contents.append(line)
-
-    contents = "\n".join(remediation_contents)
-    remediation = namedtuple('remediation', ['contents', 'config'])
-    return remediation(contents=contents, config=config)
-
-
-def parse_from_file_with_jinja(file_path, env_yaml):
-    """
-    Parses a remediation from a file. As remediations contain jinja macros,
-    we need a env_yaml context to process these. In practice, no remediations
-    use jinja in the configuration, so for extracting only the configuration,
-    env_yaml can be an abritrary product.yml dictionary.
-
-    If the logic of configuration parsing changes significantly, please also
-    update ssg.fixes.parse_platform(...).
-    """
-
-    fix_file = jinja_process_file(file_path, env_yaml)
-    return split_remediation_content_and_metadata(fix_file)
-
-
-def parse_from_file_without_jinja(file_path):
-    """
-    Parses a remediation from a file. Doesn't process the Jinja macros.
-    This function is useful in build phases in which all the Jinja macros
-    are already resolved.
-    """
-    with open(file_path, "r") as f:
-        f_str = f.read()
-        return split_remediation_content_and_metadata(f_str)
 
 
 class Remediation(object):
@@ -189,21 +121,25 @@ class BashRemediation(Remediation):
                     p for p in self.associated_rule.cpe_platform_names
                     if p not in inherited_cpe_platform_names}
 
-        inherited_conditionals = [
-            cpe_platforms[p].to_bash_conditional()
-            for p in inherited_cpe_platform_names]
-        rule_specific_conditionals = [
-            cpe_platforms[p].to_bash_conditional()
-            for p in rule_specific_cpe_platform_names]
-        # remove potential "None" from lists
-        inherited_conditionals = sorted([
-            p for p in inherited_conditionals if p != ''])
-        rule_specific_conditionals = sorted([
-            p for p in rule_specific_conditionals if p != ''])
+        inherited_conditionals = []
+        for p in inherited_cpe_platform_names:
+            r = cpe_platforms[p].get_bash_conditional()
+            if r is not None:
+                stripped = r.contents.strip()
+                if stripped:
+                    inherited_conditionals.append(stripped)
+
+        rule_specific_conditionals = []
+        for p in rule_specific_cpe_platform_names:
+            r = cpe_platforms[p].get_bash_conditional()
+            if r is not None:
+                stripped = r.contents.strip()
+                if stripped:
+                    rule_specific_conditionals.append(stripped)
 
         if inherited_conditionals or rule_specific_conditionals:
-            wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
-
+            wrapped_fix_text = ["# Remediation is applicable only in certain platforms",
+                                "do_something_magical"]
             all_conditions = ""
             if inherited_conditionals:
                 all_conditions += " && ".join(inherited_conditionals)
@@ -224,9 +160,8 @@ class BashRemediation(Remediation):
                 "    >&2 echo 'Remediation is not applicable, nothing was done'")
             wrapped_fix_text.append("fi")
 
-            remediation = namedtuple('remediation', ['contents', 'config'])
-            result = remediation(contents="\n".join(wrapped_fix_text), config=result.config)
-
+            result = namedtuple('remediation', ['contents', 'config'])(contents="\n".join(wrapped_fix_text),
+                                                                       config=result.config)
         return result
 
 
@@ -351,28 +286,33 @@ class AnsibleRemediation(Remediation):
                     p for p in self.associated_rule.cpe_platform_names
                     if p not in inherited_cpe_platform_names}
 
-        inherited_conditionals = [
-            cpe_platforms[p].to_ansible_conditional()
-            for p in inherited_cpe_platform_names]
-        rule_specific_conditionals = [
-            cpe_platforms[p].to_ansible_conditional()
-            for p in rule_specific_cpe_platform_names]
-        # remove potential "None" from lists
-        inherited_conditionals = sorted([
-            p for p in inherited_conditionals if p != ''])
-        rule_specific_conditionals = sorted([
-            p for p in rule_specific_conditionals if p != ''])
+        inherited_conditionals = []
+        for p in inherited_cpe_platform_names:
+            r = cpe_platforms[p].get_ansible_conditional()
+            if r is not None:
+                stripped = r.contents.strip()
+                if stripped:
+                    inherited_conditionals.append(stripped)
 
-        # remove conditionals related to package CPEs if the updated task
-        # collects package facts
+        rule_specific_conditionals = []
+        for p in rule_specific_cpe_platform_names:
+            r = cpe_platforms[p].get_ansible_conditional()
+            if r is not None:
+                stripped = r.contents.strip()
+                if stripped:
+                    rule_specific_conditionals.append(stripped)
+
+            cpe_platforms[p].get_ansible_conditional()
+
+        # Remove conditionals related to package CPEs if the updated task collects package facts
         if "package_facts" in to_update:
-            inherited_conditionals = [
-                c for c in inherited_conditionals if "in ansible_facts.packages" not in c]
-            rule_specific_conditionals = [
-                c for c in rule_specific_conditionals if "in ansible_facts.packages" not in c]
+            inherited_conditionals = filter(lambda c: "in ansible_facts.packages" not in c,
+                                            inherited_conditionals)
+            rule_specific_conditionals = filter(lambda c: "in ansible_facts.packages" not in c,
+                                                rule_specific_conditionals)
 
         if inherited_conditionals:
-            additional_when = additional_when + inherited_conditionals
+            additional_when.extend(inherited_conditionals)
 
         if rule_specific_conditionals:
             additional_when.append(" or ".join(rule_specific_conditionals))

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -77,25 +77,27 @@ class Remediation(object):
                     if p not in inherited_cpe_platform_names}
         return rule_specific_cpe_platform_names
 
+    def get_stripped_conditionals(self, language, cpe_platform_names, cpe_platforms):
+        """
+        collect conditionals of platforms defined by cpe_platform_names
+        and strip them of white spaces
+        """
+        stripped_conditionals = []
+        for p in cpe_platform_names:
+            conditional = cpe_platforms[p].get_remediation_conditional(language)
+            if conditional is not None:
+                stripped_conditional = conditional.contents.strip()
+                if stripped_conditional:
+                    stripped_conditionals.append(stripped_conditional)
+        return stripped_conditionals
+
     def get_rule_specific_conditionals(self, language, cpe_platforms):
-        rule_specific_conditionals = []
-        for p in self.get_rule_specific_cpe_platform_names():
-            r = cpe_platforms[p].get_remediation_conditional(language)
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    rule_specific_conditionals.append(stripped)
-        return rule_specific_conditionals
+        cpe_platform_names = self.get_rule_specific_cpe_platform_names()
+        return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
 
     def get_inherited_conditionals(self, language, cpe_platforms):
-        inherited_conditionals = []
-        for p in self.get_inherited_cpe_platform_names():
-            r = cpe_platforms[p].get_remediation_conditional(language)
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    inherited_conditionals.append(stripped)
-        return inherited_conditionals
+        cpe_platform_names = self.get_inherited_cpe_platform_names()
+        return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
 
 
 def process(remediation, env_yaml, cpe_platforms):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1636,11 +1636,10 @@ class Platform(XCCDFEntity):
     def to_xml_element(self):
         return ET.fromstring(self.xml_content)
 
-    def get_bash_conditional(self):
-        return self.conditional.get('bash', '')
+    def get_remediation_conditional(self, language):
+        return self.conditional.get(language, '')
 
-    def get_ansible_conditional(self):
-        return self.conditional.get('ansible', '')
+
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None, conditionals_path=None):
@@ -1651,8 +1650,10 @@ class Platform(XCCDFEntity):
             platform.test = product_cpes.algebra.parse(
                 platform.original_expression, simplify=True)
             platform.conditional = {
-                'bash': platform.test.get_bash_conditional(product_cpes, conditionals_path, env_yaml),
-                'ansible': platform.test.get_ansible_conditional(product_cpes, conditionals_path, env_yaml)
+                'bash': platform.test.get_remediation_conditional(
+                    "bash", product_cpes, conditionals_path, env_yaml),
+                'ansible': platform.test.get_remediation_conditional(
+                    "ansible", product_cpes, conditionals_path, env_yaml)
             }
 
         return platform

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -465,3 +465,16 @@ DEFAULT_SSH_DISTRIBUTED_CONFIG = 'false'
 DEFAULT_PRODUCT = 'example'
 DEFAULT_CHRONY_CONF_PATH = '/etc/chrony.conf'
 DEFAULT_AUDISP_CONF_PATH = '/etc/audit'
+
+CONDITIONAL_OPERATORS = {
+    "ansible": {
+        "or": "or",
+        "and": "and",
+        "not": "not"
+    },
+    "bash": {
+        "and": "&&",
+        "or": "||",
+        "not": "!"
+    }
+}

--- a/ssg/entities/common.py
+++ b/ssg/entities/common.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import os
 import yaml
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from copy import deepcopy
 
 from ..xml import ElementTree as ET, add_xhtml_namespace
@@ -309,3 +309,11 @@ class SelectionHandler(object):
         updated_refinements = self._subtract_refinements(extended_refinements)
         updated_refinements.update(self.refine_rules)
         self.refine_rules = updated_refinements
+
+
+# this named tuple is a structure used for remediations
+# it holds the remediation config values (platform etc)
+# and the actual content
+#it is here because the structure is needed in several modules
+# currently in ssg/build_remediations and ssg/build_cpe.py
+RemediationObject = namedtuple('remediation', ['contents', 'config'])

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -129,6 +129,15 @@ def process_file(filepath, substitutions_dict):
     return template.render(substitutions_dict)
 
 
+def process_string(string, substitutions_dict):
+    """
+    Process the jinja string. Return the result as a string. Note that this will not
+    load the project macros; use process_file_with_macros(...) for that.
+    """
+    template = _get_jinja_environment(substitutions_dict).from_string(string)
+    return template.render(substitutions_dict)
+
+
 def add_python_functions(substitutions_dict):
     substitutions_dict['prodtype_to_name'] = prodtype_to_name
     substitutions_dict['name_to_platform'] = name_to_platform
@@ -169,6 +178,18 @@ def process_file_with_macros(filepath, substitutions_dict):
     substitutions_dict = load_macros(substitutions_dict)
     assert 'indent' not in substitutions_dict
     return process_file(filepath, substitutions_dict)
+
+
+def process_string_with_macros(string, substitutions_dict):
+    """
+    Process the string with jinja macros with the specified
+    substitutions. Return the result as a string.
+
+    See also: process_string
+    """
+    substitutions_dict = load_macros(substitutions_dict)
+    assert 'indent' not in substitutions_dict
+    return process_string(string, substitutions_dict)
 
 
 def url_encode(source):

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -11,6 +11,7 @@ import ssg.utils
 import ssg.yaml
 import ssg.build_yaml
 import ssg.build_remediations
+import ssg.remediations
 import ssg.environment
 
 COMMENTS_TO_PARSE = ["strategy", "complexity", "disruption"]
@@ -129,7 +130,7 @@ class PlaybookBuilder():
 
         with open(snippet_path, "r") as snippet_file:
             snippet_str = snippet_file.read()
-        fix = ssg.build_remediations.split_remediation_content_and_metadata(snippet_str)
+        fix = ssg.remediations.split_remediation_content_and_metadata(snippet_str)
         snippet_yaml = ssg.yaml.ordered_load(fix.contents)
 
         play_tasks, play_vars = self.get_data_from_snippet(

--- a/ssg/remediations.py
+++ b/ssg/remediations.py
@@ -1,0 +1,86 @@
+from collections import defaultdict, namedtuple
+from .jinja import process_file_with_macros as jinja_process_file
+from .jinja import process_string_with_macros as jinja_process_string
+
+REMEDIATION_TO_EXT_MAP = {
+    'anaconda': '.anaconda',
+    'ansible': '.yml',
+    'bash': '.sh',
+    'puppet': '.pp',
+    'ignition': '.yml',
+    'kubernetes': '.yml',
+    'blueprint': '.toml'
+}
+
+FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
+
+REMEDIATION_CONFIG_KEYS = ['complexity', 'disruption', 'platform', 'reboot',
+                           'strategy']
+
+
+def split_remediation_content_and_metadata(fix_file):
+    remediation_contents = []
+    config = defaultdict(lambda: None)
+
+    # Assignment automatically escapes shell characters for XML
+    for line in fix_file.splitlines():
+        if line.startswith(FILE_GENERATED_HASH_COMMENT):
+            continue
+
+        if line.startswith('#') and line.count('=') == 1:
+            (key, value) = line.strip('#').split('=')
+            if key.strip() in REMEDIATION_CONFIG_KEYS:
+                config[key.strip()] = value.strip()
+                continue
+
+        # If our parsed line wasn't a config item, add it to the
+        # returned file contents. This includes when the line
+        # begins with a '#' and contains an equals sign, but
+        # the "key" isn't one of the known keys from
+        # REMEDIATION_CONFIG_KEYS.
+        remediation_contents.append(line)
+
+    contents = "\n".join(remediation_contents)
+    remediation = namedtuple('remediation', ['contents', 'config'])
+    return remediation(contents=contents, config=config) #defaultdict(lambda: None)
+
+
+def parse_from_string_with_jinja(string, env_yaml):
+    """
+    Parses a remediation from a string. As remediations contain jinja macros,
+    we need a env_yaml context to process these. In practice, no remediations
+    use jinja in the configuration, so for extracting only the configuration,
+    env_yaml can be an abritrary product.yml dictionary.
+
+    If the logic of configuration parsing changes significantly, please also
+    update ssg.fixes.parse_platform(...).
+    """
+
+    fix_file = jinja_process_string(string, env_yaml)
+    return split_remediation_content_and_metadata(fix_file)
+
+
+def parse_from_file_with_jinja(file_path, env_yaml):
+    """
+    Parses a remediation from a file. As remediations contain jinja macros,
+    we need a env_yaml context to process these. In practice, no remediations
+    use jinja in the configuration, so for extracting only the configuration,
+    env_yaml can be an abritrary product.yml dictionary.
+
+    If the logic of configuration parsing changes significantly, please also
+    update ssg.fixes.parse_platform(...).
+    """
+
+    fix_file = jinja_process_file(file_path, env_yaml)
+    return split_remediation_content_and_metadata(fix_file)
+
+
+def parse_from_file_without_jinja(file_path):
+    """
+    Parses a remediation from a file. Doesn't process the Jinja macros.
+    This function is useful in build phases in which all the Jinja macros
+    are already resolved.
+    """
+    with open(file_path, "r") as f:
+        f_str = f.read()
+        return split_remediation_content_and_metadata(f_str)

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -345,12 +345,11 @@ class Builder(object):
             local_env_yaml["rule_title"] = cpe.title
             local_env_yaml["products"] = self.env_yaml["product"]
 
-            for lang in ['oval', 'bash', 'ansible']:
+            for lang in languages.values():
                 try:
                     self.build_lang(cpe_id, template_name, template_vars, lang, local_env_yaml)
                 except Exception as e:
-                    print("Error building template {0} for platform {1}".format(lang, symbol.name), file=sys.stderr)
-                    raise e
+                    raise RuntimeError("Error building template {0} for platform {1}".format(lang.name, symbol.name))
 
     def get_lang_for_rule(self, rule_id, rule_title, template, language):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -6,6 +6,7 @@ import imp
 import glob
 
 import ssg.build_yaml
+import ssg.build_cpe
 import ssg.utils
 import ssg.yaml
 from ssg.build_cpe import ProductCPEs
@@ -246,12 +247,12 @@ class Builder(object):
             template_name = template["name"]
         except KeyError:
             raise ValueError(
-                "Rule {0} is missing template name under template key".format(
-                    rule_id))
+                "Template {0} is missing template name key".format(
+                    repr(template)))
         if template_name not in templates.keys():
             raise ValueError(
-                "Rule {0} uses template {1} which does not exist.".format(
-                    rule_id, template_name))
+                "Template {0} uses template name {1} which does not exist in templates".format(
+                    repr(template), template_name))
         return template_name
 
     def get_resolved_langs_to_generate(self, rule):
@@ -316,6 +317,41 @@ class Builder(object):
                 raise e(
                     "Error building templated {0} content for rule {1}".format(lang, rule_id))
 
+    def build_platform(self, platform):
+        for symbol in platform.test.get_symbols():
+            cpe_id = symbol.as_id()
+            cpe = self.product_cpes.get_cpe(cpe_id)
+
+            if 'name' not in cpe.template:
+                continue
+            template_name = cpe.template['name']
+            arg = symbol.arg
+            if arg in cpe.args:
+                rendered_vars = cpe.args[arg]
+            elif arg is None:
+                rendered_vars = {}
+            else:
+                raise ValueError("Platform {0} does not allow arg '{1}' ".format(symbol.name, arg))
+            rendered_vars.update(symbol.as_dict())
+            template_vars = self.process_product_vars(rendered_vars)
+
+            # Add the rule_id ID which will be reused in OVAL templates as OVAL
+            # definition ID so that the build system matches the generated
+            # check with the rule.
+            template_vars["_rule_id"] = cpe_id
+            # checks and remediations are processed with a custom YAML dict
+            local_env_yaml = self.env_yaml.copy()
+            local_env_yaml["rule_id"] = cpe_id
+            local_env_yaml["rule_title"] = cpe.title
+            local_env_yaml["products"] = self.env_yaml["product"]
+
+            for lang in ['oval', 'bash', 'ansible']:
+                try:
+                    self.build_lang(cpe_id, template_name, template_vars, lang, local_env_yaml)
+                except Exception as e:
+                    print("Error building template {0} for platform {1}".format(lang, symbol.name), file=sys.stderr)
+                    raise e
+
     def get_lang_for_rule(self, rule_id, rule_title, template, language):
         """
         For the specified rule, build and return only the specified language
@@ -367,6 +403,12 @@ class Builder(object):
             self.build_rule(rule.id_, rule.title, rule.template, langs_to_generate,
                             rule.identifiers, platforms=rule.platforms)
 
+    def build_all_platforms(self):
+        for platform_file in sorted(os.listdir(self.platforms_dir)):
+            platform_path = os.path.join(self.platforms_dir, platform_file)
+            platform = ssg.build_yaml.Platform.from_yaml(platform_path, self.env_yaml, self.product_cpes)
+            self.build_platform(platform)
+
     def build(self):
         """
         Builds all templated content for all languages, writing
@@ -379,3 +421,4 @@ class Builder(object):
 
         self.build_extra_ovals()
         self.build_all_rules()
+        self.build_all_platforms()

--- a/tests/unit/ssg-module/data/applicability/chrony.yml
+++ b/tests/unit/ssg-module/data/applicability/chrony.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:chrony"
 title: "Package chrony is installed"
-check_id: installed_env_has_chrony_package
-bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("chrony") }}}
+    ansible: {{{ ansible_pkg_conditional("chrony") }}}
+    oval_id: installed_env_has_chrony_package

--- a/tests/unit/ssg-module/data/applicability/krb5_server_older_than_1_17-18.yml
+++ b/tests/unit/ssg-module/data/applicability/krb5_server_older_than_1_17-18.yml
@@ -1,3 +1,4 @@
 name: "cpe:/a:krb5_server_older_than_1_17-18"
 title: "Package krb5 server is installed and version is lesser than 1.17-18"
-check_id: krb5_server_older_than_1_17_18
+conditional:
+    oval_id: krb5_server_older_than_1_17_18

--- a/tests/unit/ssg-module/data/applicability/krb5_workstation_older_than_1_17-18.yml
+++ b/tests/unit/ssg-module/data/applicability/krb5_workstation_older_than_1_17-18.yml
@@ -1,3 +1,4 @@
 name: "cpe:/a:krb5_workstation_older_than_1_17-18"
 title: "Package krb5 workstation is installed and version is lesser than 1.17-18"
-check_id: krb5_workstation_older_than_1_17_18
+conditional:
+    oval_id: krb5_workstation_older_than_1_17_18

--- a/tests/unit/ssg-module/data/applicability/machine.yml
+++ b/tests/unit/ssg-module/data/applicability/machine.yml
@@ -1,5 +1,6 @@
 name: cpe:/a:machine
 title: Bare-metal or Virtual Machine
-check_id: installed_env_is_a_machine
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
-ansible_conditional: 'ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]'
+conditional:
+    bash: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+    ansible: ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]
+    oval_id: installed_env_is_a_machine

--- a/tests/unit/ssg-module/data/applicability/ntp.yml
+++ b/tests/unit/ssg-module/data/applicability/ntp.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:ntp"
 title: "Package ntp is installed"
-check_id: installed_env_has_ntp_package
-bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("ntp") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("ntp") }}}
+    ansible: {{{ ansible_pkg_conditional("ntp") }}}
+    oval_id: installed_env_has_ntp_package

--- a/tests/unit/ssg-module/data/applicability/systemd.yml
+++ b/tests/unit/ssg-module/data/applicability/systemd.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:systemd"
 title: "Package systemd is installed"
-check_id: installed_env_has_systemd_package
-bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("systemd") }}}
+    ansible: {{{ ansible_pkg_conditional("systemd") }}}
+    oval_id: installed_env_has_systemd_package

--- a/tests/unit/ssg-module/data/applicability/yum.yml
+++ b/tests/unit/ssg-module/data/applicability/yum.yml
@@ -1,5 +1,6 @@
 name: "cpe:/a:yum"
 title: "Package yum is installed"
-check_id: installed_env_has_yum_package
-bash_conditional: {{{ bash_pkg_conditional("yum") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}
+conditional:
+    bash: {{{ bash_pkg_conditional("yum") }}}
+    ansible: {{{ ansible_pkg_conditional("yum") }}}
+    oval_id: installed_env_has_yum_package

--- a/tests/unit/ssg-module/data/machine.yml
+++ b/tests/unit/ssg-module/data/machine.yml
@@ -6,8 +6,9 @@ xml_content: !!binary |
     MDpsb2dpY2FsLXRlc3Qgb3BlcmF0b3I9IkFORCIgbmVnYXRlPSJmYWxzZSI+PG5zMDpmYWN0LXJl
     ZiBuYW1lPSJjcGU6L2E6bWFjaGluZSIgLz48L25zMDpsb2dpY2FsLXRlc3Q+PC9uczA6cGxhdGZv
     cm0+
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
-ansible_conditional: ansible_virtualization_type not in ["docker", "lxc", "openvz",
-    "podman", "container"]
+conditional:
+    bash: "# include some_helper_function
+    [ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]"
+    ansible: ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]
 definition_location: ''
 documentation_complete: true

--- a/tests/unit/ssg-module/data/product.yml
+++ b/tests/unit/ssg-module/data/product.yml
@@ -33,27 +33,32 @@ cpes:
   - rhel7:
       name: "cpe:/o:redhat:enterprise_linux:7"
       title: "Red Hat Enterprise Linux 7"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-server:
       name: "cpe:/o:redhat:enterprise_linux:7::server"
       title: "Red Hat Enterprise Linux 7 Server"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-client:
       name: "cpe:/o:redhat:enterprise_linux:7::client"
       title: "Red Hat Enterprise Linux 7 Client"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-computenode:
       name: "cpe:/o:redhat:enterprise_linux:7::computenode"
       title: "Red Hat Enterprise Linux 7 ComputeNode"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
   - rhel7-workstation:
       name: "cpe:/o:redhat:enterprise_linux:7::workstation"
       title: "red hat enterprise linux 7 workstation"
-      check_id: installed_OS_is_rhel7
+      conditional:
+        oval_id: installed_OS_is_rhel7
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/tests/unit/ssg-module/test_build_cpe.py
+++ b/tests/unit/ssg-module/test_build_cpe.py
@@ -106,8 +106,7 @@ def test_extract_referred_nodes():
 #
 # This test case test that both types are used by the ProductCPEs class and
 # that both CPE types are handled equally.
-def test_product_cpes():
-
+def test_product_cpes_by_name_and_id():
     # CPEs are loaded from `DATADIR/product.yml` but also from
     # `DATADIR/applicability` because `DATADIR/product.yml` references the
     # `DATADIR/applicability` directory in the `cpes_root` key
@@ -123,33 +122,28 @@ def test_product_cpes():
     rhel7_cpe = product_cpes.get_cpe("rhel7")
     assert(rhel7_cpe.name == "cpe:/o:redhat:enterprise_linux:7")
     assert(rhel7_cpe.title == "Red Hat Enterprise Linux 7")
-    assert(rhel7_cpe.check_id == "installed_OS_is_rhel7")
-    assert(rhel7_cpe.bash_conditional == "")
-    assert(rhel7_cpe.ansible_conditional == "")
+    assert(rhel7_cpe.id_ == "rhel7")
+    assert(rhel7_cpe.conditional == {'oval_id': 'installed_OS_is_rhel7'})
 
     # get CPE by ID and verify it's loaded, the get_cpe method should return
     # the same object as when CPE name was used above
     rhel7_cpe_2 = product_cpes.get_cpe("cpe:/o:redhat:enterprise_linux:7")
     assert(rhel7_cpe_2.name == rhel7_cpe.name)
-    assert(rhel7_cpe_2.title == rhel7_cpe.title)
-    assert(rhel7_cpe_2.check_id == rhel7_cpe.check_id)
-    assert(rhel7_cpe_2.bash_conditional == rhel7_cpe.bash_conditional)
-    assert(rhel7_cpe_2.ansible_conditional == rhel7_cpe.ansible_conditional)
+    assert(rhel7_cpe_2.title == rhel7_cpe_2.title)
+    assert(rhel7_cpe_2.conditional == rhel7_cpe.conditional)
 
     # get a content CPE by name and verify it's loaded
-    # this CPE is defined in `DATADIR/applicability/virtualization.yml`
+    # this CPE is defined in `DATADIR/applicability/machine.yml`
     cpe1 = product_cpes.get_cpe("machine")
     assert(cpe1.name == "cpe:/a:machine")
     assert(cpe1.title == "Bare-metal or Virtual Machine")
-    assert(cpe1.check_id == "installed_env_is_a_machine")
-    assert(cpe1.ansible_conditional == "ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"]")
-    assert(cpe1.bash_conditional == "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]")
+    assert(cpe1.id_ == "machine")
+    assert(cpe1.conditional["ansible"] == "ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"]")
+    assert(cpe1.conditional["bash"] == "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]")
 
     # get CPE by ID and verify it's loaded, the get_cpe method should return
     # the same object as when CPE name was used above
     cpe2 = product_cpes.get_cpe("cpe:/a:machine")
     assert(cpe2.name == cpe1.name)
     assert(cpe2.title == cpe1.title)
-    assert(cpe2.check_id == cpe1.check_id)
-    assert(cpe2.ansible_conditional == cpe1.ansible_conditional)
-    assert(cpe2.bash_conditional == cpe1.bash_conditional)
+    assert(cpe2.conditional == cpe1.conditional)

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -5,9 +5,11 @@ import ssg.build_remediations as sbr
 import ssg.utils
 import ssg.products
 from ssg.yaml import ordered_load
+import ssg.build_yaml
 
 DATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 rule_dir = os.path.join(DATADIR, "group_dir", "rule_dir")
+rule_file = os.path.join(rule_dir, "rule.yml")
 rhel_bash = os.path.join(rule_dir, "bash", "rhel.sh")
 
 
@@ -34,6 +36,7 @@ def test_is_supported_file_name():
 def do_test_contents(remediation, config):
     assert 'do_something_magical' in remediation
     assert '# a random comment' in remediation
+
 
     assert 'platform' in config
     assert 'reboot' in config
@@ -63,10 +66,17 @@ def test_process_fix(env_yaml, cpe_platforms):
     fixes = {}
 
     remediation_obj = remediation_cls(rhel_bash)
+    # create a fake rule
+    # the rule uses the "machine" platform which has bash_conditional_line
+    # and bash_inserted_before_remediation defined
+    rule = ssg.build_yaml.Rule("test_rule")
+    rule.cpe_platform_names = ["machine"]
+    remediation_obj.associate_rule(rule)
     result = sbr.process(remediation_obj, env_yaml, cpe_platforms)
 
     assert result is not None
     assert len(result) == 2
+    assert '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]' in result.contents
     do_test_contents(result.contents, result.config)
 
 

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -243,11 +243,7 @@ def test_platform_from_text_unknown_platform(product_cpes):
 
 def test_platform_from_text_simple(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("machine", product_cpes)
-    assert platform.to_ansible_conditional() == \
-        "ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"]"
-    assert platform.to_bash_conditional() == \
-        "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]"
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "machine"
     logical_tests = platform_el.findall(
@@ -263,9 +259,7 @@ def test_platform_from_text_simple(product_cpes):
 
 def test_platform_from_text_simple_product_cpe(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("rhel7-workstation", product_cpes)
-    assert platform.to_bash_conditional() == ""
-    assert platform.to_ansible_conditional() == ""
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "rhel7-workstation"
     logical_tests = platform_el.findall(
@@ -282,10 +276,7 @@ def test_platform_from_text_simple_product_cpe(product_cpes):
 
 def test_platform_from_text_or(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("ntp or chrony", product_cpes)
-    assert platform.to_bash_conditional() == "( rpm --quiet -q chrony || rpm --quiet -q ntp )"
-    assert platform.to_ansible_conditional() == \
-        "( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages )"
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "chrony_or_ntp"
     logical_tests = platform_el.findall(
@@ -310,9 +301,7 @@ def test_platform_from_text_and_empty_conditionals(product_cpes):
 def test_platform_from_text_complex_expression(product_cpes):
     platform = ssg.build_yaml.Platform.from_text(
         "systemd and !yum and (ntp or chrony)", product_cpes)
-    assert platform.to_bash_conditional() == "( rpm --quiet -q systemd && ( rpm --quiet -q chrony || rpm --quiet -q ntp ) && ! ( rpm --quiet -q yum ) )"
-    assert platform.to_ansible_conditional() == "( \"systemd\" in ansible_facts.packages and ( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages ) and not ( \"yum\" in ansible_facts.packages ) )"
-    platform_el = ET.fromstring(platform.to_xml_element())
+    platform_el = platform.to_xml_element()
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "systemd_and_chrony_or_ntp_and_not_yum"
     logical_tests = platform_el.findall(
@@ -358,8 +347,6 @@ def test_platform_as_dict(product_cpes):
     assert d["name"] == "chrony_and_rhel7"
     # the "rhel7" platform doesn't have any conditionals
     # therefore the final conditional doesn't use it
-    assert d["ansible_conditional"] == "( \"chrony\" in ansible_facts.packages )"
-    assert d["bash_conditional"] == "( rpm --quiet -q chrony )"
     assert "xml_content" in d
 
 


### PR DESCRIPTION
Warning! The PR is in draft state now. It needs:
- fixing of tests
- probably squashing of commits or reshuffling file changes tso that commits are clearer
- there are some leftovers which deal with package versions. These should be either removed or modified

#### Description:

This PR introduces a possibility to parametrize CPE items used in platform definitions. It utilizes existing templating system used in this project.
There are added new files in shared/applicability and new templates with names starting with "cond_".
Let's show this on the "package" CPE item. Look into shared/applicability/package.yml and shared/templates/cond_package.
As you can see in shared/applicability/package.yml, there is a new "template" key.
This key contains the following:
- name - name of the template to be used
- args - list of arguments which will be accepted as a parameter. These arguments can have their own keys and values, which can be later used while processed by the build system.
Look into shared/templates/cond_package/oval.template and you will see how they can be used.
If you want to try it out, pick some rule and add the following to it:
```
platforms:
    - "package[chronytest] or package[ntptest]"
```


#### Rationale:

The aim of this initiative is to simplify specification of rule applicability with CPA applicability language. After this is merged, it will be possible to get ridf of many manually written platforms for packages. Also another follow-up step will probably be adding support for specification of package / OS versions.