### PR TITLE
OCP4 update rule general-default-seccomp-profile

### DIFF
--- a/applications/openshift/general/general_default_seccomp_profile/rule.yml
+++ b/applications/openshift/general/general_default_seccomp_profile/rule.yml
@@ -31,7 +31,7 @@ ocil: |-
    Security Context Constraints.
 
 references:
-    cis@ocp4: 5.6.2
+    cis@ocp4: 5.7.2
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -258,9 +258,10 @@ selections:
   #### 5.6 General Policies
   # 5.6.1 Create administrative boundaries between resources using namespaces (info)
     - general_namespaces_in_use
-  # 5.6.2 Ensure Seccomp Profile Pod Definitions (info)
-    - general_default_seccomp_profile
   # 5.6.3 Apply Security Context to your Pods and Containers (info)
     - general_apply_scc
   # 5.6.4 The Default Namespace should not be used (info)
     - general_default_namespace_use
+  #### 5.7
+  # 5.7.2 Ensure Seccomp Profile Pod Definitions (info)
+    - general_default_seccomp_profile


### PR DESCRIPTION
#### Description:

To fix the benchmark section number for rule general-default-seccomp-profile

#### Rationale:

Rule general-default-seccomp-profile has the wrong CIS section 5.6.2, As per the CIS v1.24 it should be 5.7.2.
