### PR TITLE
OCP4: improve rule scc_limit_container_allowed_capabilities instruction

### DIFF
--- a/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
+++ b/applications/openshift/scc/scc_limit_container_allowed_capabilities/rule.yml
@@ -17,6 +17,8 @@ rationale: |-
     the container to run software as added capabilities that are not required
     allow for malicious containers or attackers.
 
+{{% set jqfilter = '[.items[] | select(.metadata.name | test("{{.var_sccs_with_allowed_capabilities_regex}}"; "") | not) | select(.allowedCapabilities != null) | .metadata.name]' %}}
+
 severity: medium
 
 references:
@@ -41,8 +43,13 @@ ocil: |-
     Review each SCC and determine that only required capabilities are either
     completely added as a list entry under <tt>allowedCapabilities</tt>,
     or that all the un-required capabilities are dropped for containers and SCCs.
-
-{{% set jqfilter = '[.items[] | select(.metadata.name | test("{{.var_sccs_with_allowed_capabilities_regex}}"; "") | not)] | map(.allowedCapabilities == null)' %}}
+    varible var_sccs_with_allowed_capabilities_regex can be set to exclude certain
+    SCCs from the check.
+    Use following command to verify if the correct regex is being used, this ouput
+    will list unqualified SCCs:
+    <pre>$ oc get scc -o json | {{{ jqfilter }}}</pre>
+    {{.var_sccs_with_allowed_capabilities_regex}} should be replace to the actual value set,
+    either the default one or the one set from TailoredProfile.
 
 
 warnings:
@@ -55,7 +62,8 @@ template:
         ocp_data: "true"
         filepath: "{{{ openshift_filtered_path('/apis/security.openshift.io/v1/securitycontextconstraints', jqfilter) }}}"
         yamlpath: "[:]"
-        check_existence: "all_exist"
+        check_existence: "none_exist"
         entity_check: "all"
         values:
-          - value: "true"
+          - value: "(.*?)"
+            operation: "pattern match"


### PR DESCRIPTION
It is often hard for a user to debug rule scc_limit_container_allowed_capabilities, this improves that by changing the jq filter, so instead of true or false being displayed, it will show the name of all the unqualified SCCs
