### PR TITLE
OCP4: Don't select ocp4-node-on-ovn rules for NIST high profile

### DIFF
--- a/products/ocp4/profiles/high.profile
+++ b/products/ocp4/profiles/high.profile
@@ -37,7 +37,7 @@ description: |-
     content as minor divergences, such as bugfixes, work through the
     consensus and release processes.
 
-filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms'
+filter_rules: '"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
 
 # CM-6 CONFIGURATION SETTINGS
 # CM-6(1) CONFIGURATION SETTINGS | AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION


### PR DESCRIPTION
#### Description:

They only belong to the high-node profile.

#### Rationale:

With the switch to OVN by default, this means that the nist-high profile contains a couple of rules that don't belong there.

#### Review Hints:

- run a high OCP4 profile, make sure that no OVN rules show up (not even as NOT_APPLICABLE)