### PR TITLE
OCP4 update CIS 5.6 Rules to CIS 5.7

### DIFF
--- a/applications/openshift/general/general_apply_scc/rule.yml
+++ b/applications/openshift/general/general_apply_scc/rule.yml
@@ -28,7 +28,7 @@ ocil: |-
    build your own, please refer to the {{{ weblink(link="https://docs.openshift.com/container-platform/4.11/authentication/managing-security-context-constraints.html", text="OpenShift security constraints documentation") }}}.
 
 references:
-    cis@ocp4: 5.6.3
+    cis@ocp4: 5.7.3
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/general/general_default_namespace_use/rule.yml
+++ b/applications/openshift/general/general_default_namespace_use/rule.yml
@@ -25,7 +25,7 @@ ocil: |-
    <tt>kubernetes</tt> and <tt>openshift</tt> service.
 
 references:
-    cis@ocp4: 5.6.4
+    cis@ocp4: 5.7.4
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/general/general_default_seccomp_profile/rule.yml
+++ b/applications/openshift/general/general_default_seccomp_profile/rule.yml
@@ -31,7 +31,7 @@ ocil: |-
    Security Context Constraints.
 
 references:
-    cis@ocp4: 5.6.2
+    cis@ocp4: 5.7.2
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/general/general_namespaces_in_use/rule.yml
+++ b/applications/openshift/general/general_namespaces_in_use/rule.yml
@@ -28,7 +28,7 @@ ocil: |-
     the ones you need and are adequately administered.
 
 references:
-    cis@ocp4: 5.6.1
+    cis@ocp4: 5.7.1
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -255,12 +255,12 @@ selections:
   #### 5.5 Extensible Admission Control
   # 5.5.1 Configure Image Provenance using ImagePolicyWebhook admission controller
     - general_configure_imagepolicywebhook
-  #### 5.6 General Policies
-  # 5.6.1 Create administrative boundaries between resources using namespaces (info)
+  #### 5.7 General Policies
+  # 5.7.1 Create administrative boundaries between resources using namespaces (info)
     - general_namespaces_in_use
-  # 5.6.2 Ensure Seccomp Profile Pod Definitions (info)
+  # 5.7.2 Ensure Seccomp Profile Pod Definitions (info)
     - general_default_seccomp_profile
-  # 5.6.3 Apply Security Context to your Pods and Containers (info)
+  # 5.7.3 Apply Security Context to your Pods and Containers (info)
     - general_apply_scc
-  # 5.6.4 The Default Namespace should not be used (info)
+  # 5.7.4 The Default Namespace should not be used (info)
     - general_default_namespace_use


### PR DESCRIPTION
#### Description:

To fix the benchmark section number for rule in CIS 5.6 General Policies

#### Rationale:
latest CIS has moved all the rules from section 5.6 to section 5.7, this PR updates all the rules to 5.7