### PR TITLE
parametrize methods for getting remediation conditionals of XCCDF platforms

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -190,10 +190,10 @@ class BashRemediation(Remediation):
                     if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            cpe_platforms[p].to_bash_conditional()
+            cpe_platforms[p].get_remediation_conditional("bash")
             for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            cpe_platforms[p].to_bash_conditional()
+            cpe_platforms[p].get_remediation_conditional("bash")
             for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([
@@ -352,10 +352,10 @@ class AnsibleRemediation(Remediation):
                     if p not in inherited_cpe_platform_names}
 
         inherited_conditionals = [
-            cpe_platforms[p].to_ansible_conditional()
+            cpe_platforms[p].get_remediation_conditional("ansible")
             for p in inherited_cpe_platform_names]
         rule_specific_conditionals = [
-            cpe_platforms[p].to_ansible_conditional()
+            cpe_platforms[p].get_remediation_conditional("ansible")
             for p in rule_specific_cpe_platform_names]
         # remove potential "None" from lists
         inherited_conditionals = sorted([

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1637,11 +1637,13 @@ class Platform(XCCDFEntity):
     def to_xml_element(self):
         return self.xml_content
 
-    def to_bash_conditional(self):
-        return self.bash_conditional
-
-    def to_ansible_conditional(self):
-        return self.ansible_conditional
+    def get_remediation_conditional(self, language):
+        if language == "bash":
+            return self.bash_conditional
+        elif language == "ansible":
+            return self.ansible_conditional
+        else:
+            raise AttributeError("Invalid remediation language {0} specified.".format(language))
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None):

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -243,9 +243,9 @@ def test_platform_from_text_unknown_platform(product_cpes):
 
 def test_platform_from_text_simple(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("machine", product_cpes)
-    assert platform.to_ansible_conditional() == \
+    assert platform.get_remediation_conditional("ansible") == \
         "ansible_virtualization_type not in [\"docker\", \"lxc\", \"openvz\", \"podman\", \"container\"]"
-    assert platform.to_bash_conditional() == \
+    assert platform.get_remediation_conditional("bash") == \
         "[ ! -f /.dockerenv ] && [ ! -f /run/.containerenv ]"
     platform_el = ET.fromstring(platform.to_xml_element())
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
@@ -263,8 +263,8 @@ def test_platform_from_text_simple(product_cpes):
 
 def test_platform_from_text_simple_product_cpe(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("rhel7-workstation", product_cpes)
-    assert platform.to_bash_conditional() == ""
-    assert platform.to_ansible_conditional() == ""
+    assert platform.get_remediation_conditional("bash") == ""
+    assert platform.get_remediation_conditional("ansible") == ""
     platform_el = ET.fromstring(platform.to_xml_element())
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "rhel7-workstation"
@@ -282,8 +282,8 @@ def test_platform_from_text_simple_product_cpe(product_cpes):
 
 def test_platform_from_text_or(product_cpes):
     platform = ssg.build_yaml.Platform.from_text("ntp or chrony", product_cpes)
-    assert platform.to_bash_conditional() == "( rpm --quiet -q chrony || rpm --quiet -q ntp )"
-    assert platform.to_ansible_conditional() == \
+    assert platform.get_remediation_conditional("bash") == "( rpm --quiet -q chrony || rpm --quiet -q ntp )"
+    assert platform.get_remediation_conditional("ansible") == \
         "( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages )"
     platform_el = ET.fromstring(platform.to_xml_element())
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
@@ -303,15 +303,15 @@ def test_platform_from_text_or(product_cpes):
 def test_platform_from_text_and_empty_conditionals(product_cpes):
     platform = ssg.build_yaml.Platform.from_text(
         "krb5_server_older_than_1_17-18 and krb5_workstation_older_than_1_17-18", product_cpes)
-    assert platform.to_bash_conditional() == ""
-    assert platform.to_ansible_conditional() == ""
+    assert platform.get_remediation_conditional("bash") == ""
+    assert platform.get_remediation_conditional("ansible") == ""
 
 
 def test_platform_from_text_complex_expression(product_cpes):
     platform = ssg.build_yaml.Platform.from_text(
         "systemd and !yum and (ntp or chrony)", product_cpes)
-    assert platform.to_bash_conditional() == "( rpm --quiet -q systemd && ( rpm --quiet -q chrony || rpm --quiet -q ntp ) && ! ( rpm --quiet -q yum ) )"
-    assert platform.to_ansible_conditional() == "( \"systemd\" in ansible_facts.packages and ( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages ) and not ( \"yum\" in ansible_facts.packages ) )"
+    assert platform.get_remediation_conditional("bash") == "( rpm --quiet -q systemd && ( rpm --quiet -q chrony || rpm --quiet -q ntp ) && ! ( rpm --quiet -q yum ) )"
+    assert platform.get_remediation_conditional("ansible") == "( \"systemd\" in ansible_facts.packages and ( \"chrony\" in ansible_facts.packages or \"ntp\" in ansible_facts.packages ) and not ( \"yum\" in ansible_facts.packages ) )"
     platform_el = ET.fromstring(platform.to_xml_element())
     assert platform_el.tag == "{%s}platform" % cpe_language_namespace
     assert platform_el.get("id") == "systemd_and_chrony_or_ntp_and_not_yum"
@@ -361,6 +361,11 @@ def test_platform_as_dict(product_cpes):
     assert d["ansible_conditional"] == "( \"chrony\" in ansible_facts.packages )"
     assert d["bash_conditional"] == "( rpm --quiet -q chrony )"
     assert "xml_content" in d
+
+def test_platform_get_invalid_conditional_language(product_cpes):
+    platform = ssg.build_yaml.Platform.from_text("ntp or chrony", product_cpes)
+    with pytest.raises(AttributeError):
+        assert platform.get_remediation_conditional("foo")
 
 
 def test_derive_id_from_file_name():


### PR DESCRIPTION
#### Description:

- Platform.to_bash_conditional now becomes Platform.get_remediation_conditional("bash")
- the same goes for Ansible
- unit tests are adjusted accordignly

#### Rationale:

This will allow greater flexibility in future and it will make code deduplication easier.