### PR TITLE
Introduce parametrized CPE items and sample template

### DIFF
--- a/build-scripts/collect_remediations.py
+++ b/build-scripts/collect_remediations.py
@@ -129,7 +129,8 @@ def main():
     for platform_file in os.listdir(args.platforms_dir):
         platform_path = os.path.join(args.platforms_dir, platform_file)
         try:
-            platform = ssg.build_yaml.Platform.from_yaml(platform_path, env_yaml, product_cpes)
+            platform = ssg.build_yaml.Platform.from_yaml(platform_path, env_yaml, product_cpes,
+                                                         args.fixes_from_templates_dir)
         except ssg.build_yaml.DocumentationNotComplete:
             # Happens on non-debug build when a platform is
             # "documentation-incomplete"

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_time_service_set_maxpoll") }}}
 

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/rule.yml
@@ -71,7 +71,7 @@ rationale: |-
 severity: medium
 
 platforms:
-    - ntp or chrony
+    - ntp or package[chrony]
 
 identifiers:
     cce@rhcos4: CCE-82684-2

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_specify_remote_server/rule.yml
@@ -86,7 +86,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine and (chrony or ntp)  # The check uses service_... extended definition, which doesnt support offline mode
+platform: machine and (package[chrony] or ntp)  # The check uses service_... extended definition, which doesnt support offline mode
 
 identifiers:
     cce@rhcos4: CCE-82683-4

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
@@ -32,7 +32,7 @@ rationale: |-
 
 severity: medium
 
-platform: chrony
+platform: package[chrony]
 
 references:
     cis@alinux2: 2.1.1.3

--- a/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
@@ -10,7 +10,7 @@ rationale: |-
 
 severity: medium
 
-platform: chrony
+platform: package[chrony]
 
 warnings:
   - general: This rule doesn't come with a remediation, the time source needs to be added by the adminstrator.

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
@@ -19,7 +19,8 @@ rationale: |-
 
 severity: medium
 
-platform: chrony
+platforms:
+    - "package[chrony]"
 
 identifiers:
     cce@rhel7: CCE-83418-4

--- a/shared/applicability/chrony.yml
+++ b/shared/applicability/chrony.yml
@@ -1,5 +1,0 @@
-name: "cpe:/a:chrony"
-title: "Package chrony is installed"
-check_id: installed_env_has_chrony_package
-bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -4,10 +4,6 @@ check_id: 'package_{arg}'
 template:
     name: cond_package
 args:
-    chronytest:
-        title: "Chrony Server Test"
+    chrony:
+        title: "Chrony package installed"
         pkgname: chrony
-        pkgname@debian10: chrony
-    ntptest:
-        title: "NTP Server Test"
-        pkgname: ntp

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -1,0 +1,13 @@
+name: 'cpe:/a:{arg}'
+title: 'Package {arg} is installed'
+check_id: 'package_{arg}'
+template:
+    name: cond_package
+args:
+    chronytest:
+        title: "Chrony Server Test"
+        pkgname: chrony
+        pkgname@debian10: chrony
+    ntptest:
+        title: "NTP Server Test"
+        pkgname: ntp

--- a/shared/templates/cond_package/ansible.template
+++ b/shared/templates/cond_package/ansible.template
@@ -1,0 +1,8 @@
+{{%- macro ansible_package_conditionals(pkgname, specs) %}}
+  {{%- for spec in specs %}}
+    ansible_facts.packages["{{{ pkgname }}}"][0]["version"] is version("{{{ spec.ver }}}", "{{{ spec.op }}}")
+  {{%- else %}}
+    {{{ ansible_pkg_conditional(pigname) }}}
+  {{% endfor %}}
+{{% endmacro %}}
+{{{ ansible_package_conditionals(PKGNAME, SPECS).strip().split("\n")|join(" and ") }}}

--- a/shared/templates/cond_package/ansible.template
+++ b/shared/templates/cond_package/ansible.template
@@ -2,7 +2,7 @@
   {{%- for spec in specs %}}
     ansible_facts.packages["{{{ pkgname }}}"][0]["version"] is version("{{{ spec.ver }}}", "{{{ spec.op }}}")
   {{%- else %}}
-    {{{ ansible_pkg_conditional(pigname) }}}
+    {{{ ansible_pkg_conditional(pkgname) }}}
   {{% endfor %}}
 {{% endmacro %}}
 {{{ ansible_package_conditionals(PKGNAME, SPECS).strip().split("\n")|join(" and ") }}}

--- a/shared/templates/cond_package/bash.template
+++ b/shared/templates/cond_package/bash.template
@@ -1,0 +1,2 @@
+
+{{{ bash_pkg_conditional(PKGNAME) }}}

