### PR TITLE
Remove deprecated code

### DIFF
--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -185,14 +185,7 @@ def main():
 
     check_content_refs = xccdftree.findall(".//{%s}check-content-ref"
                                            % xccdf_ns)
-
-    # decide on usage of .iter or .getiterator method of elementtree class.
-    # getiterator is deprecated in Python 3.9, but iter is not available in
-    # older versions
-    if getattr(xccdftree, 'iter', None) == None:
-        xccdf_parent_map = dict((c, p) for p in xccdftree.getiterator() for c in p)
-    else:
-        xccdf_parent_map = dict((c, p) for p in xccdftree.iter() for c in p)
+    xccdf_parent_map = dict((c, p) for p in xccdftree.iter() for c in p)
     # now we can actually do the verification work here
     if options.rules_with_invalid_checks or options.all_checks:
         for check_content_ref in check_content_refs:

--- a/ssg/id_translate.py
+++ b/ssg/id_translate.py
@@ -64,14 +64,7 @@ class IDTranslator(object):
         )
 
     def translate(self, tree, store_defname=False):
-        # decide on usage of .iter or .getiterator method of elementtree class.
-        # getiterator is deprecated in Python 3.9, but iter is not available in
-        # older versions
-        if getattr(tree, "iter", None) == None:
-            tree_iterator = tree.getiterator()
-        else:
-            tree_iterator = tree.iter()
-        for element in tree_iterator:
+        for element in tree.iter():
             idname = element.get("id")
             if idname:
                 # store the old name if requested (for OVAL definitions)


### PR DESCRIPTION
The getiterator method is deprecated since Python 2.7, it can be replaced by the iter method.

Fixes: #9730
