### PR TITLE
SRG Diff: Add section for rows without a CCE

### DIFF
--- a/utils/srg_diff.html
+++ b/utils/srg_diff.html
@@ -28,6 +28,24 @@
         <li>{{ rule }}</li>
     {% endfor %}
 </ul>
+{% if disa_missing_cces %}
+<h2>Requirements Missing CCE in DISA</h2>
+<ul>
+    {% for requirement in disa_missing_cces %}
+        <li>{{ requirement }}</li>
+    {% endfor %}
+</ul>
+{% endif %}
+
+{% if cac_missing_cces %}
+<h2>Requirements Missing CCE in CaC</h2>
+<ul>
+    {% for requirement in cac_missing_cces %}
+        <li>{{ requirement }}</li>
+    {% endfor %}
+</ul>
+{% endif %}
+
 <h2>Deltas</h2>
 {% for delta in deltas %}
     {% if delta.should_display() %}

--- a/utils/srg_diff.py
+++ b/utils/srg_diff.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import argparse
 import difflib
 import os.path
@@ -94,6 +96,22 @@ def _create_template(root_path: str) -> jinja2.Template:
     return template
 
 
+def get_requirements_with_no_cces(sheet: Worksheet, end_row: int) -> list:
+    result = list()
+    for i in range(2, end_row):
+        requirement = sheet[f'F{i}'].value
+        if requirement is None or requirement.strip() == "":
+            continue
+        cce = sheet[f'D{i}'].value
+        if cce is not None and cce.startswith('CCE-') and requirement.strip() != "":
+            continue
+        status = sheet[f'I{i}'].value
+        if status is not None and status.strip() == 'Applicable - Configurable':
+            srgs_ids = sheet[f'C{i}'].value
+            result.append(f'{requirement.strip()} - {srgs_ids}')
+    return result
+
+
 def main():
     args = _parse_args()
     disa_path = args.disa
@@ -105,6 +123,9 @@ def main():
     disa_sheet = disa_wb['Sheet']
     cac_set = get_stigid_set(cac_sheet, args.end_row)
     full_name = get_full_name(args.root, args.product)
+
+    cac_missing_cces = get_requirements_with_no_cces(cac_sheet, args.end_row)
+    disa_missing_cces = get_requirements_with_no_cces(disa_sheet, args.end_row)
 
     cac_cce_dict = get_cce_dict_to_row_dict(cac_sheet, full_name, args.changed_name, args.end_row)
     disa_cce_dict = get_cce_dict_to_row_dict(disa_sheet, full_name, args.changed_name,
@@ -135,7 +156,9 @@ def main():
 
     template = _create_template(args.root)
     output = template.render(missing_in_disa=missing_in_disa, deltas=deltas,
-                             missing_in_cac=missing_in_cac, title=title)
+                             missing_in_cac=missing_in_cac, title=title,
+                             cac_missing_cces=cac_missing_cces,
+                             disa_missing_cces=disa_missing_cces)
     with open(args.output, 'w') as f:
         f.write(output)
 

--- a/utils/srg_diff.py
+++ b/utils/srg_diff.py
@@ -117,13 +117,13 @@ def main():
     deltas = list()
     missing_in_disa = list()
     missing_in_cac = list()
-    for cci in (cac_set - disa_set):
-        cci = cci.replace('\n', '').strip()
-        missing_in_disa.append(f"{cci} - {cce_rule_id_dict[cci]}")
+    for cce in (cac_set - disa_set):
+        cce = cce.replace('\n', '').strip()
+        missing_in_disa.append(f"{cce} - {cce_rule_id_dict[cce]}")
 
-    for cci in (disa_set - cac_set):
-        cci = cci.replace('\n', '').strip()
-        missing_in_cac.append(f"{cci} - {cce_rule_id_dict[cci]}")
+    for cce in (disa_set - cac_set):
+        cce = cce.replace('\n', '').strip()
+        missing_in_cac.append(f"{cce} - {cce_rule_id_dict[cce]}")
 
     for cce in common_set:
         disa = disa_cce_dict[cce]


### PR DESCRIPTION
#### Description:

- Changes the mode of the `srg_diff.py` script to 755
- Add a section to the report that lists rules without an SRG

#### Rationale:

To help show potential blind spots in the report. 

#### Review Hints:
* The November 2022 submission should be used as the DISA file.