--- a/shared/templates/cond_package/oval.template
+++ b/shared/templates/cond_package/oval.template
@@ -1,0 +1,10 @@
+<def-group>
+  <definition class="inventory" id="{{{ _RULE_ID }}}" version="1">
+    {{{ oval_metadata("The " + pkg_system|upper + " package " + PKGNAME + " should be installed.", affected_platforms=["multi_platform_all"]) }}}
+    <criteria>
+      <criterion comment="Conditional package {{{ PKGNAME }}} is installed"
+      test_ref="test_inventory_{{{ _RULE_ID }}}_installed" />
+    </criteria>
+  </definition>
+{{{ oval_test_package_installed(package=PKGNAME, test_id="test_inventory_" + _RULE_ID + "_installed") }}}
+</def-group>

--- a/shared/templates/cond_package/template.py
+++ b/shared/templates/cond_package/template.py
@@ -1,0 +1,12 @@
+import re
+
+
+def preprocess(data, lang):
+    if "evr" in data:
+        evr = data["evr"]
+        if evr and not re.match(r'\d:\d[\d\w+.]*-\d[\d\w+.]*', evr, 0):
+            raise RuntimeError(
+                "ERROR: input violation: evr key should be in "
+                "epoch:version-release format, but package {0} has set "
+                "evr to {1}".format(data["pkgname"], evr))
+    return data

