### PR TITLE
Align ClientAliveCountMax on RHEL8 STIG V1R8

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/oval/shared.xml
@@ -49,7 +49,7 @@
   <ind:textfilecontent54_object id="obj_sshd_clientalivecountmax" version="2">
     <ind:filepath>/etc/ssh/sshd_config</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*(?i)ClientAliveCountMax[\s]+([\d]+)[\s]*(?:#.*)?$</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{%- if sshd_distributed_config == "true" %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -7,14 +7,15 @@ description: |-
     during a SSH session and waits for a response from the SSH client.
     The option <tt>ClientAliveInterval</tt> configures timeout after
     each <tt>ClientAliveCountMax</tt> message. If the SSH server does not
-    receive a response from the client, then the connection is considered idle
+    receive a response from the client, then the connection is considered unresponsive
     and terminated.
     For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt>
-    causes an idle timeout precisely when the <tt>ClientAliveInterval</tt> is set.
+    causes a timeout precisely when the <tt>ClientAliveInterval</tt> is set.
     Starting with v8.2, a value of <tt>0</tt> disables the timeout functionality
     completely. If the option is set to a number greater than <tt>0</tt>, then
-    the idle session will be disconnected after
-    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds.
+    the session will be disconnected after
+    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds without receiving
+    a keep alive message.
 
 rationale: |-
     This ensures a user login will be terminated as soon as the <tt>ClientAliveInterval</tt>
@@ -70,8 +71,8 @@ ocil: |-
     <pre>$ sudo grep ClientAliveCountMax /etc/ssh/sshd_config</pre>
     If properly configured, the output should be:
     <pre>ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}</pre>
-    For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt> causes an idle timeout precisely when
+    For SSH earlier than v8.2, a <tt>ClientAliveCountMax</tt> value of <tt>0</tt> causes a timeout precisely when
     the <tt>ClientAliveInterval</tt> is set.  Starting with v8.2, a value of <tt>0</tt> disables the timeout
     functionality completely.
-    If the option is set to a number greater than <tt>0</tt>, then the idle session will be disconnected after
-    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds.
+    If the option is set to a number greater than <tt>0</tt>, then the session will be disconnected after
+    <tt>ClientAliveInterval * ClientAliveCountMax</tt> seconds witout receiving a keep alive message.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -55,6 +55,7 @@ references:
     pcidss: Req-8.1.8
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
     stigid@ol7: OL07-00-040340
+    stigid@rhel8: RHEL-08-010200
     stigid@sle12: SLES-12-030191
     stigid@ubuntu2004: UBTU-20-010036
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/param_conflict.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/param_conflict.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+	sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "ClientAliveCountMax 0" >> /etc/ssh/sshd_config
+echo "ClientAliveCountMax 1" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/param_conflict_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/tests/param_conflict_directory.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*ClientAliveCountMax" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+	sed -i "/^\s*ClientAliveCountMax.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "ClientAliveCountMax 0" > /etc/ssh/sshd_config.d/good_config.conf
+echo "ClientAliveCountMax 1" > /etc/ssh/sshd_config.d/bad_config.conf

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
@@ -54,7 +54,6 @@ references:
     stigid@ol7: OL07-00-040340
     stigid@ol8: OL08-00-010200
     stigid@rhel7: RHEL-07-040340
-    stigid@rhel8: RHEL-08-010200
     stigid@sle12: SLES-12-030191
     stigid@sle15: SLES-15-010320
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive_0/rule.yml
@@ -10,10 +10,10 @@ description: |-
     during a SSH session and waits for a response from the SSH client.
     The option <tt>ClientAliveInterval</tt> configures timeout after
     each <tt>ClientAliveCountMax</tt> message. If the SSH server does not
-    receive a response from the client, then the connection is considered idle
+    receive a response from the client, then the connection is considered unresponsive
     and terminated.
 
-    To ensure the SSH idle timeout occurs precisely when the
+    To ensure the SSH timeout occurs precisely when the
     <tt>ClientAliveInterval</tt> is set, set the <tt>ClientAliveCountMax</tt> to
     value of <tt>0</tt> in
     {{{ sshd_config_file() }}}
@@ -73,7 +73,7 @@ ocil: |-
     If properly configured, the output should be:
     <pre>ClientAliveCountMax 0</pre>
 
-    In this case, the SSH idle timeout occurs precisely when
+    In this case, the SSH timeout occurs precisely when
     the <tt>ClientAliveInterval</tt> is set.
 
 template:

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -50,7 +50,7 @@ selections:
     - var_password_pam_lcredit=1
     - var_password_pam_retry=3
     - var_password_pam_minlen=15
-    # - var_sshd_set_keepalive=0
+    - var_sshd_set_keepalive=1
     - sshd_approved_macs=stig
     - sshd_approved_ciphers=stig
     - sshd_idle_timeout_value=10_minutes
@@ -174,7 +174,7 @@ selections:
     # they still need to be selected so it follows exactly what STIG
     # states.
     # RHEL-08-010200
-    - sshd_set_keepalive_0
+    - sshd_set_keepalive
     # RHEL-08-010201
     - sshd_set_idle_timeout
 


### PR DESCRIPTION
#### Description:

- RHEL8 STIG V1R8 configures `ClientAliveCountMax 1`.
  - This change is valid and keeps the timeout by network availability.
- Update description of `sshd_set_keepalive` to reduce misunderstanding of what the rule configures, which is the timeout of SSH sessions based on network timeout, not user idleness.

#### Rationale:

- Align with RHEL8 STIG V1R8