### PR TITLE
build_remediations.py: deduplicate code which retrieves conditionals

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -139,11 +139,10 @@ class Remediation(object):
     def get_rule_specific_cpe_platform_names(self):
         rule_specific_cpe_platform_names = set()
         inherited_cpe_platform_names = self.get_inherited_cpe_platform_names()
-        if self.associated_rule:
-            if self.associated_rule.cpe_platform_names is not None:
-                rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names
-                    if p not in inherited_cpe_platform_names}
+        if self.associated_rule and self.associated_rule.cpe_platform_names is not None:
+            rule_specific_cpe_platform_names = {
+                p for p in self.associated_rule.cpe_platform_names
+                if p not in inherited_cpe_platform_names}
         return rule_specific_cpe_platform_names
 
     def get_stripped_conditionals(self, language, cpe_platform_names, cpe_platforms):

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -128,6 +128,46 @@ class Remediation(object):
     def parse_from_file_with_jinja(self, env_yaml, cpe_platforms):
         return parse_from_file_with_jinja(self.file_path, env_yaml)
 
+    def get_inherited_cpe_platform_names(self):
+        inherited_cpe_platform_names = set()
+        if self.associated_rule:
+            # There can be repeated inherited platforms and rule platforms
+            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
+        return inherited_cpe_platform_names
+
+    def get_rule_specific_cpe_platform_names(self):
+        rule_specific_cpe_platform_names = set()
+        inherited_cpe_platform_names = self.get_inherited_cpe_platform_names()
+        if self.associated_rule:
+            if self.associated_rule.cpe_platform_names is not None:
+                rule_specific_cpe_platform_names = {
+                    p for p in self.associated_rule.cpe_platform_names
+                    if p not in inherited_cpe_platform_names}
+        return rule_specific_cpe_platform_names
+
+    def get_stripped_conditionals(self, language, cpe_platform_names, cpe_platforms):
+        """
+        collect conditionals of platforms defined by cpe_platform_names
+        and strip them of white spaces
+        """
+        stripped_conditionals = []
+        for p in cpe_platform_names:
+            conditional = cpe_platforms[p].get_remediation_conditional(language)
+            if conditional is not None:
+                stripped_conditional = conditional.strip()
+                if stripped_conditional:
+                    stripped_conditionals.append(stripped_conditional)
+        return stripped_conditionals
+
+    def get_rule_specific_conditionals(self, language, cpe_platforms):
+        cpe_platform_names = self.get_rule_specific_cpe_platform_names()
+        return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
+
+    def get_inherited_conditionals(self, language, cpe_platforms):
+        cpe_platform_names = self.get_inherited_cpe_platform_names()
+        return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
+
+
 
 def process(remediation, env_yaml, cpe_platforms):
     """
@@ -179,28 +219,10 @@ class BashRemediation(Remediation):
         if stripped_fix_text == "":
             return result
 
-        rule_specific_cpe_platform_names = set()
-        inherited_cpe_platform_names = set()
-        if self.associated_rule:
-            # There can be repeated inherited platforms and rule platforms
-            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
-            if self.associated_rule.cpe_platform_names is not None:
-                rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names
-                    if p not in inherited_cpe_platform_names}
-
-        inherited_conditionals = [
-            cpe_platforms[p].get_remediation_conditional("bash")
-            for p in inherited_cpe_platform_names]
-        rule_specific_conditionals = [
-            cpe_platforms[p].get_remediation_conditional("bash")
-            for p in rule_specific_cpe_platform_names]
-        # remove potential "None" from lists
-        inherited_conditionals = sorted([
-            p for p in inherited_conditionals if p != ''])
-        rule_specific_conditionals = sorted([
-            p for p in rule_specific_conditionals if p != ''])
-
+        inherited_conditionals = super(
+            BashRemediation, self).get_inherited_conditionals("bash", cpe_platforms)
+        rule_specific_conditionals = super(
+            BashRemediation, self).get_rule_specific_conditionals("bash", cpe_platforms)
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
 
@@ -340,38 +362,20 @@ class AnsibleRemediation(Remediation):
 
     def update_when_from_rule(self, to_update, cpe_platforms):
         additional_when = []
-        rule_specific_cpe_platform_names = set()
-        inherited_cpe_platform_names = set()
-        if self.associated_rule:
-            # There can be repeated inherited platforms and rule platforms
-            inherited_cpe_platform_names.update(self.associated_rule.inherited_cpe_platform_names)
-            if self.associated_rule.cpe_platform_names is not None:
-                rule_specific_cpe_platform_names = {
-                    p for p in self.associated_rule.cpe_platform_names
-                    if p not in inherited_cpe_platform_names}
-
-        inherited_conditionals = [
-            cpe_platforms[p].get_remediation_conditional("ansible")
-            for p in inherited_cpe_platform_names]
-        rule_specific_conditionals = [
-            cpe_platforms[p].get_remediation_conditional("ansible")
-            for p in rule_specific_cpe_platform_names]
-        # remove potential "None" from lists
-        inherited_conditionals = sorted([
-            p for p in inherited_conditionals if p != ''])
-        rule_specific_conditionals = sorted([
-            p for p in rule_specific_conditionals if p != ''])
-
-        # remove conditionals related to package CPEs if the updated task
-        # collects package facts
+        inherited_conditionals = super(
+            AnsibleRemediation, self).get_inherited_conditionals("ansible", cpe_platforms)
+        rule_specific_conditionals = super(
+            AnsibleRemediation, self).get_rule_specific_conditionals("ansible", cpe_platforms)
+        # Remove conditionals related to package CPEs if the updated task collects package facts
         if "package_facts" in to_update:
-            inherited_conditionals = [
-                c for c in inherited_conditionals if "in ansible_facts.packages" not in c]
-            rule_specific_conditionals = [
-                c for c in rule_specific_conditionals if "in ansible_facts.packages" not in c]
+            inherited_conditionals = filter(
+                lambda c: "in ansible_facts.packages" not in c,
+                inherited_conditionals)
+            rule_specific_conditionals = filter(
+                lambda c: "in ansible_facts.packages" not in c, rule_specific_conditionals)
 
         if inherited_conditionals:
-            additional_when = additional_when + inherited_conditionals
+            additional_when.extend(inherited_conditionals)
 
         if rule_specific_conditionals:
             additional_when.append(" or ".join(rule_specific_conditionals))

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -35,6 +35,7 @@ REMEDIATION_CONFIG_KEYS = ['complexity', 'disruption', 'platform', 'reboot',
                            'strategy']
 REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
 
+RemediationObject = namedtuple('remediation', ['contents', 'config'])
 
 def is_supported_filename(remediation_type, filename):
     """