--- a/shared/templates/cond_package/template.yml
+++ b/shared/templates/cond_package/template.yml
@@ -1,0 +1,4 @@
+supported_languages:
+  - oval
+  - bash
+  - ansible

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -146,7 +146,9 @@ class CPEItem(XCCDFEntity):
     KEYS = dict(
         name=lambda: "",
         title=lambda: "",
-        conditional=lambda: {},
+        check_id=lambda: "",
+        bash_conditional=lambda: "",
+        ansible_conditional=lambda: "",
         template=lambda: {},
         is_product_cpe=lambda: False,
         args=lambda: {},
@@ -172,7 +174,7 @@ class CPEItem(XCCDFEntity):
         cpe_item_check = ET.SubElement(cpe_item, "{%s}check" % CPEItem.ns)
         cpe_item_check.set('system', oval_namespace)
         cpe_item_check.set('href', cpe_oval_filename)
-        cpe_item_check.text = self.conditional.get('oval_id', self.id_)
+        cpe_item_check.text = self.check_id
         return cpe_item
 
     @classmethod
@@ -255,7 +257,12 @@ class CPEALFactRef(Symbol):
 
     def get_remediation_conditional(self, language, product_cpes, conditionals_path, env_yaml):
         cpe = product_cpes.get_cpe(self.as_id())
-        cond = cpe.conditional.get(language, "")
+        if language == "bash":
+            cond = cpe.bash_conditional
+        elif language == "ansible":
+            cond = cpe.ansible_conditional
+        else:
+            raise KeyError("Invalid language {0} supplied for remediation conditional".format(language))
         if cond:
             return remediations.parse_from_string_with_jinja(cond, env_yaml)
         elif conditionals_path is not None:

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -203,7 +203,7 @@ class CPEALLogicalTest(Function):
         for arg in self.args:
             arg.add_enriched_cpe_items(product_cpes)
 
-    def get_conditional(self, language, product_cpes, conditionals_path, env_yaml):
+    def get_remediation_conditional(self, language, product_cpes, conditionals_path, env_yaml):
         contents = ''
         config = defaultdict(lambda: None)
         op = " "
@@ -212,12 +212,7 @@ class CPEALLogicalTest(Function):
         contents += "( "
         child_condlines = []
         for a in self.args:
-            if language == "bash":
-                r = a.get_bash_conditional(product_cpes, conditionals_path, env_yaml)
-            elif language == "ansible":
-                r = a.get_ansible_conditional(product_cpes, conditionals_path, env_yaml)
-            else:
-                raise Exception("Conditionals for {0} are not supported.".format(language))
+            r = a.get_remediation_conditional(language, product_cpes, conditionals_path, env_yaml)
             if r is not None:
                 cont = r.contents.strip()
                 if cont:
@@ -230,14 +225,8 @@ class CPEALLogicalTest(Function):
         contents += " )"
         return namedtuple('remediation', ['contents', 'config'])(contents=contents, config=config)
 
-    def get_bash_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("bash", product_cpes, conditionals_path, env_yaml)
 
-    def get_ansible_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("ansible", product_cpes, conditionals_path, env_yaml)
-
-
-class CPEALFactRef (Symbol):
+class CPEALFactRef(Symbol):
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
@@ -263,7 +252,7 @@ class CPEALFactRef (Symbol):
 
         return cpe_factref
 
-    def get_conditional(self, language, product_cpes, conditionals_path, env_yaml):
+    def get_remediation_conditional(self, language, product_cpes, conditionals_path, env_yaml):
         cpe = product_cpes.get_cpe(self.as_id())
         cond = cpe.conditional.get(language, "")
         if cond:
@@ -276,13 +265,6 @@ class CPEALFactRef (Symbol):
             if os.path.exists(templated_conditional_file):
                 return remediations.parse_from_file_without_jinja(templated_conditional_file)
         return None
-
-    def get_bash_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("bash", product_cpes, conditionals_path, env_yaml)
-
-    def get_ansible_conditional(self, product_cpes, conditionals_path, env_yaml):
-        return self.get_conditional("ansible", product_cpes, conditionals_path, env_yaml)
-
 
 def extract_subelement(objects, sub_elem_type):
     """

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -26,16 +26,16 @@ class CPEDoesNotExist(Exception):
 
 class ProductCPEs(object):
     """
-    Reads from the disk all the yaml CPEs related to a product
-    and provides them in a structured way.
+    This class serves as a structure for CPE items during the build process.
+    It allows adding and retrieving of items.
     """
 
     def __init__(self):
 
-        self.cpes_by_id = {}
-        self.cpes_by_name = {}
-        self.product_cpes = {}
-        self.platforms = {}
+        self.cpes_by_id = {} # CPE items indexed by internal ID
+        self.cpes_by_name = {} # CPE items indexed by CPE name
+        self.product_cpes = {} # CPE items which define applicability of a product indexed by internal ID
+        self.platforms = {} # CPE AL platforms indexed by internal ID
         self.algebra = Algebra(symbol_cls=CPEALFactRef, function_cls=CPEALLogicalTest)
 
     def load_product_cpes(self, env_yaml):
@@ -185,6 +185,12 @@ class CPEItem(XCCDFEntity):
         return cpe_item
 
 class CPEALLogicalTest(Function):
+    """
+    This class represents the logical-test element of CPE applicability language
+    Each test must contain at least one test or fact-ref.
+    This class inherits from boolean_expression.Function because it also represents boolean function when handling logical expressions of CPE AL.
+    """
+
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]
@@ -230,6 +236,13 @@ class CPEALLogicalTest(Function):
 
 
 class CPEALFactRef(Symbol):
+    """
+    This class represents the fact-ref element of CPE applicability language.
+    Each fact-ref points to particular CPE item.
+    If a Platform (defined in build_yaml.py) receives some kind of parameters
+    such as package[chrony], then application of those parameters to the resulting CPE item happens here.
+    This class inherits from boolean_expression.Symbol because it also represents symbol in a boolean expression when handling logical expressions of CPE AL.
+    """
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import os
 import sys
-from collections import namedtuple, defaultdict
+from collections import defaultdict
 
 from .constants import oval_namespace
 from .constants import PREFIX_TO_NS
@@ -14,7 +14,7 @@ from .constants import CONDITIONAL_OPERATORS
 from .utils import required_key
 from .xml import ElementTree as ET
 from .boolean_expression import Algebra, Symbol, Function
-from .entities.common import XCCDFEntity
+from .entities.common import XCCDFEntity, RemediationObject
 from .yaml import convert_string_to_bool
 
 from . import remediations
@@ -223,7 +223,7 @@ class CPEALLogicalTest(Function):
             op = " " + CONDITIONAL_OPERATORS[language]["and"] + " "
         contents += op.join(child_condlines)
         contents += " )"
-        return namedtuple('remediation', ['contents', 'config'])(contents=contents, config=config)
+        return RemediationObject(contents=contents, config=config)
 
 
 class CPEALFactRef(Symbol):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -242,7 +242,7 @@ class CPEALFactRef(Symbol):
     def add_enriched_cpe_items(self, product_cpes):
         old_cpe_dict = product_cpes.get_cpe(self.cpe_name).represent_as_dict()
         # ignore remediation snippets for now when templating, they will be removed eventually from the CPE item definition
-        not_templated_keys = ["conditional"]
+        not_templated_keys = ["bash_conditional", "ansible_conditional"]
         new_cpe_dict = apply_formatting_on_dict_values(old_cpe_dict, self.as_dict(), not_templated_keys)
         new_cpe_dict["id_"] = self.as_id()
         new_cpe = CPEItem.get_instance_from_full_dict(new_cpe_dict)

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -207,9 +207,6 @@ class CPEALLogicalTest(Function):
         contents = ''
         config = defaultdict(lambda: None)
         op = " "
-        if self.is_not():
-            contents += CONDITIONAL_OPERATORS[language]["not"] + " "
-        contents += "( "
         child_condlines = []
         for a in self.args:
             r = a.get_remediation_conditional(language, product_cpes, conditionals_path, env_yaml)
@@ -217,12 +214,16 @@ class CPEALLogicalTest(Function):
                 cont = r.contents.strip()
                 if cont:
                     child_condlines.append(cont)
-        if self.is_or():
-            op = " " + CONDITIONAL_OPERATORS[language]["or"] + " "
-        elif self.is_and():
-            op = " " + CONDITIONAL_OPERATORS[language]["and"] + " "
-        contents += op.join(child_condlines)
-        contents += " )"
+        if child_condlines:
+            if self.is_not():
+                contents += CONDITIONAL_OPERATORS[language]["not"] + " "
+            contents += "( "
+            if self.is_or():
+                op = " " + CONDITIONAL_OPERATORS[language]["or"] + " "
+            elif self.is_and():
+                op = " " + CONDITIONAL_OPERATORS[language]["and"] + " "
+            contents += op.join(child_condlines)
+            contents += " )"
         return RemediationObject(contents=contents, config=config)
 
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -88,7 +88,7 @@ class Remediation(object):
         for p in cpe_platform_names:
             conditional = cpe_platforms[p].get_remediation_conditional(language)
             if conditional is not None:
-                stripped_conditional = conditional.contents.strip()
+                stripped_conditional = conditional.strip()
                 if stripped_conditional:
                     stripped_conditionals.append(stripped_conditional)
         return stripped_conditionals

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -123,7 +123,7 @@ class BashRemediation(Remediation):
 
         inherited_conditionals = []
         for p in inherited_cpe_platform_names:
-            r = cpe_platforms[p].get_bash_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("bash")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
@@ -131,7 +131,7 @@ class BashRemediation(Remediation):
 
         rule_specific_conditionals = []
         for p in rule_specific_cpe_platform_names:
-            r = cpe_platforms[p].get_bash_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("bash")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
@@ -287,7 +287,7 @@ class AnsibleRemediation(Remediation):
 
         inherited_conditionals = []
         for p in inherited_cpe_platform_names:
-            r = cpe_platforms[p].get_ansible_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("ansible")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
@@ -295,13 +295,13 @@ class AnsibleRemediation(Remediation):
 
         rule_specific_conditionals = []
         for p in rule_specific_cpe_platform_names:
-            r = cpe_platforms[p].get_ansible_conditional()
+            r = cpe_platforms[p].get_remediation_conditional("ansible")
             if r is not None:
                 stripped = r.contents.strip()
                 if stripped:
                     rule_specific_conditionals.append(stripped)
 
-            cpe_platforms[p].get_ansible_conditional()
+            cpe_platforms[p].get_remediation_conditional("ansible")
 
         # Remove conditionals related to package CPEs if the updated task collects package facts
         if "package_facts" in to_update:

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -5,7 +5,7 @@ import sys
 import os
 import os.path
 import re
-from collections import defaultdict, namedtuple, OrderedDict
+from collections import defaultdict, OrderedDict
 
 import ssg.yaml
 import ssg.build_yaml
@@ -13,10 +13,12 @@ from . import rules
 from . import utils
 from . import constants
 
-from .remediations import parse_from_file_with_jinja, parse_from_file_without_jinja, REMEDIATION_TO_EXT_MAP
-
+from .remediations import parse_from_file_with_jinja, parse_from_file_without_jinja
+from .remediations import REMEDIATION_TO_EXT_MAP
+from .entities.common import RemediationObject
 from .xml import ElementTree
 from .constants import XCCDF12_NS
+
 
 REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
 
@@ -180,8 +182,7 @@ class BashRemediation(Remediation):
                 "    >&2 echo 'Remediation is not applicable, nothing was done'")
             wrapped_fix_text.append("fi")
 
-            result = namedtuple('remediation', ['contents', 'config'])(contents="\n".join(wrapped_fix_text),
-                                                                       config=result.config)
+            result = RemediationObject(contents="\n".join(wrapped_fix_text), config=result.config)
         return result
 
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -77,25 +77,27 @@ class Remediation(object):
                     if p not in inherited_cpe_platform_names}
         return rule_specific_cpe_platform_names
 
+    def get_stripped_conditionals(self, language, cpe_platform_names, cpe_platforms):
+        """
+        collect conditionals of platforms defined by cpe_platform_names
+        and strip them of white spaces
+        """
+        stripped_conditionals = []
+        for p in cpe_platform_names:
+            conditional = cpe_platforms[p].get_remediation_conditional(language)
+            if conditional is not None:
+                stripped_conditional = conditional.contents.strip()
+                if stripped_conditional:
+                    stripped_conditionals.append(stripped_conditional)
+        return stripped_conditionals
+
     def get_rule_specific_conditionals(self, language, cpe_platforms):
-        rule_specific_conditionals = []
-        for p in self.get_rule_specific_cpe_platform_names():
-            r = cpe_platforms[p].get_remediation_conditional(language)
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    rule_specific_conditionals.append(stripped)
-        return rule_specific_conditionals
+        cpe_platform_names = self.get_rule_specific_cpe_platform_names()
+        return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
 
     def get_inherited_conditionals(self, language, cpe_platforms):
-        inherited_conditionals = []
-        for p in self.get_inherited_cpe_platform_names():
-            r = cpe_platforms[p].get_remediation_conditional(language)
-            if r is not None:
-                stripped = r.contents.strip()
-                if stripped:
-                    inherited_conditionals.append(stripped)
-        return inherited_conditionals
+        cpe_platform_names = self.get_inherited_cpe_platform_names()
+        return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
 
 
 def process(remediation, env_yaml, cpe_platforms):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1636,11 +1636,10 @@ class Platform(XCCDFEntity):
     def to_xml_element(self):
         return ET.fromstring(self.xml_content)
 
-    def get_bash_conditional(self):
-        return self.conditional.get('bash', '')
+    def get_remediation_conditional(self, language):
+        return self.conditional.get(language, '')
 
-    def get_ansible_conditional(self):
-        return self.conditional.get('ansible', '')
+
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None, conditionals_path=None):
@@ -1651,8 +1650,10 @@ class Platform(XCCDFEntity):
             platform.test = product_cpes.algebra.parse(
                 platform.original_expression, simplify=True)
             platform.conditional = {
-                'bash': platform.test.get_bash_conditional(product_cpes, conditionals_path, env_yaml),
-                'ansible': platform.test.get_ansible_conditional(product_cpes, conditionals_path, env_yaml)
+                'bash': platform.test.get_remediation_conditional(
+                    "bash", product_cpes, conditionals_path, env_yaml),
+                'ansible': platform.test.get_remediation_conditional(
+                    "ansible", product_cpes, conditionals_path, env_yaml)
             }
 
         return platform

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1532,11 +1532,13 @@ class LinearLoader(object):
         filenames = glob.glob(os.path.join(self.resolved_values_dir, "*.yml"))
         self.load_entities_by_id(filenames, self.values, Value)
 
+        self.product_cpes.load_cpes_from_directory_tree(self.resolved_cpe_items_dir, self.env_yaml)
+
         filenames = glob.glob(os.path.join(self.resolved_platforms_dir, "*.yml"))
         self.load_entities_by_id(filenames, self.platforms, Platform)
         self.product_cpes.platforms = self.platforms
 
-        self.product_cpes.load_cpes_from_directory_tree(self.resolved_cpe_items_dir, self.env_yaml)
+
 
         for g in self.groups.values():
             g.load_entities(self.rules, self.values, self.groups)
@@ -1585,8 +1587,7 @@ class Platform(XCCDFEntity):
         name=lambda: "",
         original_expression=lambda: "",
         xml_content=lambda: "",
-        bash_conditional=lambda: "",
-        ansible_conditional=lambda: "",
+        conditional=lambda: {},
         ** XCCDFEntity.KEYS
     )
 
@@ -1594,8 +1595,7 @@ class Platform(XCCDFEntity):
         "name",
         "xml_content",
         "original_expression",
-        "bash_conditional",
-        "ansible_conditional"
+        "conditional",
     ]
 
     prefix = "cpe-lang"
@@ -1610,19 +1610,18 @@ class Platform(XCCDFEntity):
         id = test.as_id()
         platform = cls(id)
         platform.test = test
-        platform.test.enrich_with_cpe_info(product_cpes)
+        # in case some cpe_items were parametrized, we might need to create new CPE items
+        platform.test.add_enriched_cpe_items(product_cpes)
         platform.name = id
         platform.original_expression = expression
         platform.xml_content = platform.get_xml()
-        platform.bash_conditional = platform.test.to_bash_conditional()
-        platform.ansible_conditional = platform.test.to_ansible_conditional()
         return platform
 
     def get_xml(self):
         cpe_platform = ET.Element("{%s}platform" % Platform.ns)
         cpe_platform.set('id', self.name)
         # in case the platform contains only single CPE name, fake the logical test
-        # we have to athere to CPE specification
+        # we have to adhere to CPE specification
         if isinstance(self.test, CPEALFactRef):
             cpe_test = ET.Element("{%s}logical-test" % CPEALLogicalTest.ns)
             cpe_test.set('operator', 'AND')
@@ -1635,23 +1634,27 @@ class Platform(XCCDFEntity):
         return xmlstr
 
     def to_xml_element(self):
-        return self.xml_content
+        return ET.fromstring(self.xml_content)
 
-    def to_bash_conditional(self):
-        return self.bash_conditional
+    def get_bash_conditional(self):
+        return self.conditional.get('bash', '')
 
-    def to_ansible_conditional(self):
-        return self.ansible_conditional
+    def get_ansible_conditional(self):
+        return self.conditional.get('ansible', '')
 
     @classmethod
-    def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None):
+    def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None, conditionals_path=None):
         platform = super(Platform, cls).from_yaml(yaml_file, env_yaml)
-        platform.xml_content = ET.fromstring(platform.xml_content)
         # if we did receive a product_cpes, we can restore also the original test object
         # it can be later used e.g. for comparison
         if product_cpes:
             platform.test = product_cpes.algebra.parse(
                 platform.original_expression, simplify=True)
+            platform.conditional = {
+                'bash': platform.test.get_bash_conditional(product_cpes, conditionals_path, env_yaml),
+                'ansible': platform.test.get_ansible_conditional(product_cpes, conditionals_path, env_yaml)
+            }
+
         return platform
 
     def __eq__(self, other):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1582,6 +1582,10 @@ class LinearLoader(object):
 
 
 class Platform(XCCDFEntity):
+    """
+    This class represents CPE applicability language platform.
+    Each platform has at least one CPE logical test.
+    """
 
     KEYS = dict(
         name=lambda: "",
@@ -1639,8 +1643,6 @@ class Platform(XCCDFEntity):
     def get_remediation_conditional(self, language):
         return self.conditional.get(language, '')
 
-
-
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None, conditionals_path=None):
         platform = super(Platform, cls).from_yaml(yaml_file, env_yaml)
@@ -1655,7 +1657,6 @@ class Platform(XCCDFEntity):
                 'ansible': platform.test.get_remediation_conditional(
                     "ansible", product_cpes, conditionals_path, env_yaml)
             }
-
         return platform
 
     def __eq__(self, other):

--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -465,3 +465,16 @@ DEFAULT_SSH_DISTRIBUTED_CONFIG = 'false'
 DEFAULT_PRODUCT = 'example'
 DEFAULT_CHRONY_CONF_PATH = '/etc/chrony.conf'
 DEFAULT_AUDISP_CONF_PATH = '/etc/audit'
+
+CONDITIONAL_OPERATORS = {
+    "ansible": {
+        "or": "or",
+        "and": "and",
+        "not": "not"
+    },
+    "bash": {
+        "and": "&&",
+        "or": "||",
+        "not": "!"
+    }
+}

--- a/ssg/entities/common.py
+++ b/ssg/entities/common.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 
 import os
 import yaml
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from copy import deepcopy
 
 from ..xml import ElementTree as ET, add_xhtml_namespace
@@ -309,3 +309,11 @@ class SelectionHandler(object):
         updated_refinements = self._subtract_refinements(extended_refinements)
         updated_refinements.update(self.refine_rules)
         self.refine_rules = updated_refinements
+
+
+# this named tuple is a structure used for remediations
+# it holds the remediation config values (platform etc)
+# and the actual content
+#it is here because the structure is needed in several modules
+# currently in ssg/build_remediations and ssg/build_cpe.py
+RemediationObject = namedtuple('remediation', ['contents', 'config'])

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -129,6 +129,15 @@ def process_file(filepath, substitutions_dict):
     return template.render(substitutions_dict)
 
 
+def process_string(string, substitutions_dict):
+    """
+    Process the jinja string. Return the result as a string. Note that this will not
+    load the project macros; use process_file_with_macros(...) for that.
+    """
+    template = _get_jinja_environment(substitutions_dict).from_string(string)
+    return template.render(substitutions_dict)
+
+
 def add_python_functions(substitutions_dict):
     substitutions_dict['prodtype_to_name'] = prodtype_to_name
     substitutions_dict['name_to_platform'] = name_to_platform
@@ -169,6 +178,18 @@ def process_file_with_macros(filepath, substitutions_dict):
     substitutions_dict = load_macros(substitutions_dict)
     assert 'indent' not in substitutions_dict
     return process_file(filepath, substitutions_dict)
+
+
+def process_string_with_macros(string, substitutions_dict):
+    """
+    Process the string with jinja macros with the specified
+    substitutions. Return the result as a string.
+
+    See also: process_string
+    """
+    substitutions_dict = load_macros(substitutions_dict)
+    assert 'indent' not in substitutions_dict
+    return process_string(string, substitutions_dict)
 
 
 def url_encode(source):

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -11,6 +11,7 @@ import ssg.utils
 import ssg.yaml
 import ssg.build_yaml
 import ssg.build_remediations
+import ssg.remediations
 import ssg.environment
 
 COMMENTS_TO_PARSE = ["strategy", "complexity", "disruption"]
@@ -129,7 +130,7 @@ class PlaybookBuilder():
 
         with open(snippet_path, "r") as snippet_file:
             snippet_str = snippet_file.read()
-        fix = ssg.build_remediations.split_remediation_content_and_metadata(snippet_str)
+        fix = ssg.remediations.split_remediation_content_and_metadata(snippet_str)
         snippet_yaml = ssg.yaml.ordered_load(fix.contents)
 
         play_tasks, play_vars = self.get_data_from_snippet(

--- a/ssg/remediations.py
+++ b/ssg/remediations.py
@@ -1,0 +1,86 @@
+from collections import defaultdict, namedtuple
+from .jinja import process_file_with_macros as jinja_process_file
+from .jinja import process_string_with_macros as jinja_process_string
+
+REMEDIATION_TO_EXT_MAP = {
+    'anaconda': '.anaconda',
+    'ansible': '.yml',
+    'bash': '.sh',
+    'puppet': '.pp',
+    'ignition': '.yml',
+    'kubernetes': '.yml',
+    'blueprint': '.toml'
+}
+
+FILE_GENERATED_HASH_COMMENT = '# THIS FILE IS GENERATED'
+
+REMEDIATION_CONFIG_KEYS = ['complexity', 'disruption', 'platform', 'reboot',
+                           'strategy']
+
+
+def split_remediation_content_and_metadata(fix_file):
+    remediation_contents = []
+    config = defaultdict(lambda: None)
+
+    # Assignment automatically escapes shell characters for XML
+    for line in fix_file.splitlines():
+        if line.startswith(FILE_GENERATED_HASH_COMMENT):
+            continue
+
+        if line.startswith('#') and line.count('=') == 1:
+            (key, value) = line.strip('#').split('=')
+            if key.strip() in REMEDIATION_CONFIG_KEYS:
+                config[key.strip()] = value.strip()
+                continue
+
+        # If our parsed line wasn't a config item, add it to the
+        # returned file contents. This includes when the line
+        # begins with a '#' and contains an equals sign, but
+        # the "key" isn't one of the known keys from
+        # REMEDIATION_CONFIG_KEYS.
+        remediation_contents.append(line)
+
+    contents = "\n".join(remediation_contents)
+    remediation = namedtuple('remediation', ['contents', 'config'])
+    return remediation(contents=contents, config=config) #defaultdict(lambda: None)
+
+
+def parse_from_string_with_jinja(string, env_yaml):
+    """
+    Parses a remediation from a string. As remediations contain jinja macros,
+    we need a env_yaml context to process these. In practice, no remediations
+    use jinja in the configuration, so for extracting only the configuration,
+    env_yaml can be an abritrary product.yml dictionary.
+
+    If the logic of configuration parsing changes significantly, please also
+    update ssg.fixes.parse_platform(...).
+    """
+
+    fix_file = jinja_process_string(string, env_yaml)
+    return split_remediation_content_and_metadata(fix_file)
+
+
+def parse_from_file_with_jinja(file_path, env_yaml):
+    """
+    Parses a remediation from a file. As remediations contain jinja macros,
+    we need a env_yaml context to process these. In practice, no remediations
+    use jinja in the configuration, so for extracting only the configuration,
+    env_yaml can be an abritrary product.yml dictionary.
+
+    If the logic of configuration parsing changes significantly, please also
+    update ssg.fixes.parse_platform(...).
+    """
+
+    fix_file = jinja_process_file(file_path, env_yaml)
+    return split_remediation_content_and_metadata(fix_file)
+
+
+def parse_from_file_without_jinja(file_path):
+    """
+    Parses a remediation from a file. Doesn't process the Jinja macros.
+    This function is useful in build phases in which all the Jinja macros
+    are already resolved.
+    """
+    with open(file_path, "r") as f:
+        f_str = f.read()
+        return split_remediation_content_and_metadata(f_str)

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -298,12 +298,11 @@ class Builder(object):
             local_env_yaml["rule_title"] = cpe.title
             local_env_yaml["products"] = self.env_yaml["product"]
 
-            for lang in ['oval', 'bash', 'ansible']:
+            for lang in languages.values():
                 try:
                     self.build_lang(cpe_id, template_name, template_vars, lang, local_env_yaml)
                 except Exception as e:
-                    print("Error building template {0} for platform {1}".format(lang, symbol.name), file=sys.stderr)
-                    raise e
+                    raise RuntimeError("Error building template {0} for platform {1}".format(lang.name, symbol.name))
 
     def get_lang_for_rule(self, rule_id, rule_title, template, language):
         """

--- a/tests/unit/ssg-module/data/machine.yml
+++ b/tests/unit/ssg-module/data/machine.yml
@@ -6,8 +6,8 @@ xml_content: !!binary |
     MDpsb2dpY2FsLXRlc3Qgb3BlcmF0b3I9IkFORCIgbmVnYXRlPSJmYWxzZSI+PG5zMDpmYWN0LXJl
     ZiBuYW1lPSJjcGU6L2E6bWFjaGluZSIgLz48L25zMDpsb2dpY2FsLXRlc3Q+PC9uczA6cGxhdGZv
     cm0+
-bash_conditional: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
-ansible_conditional: ansible_virtualization_type not in ["docker", "lxc", "openvz",
-    "podman", "container"]
+conditional:
+    bash: '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]'
+    ansible: ansible_virtualization_type not in ["docker", "lxc", "openvz", "podman", "container"]
 definition_location: ''
 documentation_complete: true

--- a/tests/unit/ssg-module/test_boolean_expressions.py
+++ b/tests/unit/ssg-module/test_boolean_expressions.py
@@ -48,11 +48,8 @@ def test_id(expression1):
     assert str(expression1.as_id()) == 'apple_and_banana_or_oranges_eq_2.0_or_not_pie'
 
 
-def test_cnf(algebra, expression1):
+def test_expression1_cnf_dnf(algebra, expression1):
     assert str(algebra.cnf(expression1)) == '(apple|~pie)&(banana|oranges==2.0|~pie)'
-
-
-def test_dnf(algebra, expression1):
     assert str(algebra.dnf(expression1)) == '(apple&banana)|(apple&oranges==2.0)|~pie'
 
 

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -5,9 +5,11 @@ import ssg.build_remediations as sbr
 import ssg.utils
 import ssg.products
 from ssg.yaml import ordered_load
+import ssg.build_yaml
 
 DATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 rule_dir = os.path.join(DATADIR, "group_dir", "rule_dir")
+rule_file = os.path.join(rule_dir, "rule.yml")
 rhel_bash = os.path.join(rule_dir, "bash", "rhel.sh")
 
 
@@ -34,6 +36,7 @@ def test_is_supported_file_name():
 def do_test_contents(remediation, config):
     assert 'do_something_magical' in remediation
     assert '# a random comment' in remediation
+
 
     assert 'platform' in config
     assert 'reboot' in config
@@ -63,10 +66,18 @@ def test_process_fix(env_yaml, cpe_platforms):
     fixes = {}
 
     remediation_obj = remediation_cls(rhel_bash)
+    # create a fake rule
+    # the rule uses the "machine" platform which has bash_conditional_line
+    # and bash_inserted_before_remediation defined
+    rule = ssg.build_yaml.Rule("test_rule")
+    rule.cpe_platform_names = ["machine"]
+    remediation_obj.associate_rule(rule)
+    print (cpe_platforms["machine"].get_remediation_conditional("bash"))
     result = sbr.process(remediation_obj, env_yaml, cpe_platforms)
 
     assert result is not None
     assert len(result) == 2
+    assert '[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]' in result.contents
     do_test_contents(result.contents, result.config)
 
 


### PR DESCRIPTION
#### Description:

This PR adds:
1. possibility to specify a parameter when defining a platform. Til now it was possible only to write

```
platforms:
    - chrony
```

And there had to be a file shared/applicability/chrony.yml. 
Now it is possible to write:

```
platforms
    - package[chrony]
```

And the parameter "chrony" will be inserted into the file shared/applicability/package.yml on places where the {arg} token appears.

2. It is possible to use templates for CPE items. There exists one new example template in shared/templates/cond_package. The example usage of template in CPE item definition can be found in shared/applicability/package.yml. The template can create an OVAL check, and also Bash and Ansible conditionals which are placed into correct places of respective remediations.

The new platform is demonstratively used in the following rules:
- chronyd_or_ntpd_set_maxpoll
- chronyd_or_ntpd_specify_remote_server
- chronyd_run_as_chrony_user
- chronyd_server_directive
- chronyd_specify_remote_server

#### Rationale:

This should be one step towards possibility of specifying software versions in platform definitions.

This PR replaces https://github.com/ComplianceAsCode/content/pull/9754

