### PR TITLE
Remove STIGIDs from deprecated rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_audit/rule.yml
@@ -18,8 +18,6 @@ references:
     disa: CCI-000044
     nist: AC-7 (a)
     srg: SRG-OS-000021-GPOS-00005
-    stigid@ol8: OL08-00-020021
-    stigid@rhel8: RHEL-08-020021
 
 ocil_clause: 'the "audit" option is not set, is missing or commented out'
 


### PR DESCRIPTION


#### Description:

- Remove RHEL-8 and OL-8 STIGIDs from deprecated rule.
- 
#### Rationale:

- This makes sure the rule is not processed erroneously as a rule needed for STIG profiles.
- Follow up from #9462