### PR TITLE
Fix broken Automatus CI jobs

### DIFF
--- a/.github/workflows/automatus-cs8.yaml
+++ b/.github/workflows/automatus-cs8.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -104,28 +104,28 @@ jobs:
       - name: Get rule ids to be tested
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'rules'
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Get bash attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'bash'
       - name: Get ansible attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'ansible'

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -104,28 +104,28 @@ jobs:
       - name: Get rule ids to be tested
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'rules'
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Get bash attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'bash'
       - name: Get ansible attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'ansible'

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'
@@ -102,28 +102,28 @@ jobs:
       - name: Get rule ids to be tested
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: rules
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'rules'
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'
       - name: Get bash attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: bash
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'bash'
       - name: Get ansible attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: ansible
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'ansible'

--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'

--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Get product attribute
         if: ${{ steps.ctf.outputs.CTF_OUTPUT_SIZE != '0' }}
         id: product
-        uses: notiz-dev/github-action-json-property@release
+        uses: notiz-dev/github-action-json-property@v0.1.0
         with:
           path: 'output.json'
           prop_path: 'product'


### PR DESCRIPTION
The latest release of
https://github.com/notiz-dev/github-action-json-property caused that the parameters of the test_rule_in_container.sh contain `[` and `]`, which it doesn't understand. The old version of the
github-action-json-property doesn't suffer from this problem.

This is a temporary solution until we find how to use the new version.

