### PR TITLE
OCP4: 4.12 uses ebs.csi.aws.com not kubernetes.io/aws-ebs as storage provisioner on AWS

### DIFF
--- a/applications/openshift/integrity/crypto/storageclass_encryption_enabled/rule.yml
+++ b/applications/openshift/integrity/crypto/storageclass_encryption_enabled/rule.yml
@@ -26,20 +26,22 @@ ocil_clause: 'EBS encryption is not enabled on storage classes'
 
 ocil: |-
     Run the following command to retrieve if the EBS encryption is enabled:
-    <pre>$ oc get storageclass -o json| jq '[.items[] | select (.provisioner == "kubernetes.io/aws-ebs")] | map(.parameters.encrypted)'</pre>
+    <pre>$ oc get storageclass -o json | jq {{{ jqfilter }}}</pre>
     Make sure that the result is an array of 'true' values.
+
+{{% set jqfilter = '[.items[] | select (.provisioner == "kubernetes.io/aws-ebs" or .provisioner == "ebs.csi.aws.com")] | map(.parameters.encrypted)' %}}
 
 severity: high
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/apis/storage.k8s.io/v1/storageclasses': '[.items[] | select (.provisioner == "kubernetes.io/aws-ebs")] | map(.parameters.encrypted)'}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/apis/storage.k8s.io/v1/storageclasses': jqfilter}) | indent(4) }}}
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path('/apis/storage.k8s.io/v1/storageclasses', '[.items[] | select (.provisioner == "kubernetes.io/aws-ebs")] | map(.parameters.encrypted)') }}}
+      {{{ openshift_filtered_path('/apis/storage.k8s.io/v1/storageclasses', jqfilter) }}}
     yamlpath: "[:]"
     check_existence: "all_exist"
     entity_check: "all"

--- a/applications/openshift/integrity/crypto/storageclass_encryption_enabled/tests/storageclass_encrypted.pass.sh
+++ b/applications/openshift/integrity/crypto/storageclass_encryption_enabled/tests/storageclass_encrypted.pass.sh
@@ -103,7 +103,7 @@ cat <<EOF > "$kube_apipath/$storageclass_apipath"
 }
 EOF
 
-jq_filter='[.items[] | select (.provisioner == "kubernetes.io/aws-ebs")] | map(.parameters.encrypted)'
+jq_filter='[.items[] | select (.provisioner == "kubernetes.io/aws-ebs" or .provisioner == "ebs.csi.aws.com")] | map(.parameters.encrypted)'
 
 # Get filtered path. This will actually be read by the scan
 filteredpath="$kube_apipath/$storageclass_apipath#$(echo -n "$storageclass_apipath$jq_filter" | sha256sum | awk '{print $1}')"

--- a/applications/openshift/integrity/crypto/storageclass_encryption_enabled/tests/storageclass_encrypted_csi_driver.pass.sh
+++ b/applications/openshift/integrity/crypto/storageclass_encryption_enabled/tests/storageclass_encrypted_csi_driver.pass.sh
@@ -69,10 +69,10 @@ cat <<EOF > "$kube_apipath/$storageclass_apipath"
                 "uid": "ef333e5a-0429-4494-a419-1398636e1c64"
             },
             "parameters": {
-                "encrypted": "false",
+                "encrypted": "true",
                 "type": "gp2"
             },
-            "provisioner": "kubernetes.io/aws-ebs",
+            "provisioner": "ebs.csi.aws.com",
             "reclaimPolicy": "Delete",
             "volumeBindingMode": "WaitForFirstConsumer"
         },
@@ -110,3 +110,4 @@ filteredpath="$kube_apipath/$storageclass_apipath#$(echo -n "$storageclass_apipa
 
 # populate filtered path with jq-filtered result
 jq "$jq_filter" "$kube_apipath/$storageclass_apipath" > "$filteredpath"
+


### PR DESCRIPTION
#### Description:

The two provisioners are more or less equal, except kubernetes.io/aws-ebs
was an in-tree one that's no longer maintained and ebs.csi.aws.com is a
CSI driver maintained by AWS


#### Rationale:

Porting OCP4 content to 4.12

#### Review Hints:

- get a 4.12 cluster
- push the profile into the cluster (`./utils/build_ds_container.py -c -p`)
- run a PCI-DSS profile. I used:
```
piVersion: compliance.openshift.io/v1alpha1
kind: ScanSettingBinding
metadata:
  name: pcidss-compliance
profiles:
  - name: upstream-ocp4-pci-dss-node
    kind: Profile
    apiGroup: compliance.openshift.io/v1alpha1
  - name: upstream-ocp4-pci-dss
    kind: Profile
    apiGroup: compliance.openshift.io/v1alpha1
settingsRef:
  name: default
  kind: ScanSetting
  apiGroup: compliance.openshift.io/v1alpha1
```
- the rule `storageclass-encryption-enabled` should pass