@@ -73,8 +74,7 @@ def split_remediation_content_and_metadata(fix_file):
         remediation_contents.append(line)
 
     contents = "\n".join(remediation_contents)
-    remediation = namedtuple('remediation', ['contents', 'config'])
-    return remediation(contents=contents, config=config)
+    return RemediationObject(contents=contents, config=config)
 
 
 def parse_from_file_with_jinja(file_path, env_yaml):
@@ -224,8 +224,7 @@ class BashRemediation(Remediation):
                 "    >&2 echo 'Remediation is not applicable, nothing was done'")
             wrapped_fix_text.append("fi")
 
-            remediation = namedtuple('remediation', ['contents', 'config'])
-            result = remediation(contents="\n".join(wrapped_fix_text), config=result.config)
+            result = RemediationObject(contents="\n".join(wrapped_fix_text), config=result.config)
 
         return result
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -37,6 +37,7 @@ REMEDIATION_ELM_KEYS = ['complexity', 'disruption', 'reboot', 'strategy']
 
 RemediationObject = namedtuple('remediation', ['contents', 'config'])
 
+
 def is_supported_filename(remediation_type, filename):
     """
     Checks if filename has a supported extension for remediation_type.
@@ -166,7 +167,6 @@ class Remediation(object):
     def get_inherited_conditionals(self, language, cpe_platforms):
         cpe_platform_names = self.get_inherited_cpe_platform_names()
         return self.get_stripped_conditionals(language, cpe_platform_names, cpe_platforms)
-
 
 
 def process(remediation, env_yaml, cpe_platforms):


### PR DESCRIPTION
#### Description:

Code for retrieving remediation conditionals of rules was duplicated. Now the processing is defined at one place.

See commit messages for more information.

#### Rationale:

Deduplication of code.