### PR TITLE
Sync rules for RHEL 9 STIG

### DIFF
--- a/controls/srg_gpos/SRG-OS-000120-GPOS-00061.yml
+++ b/controls/srg_gpos/SRG-OS-000120-GPOS-00061.yml
@@ -9,6 +9,5 @@ controls:
             - accounts_password_all_shadowed_sha512
             - package_rsyslog-gnutls_installed
             - libreswan_approved_tunnels
-            - configure_kerberos_crypto_policy
             - set_password_hashing_algorithm_passwordauth
         status: automated

--- a/controls/srg_gpos/SRG-OS-000163-GPOS-00072.yml
+++ b/controls/srg_gpos/SRG-OS-000163-GPOS-00072.yml
@@ -11,7 +11,6 @@ controls:
         rules:
             - sshd_set_idle_timeout
             - sshd_set_keepalive
-            - sshd_set_keepalive_0
             - accounts_tmout
             - var_accounts_tmout=10_min
         status_justification: |-

--- a/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
+++ b/controls/srg_gpos/SRG-OS-000250-GPOS-00093.yml
@@ -11,4 +11,5 @@ controls:
             - configure_openssl_tls_crypto_policy
             - configure_ssh_crypto_policy
             - harden_sshd_ciphers_opensshserver_conf_crypto_policy
+            - harden_sshd_macs_opensshserver_conf_crypto_policy
         status: automated

--- a/controls/srg_gpos/SRG-OS-000279-GPOS-00109.yml
+++ b/controls/srg_gpos/SRG-OS-000279-GPOS-00109.yml
@@ -7,4 +7,3 @@ controls:
         status: automated
         rules:
             - sshd_set_idle_timeout
-            - sshd_set_keepalive_0

--- a/controls/srg_gpos/SRG-OS-000341-GPOS-00132.yml
+++ b/controls/srg_gpos/SRG-OS-000341-GPOS-00132.yml
@@ -8,4 +8,5 @@ controls:
         rules:
             - grub2_audit_backlog_limit_argument
             - partition_for_var_log_audit
+            - auditd_audispd_configure_sufficiently_large_partition
         status: automated

--- a/controls/srg_gpos/SRG-OS-000368-GPOS-00154.yml
+++ b/controls/srg_gpos/SRG-OS-000368-GPOS-00154.yml
@@ -10,6 +10,7 @@ controls:
             - service_fapolicyd_enabled
             - mount_option_boot_nodev
             - mount_option_boot_nosuid
+            - mount_option_boot_efi_nosuid
             - mount_option_dev_shm_nodev
             - mount_option_dev_shm_noexec
             - mount_option_dev_shm_nosuid

--- a/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
+++ b/controls/srg_gpos/SRG-OS-000480-GPOS-00227.yml
@@ -129,7 +129,6 @@ controls:
             - sshd_enable_strictmodes
             - sshd_print_last_log
             - sshd_rekey_limit
-            - sshd_use_strong_rng
             - sshd_x11_use_localhost
 
             # auditd config
@@ -147,8 +146,9 @@ controls:
             - sysctl_net_ipv6_conf_default_accept_source_route
             - sysctl_net_ipv4_conf_all_accept_redirects
             - sysctl_net_ipv4_conf_all_accept_source_route
-            - sysctl_net_ipv4_conf_all_log_martians
+            - sysctl_net_ipv4_conf_default_accept_source_route
             - sysctl_net_ipv4_conf_all_rp_filter
+            - sysctl_net_ipv4_conf_default_rp_filter
             - sysctl_net_ipv4_conf_all_secure_redirects
             - sysctl_net_ipv4_icmp_echo_ignore_broadcasts
             - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
@@ -188,6 +188,7 @@ controls:
             - dconf_gnome_disable_autorun
             - dconf_gnome_disable_ctrlaltdel_reboot
             - dconf_gnome_disable_user_list
+            - dconf_gnome_disable_restart_shutdown
             - dconf_db_up_to_date
 
             # partition
@@ -236,6 +237,5 @@ controls:
             - display_login_attempts
             - installed_OS_is_vendor_supported
             - security_patches_up_to_date
-            - grub2_kernel_trust_cpu_rng
 
         status: automated

--- a/linux_os/guide/services/base/service_kdump_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/policy/stig/shared.yml
@@ -9,36 +9,35 @@ vuldiscussion: |-
     development or testing, there is little need to run the kdump service.
 
 checktext: |-
-    To check that the  kdump  service is disabled in system boot configuration,
-    run the following command:
-     $ sudo systemctl is-enabled  kdump
-    Output should indicate the  kdump  service has either not been installed,
-    or has been disabled at all runlevels, as shown in the example below:
-     $ sudo systemctl is-enabled  kdump
-     disabled
+    Verify that the kdump service is disabled in system boot configuration with the following command:
 
-    Run the following command to verify  kdump  is not active (i.e. not running) through current runtime configuration:
-     $ sudo systemctl is-active kdump
+    $ systemctl is-enabled  kdump
 
-    If the service is not running the command will return the following output:
-     inactive
+    disabled
 
-    The service will also be masked, to check that the  kdump  is masked, run the following command:
-     $ sudo systemctl show  kdump  | grep "LoadState\|UnitFileState"
+    Verify that the kdump service is not active (i.e. not running) through current runtime configuration with the following command:
 
-    If the service is masked the command will return the following outputs:
+    $ systemctl is-active kdump
 
-     LoadState=masked
+    inactive
+    Verify that the kdump service is masked with the following command:
 
-     UnitFileState=masked
+    $ sudo systemctl show  kdump  | grep "LoadState\|UnitFileState"
 
-    If the "kdump" is loaded and not masked, then this is a finding.
+    LoadState=masked
+
+    UnitFileState=masked
+
+    If the "kdump" service is loaded or active, and is not masked, this is a finding.
 
 fixtext: |-
-    Disable the kdump {{{ full_name }}} service.
+    Disable and mask the kdump service on {{{ full_name }}}.
 
     To disable the kdump service run the following command:
 
     $ sudo systemctl disable --now kdump
 
+    To mask the kdump service run the following command:
+
+    $ sudo systemctl mask --now kdump
     $ sudo systemctl mask --now kdump

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/policy/stig/shared.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/policy/stig/shared.yml
@@ -7,10 +7,10 @@ vuldiscussion: |-
     correct group to prevent unauthorized changes.
 
 checktext: |-
-    To check the group ownership of all cron configuration files,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/cron*
-    If properly configured, the output should indicate the following group-owner for all files:
+    Verify the group ownership of all cron configuration files with the following command:
+
+    $ stat -c "%G %n" /etc/cron*
+
     root /etc/cron.d
     root /etc/cron.daily
     root /etc/cron.deny
@@ -19,8 +19,7 @@ checktext: |-
     root /etc/crontab
     root /etc/cron.weekly
 
-
-    If any crontab is not group owned by group, this is a finding.
+    If any crontab is not group owned by root, this is a finding.
 
 fixtext: |-
     Configure any cron configuration not group-owned by root with the following command:

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/policy/stig/shared.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/policy/stig/shared.yml
@@ -7,10 +7,10 @@ vuldiscussion: |-
     correct group to prevent unauthorized changes.
 
 checktext: |-
-    To check the group ownership of all cron configuration files,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/cron*
-    If properly configured, the output should indicate the following owner for all files:
+    Verify the ownership of all cron configuration files with the command:
+
+    $ stat -c "%U %n" /etc/cron*
+
     root /etc/cron.d
     root /etc/cron.daily
     root /etc/cron.deny
@@ -19,8 +19,7 @@ checktext: |-
     root /etc/crontab
     root /etc/cron.weekly
 
-
-    If any crontab is not owned by group, this is a finding.
+    If any crontab is not owned by root, this is a finding.
 
 fixtext: |-
     Configure any cron configuration not owned by root with the following command:

--- a/linux_os/guide/services/cron_and_at/file_permissions_cron_d/policy/stig/shared.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_cron_d/policy/stig/shared.yml
@@ -7,10 +7,9 @@ vuldiscussion: |-
     correct access rights to prevent unauthorized changes.
 
 checktext: |-
-    To check the permissions of the cron directories,
-    run the command:
-     $ find /etc/cron* -type d | xargs stat -c "%a %n"
-    If properly configured, the output should indicate the following permissions:
+    Verify the permissions of the cron directories with the following command:
+
+    $ find /etc/cron* -type d | xargs stat -c "%a %n"
 
     700 /etc/cron.d
     700 /etc/cron.daily
@@ -18,8 +17,7 @@ checktext: |-
     700 /etc/cron.monthly
     700 /etc/cron.weekly
 
-
-    If any cron configuration directory is more permissive than 700, then this is a finding.
+    If any cron configuration directory is more permissive than 700, this is a finding.
 
 fixtext: |-
     Configure any {{{ full_name }}} cron configration directory with a mode more permissive than 0700 as follows:

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/policy/stig/shared.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} file must have mode 0600 /etc/crontab.
+    The {{{ full_name }}} /etc/crontab file must have mode 0600.
 
 vuldiscussion: |-
     Service configuration files enable or disable features of their respective services that if configured incorrectly
@@ -7,15 +7,16 @@ vuldiscussion: |-
     correct access rights to prevent unauthorized changes.
 
 checktext: |-
-    To check the permissions of  /etc/crontab ,
-    run the command:
-     $ stat -c "%a %n" /etc/crontab
-    If properly configured, the output should indicate the following permissions:
-    644
+    Verify the permissions of /etc/crontab with the following command:
 
-    If /etc/crontab does not have unix mode 644 then this is a finding.
+    $ stat -c "%a %n" /etc/crontab
+
+    0600
+
+    If /etc/crontab does not have a mode of 0600, this is a finding.
 
 fixtext: |-
     Configure the {{{ full_name }}} file /etc/crontab with mode 600.
 
+    $ sudo chmod 0600 /etc/crontab
     chmod 0600 /etc/crontab

--- a/linux_os/guide/services/fapolicyd/package_fapolicyd_installed/policy/stig/shared.yml
+++ b/linux_os/guide/services/fapolicyd/package_fapolicyd_installed/policy/stig/shared.yml
@@ -19,9 +19,9 @@ checktext: |-
 
     fapolicyd.x86_64      1.1-103.el9_0
 
-    If the fapolicyd package is not installed, this is a finding.
+    If the "fapolicyd" package is not installed, this is a finding.
 
 fixtext: |-
-    The fapolicyd package can be installed with the following command:
+    The  fapolicyd  package can be installed with the following command:
 
     $ sudo dnf install fapolicyd

--- a/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/policy/stig/shared.yml
+++ b/linux_os/guide/services/fapolicyd/service_fapolicyd_enabled/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     active
 
-    If fapolicyd is not active, this is a finding.
+    If fapolicyd module is not active, this is a finding.
 
 fixtext: |-
     Enable the fapolicyd with the following command:

--- a/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ftp/disabling_vsftpd/package_vsftpd_removed/policy/stig/shared.yml
@@ -10,7 +10,7 @@ checktext: |-
 
     $ sudo dnf list --installed | grep ftp
 
-    If a ftp package is installed, this is a finding.
+    If the "ftp" package is installed, this is a finding.
 
 fixtext: |-
     The ftp package can be removed with the following command (using vsftpd as an example):

--- a/linux_os/guide/services/mail/package_sendmail_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/mail/package_sendmail_removed/policy/stig/shared.yml
@@ -13,7 +13,7 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the sendmail package is installed, this is a finding.
+    If the "sendmail" package is installed, this is a finding.
 
 fixtext: |-
     Remove the sendmail package with the following command:

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/policy/stig/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/policy/stig/shared.yml
@@ -9,11 +9,12 @@ vuldiscussion: |-
     This requirement applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the centralized audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both.
 
 checktext: |-
-    Find the list of alias maps used by the Postfix mail server for root.
+    Verify that {{{ full_name }}} is configured to notify the appropraite interactive users in the event of an audit processing failure.
 
     Find the alias maps that are being used with the following command:
 
     $ postconf alias_maps
+
     alias_maps = hash:/etc/aliases
 
     Query the Postfix alias maps for an alias for the root user with the following command:
@@ -21,7 +22,7 @@ checktext: |-
     $ postmap -q root hash:/etc/aliases
     isso
 
-    If an alias is not set, then this is a finding.
+    If an alias is not set, this is a finding.
 
 fixtext: |-
     Edit the aliases map file (by default /etc/aliases) used by Postfix and configure a root alias (using the user ISSO as an example):

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/policy/stig/shared.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias_postmaster/policy/stig/shared.yml
@@ -11,14 +11,15 @@ vuldiscussion: |-
     mechanisms, and audit storage capacity being reached or exceeded.
 
 checktext: |-
-   Verify that the administrators are notified in the event of an audit processing failure.
+    Verify that the administrators are notified in the event of an audit processing failure.
 
-    Check that the "/etc/aliases" file has a defined value for "root".
+     Check that the "/etc/aliases" file has a defined value for "root".
 
-    $ sudo grep "postmaster:\s*root$" /etc/aliases
+     $ sudo grep "postmaster:\s*root$" /etc/aliases
 
-    If the command does not return a line, or the line is commented out, ask the system administrator to indicate how they and the ISSO are notified of an audit process failure.
-    If there is no evidence of the proper personnel being notified of an audit processing failure, this is a finding.
+     If the command does not return a line, or the line is commented out, ask the system administrator to indicate how they and the ISSO are notified of an audit process failure.
+     If there is no evidence of the proper personnel being notified of an audit processing failure, this is a finding.
+
 
 fixtext: |-
     Configure a valid email address as an alias for the root account.

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/policy/stig/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/policy/stig/shared.yml
@@ -1,0 +1,20 @@
+srg_requirement: |-
+    {{{ full_name }}} must be configured so that the Network File System (NFS) is configured to use RPCSEC_GSS.
+
+vuldiscussion: |-
+    When an NFS server is configured to use RPCSEC_SYS, a selected userid and groupid are used to handle requests from the remote user. The userid and groupid could mistakenly or maliciously be set incorrectly. The RPCSEC_GSS method of authentication uses certificates on the server and client systems to more securely authenticate the remote mount request.
+
+checktext: |-
+    Verify {{{ full_name }}} has the "sec" option configured for all NFS mounts with the following command:
+
+    $ cat /etc/fstab | grep nfs
+
+    192.168.22.2:/mnt/export /data nfs4 rw,nosuid,nodev,noexec,sync,soft,sec=krb5p:krb5i:krb5
+
+    If no NFS mounts are configured this requirement is not applicable.
+
+    If the system is mounting file systems via NFS and has the sec option without the "krb5:krb5i:krb5p" settings, the "sec" option has the "sys" setting, or the "sec" option is missing, this is a finding.
+
+fixtext: |-
+    Update each NFS mounted file system to use the "sec" option with flavors defined as "krb5p:krb5i:krb5".
+

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/policy/stig/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/policy/stig/shared.yml
@@ -22,3 +22,4 @@ fixtext: |-
     Update the "/etc/fstab" file so the option "sec" is defined for each NFS mounted file system and the "sec" option does not have the "sys" setting.
 
     Ensure the "sec" option is defined as "krb5p:krb5i:krb5".
+

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the nfs-utils package is installed, this is a finding.
+    If the "nfs-utils" package is installed, this is a finding.
 
 fixtext: |-
     Remove the nfs-utils package with the following command:

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/policy/stig/shared.yml
@@ -21,3 +21,4 @@ fixtext: |-
     Remove the nfs-utils package with the following command:
 
     $ sudo dnf remove nfs-utils
+

--- a/linux_os/guide/services/ntp/chronyd_server_directive/policy/stig/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/policy/stig/shared.yml
@@ -2,14 +2,27 @@ srg_requirement: |-
     {{{ full_name }}} must securely compare internal information system clocks at least every 24 hours with a server synchronized to an authoritative time source, such as the United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).
 
 vuldiscussion: |-
+    Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events. Sources outside the configured acceptable allowance (drift) may be inaccurate.
+
+    Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
+
     Depending on the infrastruture being used the "pool" directive may not be supported.
 
 checktext: |-
-    Run the following command and verify that time sources are only configure with "server" directive:
-     # grep -E "^(server|pool)" /etc/chrony.conf
-    A line with the appropriate server should be returned, any line returned starting with "pool" is a finding.
+    Verify {{{ full_name }}} is securely comparing internal information system clocks at least every 24 hours with an NTP server with the following commands:
 
-    If an authoritative remote time server is not configured or configured with pool directive, then this is a finding.
+    $ sudo grep maxpoll /etc/chrony.conf
+
+    server 0.us.pool.ntp.mil iburst maxpoll 16
+
+    If the "maxpoll" option is set to a number greater than 16 or the line is commented out, this is a finding.
+
+    Verify the "chrony.conf" file is configured to an authoritative DoD time source by running the following command:
+
+    $ sudo grep -i server /etc/chrony.conf
+    server 0.us.pool.ntp.mil
+
+    If the parameter "server" is not set or is not set to an authoritative DoD time source, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to securely compare internal information system clocks at least every 24 hours with an NTP server by adding/modifying the following line in the /etc/chrony.conf file.

--- a/linux_os/guide/services/ntp/package_chrony_installed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     chrony.x86_64                                                                4.1-3.el9
 
-    If the chrony package is not installed, this is a finding.
+    If the "chrony" package is not installed, this is a finding.
 
 fixtext: |-
     The chrony package can be installed with the following command:

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/policy/stig/shared.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/policy/stig/shared.yml
@@ -1,17 +1,19 @@
 srg_requirement: |-
-    The {{{ full_name }}} service chronyd must be enabled.
+    The {{{ full_name }}} chronyd service must be enabled.
 
 vuldiscussion: |-
-    If chrony is in use on the system proper configuration is vital to ensuring time
-    synchronization is working properly.
+    Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events. Sources outside the configured acceptable allowance (drift) may be inaccurate.
+
+    Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
 
 checktext: |-
-    Run the following command to determine the current status of the
-     chronyd service:
-     $ sudo systemctl is-active chronyd
-    If the service is running, it should return the following: active
+    Verify the chronyd service is active with the following command:
 
-    If the chronyd process is not running, then this is a finding.
+    $ systemctl is-active chronyd
+
+    active
+
+    If the chronyd service is not active, this is a finding.
 
 fixtext: |-
     To enable the chronyd service run the following command:

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/policy/stig/shared.yml
@@ -25,9 +25,10 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the telnet-server package is installed, this is a finding.
+    If the "telnet-server" package is installed, this is a finding.
 
 fixtext: |-
     Remove the telnet-server package with the following command:
 
     $ sudo dnf remove telnet-server
+

--- a/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/package_tftp-server_removed/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ sudo dnf list --installed | grep tftp
 
-    If a tftp package is installed, this is a finding.
+    If the "tftp" package is installed, this is a finding.
 
 fixtext: |-
     The tftp package can be removed with the following command:

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/policy/stig/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/policy/stig/shared.yml
@@ -14,13 +14,12 @@ checktext: |-
 
     tftp-server.x86_64    5.2-35.el9.x86_64
 
-    If a TFTP server is not installed, this is Not Applicable.
+    If a TFTP server is not installed, this requirement is Not Applicable.
 
     If a TFTP server is installed, check for the server arguments with the following command:
 
-    $ systemctl cat tftp | grep ExecStart=
+    $ systemctl cat tftp | grep ExecStart
     ExecStart=/usr/sbin/in.tftpd -s /var/lib/tftpboot
-
 
     If the "ExecStart" line does not have a "-s" option, and a subdirectory is not assigned, this is a finding.
 

--- a/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/policy/stig/shared.yml
@@ -19,4 +19,3 @@ fixtext: |-
     Remove the quagga package with the following command:
 
     $ sudo dnf remove quagga
-

--- a/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/routing/disabling_quagga/package_quagga_removed/policy/stig/shared.yml
@@ -13,9 +13,10 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the quagga package is installed, and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
+    If the "quagga" package is installed, and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
 fixtext: |-
     Remove the quagga package with the following command:
 
     $ sudo dnf remove quagga
+

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     rw-------. 1 root root 3669 Feb 22 11:34 /etc/ssh/sshd_config
 
-    If the "/etc/ssh/sshd_config" file does not have a group owner of "root", then this is a finding.
+    If the "/etc/ssh/sshd_config" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Configure the "/etc/ssh/sshd_config" file to be group-owned by root with the following command:

--- a/linux_os/guide/services/ssh/file_owner_sshd_config/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/file_owner_sshd_config/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     rw-------. 1 root root 3669 Feb 22 11:34 /etc/ssh/sshd_config
 
-    If the "/etc/ssh/sshd_config" file does not have an owner of "root", then this is a finding.
+    If the "/etc/ssh/sshd_config" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
     Configure the "/etc/ssh/sshd_config" file to be owned by root with the following command:

--- a/linux_os/guide/services/ssh/file_permissions_sshd_config/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_config/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     rw-------. 1 root root 3669 Feb 22 11:34 /etc/ssh/sshd_config
 
-    If the "/etc/ssh/sshd_config" permissions are not 0600, then this is a finding.
+    If the "/etc/ssh/sshd_config" permissions are not 0600, this is a finding.
 
 fixtext: |-
     Configure the "/etc/ssh/sshd_config" permissions to be 0600 with the following command:

--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/policy/stig/shared.yml
@@ -6,7 +6,7 @@ vuldiscussion: |-
     impersonated.
 
 checktext: |-
-    Verify the SSH private host key files have mode "0600" or less permissive with the following command:
+    Verify the SSH private host key files have a mode of "0600" or less permissive with the following command:
 
     $ ls -l /etc/ssh/*_key
 

--- a/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_pub_key/policy/stig/shared.yml
@@ -6,7 +6,7 @@ vuldiscussion: |-
     may be compromised.
 
 checktext: |-
-    Verify the SSH public host key files have mode "0644" or less permissive with the following command:
+    Verify the SSH public host key files have a mode of "0644" or less permissive with the following command:
 
     Note: SSH public key files may be found in other directories on the system depending on the installation.
 
@@ -16,7 +16,6 @@ checktext: |-
     644 /etc/ssh/ssh_host_ecdsa_key.pub
     644 /etc/ssh/ssh_host_ed25519_key.pub
     644 /etc/ssh/ssh_host_rsa_key.pub
-
 
     If any key.pub file has a mode more permissive than "0644", this is a finding.
 

--- a/linux_os/guide/services/ssh/package_openssh-clients_installed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/package_openssh-clients_installed/policy/stig/shared.yml
@@ -5,7 +5,13 @@ vuldiscussion: |-
     This package includes utilities to make encrypted connections and transfer files securely to SSH servers.
 
 checktext: |-
-    Verify that {{{ full_name }}} has the openssh-clients package installed with the following command:$sudo dnf list --installed openssh-clientsopenssh-clients.x86_64     8.7p1-8.el9If a openssh-clients package is not installed, this is a finding.
+    Verify that {{{ full_name }}} has the openssh-clients package installed with the following command:
+
+    $sudo dnf list --installed openssh-clients
+
+    openssh-clients.x86_64             8.7p1-8.el9
+
+    If the "openssh-clients" package is not installed, this is a finding.
 
 fixtext: |-
     The  openssh-clients  package can be installed with the following command:

--- a/linux_os/guide/services/ssh/package_openssh-server_installed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/policy/stig/shared.yml
@@ -9,7 +9,13 @@ vuldiscussion: |-
     Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.
 
 checktext: |-
-    Verify that {{{ full_name }}} has the openssh-server package installed with the following command:$ sudo dnf list --installed openssh-serveropenssh-server.x86_64    8.7p1-8.el9If the openssh-server package is not installed, this is a finding.
+    Verify that {{{ full_name }}} has the openssh-server package installed with the following command:
+
+    $ sudo dnf list --installed openssh-server
+
+    openssh-server.x86_64            8.7p1-8.el9
+
+    If the "openssh-server" package is not installed, this is a finding.
 
 fixtext: |-
     The  openssh-server  package can be installed with the following command:

--- a/linux_os/guide/services/ssh/package_openssh-server_installed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/policy/stig/shared.yml
@@ -21,3 +21,4 @@ fixtext: |-
     The  openssh-server  package can be installed with the following command:
 
     $ sudo dnf install openssh-server
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_gssapi_auth/policy/stig/shared.yml
@@ -16,7 +16,7 @@ checktext: |-
 
     Fix Text: Configure the SSH daemon to not allow GSSAPI authentication.
 
-    If the required value is not set, then this is a finding.
+    If the required value is not set, this is a finding.
 
 fixtext: |-
     Configure the SSH daemon to not allow GSSAPI authentication.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/policy/stig/shared.yml
@@ -8,7 +8,7 @@ vuldiscussion: |-
     on login or disallow access to the server.
 
 checktext: |-
-    Verify the RHEL9 SSHD is configured to allow for the UsePAM interface with the following command:
+    Verify the {{{ full_name }}} SSHD is configured to allow for the UsePAM interface with the following command:
 
     $ sudo grep -i usepam /etc/ssh/sshd_config
 
@@ -17,7 +17,7 @@ checktext: |-
     If the "UsePAM" keyword is set to "no", is missing, or is commented out, this is a finding.
 
 fixtext: |-
-    Configure the RHEL9 SSHD to use the UsePAM interface add or modify the following line in "/etc/ssh/sshd_config".
+    Configure the {{{ full_name }}} SSHD to use the UsePAM interface add or modify the following line in "/etc/ssh/sshd_config".
 
     UsePAM yes
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_enable_pam/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} must enable the Pluggable Authenitcation Module interface for SSHD.
+    {{{ full_name }}} must enable the Pluggable Authenitcation Module (PAM) interface for SSHD.
 
 vuldiscussion: |-
     When UsePAM is set to yes, PAM runs through account and session types properly. This is
@@ -8,7 +8,7 @@ vuldiscussion: |-
     on login or disallow access to the server.
 
 checktext: |-
-    Verify the {{{ full_name }}} SSHD is configure to allow for the UsePAM interface with the following command:
+    Verify the RHEL9 SSHD is configured to allow for the UsePAM interface with the following command:
 
     $ sudo grep -i usepam /etc/ssh/sshd_config
 
@@ -17,7 +17,7 @@ checktext: |-
     If the "UsePAM" keyword is set to "no", is missing, or is commented out, this is a finding.
 
 fixtext: |-
-    Configure the {{{ full_name }}} SSHD to use the UsePAM interface add or modify the following line in "/etc/ssh/sshd_config".
+    Configure the RHEL9 SSHD to use the UsePAM interface add or modify the following line in "/etc/ssh/sshd_config".
 
     UsePAM yes
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_verbose/policy/stig/shared.yml
@@ -17,6 +17,8 @@ checktext: |-
 
     $ sudo grep -i LogLevel /etc/ssh/sshd_config
 
+    LogLevel VERBOSE
+
     If a value of "VERBOSE" is not returned, the line is commented out, or is missing, this is a finding.
 
 fixtext: |-

--- a/linux_os/guide/services/sssd/sssd_enable_certmap/policy/stig/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_enable_certmap/policy/stig/shared.yml
@@ -10,7 +10,7 @@ checktext: |-
     $ sudo cat /etc/sssd/sssd.conf
 
     [certmap/testing.test/rule_name]
-    matchrule =&lt;SAN&gt;.*EDIPI@mil
+    matchrule =&ltSAN&gt.*EDIPI@mil
     maprule = (userCertificate;binary={cert!bin})
     domains = testing.test
 

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/policy/stig/shared.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/policy/stig/shared.yml
@@ -1,18 +1,33 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Provide Audit Record Generation Capability For Dod-Defined Auditable Events For All Operating System Components.
+    {{{ full_name }}} must enable Linux audit logging for the USBGuard daemon.
 
 vuldiscussion: |-
-    Using the Linux Audit logging allows for centralized trace
-    of events.
+    Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+    If auditing is enabled late in the startup process, the actions of some startup processes may not be audited. Some audit systems also maintain state information only available if auditing is enabled before a given process is created.
+
+    Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+    The list of audited events is the set of events for which audits are to be generated. This set of events is typically a subset of the list of all events for which the system is capable of generating audit records.
+
+    DoD has defined the list of events for which {{{ full_name }}} will provide an audit record generation capability as the following:
+
+    1) Successful and unsuccessful attempts to access, modify, or delete privileges, security objects, security levels, or categories of information (e.g., classification levels);
+
+    2) Access actions, such as successful and unsuccessful logon attempts, privileged activities or other system-level access, starting and ending time for user access to the system, concurrent logons from different workstations, successful and unsuccessful accesses to objects, all program initiations, and all direct access to the information system;
+
+    3) All account creations, modifications, disabling, and terminations; and
+
+    4) All kernel module load, unload, and restart actions.
 
 checktext: |-
-    To verify that Linux Audit logging is enabled for the USBGuard daemon,
-    run the following command:
-     $ sudo grep AuditBackend
-    The output should be
-     AuditBackend=LinuxAudit
+    To verify that Linux Audit logging is enabled for the USBGuard daemon with the following command:
 
-    If AuditBackend is not set to LinuxAudit, then this is a finding.
+    $ sudo grep AuditBackend /etc/usbguard/usbguard-daemon.conf
+
+    AuditBackend=LinuxAudit
+
+    If "AuditBackend" is not set to "LinuxAudit", this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} USBGuard AuditBackend to use the audit system.
@@ -20,3 +35,4 @@ fixtext: |-
     Add or edit the following line in /etc/usbguard/usbguard-daemon.conf
 
     AuditBackend=LinuxAudit
+

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/rule.yml
@@ -14,7 +14,7 @@ rationale: |-
     Using the Linux Audit logging allows for centralized trace
     of events.
 
-severity: medium
+severity: low
 
 identifiers:
     cce@rhcos4: CCE-82538-0

--- a/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/package_xorg-x11-server-common_removed/policy/stig/shared.yml
@@ -12,7 +12,7 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the x11-server-common package is installed and the use of a graphical user interface has not been documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
+    If the "x11-server-common" package is installed and the use of a graphical user interface has not been documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
 fixtext: |-
     Document the requirement for a graphical user interface with the ISSO or remove all xorg packages with the following command:

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/policy/stig/shared.yml
@@ -7,16 +7,13 @@ vuldiscussion: |-
     capability, it is critical the user re-authenticate.
 
 checktext: |-
-    Verify the operating system is not configured to bypass password requirements for privilege
-    escalation. Check the configuration of the "/etc/pam.d/sudo" file with the following command:
-     $ sudo grep pam_succeed_if /etc/pam.d/sudo
+    Verify the operating system is not configured to bypass password requirements for privilege escalation with the following command:
 
-    If system is configured to bypass password requirements for privilege escalation, then this is a finding.
+    $ sudo grep pam_succeed_if /etc/pam.d/sudo
+
+    If any occurances of "pam_succeed_if" are returned, this is a finding.
 
 fixtext: |-
     Configure the operating system to require users to supply a password for privilege escalation.
 
-    Check the configuration of the "/etc/pam.d/sudo" file with the following command:
-    $ sudo vi /etc/pam.d/sudo
-
-    Remove any occurrences of " pam_succeed_if " in the file.
+    Remove any occurrences of " pam_succeed_if " in the  "/etc/pam.d/sudo" file.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_password_auth/policy/stig/shared.yml
@@ -8,13 +8,13 @@ vuldiscussion: |-
 checktext: |-
     Verify the pam_faillock.so module is present in the "/etc/pam.d/password-auth" file:
 
-    $ sudo grep pam_faillock.so /etc/pam.d/password-auth
+    $ grep pam_faillock.so /etc/pam.d/password-auth
 
     auth required pam_faillock.so preauth
     auth required pam_faillock.so authfail
     account required pam_faillock.so
 
-    If the pam_faillock.so module is not present in the "/etc/pam.d/password-auth" file with the "preauth" line listed before pam_unix.so, then this is a finding.
+    If the pam_faillock.so module is not present in the "/etc/pam.d/password-auth" file with the "preauth" line listed before pam_unix.so, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to include the use of the pam_faillock.so module in the /etc/pam.d/password-auth file.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_pam_faillock_system_auth/policy/stig/shared.yml
@@ -8,13 +8,13 @@ vuldiscussion: |-
 checktext: |-
     Verify the pam_faillock.so module is present in the "/etc/pam.d/system-auth" file:
 
-    $ sudo grep pam_faillock.so /etc/pam.d/system-auth
+    $ grep pam_faillock.so /etc/pam.d/system-auth
 
     auth required pam_faillock.so preauth
     auth required pam_faillock.so authfail
     account required pam_faillock.so
 
-    If the pam_faillock.so module is not present in the "/etc/pam.d/system-auth" file with the "preauth" line listed before pam_unix.so, then this is a finding.
+    If the pam_faillock.so module is not present in the "/etc/pam.d/system-auth" file with the "preauth" line listed before pam_unix.so, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to include the use of the pam_faillock.so module in the /etc/pam.d/system-auth file.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/policy/stig/shared.yml
@@ -5,21 +5,21 @@ vuldiscussion: |-
     Not having the correct SELinux context on the faillock directory may lead to unauthorized access to the directory.
 
 checktext: |-
-    If the system does not have SELinux enabled and enforcing a targeted policy, or if the pam_faillock module is not configured for use, this requirement is not applicable.
-
     Verify the location of the non-default tally directory for the pam_faillock module with the following command:
 
-    $ sudo grep -w dir /etc/security/faillock.conf
+    Note: If the system does not have SELinux enabled and enforcing a targeted policy, or if the pam_faillock module is not configured for use, this requirement is not applicable.
+
+    $ grep 'dir =' /etc/security/faillock.conf
 
     dir = /var/log/faillock
 
     Check the security context type of the non-default tally directory with the following command:
 
-    $ sudo ls -Zd /var/log/faillock
+    $ ls -Zd /var/log/faillock
 
     unconfined_u:object_r:faillog_t:s0 /var/log/faillock
 
-    If the security context type of the non-default tally directory is not "faillog_t", then this is a finding.
+    If the security context type of the non-default tally directory is not "faillog_t", this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to allow the use of a non-default faillock tally directory while SELinux enforces a targeted policy.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/policy/stig/shared.yml
@@ -2,24 +2,24 @@ srg_requirement: |-
     {{{ full_name }}} must maintain an account lock until the locked account is released by an administrator.
 
 vuldiscussion: |-
-    By limiting the number of failed logon attempts the risk of unauthorized system
+    by limiting the number of failed logon attempts the risk of unauthorized system
     access via user password guessing, otherwise known as brute-forcing, is reduced.
-    Limits are imposed by locking the account.
+    limits are imposed by locking the account.
 
 checktext: |-
-    Verify {{{ full_name }}} is configured to lock an account until released by an administrator after three unsuccessful logon attempts with the command:
+    verify {{{ full_name }}} is configured to lock an account until released by an administrator after three unsuccessful logon attempts with the command:
 
     $ grep 'unlock_time =' /etc/security/faillock.conf
 
     unlock_time = 0
 
-    If the "unlock_time" option is not set to "0", the line is missing, or commented out, this is a finding.
+    if the "unlock_time" option is not set to "0", the line is missing, or commented out, this is a finding.
 
 fixtext: |-
-    Configure {{{ full_name }}} to lock an account until released by an administrator after three unsuccessful logon attempts with the command:
+    configure {{{ full_name }}} to lock an account until released by an administrator after three unsuccessful logon attempts with the command:
 
     $ authselect enable-feature with-faillock
 
-    Then edit the "/etc/security/faillock.conf" file as follows:
+    then edit the "/etc/security/faillock.conf" file as follows:
 
     unlock_time = 0

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_maxclassrepeat/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     maxclassrepeat = 4
 
-    If the value of "maxclassrepeat" is set to "0", more than "4" or is commented out, then this is a finding.
+    If the value of "maxclassrepeat" is set to "0", more than "4" or is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to require the change of the number of repeating characters of the same character class when passwords are changed by setting the "maxclassrepeat" option.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/policy/stig/shared.yml
@@ -6,12 +6,13 @@ vuldiscussion: |-
     makes the system less prone to dictionary attacks.
 
 checktext: |-
-    To check if pam_pwhistory.so is enabled in password-auth, run the following command:
-     $ grep pam_pwquality /etc/pam.d/password-auth
-    The output should be similar to the following:
-     password requisite pam_pwquality.so
+    Verify {{{ full_name }}} uses "pwquality" to enforce the password complexity rules in the password-auth file with the following command:
 
-    If pam_pwquality.so is not enabled in password-auth, then this is a finding.
+    $ cat /etc/pam.d/password-auth | grep pam_pwquality
+
+    password required pam_pwquality.so
+
+    If the command does not return a line containing the value "pam_pwquality.so", or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to use "pwquality" to enforce password complexity rules.

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_system_auth/policy/stig/shared.yml
@@ -6,12 +6,13 @@ vuldiscussion: |-
     makes the system less prone to dictionary attacks.
 
 checktext: |-
-    To check if pam_pwhistory.so is enabled in system-auth, run the following command:
-     $ grep pam_pwquality /etc/pam.d/system-auth
-    The output should be similar to the following:
-     password requisite pam_pwquality.so
+    Verify {{{ full_name }}} uses "pwquality" to enforce the password complexity rules in the system-auth file with the following command:
 
-    If pam_pwquality.so is not enabled in system-auth, then this is a finding.
+    $ cat /etc/pam.d/system-auth | grep pam_pwquality
+
+    password required pam_pwquality.so
+
+    If the command does not return a line containing the value "pam_pwquality.so", or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to use "pwquality" to enforce password complexity rules.

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/policy/stig/shared.yml
@@ -21,3 +21,4 @@ fixtext: |-
     Configure {{{ full_name }}} to allow a user to initiate a sessions lock by adding the following line to the file "/etc/tmux.conf":
 
      set -g lock-command vlock
+

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_command/policy/stig/shared.yml
@@ -21,4 +21,3 @@ fixtext: |-
     Configure {{{ full_name }}} to allow a user to initiate a sessions lock by adding the following line to the file "/etc/tmux.conf":
 
      set -g lock-command vlock
-

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/policy/stig/shared.yml
@@ -21,4 +21,3 @@ fixtext: |-
     The tmux package can be installed with the following command:
 
     $ sudo dnf install tmux
-

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/package_tmux_installed/policy/stig/shared.yml
@@ -12,11 +12,13 @@ checktext: |-
     Verify that {{{ full_name }}} has the tmux package installed with the following command:
 
     $ sudo dnf list --installed tmux
-    tmux.x86_64  3.2a-4.el9
 
-    If the tmux package is not installed, this is a finding.
+    tmux.x86_64          3.2a-4.el9
+
+    If the "tmux" package is not installed, this is a finding.
 
 fixtext: |-
     The tmux package can be installed with the following command:
 
     $ sudo dnf install tmux
+

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/policy/stig/shared.yml
@@ -18,7 +18,7 @@ checktext: |-
     openssl-pkcs.i686        0.4.11-7.el9
     openssl-pkcs.x86_64        0.4.11-7.el9
 
-    If a openssl-pkcs11 package is not installed, this is a finding.
+    If the "openssl-pkcs11" package is not installed, this is a finding.
 
 fixtext: |-
     The openssl-pkcs11 package can be installed with the following command:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/policy/stig/shared.yml
@@ -10,11 +10,12 @@ checktext: |-
     Verify that {{{ full_name }}} has the opensc package installed with the following command:
 
     $ sudo dnf list --installed opensc
-    opensc.x86_64  0.22.0-2.el9
 
-    If the opensc package is not installed, this is a finding.
+    opensc.x86_64          0.22.0-2.el9
+
+    If the "opensc" package is not installed, this is a finding.
 
 fixtext: |-
-    The opensc package can be installed with the following command:
+    The  opensc  package can be installed with the following command:
 
     $ sudo dnf install opensc

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/policy/stig/shared.yml
@@ -6,7 +6,13 @@ vuldiscussion: |-
     multifactor authentication using smartcards.
 
 checktext: |-
-    Verify that {{{ full_name }}} has the pcsc-lite package installed with the following command:$sudo dnf list --installed pcsc-litepcsc-lite.x86_641.9.4-1.el9If a pcsc-lite package is not installed, this is a finding.
+    Verify that {{{ full_name }}} has the pcsc-lite package installed with the following command:
+
+    $sudo dnf list --installed pcsc-lite
+
+    pcsc-lite.x86_64        1.9.4-1.el9
+
+    If the "pcsc-lite" package is not installed, this is a finding.
 
 fixtext: |-
     The  pcsc-lite  package can be installed with the following command:

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/policy/stig/shared.yml
@@ -18,4 +18,3 @@ fixtext: |-
     The  pcsc-lite  package can be installed with the following command:
 
     $ sudo dnf install pcsc-lite
-

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_pcsc-lite_installed/policy/stig/shared.yml
@@ -18,3 +18,4 @@ fixtext: |-
     The  pcsc-lite  package can be installed with the following command:
 
     $ sudo dnf install pcsc-lite
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/policy/stig/shared.yml
@@ -25,3 +25,4 @@ fixtext: |-
     $ sudo useradd -D -f 35
 
     A recommendation is 35 days, but a lower value is acceptable.
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/policy/stig/shared.yml
@@ -25,4 +25,3 @@ fixtext: |-
     $ sudo useradd -D -f 35
 
     A recommendation is 35 days, but a lower value is acceptable.
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/policy/stig/shared.yml
@@ -2,12 +2,10 @@ srg_requirement: |-
     {{{ full_name }}} temporary user accounts must be provisioned with an expiration time of 72 hours or less.
 
 vuldiscussion: |-
-    If temporary user accounts remain active when no longer needed or for
-    an excessive period, these accounts may be used to gain unauthorized access.
-    To mitigate this risk, automated termination of all temporary accounts
-    must be set upon account creation.
-
-
+    If temporary user accounts remain active when no longer needed or for
+    an excessive period, these accounts may be used to gain unauthorized access.
+    To mitigate this risk, automated termination of all temporary accounts must be
+    set upon account creation.
 
 checktext: |-
     Verify that temporary accounts have been provisioned with an expiration date of 72 hours.

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_unique_id/policy/stig/shared.yml
@@ -5,9 +5,7 @@ vuldiscussion: |-
     To assure accountability and prevent unauthenticated access, interactive users must be identified and authenticated to prevent potential misuse and compromise of the system.
 
 checktext: |-
-    Verify that {{{ full_name }}} contains no duplicate User IDs (UIDs) for interactive users.
-
-    Check that the operating system contains no duplicate UIDs for interactive users with the following command:
+    Verify that {{{ full_name }}} contains no duplicate User IDs (UIDs) for interactive users with the following command:
 
     $ sudo awk -F ":" 'list[$3]++{print $1, $3}' /etc/passwd
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Be Configured In Accordance With The Security Configuration Settings Based On Dod Security Configuration Or Implementation Guidance, Including Stigs, Nsa Configuration Guides, Ctos, And Dtms.
+    {{{ full_name }}} must not have unauthorized interactive accounts.
 
 vuldiscussion: |-
     Accounts providing no operational purpose provide additional opportunities for
@@ -8,10 +8,23 @@ vuldiscussion: |-
     on the system.
 
 checktext: |-
-    To verify that there are no unauthorized local user accounts, run the following command:
-     $ less /etc/passwd
-    Inspect the results, and if unauthorized local user accounts exist, remove them by running
-    the following command:
-     $ sudo userdel  unauthorized_user
+    Verify that there are no unauthorized local interactive user accounts with the following command:
 
-    If there are unauthorized local user accounts on the system, then this is a finding.
+    $ less /etc/passwd
+
+    root:x:0:0:root:/root:/bin/bash
+    ...
+    smithk:x:1000:1000:smithk:/home/smithk:/bin/bash
+    throckw:x:1001:1001:throckw:/home/throckw:/bin/bash
+
+    Interactive user account, generally will have a UID of 1000 or greater, a home directory in a specific partition, and an interactive shell.
+
+    Obtain the list of interactive user accounts authorized to be on the system from the System Administrator or Information System Security Officer (ISSO) and compare it to the list of local interactive user accounts on the system.
+
+    If there are unauthorized local user accounts on the system, this is a finding.
+
+fixtext: |-
+    Remove unauthorized local interactive user accounts with the following command where &ltunauthorized_user&gt is the unauthorized account:
+
+    $ sudo userdel  &ltunauthorized_user&gt
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/policy/stig/shared.yml
@@ -27,4 +27,3 @@ fixtext: |-
     Remove unauthorized local interactive user accounts with the following command where &ltunauthorized_user&gt is the unauthorized account:
 
     $ sudo userdel  &ltunauthorized_user&gt
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/policy/stig/shared.yml
@@ -5,9 +5,7 @@ vuldiscussion: |-
     To assure accountability and prevent unauthenticated access, groups must be identified uniquely to prevent potential misuse and compromise of the system.
 
 checktext: |-
-    Verify that {{{ full_name }}} contains no duplicate Group IDs (GID) for interactive users.
-
-    Check that the operating system contains no duplicate group names for interactive users by running the following command:
+    Verify that {{{ full_name }}} contains no duplicate Group IDs (GID) for interactive users with the following command:
 
      $  cut -d : -f 3 /etc/group | uniq -d
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/ansible/shared.yml
@@ -15,4 +15,3 @@
   with_items: "{{ users_nopasswd.stdout_lines }}"
   when: users_nopasswd.stdout_lines | length > 0
 
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/policy/stig/shared.yml
@@ -23,4 +23,3 @@ fixtext: |-
     To lock an account:
 
     $ sudo passwd -l [username]
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} must have no accounts with blank or null passwords.
+    {{{ full_name }}} must not have accounts configured with blank or null passwords.
 
 vuldiscussion: |-
     If an account has an empty password, anyone could log in and
@@ -7,17 +7,20 @@ vuldiscussion: |-
     empty passwords should never be used in operational environments.
 
 checktext: |-
-    To verify that null passwords cannot be used, run the following command:
-     $ sudo awk -F: '!$2 {print $1}' /etc/shadow
-    If this produces any output, it may be possible to log into accounts
-    with empty passwords.
+    Verify that null or blank passwords cannot be used with the following command:
 
-    If Blank or NULL passwords can be used, then this is a finding.
+    $ sudo awk -F: '!$2 {print $1}' /etc/shadow
+
+    If the command returns any results, this is a finding.
 
 fixtext: |-
-    Configure all accounts on {{{ full_name }}} to have a password or lock
-    the account with the following commands:
+    Configure all accounts on {{{ full_name }}} to have a password or lock the account with the following commands:
+
     Perform a password reset:
-     $ sudo passwd [username]
-    Lock an account:
-     $ sudo passwd -l [username]
+
+    $ sudo passwd [username]
+
+    To lock an account:
+
+    $ sudo passwd -l [username]
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/policy/stig/shared.yml
@@ -21,3 +21,4 @@ fixtext: |-
     Change the UID of any account on the system, other than root, that has a UID of "0".
 
     If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Be Configured In Accordance With The Security Configuration Settings Based On Dod Security Configuration Or Implementation Guidance, Including Stigs, Nsa Configuration Guides, Ctos, And Dtms.
+    {{{ full_name }}} system accounts must not have have login shell.
 
 vuldiscussion: |-
     Ensuring shells are not given to system accounts upon login makes it more
@@ -9,20 +9,34 @@ checktext: |-
     To obtain a listing of all users, their UIDs, and their shells, run the
     command:
 
+    This requirement is Not Applicable for system accounts that require a shell for mission applications.
+
     $ awk -F: '{print $1 ":" $3 ":" $7}' /etc/passwd
+    root:0:/bin/bash
+    bin:1:/sbin/nologin
+    daemon:2:/sbin/nologin
+    adm:3:/sbin/nologin
+    lp:4:/sbin/nologin
+
+
 
     Identify the system accounts from this listing. These will primarily be the accounts
     with UID numbers less than UID_MIN, other than root. Value of the UID_MIN
     directive is set in /etc/login.defs configuration file. In the default
     configuration UID_MIN is set to 1000.
 
-    If any system account (other than root) has a login shell, then this is a finding.
+    If any system account (other than root) has a login shell and it is not docmented with the Information System Security Officer (ISSO)., this is a finding.
 
 fixtext: |-
-    Configure {{{ full_name }}} so that all non-interactive accounts on the system have no interactive shell assigned to them.
+    Configure {{{ full_name }}} so that all non-interactive accounts on the system do not have an interactive shell assigned to them.
+
+    If the system account needs a shell assigned for mission operations, doucment the need with the Information System Security Officer (ISSO).
 
     Run the following command to disable the interactive shell for a specific non-interactive user account:
 
-    $ sudo usermod --shell /sbin/nologin nobody
+    Replace &ltuser&gt with the user that has a login shell.
 
-    Do not perform the steps in this section on the root account. Doing so mightcause the system to become inaccessible.
+    $ sudo usermod --shell /sbin/nologin &ltuser&gt
+
+    Do not perform the steps in this section on the root account. Doing so will cause the system to become inaccessible.
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/policy/stig/shared.yml
@@ -7,12 +7,13 @@ vuldiscussion: |-
     access to such command is considered a good security practice.
 
 checktext: |-
-    Run the following command to check if the line is present:
-     grep pam_wheel /etc/pam.d/su
-    The output should contain the following line:
-     auth             required        pam_wheel.so use_uid
+    Verify that {{{ full_name }}} requires uses to be members of the "wheel" group with the following command:
 
-    If the line is not in the file or it is commented, then this is a finding.
+    $grep pam_wheel /etc/pam.d/su
+
+    auth             required        pam_wheel.so use_uid
+
+    If a line for "pam_wheel.so" does not exist, or is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to require users to be in the "wheel" group to run "su" command.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Terminate All Network Connections Associated With A Communications Session At The End Of The Session, Or As Follows: For In-Band Management Sessions (Privileged Sessions), The Session Must Be Terminated After 10 Minutes Of Inactivity; And For User Sessions (Non-Privileged Session), The Session Must Be Terminated After 15 Minutes Of Inactivity, Except To Fulfill Documented And Validated Mission Requirements.
+    {{{ full_name }}} must be configured so that all network connections associated with a communication session are terminated at the end of the session or after 15 minutes of inactivity from the user at a command prompt, except to fulfill documented and validated mission requirements.
 
 vuldiscussion: |-
     Terminating an idle session within a short time period reduces
@@ -8,19 +8,17 @@ vuldiscussion: |-
     left unattended.
 
 checktext: |-
-    Run the following command to ensure the "TMOUT" value is configured for all users
-    on the system:
+    Verify {{{ full_name }}} terminates all network connections associated with a communications session at the end of the session or based on inactivity with the following command:
 
-     $ sudo grep TMOUT /etc/profile /etc/profile.d/*.sh
+    $ sudo grep -i tmout /etc/profile /etc/profile.d/*.sh
 
-    The output should return the following:
-     TMOUT=600
+    etc/profile.d/tmout.sh:declare -xr TMOUT=900
 
-    If value of TMOUT is not less than or equal to expected setting, then this is a finding.
+    If "TMOUT" is not set to "900" or less in a script located in the /etc/profile.d/ directory to enforce session termination after inactivity, this is a finding.
 
 fixtext: |-
-    Configure {{{ full_name }}} to terminate user sessions after 600 seconds of inactivity.
+    Configure {{{ full_name }}} to terminate user sessions after 900 seconds of inactivity.
 
     Add or edit the following line in "/etc/profile.d/tmout.sh":
 
-     TMOUT=600
+     TMOUT=900

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/policy/stig/shared.yml
@@ -8,11 +8,15 @@ vuldiscussion: |-
 checktext: |-
     Verify that interactive users on the system have a home directory assigned with the following command:
 
-    $ sudo awk -F: '($3>=1000)&&($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd
+    $ sudo awk -F: '($3&gt=1000)&&($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd
+
+    smithk:x:1000:1000:smithk:/home/smithk:/bin/bash
+    throckw:x:1001:1001:throckw:/home/throckw:/bin/bash
 
     Inspect the output and verify that all interactive users (normally users with a UID greater that 1000) have a home directory defined.
 
-    If users home directory is not defined, then this is a finding.
+    If users home directory is not defined, this is a finding.
 
 fixtext: |-
+    Create and assign home directories to all local interactive users on {{{ full_name }}} that currently do not have a home directory assigned.
     Assign home directories to all local interactive users on {{{ full_name }}} that currently do not have a home directory assigned.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     The output should not return any interactive users.
 
-    If users home directory does not exist, then this is a finding.
+    If users home directory does not exist, this is a finding.
 
 fixtext: |-
     Create home directories to all local interactive users that currently do not have a home directory assigned. Use the following commands to create the user home directory assigned in "/etc/ passwd":

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/policy/stig/shared.yml
@@ -6,11 +6,11 @@ vuldiscussion: |-
     unauthorized access to user files by other users.
 
 checktext: |-
-    Verify the assigned home directory of all local interactive users has a mode of "0750" or less permissive with the following command:
+     Verify the assigned home directory of all local interactive users has a mode of "0750" or less permissive with the following command:
 
     Note: This may miss interactive users that have been assigned a privileged User Identifier (UID). Evidence of interactive use may be obtained from a number of log files containing system logon information.
 
-    $ sudo ls -ld $(awk -F: '($3>=1000)&&($7 !~ /nologin/){print $6}' /etc/passwd)
+    $ sudo ls -ld $(awk -F: '($3&gt=1000)&&($7 !~ /nologin/){print $6}' /etc/passwd)
 
     drwxr-x--- 2 smithj admin 4096 Jun 5 12:41 smithj
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/policy/stig/shared.yml
@@ -6,7 +6,7 @@ vuldiscussion: |-
     unauthorized access to user files by other users.
 
 checktext: |-
-     Verify the assigned home directory of all local interactive users has a mode of "0750" or less permissive with the following command:
+    Verify the assigned home directory of all local interactive users has a mode of "0750" or less permissive with the following command:
 
     Note: This may miss interactive users that have been assigned a privileged User Identifier (UID). Evidence of interactive use may be obtained from a number of log files containing system logon information.
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/policy/stig/shared.yml
@@ -15,13 +15,14 @@ checktext: |-
 
     $ sudo auditctl -l | grep setsebool
 
-     -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+     -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt=1000 -F auid!=unset -F key=privileged
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate an audit event for any successful/unsuccessful use of the "setsebool " command by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged
+    -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt=1000 -F auid!=unset -F key=privileged
 
     The audit daemon must be restarted for the changes to take effect.
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/policy/stig/shared.yml
@@ -15,11 +15,11 @@ checktext: |-
 
     $ sudo auditctl -l | grep'open\|truncate\|creat'
 
-    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt=1000 -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt=1000 -F auid!=unset -k perm_access
 
     If the output does not produce rules containing "-F exit=-EPERM", this is a finding.
     If the output does not produce rules containing "-F exit=-EACCES", this is a finding.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
@@ -54,4 +54,3 @@
       syscall_grouping=[],
       )|indent(4) }}}
   when: audit_arch == "b64"
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_faillock/policy/stig/shared.yml
@@ -5,11 +5,11 @@ vuldiscussion: |-
     Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
 checktext: |-
-    Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/var/log/faillock" with the following command:
+    Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/var/run/faillock" with the following command:
 
     $ sudo auditctl -l | grep /var/log/faillock
 
-    -w /var/log/faillock -p wa -k logins
+    -w /var/run/faillock -p wa -k logins
 
     If the command does not return a line, or the line is commented out, this is a finding.
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_login_events/audit_rules_login_events_tallylog/policy/stig/shared.yml
@@ -7,11 +7,11 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/var/log/tallylog" with the following command:
 
-    $ sudo auditctl -l | grep /var/log/tallylog
+    $ sudo auditctl -l | grep /var/log/tallylog
 
-    -w /var/log/tallylog -p wa -k logins
+    -w /var/log/tallylog -p wa -k logins
 
-    If the command does not return a line, or the line is commented out, this is a finding.
+    If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/var/log/tallylog".

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_init/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_init/policy/stig/shared.yml
@@ -5,13 +5,13 @@ vuldiscussion: |-
     Misuse of the init command may cause availability issues for the system.
 
 checktext: |-
-    Verify that an audit event is generated for any successful/unsuccessful use of the init command by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+    Verify that {{{ full_name }}} is configured to audit the execution of the "init" command with the following command:
 
-    $ sudo grep -w init /etc/audit/audit.rules
+    $ sudo auditctl -l | grep init
 
-    -a always,exit -F path=/usr/sbin/init -F perm=x -F auid>=1000 -F auid!=unset -k privileged-init
+    -a always,exit -F path=/usr/sbin/init -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-init
 
-    If the command does not return a line, or the line is commented out, then this is a finding.
+    If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "init" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_poweroff/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_poweroff/policy/stig/shared.yml
@@ -5,13 +5,13 @@ vuldiscussion: |-
     Misuse of the poweroff command may cause availability issues for the system.
 
 checktext: |-
-    Verify that an audit event is generated for any successful/unsuccessful use of the poweroff command by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+    Verify that {{{ full_name }}} is configured to audit the execution of the "poweroff" command with the following command:
 
-    $ sudo grep -w poweroff /etc/audit/audit.rules
+    $ sudo auditctl -l | grep poweroff
 
-    -a always,exit -F path=/usr/sbin/poweroff -F perm=x -F auid>=1000 -F auid!=unset -k privileged-poweroff
+    -a always,exit -F path=/usr/sbin/poweroff -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-poweroff
 
-    If the command does not return a line, or the line is commented out, then this is a finding.
+    If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "poweroff" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_reboot/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_reboot/policy/stig/shared.yml
@@ -5,13 +5,13 @@ vuldiscussion: |-
     Misuse of the reboot command may cause availability issues for the system.
 
 checktext: |-
-    Verify that an audit event is generated for any successful/unsuccessful use of the reboot command by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+    Verify that {{{ full_name }}} is configured to audit the execution of the "reboot" command with the following command:
 
-    $ sudo grep -w reboot /etc/audit/audit.rules
+    $ sudo auditctl -l | grep reboot
 
-    -a always,exit -F path=/usr/sbin/reboot -F perm=x -F auid>=1000 -F auid!=unset -k privileged-reboot
+    -a always,exit -F path=/usr/sbin/reboot -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-reboot
 
-    If the command does not return a line, or the line is commented out, then this is a finding.
+    If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "reboot" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_shutdown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_shutdown/policy/stig/shared.yml
@@ -5,13 +5,13 @@ vuldiscussion: |-
     Misuse of the shutdown command may cause availability issues for the system.
 
 checktext: |-
-    Verify that an audit event is generated for any successful/unsuccessful use of the shutdown command by performing the following command to check the file system rules in "/etc/audit/audit.rules":
+    Verify that {{{ full_name }}} is configured to audit the execution of the "shutdown" command with the following command:
 
-    $ sudo grep -w shutdown /etc/audit/audit.rules
+    $ sudo auditctl -l | grep shutdown
 
-    -a always,exit -F path=/usr/sbin/shutdown -F perm=x -F auid>=1000 -F auid!=unset -k privileged-shutdown
+    -a always,exit -F path=/usr/sbin/shutdown -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-shutdown
 
-    If the command does not return a line, or the line is commented out, then this is a finding.
+    If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "shutdown" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/policy/stig/shared.yml
@@ -13,7 +13,7 @@ checktext: |-
 
     $ sudo auditctl -l | grep /usr/bin/mount
 
-    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -k privileged-mount
+    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-mount
 
     If the command does not return a line, or the line is commented out, this is a finding.
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ sudo auditctl -l | egrep '(/usr/bin/passwd)'
 
-    -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -k privileged-passwd
+    -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-passwd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/policy/stig/shared.yml
@@ -24,5 +24,5 @@ fixtext: |-
 
     -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-mount
 
-    The audit daemon must be restarted for the changes to take effect.
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/policy/stig/shared.yml
@@ -1,24 +1,28 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Generate Audit Records For Privileged Activities Or Other System-Level Access.
+    {{{ full_name }}} must audit all uses of umount system calls.
 
 vuldiscussion: |-
-    Misuse of privileged functions, either intentionally or unintentionally by
-    authorized users, or by unauthorized external entities that have compromised system accounts,
-    is a serious and ongoing concern and can have significant adverse impacts on organizations.
-    Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threats.
+    Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
 
+    Audit records can be generated from various components within the information system (e.g., module or policy filter).
 
+    When a user logs on, the auid is set to the uid of the account that is being authenticated. Daemons are not user sessions and have the loginuid set to -1. The auid representation is an unsigned 32-bit integer, which equals 4294967295. The audit system interprets -1, 4294967295, and "unset" in the same way.
 
-    Privileged programs are subject to escalation-of-privilege attacks,
-    which attempt to subvert their normal role of providing some necessary but
-    limited capability. As such, motivation exists to monitor these programs for
-    unusual activity.
+    The system call rules are loaded into a matching engine that intercepts each syscall made by all programs on the system. Therefore, it is very important to use syscall rules only when absolutely necessary since these affect performance. The more rules, the bigger the performance hit. The performance can be helped, however, by combining syscalls into one rule whenever possible.
 
 checktext: |-
-    To verify that auditing of privileged command use is configured, run the
-    following command:
-     $ sudo grep umount /etc/audit/audit.rules /etc/audit/rules.d/*
-    It should return a relevant line in the audit rules.
+    Verify that {{{ full_name }}} is configured to audit the execution of the "umount"command with the following command:
 
-    If it is not the case, then this is a finding.
+    $ sudo auditctl -l | grep umount
+
+    -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-mount
+
+    If the command does not return an audit rule for "umount" or any of the lines returned are commented out, this is a finding.
+
+fixtext: |-
+    Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "umount" command by adding or updating the following rules in "/etc/audit/rules.d/audit.rules":
+
+    -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt=1000 -F auid!=unset -k privileged-mount
+
+    The audit daemon must be restarted for the changes to take effect.
+    The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_immutable/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     -e 2
 
-    If the audit system is not set to be immutable by adding the "-e 2" option to the end of "/etc/audit/audit.rules", then this is a finding.
+    If the audit system is not set to be immutable by adding the "-e 2" option to the end of "/etc/audit/audit.rules", this is a finding.
 
 fixtext: |-
     Configure the audit system to set the audit rules to be immutable by adding the following line to end of "/etc/audit/rules.d/audit.rules"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/policy/stig/shared.yml
@@ -21,5 +21,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/sudoers".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/sudoers -p wa -k identity
-    The audit daemon must be restarted for the changes to take effect.
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/policy/stig/shared.yml
@@ -22,3 +22,4 @@ fixtext: |-
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/sudoers -p wa -k identity
     The audit daemon must be restarted for the changes to take effect.
+    The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/policy/stig/shared.yml
@@ -21,5 +21,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/sudoers.d/".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/sudoers.d/ -p wa -k identity
-    The audit daemon must be restarted for the changes to take effect.
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/policy/stig/shared.yml
@@ -11,7 +11,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/sudoers.d/" with the following command:
 
-    $ sudo auditctl -l | grep/etc/sudoers.d
+    $ sudo auditctl -l | grep /etc/sudoers.d
 
     -w /etc/sudoers.d/ -p wa -k identity
 
@@ -21,4 +21,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/sudoers.d/".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/sudoers.d/ -p wa -k identity
+    The audit daemon must be restarted for the changes to take effect.
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} audit system must be configured to audit the execution of privileged functions and prevent all software from executing at higher privilege levels than users executing the software.
+    {{{ full_name }}} must audit uses of the "execve" system call.
 
 vuldiscussion: |-
     Misuse of privileged functions, either intentionally or unintentionally by
@@ -31,4 +31,5 @@ fixtext: |-
     -a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k execpriv
     -a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k execpriv
 
+    The audit daemon must be restarted for the changes to take effect.
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/policy/stig/shared.yml
@@ -31,5 +31,5 @@ fixtext: |-
     -a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k execpriv
     -a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k execpriv
 
-    The audit daemon must be restarted for the changes to take effect.
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/ansible/shared.yml
@@ -25,4 +25,3 @@
   loop:
     - "/etc/audit/audit.rules"
     - "/etc/audit/rules.d/immutable.rules"
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/policy/stig/shared.yml
@@ -2,16 +2,8 @@ srg_requirement: |-
     {{{ full_name }}} must take appropriate action when a critical audit processing failure occurs.
 
 vuldiscussion: |-
-    It is critical for the appropriate personnel to be aware if a system
-    is at risk of failing to process audit logs as required. Without this
-    notification, the security personnel may be unaware of an impending failure of
-    the audit capability, and system operation may be adversely affected.
-
-
-
-    Audit processing failures include software/hardware errors, failures in the
-    audit capturing mechanisms, and audit storage capacity being reached or
-    exceeded.
+    It is critical for the appropriate personnel to be aware if a systemis at risk of failing to process audit logs as required. Without thisnotification, the security personnel may be unaware of an impending failure ofthe audit capability, and system operation may be adversely affected.
+    Audit processing failures include software/hardware errors, failures in theaudit capturing mechanisms, and audit storage capacity being reached orexceeded.
 
 checktext: |-
     Verify the audit service is configured to panic on a critical error with the following command:
@@ -26,4 +18,6 @@ fixtext: |-
     Configure {{{ full_name }}} to shutdown when auditing failures occur.
 
     Add the following line to the bottom of the /etc/audit/audit.rules file:
+
+    -f 2
     -f 2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/policy/stig/shared.yml
@@ -20,4 +20,3 @@ fixtext: |-
     Add the following line to the bottom of the /etc/audit/audit.rules file:
 
     -f 2
-    -f 2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/policy/stig/shared.yml
@@ -19,4 +19,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/group".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/group -p wa -k identity
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/policy/stig/shared.yml
@@ -19,4 +19,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/gshadow -p wa -k identity
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/policy/stig/shared.yml
@@ -19,4 +19,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/security/opasswd -p wa -k identity
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/policy/stig/shared.yml
@@ -19,4 +19,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/passwd -p wa -k identity
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/policy/stig/shared.yml
@@ -19,4 +19,5 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/shadow".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/shadow -p wa -k identity
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} audit logs file must have mode 0640 or less permissive to prevent unauthorized access to the audit log.
+    {{{ full_name }}} audit logs file must have mode 0600 or less permissive to prevent unauthorized access to the audit log.
 
 vuldiscussion: |-
     Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the {{{ full_name }}} system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
@@ -7,7 +7,7 @@ vuldiscussion: |-
     The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.
 
 checktext: |-
-    Verify the audit logs have a mode of "0640".
+    Verify the audit logs have a mode of "0600".
 
     First determine where the audit logs are stored with the following command:
 
@@ -19,16 +19,16 @@ checktext: |-
 
     $ sudo ls -la /var/log/audit/*.log
 
-    rw-rw----. 2 root root 237923 Jun 11 11:56 /var/log/audit/audit.log
+    rw-------. 2 root root 237923 Jun 11 11:56 /var/log/audit/audit.log
 
-    If the audit logs have a mode more permissive than "0640", this is a finding.
+    If the audit logs have a mode more permissive than "0600", this is a finding.
 
 fixtext: |-
-    Configure the audit logs to have a mode of "0640" with the following command:
+    Configure the audit logs to have a mode of "0600" with the following command:
 
     Replace "[audit_log_file]" to the correct audit log path, by default this location is "/var/log/audit/audit.log".
 
-    $ sudo chmod 0640 /var/log/audit/[audit_log_file]
+    $ sudo chmod 0600 /var/log/audit/[audit_log_file]
     Check the group that owns the system audit logs:
 
     $ sudo grep -m 1 -q ^log_group /etc/audit/auditd.conf
@@ -42,3 +42,4 @@ fixtext: |-
 
     $ sudo chmod 0600 $log_file
     $ sudo chmod 0400 $log_file.*
+

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_permissions_var_log_audit/policy/stig/shared.yml
@@ -42,4 +42,3 @@ fixtext: |-
 
     $ sudo chmod 0600 $log_file
     $ sudo chmod 0400 $log_file.*
-

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_sufficiently_large_partition/policy/stig/shared.yml
@@ -1,0 +1,33 @@
+srg_requirement: |-
+    {{{ full_name }}} Must Allocate Audit Record Storage Capacity To Store At Least One Weeks Worth Of Audit Records, When Audit Records Are Not Immediately Sent To A Central Audit Record Storage Facility.
+
+vuldiscussion: |-
+    To ensure {{{ full_name }}} systems have a sufficient storage capacity in which to write the audit logs, RHEL 8 needs to be able to allocate audit record storage capacity.
+
+    The task of allocating audit record storage capacity is usually performed during initial installation of {{{ full_name }}}.
+
+checktext: |-
+    Verify {{{ full_name }}} allocates audit record storage capacity to store at least one week of audit records when audit records are not immediately sent to a central audit record storage facility.
+
+    Note: The partition size needed to capture a week of audit records is based on the activity level of the system and the total storage capacity available. Typically 10.0 GB of storage space for audit records should be sufficient.
+
+    Determine which partition the audit records are being written to with the
+    following command:
+
+    $ sudo grep log_file /etc/audit/auditd.conf
+    log_file = /var/log/audit/audit.log
+
+    Check the size of the partition that audit records are written to with the
+    following command and verify whether it is sufficiently large:
+
+     # df -h /var/log/audit/
+    /dev/sda2 24G 10.4G 13.6G 43% /var/log/audit
+
+    If the audit record partition is not allocated for sufficient storage capacity, this is a finding.
+
+fixtext: |-
+    Allocate enough storage capacity for at least one week of audit records when audit records are not immediately sent to a central audit record storage facility.
+
+    If audit records are stored on a partition made specifically for audit records, resize the partition with sufficient space to contain one week of audit records.
+
+    If audit records are not stored on a partition made specifically for audit records, a new partition with sufficient space will need be to be created.

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/policy/stig/shared.yml
@@ -5,16 +5,13 @@ vuldiscussion: |-
     It is critical that when the operating system is at risk of failing to process audit logs as required, it takes action to mitigate the failure. Audit processing failures include: software/hardware errors; failures in the audit capturing mechanisms; and audit storage capacity being reached or exceeded. Responses to audit failure depend upon the nature of the failure mode.
 
 checktext: |-
-    Inspect "/etc/audit/auditd.conf" and locate the following line to
-    Verify {{{ full_name }}} takes the appropriate action when the audit files have reached maximum size.
-
-    Check that {{{ full_name }}} takes the appropriate action when the audit files have reached maximum size with the following command:
+    Verify that {{{ full_name }}} takes the appropriate action when the audit files have reached maximum size with the following command:
 
     $ sudo grep max_log_file_action /etc/audit/auditd.conf
 
     max_log_file_action = ROTATE
 
-    If the value of the "disk_full_action" option is not "ROTATE", "SINGLE", or the line is commented out, ask the system administrator to indicate how the system takes appropriate action when an audit storage volume is full.  If there is no evidence of appropriate action, this is a finding.
+    If the value of the "max_log_file_action" option is not "ROTATE", "SINGLE", or the line is commented out, ask the system administrator to indicate how the system takes appropriate action when an audit storage volume is full.  If there is no evidence of appropriate action, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to rotate the audit log when it reaches maximum size.

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/policy/stig/shared.yml
@@ -20,4 +20,5 @@ fixtext: |-
 
     local_events = yes
 
+
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/policy/stig/shared.yml
@@ -22,4 +22,3 @@ fixtext: |-
     write_logs = yes
 
     The audit daemon must be restarted for changes to take effect.
-

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_write_logs/policy/stig/shared.yml
@@ -22,3 +22,4 @@ fixtext: |-
     write_logs = yes
 
     The audit daemon must be restarted for changes to take effect.
+

--- a/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/grub2_audit_backlog_limit_argument/policy/stig/shared.yml
@@ -13,27 +13,9 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} allocates a sufficient audit_backlog_limit to capture processes that start prior to the audit daemon with the following commands:
 
-    First check if the GRUB recovery is enabled:
-
-    $ sudo grep 'GRUB_DISABLE_RECOVERY' /etc/default/grub
-
-    GRUB_DISABLE_RECOVERY="true"
-
-    If this option is set to true, then check that a line is output by the following command:
-
-    $ sudo grep 'GRUB_CMDLINE_LINUX_DEFAULT.*audit_backlog_limit=8192.*' /etc/default/grub
-
-    If the option is set to false, then check that a line is output by the following command:
-
-    $ sudo grep 'GRUB_CMDLINE_LINUX.*audit_backlog_limit=8192.*' /etc/default/grub
-
-    If 'audit_backlog_limit' is not set to '8192' or greater, or the option is missing, this is a finding.
-
-    Additionally command line parameters for currently installed kernels must be checked as well with the following command:
-
      $ sudo grubby --info=ALL | grep args | grep -v 'audit_backlog_limit=8192'
 
-    If the command return any outputs and audit_backlog_limit is less than 8182, this is a finding.
+    If the command return any outputs and audit_backlog_limit is less than "8192", this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to allocate sufficient audit_backlog_limit to capture processes that start prior to the audit daemon with the following command:

--- a/linux_os/guide/system/auditing/package_audit_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/package_audit_installed/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     audit-3.0.7-101.el9_0.2.x86_64
 
-    If the audit package is not installed, this is a finding.
+    If the "audit" package is not installed, this is a finding.
 
 fixtext: |-
     Install the audit service package (if the audit service is not already installed) with the following command:

--- a/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/policy/stig/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_vsyscall_argument/policy/stig/shared.yml
@@ -7,9 +7,7 @@ vuldiscussion: |-
     Virtual Syscalls provide an opportunity of attack for a user who has control of the return instruction pointer.  Disabling vsyscalls help to prevent return oriented programming (ROP) attacks via buffer overflows and overruns. If the system intends to run containers based on RHEL 6 components, then virtual syscalls will need enabled so the components function properly.
 
 checktext: |-
-    Verify that GRUB 2 is configured to disable vsyscalls .
-
-    Check that the current GRUB 2 configuration disables vsyscalls with the following command:
+    Verify the current GRUB 2 configuration disables vsyscalls with the following command:
 
     $ sudo grubby --info=ALL | grep args | grep -v 'vsyscall=none'
 

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/policy/stig/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/policy/stig/shared.yml
@@ -1,19 +1,19 @@
 srg_requirement: |-
-    The {{{ full_name }}} /boot/grub2/grub.cfg file must be group-owned by root.
+    The {{{ full_name }}} /boot/grub2/grub.cfg file must be owned by root.
 
 vuldiscussion: |-
-    The "root" group is a highly-privileged group. Furthermore, the group-owner of this
-    file should not have any access privileges anyway.
+    The " /boot/grub2/grub.cfg" file stores sensative system configuration and should be protected.
 
 checktext: |-
-    To check the group ownership of /boot/grub2/grub.cfg ,
-    run the command:
-     $ sudo stat -c "%G %n" /boot/grub2/grub.cfg
-    If properly configured, the output should indicate the following group-owner:
-     root /boot/grub2/grub.cfg
+    Verify the ownership of the "/boot/grub2/grub.cfg" file with the following command:
 
-    If /boot/grub2/grub.cfg does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /boot/grub2/grub.cfg
+
+    root /boot/grub2/grub.cfg
+
+    If "/boot/grub2/grub.cfg" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
-    Change the group of the file /boot/grub2/grub.cfg to root by running the following command:
-    $ sudo chgrp root /boot/grub2/grub.cfg
+    Change the owner of the file /boot/grub2/grub.cfg to root by running the following command:
+
+    $ sudo chown root /boot/grub2/grub.cfg

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/policy/stig/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/policy/stig/shared.yml
@@ -5,16 +5,17 @@ vuldiscussion: |-
     Having a non-default grub superuser username makes password-guessing attacks less effective.
 
 checktext: |-
-    To verify the boot loader superuser account has been set, run the following
-    command:
-     sudo grep -A1 "superusers" /etc/grub2.cfg
-    The output should show the following:
-     set superusers=" superusers-account "
+    Verify the boot loader superuser account has been set with the following command:
+
+    $ sudo grep -A1 "superusers" /etc/grub2.cfg
+
+     set superusers="&ltsuperusers-account&gt"
     export superusers
-    where superusers-account is the actual account name different from common names like root,
+
+    The &ltsuperusers-account&gt is the actual account name different from common names like root,
     admin, or administrator.
 
-    If superusers contains easily guessable username, this is a finding.
+    If superusers contains easily guessable usernames, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to have a unique username for the grub superuser account.

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/policy/stig/shared.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/policy/stig/shared.yml
@@ -8,35 +8,33 @@ vuldiscussion: |-
     important bootloader settings. These include which kernel to use, and whether to enter single-user mode.
 
 checktext: |-
-    To verify the boot loader superuser password has been set, run the following
+    Verify the boot loader superuser password has been set, run the following
     command:
 
-     sudo grep "superusers" /etc/grub2.cfg
+    $sudo grep "superusers" /etc/grub2.cfg
 
-    The output should show the following:
-     password_pbkdf2  superusers-account   ${GRUB2_PASSWORD}
+    password_pbkdf2  superusers-account   ${GRUB2_PASSWORD}
+
     To verify the boot loader superuser account password has been set,
     and the password encrypted, run the following command:
 
-     sudo cat /boot/grub2/user.cfg
-    The output should be similar to:
-     GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
+    $ sudo cat /boot/grub2/user.cfg
+
+    GRUB2_PASSWORD=grub.pbkdf2.sha512.10000.C4E08AC72FBFF7E837FD267BFAD7AEB3D42DDC
     2C99F2A94DD5E2E75C2DC331B719FE55D9411745F82D1B6CFD9E927D61925F9BBDD1CFAA0080E0
     916F7AB46E0D.1302284FCCC52CD73BA3671C6C12C26FF50BA873293B24EE2A96EE3B57963E6D7
     0C83964B473EC8F93B07FE749AA6710269E904A9B08A6BBACB00A2D242AD828
 
-    If it does not, this is a finding.
+    If a "GRUB2_PASSWORD" is not set, this is a finding.
 
 fixtext: |-
-    Configure {{{ full_name }}} to require a grub bootloader password    for the grub superuser account.
+    Configure {{{ full_name }}} to require a grub bootloader password for the grub superuser account.
 
-    Generate an encrypted grub2 password for the grub superuser account with the following    command:
+    Generate an encrypted grub2 password for the grub superuser account with the following command:
 
     $ sudo grub2-setpassword
     Enter password:
     Confirm password:
 
-    Edit the /etc/grub.d/40_custom file and add or modify the following lines in the    "### BEGIN /etc/grub.d/01_users ###" section:
 
-    set superusers="[someuniquestringhere]"
     export superusers

--- a/linux_os/guide/system/logging/journald/service_systemd-journald_enabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/logging/journald/service_systemd-journald_enabled/policy/stig/shared.yml
@@ -1,16 +1,17 @@
 srg_requirement: |-
-    The {{{ full_name }}} service systemd-journald must be enabled.
+    The {{{ full_name }}} systemd-journald service must be enabled.
 
 vuldiscussion: |-
     In the event of a system failure, {{{ full_name }}} must preserve any information necessary to determine cause of failure and any information necessary to return to operations with least disruption to system processes.
 
 checktext: |-
-    Run the following command to determine the current status of the
-     systemd-journald service:
-     $ sudo systemctl is-active systemd-journald
-    If the service is running, it should return the following: active
+    Verify that "systemd-journald" is active with the following command:
 
-    If the systemd-journald service is not running, then this is a finding.
+    $ systemctl is-active systemd-journald
+
+    active
+
+    If the systemd-journald service is not active, this is a finding.
 
 fixtext: |-
     To enable the systemd-journald service run the following command:

--- a/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/policy/stig/shared.yml
@@ -9,9 +9,10 @@ checktext: |-
     Verify that {{{ full_name }}} has the rsyslog-gnutls package installed with the following command:
 
     $ sudo dnf list --installed rsyslog-gnutls
-    rsyslog-gnutls.x86_64  8.2102.0-101.el9_0.1
 
-    If the rsyslog-gnutls package is not installed, this is a finding.
+    rsyslog-gnutls.x86_64          8.2102.0-101.el9_0.1
+
+    If the "rsyslog-gnutls" package is not installed, this is a finding.
 
 fixtext: |-
     The  rsyslog-gnutls package can be installed with the following command:

--- a/linux_os/guide/system/logging/package_rsyslog_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/logging/package_rsyslog_installed/policy/stig/shared.yml
@@ -5,7 +5,13 @@ vuldiscussion: |-
     rsyslogd is a system utility providing support for message logging.  Support for both internet and UNIX domain sockets enables this utility to support both local and remote logging.  Couple this utility with "gnutls" (which is a secure communications library implementing the SSL, TLS and DTLS protocols), and you have a method to securely encrypt and off-load auditing.
 
 checktext: |-
-    Verify that {{{ full_name }}} has the rsyslogd package installed with the following command:$ sudo dnf list --installed rsyslogrsyslog.x86_64  8.2102.0-101.el9_0.1If the rsyslogd package is not installed, this is a finding.
+    Verify that {{{ full_name }}} has the rsyslogd package installed with the following command:
+
+    $ sudo dnf list --installed rsyslog
+
+    rsyslog.x86_64          8.2102.0-101.el9_0.1
+
+    If the "rsyslogd" package is not installed, this is a finding.
 
 fixtext: |-
     The  rsyslogd  package can be installed with the following command:

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/policy/stig/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/policy/stig/shared.yml
@@ -9,9 +9,15 @@ vuldiscussion: |-
 checktext: |-
     Verify that {{{ full_name }}} is not configured to receive remote logs using rsyslog.
 
-    Check for lines in configuration that enable receiving remote messages with the following command:
+    Check for lines in configuration that enable receiving remote messages with the following commands:
 
-    $ grep -Ei -e '^\s*\$ModLoad (imtcp|imudp|imrelp)' -e '^\s*\$(InputTCP|UDP|InputRELP)ServerRun .*' /etc/rsyslog.conf /etc/rsyslog.d/*
+    $ grep -i modload /etc/rsyslog.conf /etc/rsyslog.d/*
+    $ModLoad imtcp
+    $ModLoad imrelp
+
+    $ grep -i serverrun /etc/rsyslog.conf /etc/rsyslog.d/*
+    $InputTCPServerRun 514
+    $InputRELPServerRun 514
 
     Note: You may see an error about no files or directories. This is not a finding.
 

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/policy/stig/shared.yml
@@ -12,7 +12,13 @@ vuldiscussion: |-
     Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by enforcing connection rules of remote access applications on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets)."
 
 checktext: |-
-    Run the following command to determine if the  firewalld  package is installed:$ sudo dnf list --installed firewalld firewalld.noarch1.0.0-4.el9If the firewall package is not installed, this is a finding.
+    Run the following command to determine if the  firewalld  package is installed with the following command:
+
+    $ sudo dnf list --installed firewalld
+
+    firewalld.noarch                1.0.0-4.el9
+
+    If the "firewall" package is not installed, this is a finding.
 
 fixtext: |-
     To install the "firewalld" package run the following command:

--- a/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/policy/stig/shared.yml
@@ -11,11 +11,11 @@ checktext: |-
 
     Check that the libreswan service package is installed with the following command:
 
-    $ dnf list --installed libreswan
+    $ sudo dnf list --installed libreswan
 
     libreswan.x86_64     4.6-3.el9
 
-    If the libreswan package is not installed, this is a finding.
+    If the "libreswan" package is not installed, this is a finding.
 
 fixtext: |-
     Install the libreswan service (if it is not already installed) with the following command:

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.all.accept_ra | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv6.conf.all.accept_ra | tail -1
 
     net.ipv6.conf.all.accept_ra = 0
 
@@ -30,7 +30,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv6.conf.all.accept_ra=0
+    net.ipv6.conf.all.accept_ra = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/policy/stig/shared.yml
@@ -11,7 +11,7 @@ checktext: |-
 
     Check the value of the "accept_redirects" variables with the following command:
 
-    $ sudo sysctl net.ipv6.conf.all.accept_redirects
+    $ sysctl net.ipv6.conf.all.accept_redirects
 
     net.ipv6.conf.all.accept_redirects = 0
 
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.all.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.all.accept_redirects | tail -1
 
     net.ipv6.conf.all.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/policy/stig/shared.yml
@@ -12,7 +12,7 @@ checktext: |-
 
     Check the value of the accept source route variable with the following command:
 
-    $ sudo sysctl net.ipv6.conf.all.accept_source_route
+    $ sysctl net.ipv6.conf.all.accept_source_route
 
     net.ipv6.conf.all.accept_source_route = 0
 
@@ -20,7 +20,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.all.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.all.accept_source_route | tail -1
 
     net.ipv6.conf.all.accept_source_route = 0
 
@@ -31,7 +31,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv6.conf.all.accept_source_route=0
+    net.ipv6.conf.all.accept_source_route = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/policy/stig/shared.yml
@@ -13,7 +13,7 @@ checktext: |-
 
     Check that IPv6 forwarding is disabled using the following commands:
 
-    $ sudo sysctl net.ipv6.conf.all.forwarding
+    $ sysctl net.ipv6.conf.all.forwarding
 
     net.ipv6.conf.all.forwarding = 0
 
@@ -21,7 +21,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.all.forwarding | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv6.conf.all.forwarding | tail -1
 
     net.ipv6.conf.all.forwarding = 0
 
@@ -32,7 +32,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv6.conf.all.forwarding=0
+    net.ipv6.conf.all.forwarding = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/policy/stig/shared.yml
@@ -11,7 +11,7 @@ checktext: |-
 
     Check to see if router advertisements are not accepted by default by using the following command:
 
-    $ sudo sysctl net.ipv6.conf.default.accept_ra
+    $ sysctl net.ipv6.conf.default.accept_ra
 
     net.ipv6.conf.default.accept_ra = 0
 
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.default.accept_ra | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.default.accept_ra | tail -1
 
     net.ipv6.conf.default.accept_ra = 0
 
@@ -30,7 +30,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv6.conf.default.accept_ra=0
+    net.ipv6.conf.default.accept_ra = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/policy/stig/shared.yml
@@ -11,7 +11,7 @@ checktext: |-
 
     Check the value of the default "accept_redirects" variables with the following command:
 
-    $ sudo sysctl net.ipv6.conf.default.accept_redirects
+    $ sysctl net.ipv6.conf.default.accept_redirects
 
     net.ipv6.conf.default.accept_redirects = 0
 
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.default.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.default.accept_redirects | tail -1
 
     net.ipv6.conf.default.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     Check the value of the accept source route variable with the following command:
 
-    $ sudo sysctl net.ipv6.conf.default.accept_source_route
+    $ sysctl net.ipv6.conf.default.accept_source_route
 
     net.ipv6.conf.default.accept_source_route = 0
 
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv6.conf.default.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.default.accept_source_route | tail -1
 
     net.ipv6.conf.default.accept_source_route = 0
 
@@ -33,7 +33,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv6.conf.default.accept_source_route=0
+    net.ipv6.conf.default.accept_source_route = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/policy/stig/shared.yml
@@ -16,7 +16,7 @@ checktext: |-
 
     Check the value of the all "accept_redirects" variables with the following command:
 
-    $ sudo sysctl net.ipv4.conf.all.accept_redirects
+    $ sysctl net.ipv4.conf.all.accept_redirects
 
     net.ipv4.conf.all.accept_redirects = 0
 
@@ -24,7 +24,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.all.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.all.accept_redirects | tail -1
 
     net.ipv4.conf.all.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/policy/stig/shared.yml
@@ -18,7 +18,7 @@ checktext: |-
 
     Check the value of the all "accept_source_route" variables with the following command:
 
-    $ sudo sysctl net.ipv4.conf.all.accept_source_route
+    $ sysctl net.ipv4.conf.all.accept_source_route
 
     net.ipv4.conf.all.accept_source_route = 0
 
@@ -26,7 +26,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.all.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.all.accept_source_route | tail -1
 
     net.ipv4.conf.all.accept_source_route = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/policy/stig/shared.yml
@@ -11,7 +11,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} uses reverse path filtering on all IPv4 interfaces with the following commands:
 
-    $ sudo sysctl net.ipv4.conf.all.rp_filter
+    $ sysctl net.ipv4.conf.all.rp_filter
 
     net.ipv4.conf.all.rp_filter = 1
 
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.all.rp_filter | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.all.rp_filter | tail -1
 
     net.ipv4.conf.all.rp_filter = 1
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     Check the value of the default "accept_redirects" variables with the following command:
 
-    $ sudo sysctl net.ipv4.conf.default.accept_redirects
+    $ sysctl net.ipv4.conf.default.accept_redirects
 
     net.ipv4.conf.default.accept_redirects = 0
 
@@ -23,7 +23,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.default.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.accept_redirects | tail -1
 
     net.ipv4.conf.default.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/policy/stig/shared.yml
@@ -1,0 +1,43 @@
+srg_requirement: |-
+    {{{ full_name }}} must not forward IPv4 source-routed packets by default.
+
+vuldiscussion: |-
+    Source-routed packets allow the source of the packet to suggest routers
+    forward the packet along a different path than configured on the router,
+    which can be used to bypass network security measures.
+
+
+    Accepting source-routed packets in the IPv4 protocol has few legitimate
+    uses. It should be disabled unless it is absolutely required, such as when
+    IPv4 forwarding is enabled and the system is legitimately functioning as a
+    router.
+
+checktext: |-
+    Verify {{{ full_name }}} does not accept IPv4 source-routed packets by default.
+
+    Check the value of the accept source route variable with the following command:
+
+    $ sysctl net.ipv4.conf.default.accept_source_route
+
+    net.ipv4.conf.default.accept_source_route = 0
+
+    If the returned line does not have a value of "0", a line is not returned, or the line is commented out, this is a finding.
+
+    Check that the configuration files are present to enable this network parameter.
+
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.accept_source_route | tail -1
+
+    net.ipv4.conf.default.accept_source_route = 0
+
+    If "net.ipv4.conf.default.accept_source_route" is not set to "0" or is missing, this is a finding.
+
+fixtext: |-
+    Configure {{{ full_name }}} to not forward IPv4 source-routed packets by default.
+
+    Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
+
+    net.ipv4.conf.default.accept_source_route = 0
+
+    Load settings from all system configuration files with the following command:
+
+    $ sudo sysctl --system

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/policy/stig/shared.yml
@@ -1,0 +1,37 @@
+srg_requirement: |-
+    {{{ full_name }}} must use a reverse-path filter for IPv4 network traffic when possible by default.
+
+vuldiscussion: |-
+    Enabling reverse path filtering drops packets with source addresses
+    that should not have been able to be received on the interface they were
+    received on. It should not be used on systems which are routers for
+    complicated networks, but is helpful for end hosts and routers serving small
+    networks.
+
+checktext: |-
+    Verify {{{ full_name }}} uses reverse path filtering on IPv4 interfaces with the following commands:
+
+    $ sudo sysctl net.ipv4.conf.default.rp_filter
+
+    net.ipv4.conf.default.rp_filter = 1
+
+    If the returned line does not have a value of "1", or a line is not returned, this is a finding.
+
+    Check that the configuration files are present to enable this network parameter.
+
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.rp_filter | tail -1
+
+    net.ipv4.conf.default.rp_filter = 1
+
+    If "net.ipv4.conf.default.rp_filter" is not set to "1" or is missing, this is a finding.
+
+fixtext: |-
+    Configure {{{ full_name }}} to use reverse path filtering on IPv4 interfaces by default.
+
+    Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
+
+    net.ipv4.conf.default.rp_filter = 1
+
+    Load settings from all system configuration files with the following command:
+
+    $ sudo sysctl --system

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     Check the value of the "icmp_echo_ignore_broadcasts" variable with the following command:
 
-    $ sudo sysctl net.ipv4.icmp_echo_ignore_broadcasts
+    $ sysctl net.ipv4.icmp_echo_ignore_broadcasts
 
     net.ipv4.icmp_echo_ignore_broadcasts = 1
 
@@ -33,7 +33,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv4.icmp_echo_ignore_broadcasts=1
+    net.ipv4.icmp_echo_ignore_broadcasts = 1
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ {  sudo /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.tcp_syncookies | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.tcp_syncookies | tail -1
     net.ipv4.tcp_syncookies = 1
 
     If the network parameter "ipv4.tcp_syncookies" is not equal to "1" or nothing is returned, this is a finding.

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     Check the value of the "all send_redirects" variables with the following command:
 
-    $ sudo sysctl net.ipv4.conf.all.send_redirects
+    $ sysctl net.ipv4.conf.all.send_redirects
 
     net.ipv4.conf.all.send_redirects = 0
 
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.all.send_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv4.conf.all.send_redirects | tail -1
 
     net.ipv4.conf.all.send_redirects = 0
 
@@ -33,7 +33,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv4.conf.all.send_redirects=0
+    net.ipv4.conf.all.send_redirects = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     Check the value of the "default send_redirects" variables with the following command:
 
-    $ sudo sysctl net.ipv4.conf.default.send_redirects
+    $ sysctl net.ipv4.conf.default.send_redirects
 
     net.ipv4.conf.default.send_redirects=0
 
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $  { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.default.send_redirects | tail -1
+    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.send_redirects | tail -1
 
     net.ipv4.conf.default.send_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/policy/stig/shared.yml
@@ -12,9 +12,9 @@ checktext: |-
 
     Check that IPv4 forwarding is disabled using the following command:
 
-    $ sudo sysctl net.ipv4.ip_forward
+    $ sysctl net.ipv4.conf.all.forwarding
 
-    net.ipv4.ip_forward = 0
+    net.ipv4.conf.all.forwarding = 0
 
     If the IPv4 forwarding value is not "0" and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
@@ -31,7 +31,7 @@ fixtext: |-
 
     Add or edit the following line in a single system configuration file, in the "/etc/sysctl.d/" directory:
 
-    net.ipv4.conf.all.forwarding=0
+    net.ipv4.conf.all.forwarding = 0
 
     Load settings from all system configuration files with the following command:
 

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/policy/stig/shared.yml
@@ -1,19 +1,17 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Be Configured To Disable Non-Essential Capabilities.
+    {{{ full_name }}} must be configured to disable the Controller Area Network kernel module.
 
 vuldiscussion: |-
-    Disabling Controller Area Network (CAN) protects the system against exploitation of any
-    flaws in its implementation.
+    Disabling Controller Area Network (CAN) protects the system against exploitation of any flaws in its implementation.
 
 checktext: |-
+    Verify that {{{ full_name }}} disables the ability to load the CAN kernel module with the following command:
 
-    If the system is configured to prevent the loading of the  can  kernel module,
-    it will contain lines inside any file in  /etc/modprobe.d  or the deprecated /etc/modprobe.conf .
-    These lines instruct the module loading system to run another program (such as  /bin/true ) upon a module  install  event.
-    Run the following command to search for such lines in all files in  /etc/modprobe.d  and the deprecated  /etc/modprobe.conf :
-     $ grep -r can /etc/modprobe.conf /etc/modprobe.d
+    $ sudo grep -r can /etc/modprobe.conf /etc/modprobe.d/*
 
-    If no line is returned, then this is a finding.
+    blacklist can
+
+    If the command does not return any output, or the line is commented out, and use of CAN is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
 fixtext: |-
     To configure the system to prevent the can kernel module from being loaded, add the following line to the file  /etc/modprobe.d/can.conf (or create atm.conf if it does not exist):

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -16,5 +16,3 @@
 - name: Deactivate Wireless Network Interfaces
   command: nmcli radio wifi off
   when: "'NetworkManager' in ansible_facts.packages"
-
-

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/policy/stig/shared.yml
@@ -10,14 +10,16 @@ vuldiscussion: |-
     those responsible for one.
 
 checktext: |-
-    To check the permissions of /etc/audit/auditd.conf ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/audit/auditd.conf
-    If properly configured, the output should indicate the following permissions:
+    Verify the mode of /etc/audit/auditd.conf with the command:
+
+    $ sudo stat -c "%a %n" /etc/audit/auditd.conf
+
     640 /etc/audit/auditd.conf
 
-    If /etc/audit/auditd.conf does not have unix mode 0640, then this is a finding.
+    If "/etc/audit/auditd.conf" does not have a mode of "0640", this is a finding.
 
 fixtext: |-
-    To properly set the permissions of /etc/audit/auditd.conf , run the command:
-     $ sudo chmod 0640 /etc/audit/auditd.conf
+    Set the mode of /etc/audit/auditd.conf file to 0640 with the command:
+
+    $ sudo chmod 0640 /etc/audit/auditd.conf
+

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/policy/stig/shared.yml
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is important for system security.
 
 checktext: |-
-    To check the group ownership of /etc/group- ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/group-
-    If properly configured, the output should indicate the following group-owner:
-     root /etc/group-
+    Verify the group ownership of the "/etc/group-" file with the following command:
 
-    If /etc/group- does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/group-
+
+    root /etc/group-
+
+    If "/etc/group-" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/group- to root by running the following command:
+
     $ sudo chgrp root /etc/group-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     it contains group password hashes. Protection of this file is critical for system security.
 
 checktext: |-
-    To check the group ownership of /etc/gshadow- ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/gshadow-
-    If properly configured, the output should indicate the following group-owner:
-     root
+    Verify the group ownership of the "/etc/gshadow-" file with the following command:
 
-    If /etc/gshadow- does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/gshadow-
+
+    root /etc/gshadow-
+
+    If "/etc/gshadow-" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/gshadow- to root by running the following command:
+
     $ sudo chgrp root /etc/gshadow-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/policy/stig/shared.yml
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is critical for system security.
 
 checktext: |-
-    To check the group ownership of /etc/passwd- ,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/passwd-
-    If properly configured, the output should indicate the following group-owner:
-     root
+    Verify the group ownership of the "/etc/passwd-" file with the following command:
 
-    If /etc/passwd- does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/passwd-
+
+    root /etc/passwd-
+
+    If "/etc/passwd-" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/passwd- to root by running the following command:
+
     $ sudo chgrp root /etc/passwd-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/policy/stig/shared.yml
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is critical for system security.
 
 checktext: |-
-    To check the group ownership of /etc/shadow- ,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/shadow-
-    If properly configured, the output should indicate the following group-owner:
-     root
+    Verify the group ownership of the "/etc/shadow-" file with the following command:
 
-    If /etc/shadow- does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/shadow-
+
+    root /etc/shadow-
+
+    If "/etc/shadow-" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/shadow- to root by running the following command:
+
     $ sudo chgrp root /etc/shadow-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     on the system. Protection of this file is important for system security.
 
 checktext: |-
-    To check the group ownership of /etc/group ,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/group
-    If properly configured, the output should indicate the following group-owner:
-     root /etc/group
+    Verify the group ownership of the "/etc/group" file with the following command:
 
-    If /etc/group does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/group
+
+    root /etc/group
+
+    If "/etc/group" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/group to root by running the following command:
+
     $ sudo chgrp root /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     is critical for system security.
 
 checktext: |-
-    To check the group ownership of /etc/gshadow ,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/gshadow
-    If properly configured, the output should indicate the following group-owner:
-     root /etc/gshadow
+    Verify the group ownership of the "/etc/gshadow" file with the following command:
 
-    If /etc/gshadow does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/gshadow
+
+    root /etc/gshadow
+
+    If "/etc/gshadow" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/gshadow to root by running the following command:
+
     $ sudo chgrp root /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     the system. Protection of this file is critical for system security.
 
 checktext: |-
-    To check the group ownership of /etc/passwd ,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/passwd
-    If properly configured, the output should indicate the following group-owner:
-     root /etc/passwd
+    Verify the group ownership of the "/etc/passwd" file with the following command:
 
-    If /etc/passwd does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/passwd
+
+    root /etc/passwd
+
+    If "/etc/passwd" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/passwd to root by running the following command:
+
     $ sudo chgrp root /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     critical for system security.
 
 checktext: |-
-    To check the group ownership of /etc/shadow ,
-    run the command:
-     $ sudo stat -c "%G %n" /etc/shadow
-    If properly configured, the output should indicate the following group-owner:
-     root  /etc/shadow
+    Verify the group ownership of the "/etc/shadow" file with the following command:
 
-    If /etc/shadow does not have a group owner of root, then this is a finding.
+    $ sudo stat -c "%G %n" /etc/shadow
+
+    root /etc/shadow
+
+    If "/etc/shadow" file does not have a group owner of "root", this is a finding.
 
 fixtext: |-
     Change the group of the file /etc/shadow to root by running the following command:
+
     $ sudo chgrp root /etc/shadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/group- file must be group-owned by root.
+    The {{{ full_name }}} /etc/group- file must be owned by root.
 
 vuldiscussion: |-
     The "/etc/group-" file is a backup file of "/etc/group", and as such,
@@ -7,14 +7,16 @@ vuldiscussion: |-
     Protection of this file is important for system security.
 
 checktext: |-
-    To check the ownership of /etc/group- ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/group-
-    If properly configured, the output should indicate the following owner:
-     root
+    Verify the ownership of the "/etc/group-" file with the following command:
 
-    If /etc/group- does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/group-
+
+    root /etc/group-
+
+    If "/etc/group-" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
-    Change the group of the file /etc/group- to root by running the following command:
-    $ sudo chgrp root /etc/group-
+    Change the owner of the file /etc/group- to root by running the following command:
+
+    $ sudo chown root /etc/group-
+

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_gshadow/policy/stig/shared.yml
@@ -1,19 +1,20 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/gshadow- file must be group-owned by root.
+    The {{{ full_name }}} /etc/gshadow- file must be owned by root.
 
 vuldiscussion: |-
     The "/etc/gshadow-" file is a backup of "/etc/gshadow", and as such,
     it contains group password hashes. Protection of this file is critical for system security.
 
 checktext: |-
-    To check the ownership of /etc/gshadow- ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/gshadow-
-    If properly configured, the output should indicate the following owner:
-     root
+    Verify the ownership of the "/etc/gshadow-" file with the following command:
 
-    If /etc/gshadow- does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/gshadow-
+
+    root /etc/gshadow-
+
+    If "/etc/gshadow-" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
-    Change the group of the file /etc/gshadow- to root by running the following command:
-    $ sudo chgrp root /etc/gshadow-
+    Change the owner of the file /etc/gshadow- to root by running the following command:
+
+    $ sudo chown root /etc/gshadow-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_passwd/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/passwd- file must be group-owned by root.
+    The {{{ full_name }}} /etc/passwd- file must be owned by root.
 
 vuldiscussion: |-
     The "/etc/passwd-" file is a backup file of "/etc/passwd", and as such,
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is critical for system security.
 
 checktext: |-
-    To check the ownership of /etc/passwd- ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/passwd-
-    If properly configured, the output should indicate the following owner:
-     root
+    Verify the ownership of the "/etc/passwd-" file with the following command:
 
-    If /etc/passwd- does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/passwd-
+
+    root /etc/passwd-
+
+    If "/etc/passwd-" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
-    Change the group of the file /etc/passwd- to root by running the following command:
-    $ sudo chgrp root /etc/passwd-
+    Change the owner of the file /etc/passwd- to root by running the following command:
+
+    $ sudo chown root /etc/passwd-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_shadow/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/shadow- file must be group-owned by root.
+    The {{{ full_name }}} /etc/shadow- file must be owned by root.
 
 vuldiscussion: |-
     The "/etc/shadow-" file is a backup file of "/etc/shadow", and as such,
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is critical for system security.
 
 checktext: |-
-    To check the ownership of /etc/shadow- ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/shadow-
-    If properly configured, the output should indicate the following owner:
-     root /etc/shadow
+    Verify the ownership of the "/etc/shadow-" file with the following command:
 
-    If /etc/shadow- does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/shadow-
+
+    root /etc/shadow-
+
+    If "/etc/shadow-" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
-    Change the group of the file /etc/shadow- to root by running the following command:
-    $ sudo chgrp root /etc/shadow-
+    Change the owner of the file /etc/shadow- to root by running the following command:
+
+    $ sudo chown root /etc/shadow-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_group/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     on the system. Protection of this file is important for system security.
 
 checktext: |-
-    To check the ownership of /etc/group ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/group
-    If properly configured, the output should indicate the following owner:
-     root /etc/group
+    Verify the ownership of the "/etc/group" file with the following command:
 
-    If /etc/group does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/group
+
+    root /etc/group
+
+    If "/etc/group" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
     Change the owner of the file /etc/group to root by running the following command:
+
     $ sudo chown root /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_gshadow/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     is critical for system security.
 
 checktext: |-
-    To check the ownership of /etc/gshadow ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/gshadow
-    If properly configured, the output should indicate the following owner:
-     root /etc/gshadow
+    Verify the ownership of the "/etc/gshadow" file with the following command:
 
-    If /etc/gshadow does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/gshadow
+
+    root /etc/gshadow
+
+    If "/etc/gshadow" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
     Change the owner of the file /etc/gshadow to root by running the following command:
+
     $ sudo chown root /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_passwd/policy/stig/shared.yml
@@ -6,14 +6,15 @@ vuldiscussion: |-
     the system. Protection of this file is critical for system security.
 
 checktext: |-
-    To check the ownership of /etc/passwd ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/passwd
-    If properly configured, the output should indicate the following owner:
-     root  /etc/passwd
+    Verify the ownership of the "/etc/passwd" file with the following command:
 
-    If /etc/passwd does not have an owner of root, then this is a finding.
+    $ sudo stat -c "%U %n" /etc/passwd
+
+    root /etc/passwd
+
+    If "/etc/passwd" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
     Change the owner of the file /etc/passwd to root by running the following command:
+
     $ sudo chown root /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_etc_shadow/policy/stig/shared.yml
@@ -9,14 +9,15 @@ vuldiscussion: |-
     which could weaken the system security posture.
 
 checktext: |-
-    To check the ownership of /etc/shadow ,
-    run the command:
-     $ sudo stat -c "%U %n" /etc/shadow
-    If properly configured, the output should indicate the following owner:
+    Verify the ownership of the "/etc/shadow" file with the following command:
+
+    $ sudo stat -c "%U %n" /etc/shadow
+
     root /etc/shadow
 
-    If /etc/shadow does not have an owner of root, then this is a finding.
+    If "/etc/shadow" file does not have an owner of "root", this is a finding.
 
 fixtext: |-
     Change the owner of the file /etc/shadow to root by running the following command:
+
     $ sudo chown root /etc/shadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_group/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/passwd- file must have 0644 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/group- file must have mode 0644 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/group-" file is a backup file of "/etc/group", and as such,
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is important for system security.
 
 checktext: |-
-    To check the permissions of /etc/group- ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/group-
-    If properly configured, the output should indicate the following permissions:
+    Verify that the "/etc/group-" file has mode "0644" or less permissive with the following command:
+
+    $ sudo stat -c "%a %n" /etc/group-
+
     644 /etc/group-
 
-    If /etc/group- does not have unix mode 644, then this is a finding.
+    If a value of "0644" or less permissive is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/passwd-" to "0644" by running the following command:
-    $ sudo chmod 0644 /etc/passwd-
+    Change the mode of the file "/etc/group-" to "0644" by running the following command:
+
+    $ sudo chmod 0644 /etc/group-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/policy/stig/shared.yml
@@ -1,19 +1,20 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/gshadow- file must have 0000 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/gshadow- file must have mode 0000 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/gshadow-" file is a backup of "/etc/gshadow", and as such,
     it contains group password hashes. Protection of this file is critical for system security.
 
 checktext: |-
-    To check the permissions of /etc/gshadow- ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/gshadow-
-    If properly configured, the output should indicate the following permissions:
-    000  /etc/gshadow-
+    Verify that the "/etc/gshadow-" file has mode "0000" with the following command:
 
-    If /etc/gshadow- does not have unix mode 000, then this is a finding.
+    $ sudo stat -c "%a %n" /etc/gshadow-
+
+    0 /etc/gshadow-
+
+    If a value of "0" is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/gshadow-" to "0000" by running the following command:
+    Change the mode of the file "/etc/gshadow-" to "0000" by running the following command:
+
     $ sudo chmod 0000 /etc/gshadow-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_passwd/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/passwd- file must have 0644 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/passwd- file must have mode 0644 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/passwd-" file is a backup file of "/etc/passwd", and as such,
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is critical for system security.
 
 checktext: |-
-    To check the permissions of /etc/passwd- ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/passwd-
-    If properly configured, the output should indicate the following permissions:
-     644 /etc/passwd-
+    Verify that the "/etc/passwd-" file has mode "0644" or less permissive with the following command:
 
-    If /etc/passwd- does not have unix mode 644, then this is a finding.
+    $ sudo stat -c "%a %n" /etc/passwd-
+
+    644 /etc/passwd-
+
+    If a value of "0644" or less permissive is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/passwd-" to "0644" by running the following command:
+    Change the mode of the file "/etc/passwd-" to "0644" by running the following command:
+
     $ sudo chmod 0644 /etc/passwd-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/shadow- file must have 0000 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/shadow- file must have mode 0000 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/shadow-" file is a backup file of "/etc/shadow", and as such,
@@ -7,14 +7,15 @@ vuldiscussion: |-
     Protection of this file is critical for system security.
 
 checktext: |-
-    To check the permissions of /etc/shadow- ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/shadow-
-    If properly configured, the output should indicate the following permissions:
-    000 /etc/shadow-
+    Verify that the "/etc/shadow-" file has mode "0000" with the following command:
 
-    If /etc/shadow- does not have unix mode 000, then this is a finding.
+    $ sudo stat -c "%a %n" /etc/shadow-
+
+    0 /etc/shadow-
+
+    If a value of "0" is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/shadow-" to "0000" by running the following command:
+    Change the mode of the file "/etc/shadow-" to "0000" by running the following command:
+
     $ sudo chmod 0000 /etc/shadow-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_group/policy/stig/shared.yml
@@ -1,19 +1,20 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/group file must have 0644 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/group file must have mode 0644 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/group" file contains information regarding groups that are configured
     on the system. Protection of this file is important for system security.
 
 checktext: |-
-    To check the permissions of /etc/group ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/group
-    If properly configured, the output should indicate the following permissions:
+    Verify that the "/etc/group" file has mode "0644" or less permissive with the following command:
+
+    $ sudo stat -c "%a %n" /etc/group
+
     644 /etc/group
 
-    If /etc/group does not have unix mode 644, then this is a finding.
+    If a value of "0644" or less permissive is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/group" to "0644" by running the following command:
+    Change the mode of the file "/etc/group" to "0644" by running the following command:
+
     $ sudo chmod 0644 /etc/group

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/policy/stig/shared.yml
@@ -1,19 +1,20 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/gshadow file must have 0000 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/gshadow file must have mode 0000 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/gshadow" file contains group password hashes. Protection of this file
     is critical for system security.
 
 checktext: |-
-    To check the permissions of /etc/gshadow ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/gshadow
-    If properly configured, the output should indicate the following permissions:
-     ----------
+    Verify that the "/etc/gshadow" file has mode "0000" with the following command:
 
-    If /etc/gshadow does not have unix mode 000, then this is a finding.
+    $ sudo stat -c "%a %n" /etc/gshadow
+
+    0 /etc/gshadow
+
+    If a value of "0" is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/gshadow" to "0000" by running the following command:
+    Change the mode of the file "/etc/gshadow" to "0000" by running the following command:
+
     $ sudo chmod 0000 /etc/gshadow

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_passwd/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/group file must have 0644 or less permissive to prevent unauthorized access.
+    The {{{ full_name }}} /etc/passwd file must have mode 0644 or less permissive to prevent unauthorized access.
 
 vuldiscussion: |-
     If the "/etc/passwd" file is writable by a group-owner or the
@@ -8,14 +8,15 @@ vuldiscussion: |-
     is critical for system security.
 
 checktext: |-
-    To check the permissions of /etc/passwd ,
-    run the command:
-     $ sudo stat -c "%a %n"/etc/passwd
-    If properly configured, the output should indicate the following permissions:
-    644
+    Verify that the "/etc/passwd" file has mode "0644" or less permissive with the following command:
 
-    If /etc/passwd does not have unix mode 644, then this is a finding.
+    $ sudo stat -c "%a %n" /etc/passwd
+
+    644 /etc/passwd
+
+    If a value of "0644" or less permissive is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/group" to "0644" by running the following command:
-    $ sudo chmod 0644 /etc/group
+    Change the mode of the file "/etc/passwd" to "0644" by running the following command:
+
+    $ sudo chmod 0644 /etc/passwd

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    The {{{ full_name }}} /etc/shadow file must have 0000 to prevent unauthorized access.
+    The {{{ full_name }}} /etc/shadow file must have mode 0000 to prevent unauthorized access.
 
 vuldiscussion: |-
     The "/etc/shadow" file contains the list of local
@@ -9,14 +9,15 @@ vuldiscussion: |-
     which could weaken the system security posture.
 
 checktext: |-
-    To check the permissions of /etc/shadow ,
-    run the command:
-     $ sudo stat -c "%a %n" /etc/shadow
-    If properly configured, the output should indicate the following permissions:
-    000
+    Verify that the "/etc/shadow" file has mode "0000" with the following command:
 
-    If /etc/shadow does not have unix mode 000, then this is a finding.
+    $ sudo stat -c "%a %n" /etc/shadow
+
+    0 /etc/shadow
+
+    If a value of "0" is not returned, this is a finding.
 
 fixtext: |-
-    Change the permissions of the file "/etc/shadow" to "0000" by running the following command:
+    Change the mode of the file "/etc/shadow" to "0000" by running the following command:
+
     $ sudo chmod 0000 /etc/shadow

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_permissions_library_dirs/policy/stig/shared.yml
@@ -13,17 +13,14 @@ vuldiscussion: |-
     of initiating changes, including upgrades and modifications.
 
 checktext: |-
-    Shared libraries are stored in the following directories:
-     /lib
-    /lib64
-    /usr/lib
-    /usr/lib64
+    Verify that {{{ full_name }}} library directories have a mode of 755 or less with the following commands:
 
-    To find shared libraries that are group-writable or world-writable,
-    run the following command for each directory DIR which contains shared libraries:
-     $ sudo find -L DIR -perm /022 -type d
+     $ sudo find -L /lib -perm /022 -type d
+     $ sudo find -L /lib64 -perm /022 -type d
+     $ sudo find -L /usr/lib -perm /022 -type d
+     $ sudo find -L /usr/lib64 -perm /022 -type d
 
-    If any of these files are group-writable or world-writable, then this is a finding.
+    If any of these directories are group-writable or world-writable, this is a finding
 
 fixtext: |-
     Configure the {{{ full_name }}} library directories to be protected from unauthorized access. Run the following command, replacing "[DIRECTORY]" with any library directory with a mode more permissive than 755.

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F fs.protected_hardlinks | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F fs.protected_hardlinks | tail -1
 
     fs.protected_hardlinks = 1
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/policy/stig/shared.yml
@@ -7,9 +7,9 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} is configured to enable DAC on symlinks.
 
-    Check the status of the fs.protected_hardlinks kernel parameter with the following command:
+    Check the status of the fs.protected_symlinks kernel parameter with the following command:
 
-    $ sudo sysctl fs.protected_syminks
+    $ sudo sysctl fs.protected_symlinks
 
     fs.protected_symlinks = 1
 
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F fs.protected_symlinks | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F fs.protected_symlinks | tail -1
 
     fs.protected_symlinks = 1
 

--- a/linux_os/guide/system/permissions/mounting/service_autofs_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/service_autofs_disabled/policy/stig/shared.yml
@@ -11,7 +11,7 @@ checktext: |-
 
     masked
 
-    If the returned value is not "masked", "disabled", "Failed to get unit file state for autofs.service for autofs", or "enabled" is returned and is not documented as operational requirement with the Information System Security Officer ISSO.
+    If the returned value is not "masked", "disabled", "Failed to get unit file state for autofs.service for autofs", or "enabled" is returned and is not documented as operational requirement with the Information System Security Officer ISSO, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to disable the ability to automount devices.

--- a/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_boot_nodev/policy/stig/shared.yml
@@ -1,21 +1,18 @@
 srg_requirement: |-
-    {{{ full_name }}} Must Prevent Program Execution In Accordance With Local Policies Regarding Software Program Usage And Restrictions And/Or Rules Authorizing The Terms And Conditions Of Software Program Usage.
+    {{{ full_name }}} must mount /boot with the nodev option.
 
 vuldiscussion: |-
     The only legitimate location for device files is the "/dev" directory
     located on the root partition. The only exception to this is chroot jails.
 
 checktext: |-
-    To verify the "nodev" option is configured for the "/boot" mount point,
+    Verify that the "/boot" mount point has the "nodev" option is with the following command:
 
-    This control is not applicable to {{{ full_name }}} system booted UEFI.
+    Note: This control is not applicable to {{{ full_name }}} system booted UEFI.
 
-    Run the following
+    $ sudo mount | grep '\s/boot\s'
 
-    $ sudo mount | grep '\s/boot\
-
-    The output should show the corresponding mount point along with the "nodev" setting in parentheses.
-
+    /dev/sda1 on /boot type xfs (rw,nodev,relatime,seclabel,attr2)
 
     If the "/boot" file system does not have the "nodev" option set, this is a finding.
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/policy/stig/shared.yml
@@ -6,14 +6,13 @@ vuldiscussion: |-
 
 checktext: |-
     Verify the runtime status of the kernel.kptr_restrict kernel parameter with the following command:
-
-    $ sudo sysctl kernel.kptr_restrict
+    $ sysctl kernel.kptr_restrict
 
     kernel.kptr_restrict = 1
 
     Verify the configuration of the kernel.kptr_restrict kernel parameter with the following command:
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.kptr_restrict | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F kernel.kptr_restrict | tail -1
 
     kernel.kptr_restrict =1
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/policy/stig/shared.yml
@@ -16,7 +16,7 @@ checktext: |-
     Check that the configuration files are present to enable this kernel parameter.
     Verify the configuration of the kernel.kptr_restrict kernel parameter with the following command:
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.randomize_va_space | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F kernel.randomize_va_space | tail -1
 
     kernel.randomize_va_space = 2
 

--- a/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/poisoning/grub2_slub_debug_argument/policy/stig/shared.yml
@@ -2,11 +2,11 @@ srg_requirement: |-
     {{{ full_name }}} must clear SLUB/SLAB objects to prevent use-after-free attacks.
 
 vuldiscussion: |-
-    Poisoning writes an arbitrary value to freed objects, so any modification or
-    reference to that object after being freed or before being initialized will be
-    detected and prevented.
-    This prevents many types of use-after-free vulnerabilities at little performance cost.
-    Also prevents leak of data and detection of corrupted memory.
+    Some adversaries launch attacks with the intent of executing code in non-executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can be either hardware-enforced or software-enforced with hardware providing the greater strength of mechanism.
+
+    Poisoning writes an arbitrary value to freed pages, so any modification or reference to that page after being freed or before being initialized will be detected and prevented. This prevents many types of use-after-free vulnerabilities at little performance cost. Also prevents leak of data and detection of corrupted memory.
+
+    SLAB objects are blocks of physically-contiguous memory. SLUB is the unqueued SLAB allocator.
 
 checktext: |-
     Verify that GRUB 2 is configured to enable poisoning of SLUB/SLAB objects to mitigate use-after-free vulnerabilities with the following commands:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} disables storing core dumps with the following commands:
 
-    $ sudo sysctl kernel.core_pattern
+    $ sysctl kernel.core_pattern
 
     kernel.core_pattern = |/bin/false
 
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to disable core dump storage.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.core_pattern | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.core_pattern | tail -1
 
     kernel.core_pattern = |/bin/false
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/policy/stig/shared.yml
@@ -23,7 +23,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $  {  sudo /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.dmesg_restrict | tail -1
+    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.dmesg_restrict | tail -1
     kernel.dmesg_restrict = 1
 
     If "kernel.dmesg_restrict" is not set to "1" or is missing this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/policy/stig/shared.yml
@@ -11,7 +11,7 @@ checktext: |-
 
     Check the status of the kernel.kexec_load_disabled kernel parameter with the following command:
 
-    $ sudo sysctl kernel.kexec_load_disabled
+    $ sysctl kernel.kexec_load_disabled
 
     kernel.kexec_load_disabled = 1
 
@@ -19,11 +19,11 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter with the following command:
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.kexec_load_disabled | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.kexec_load_disabled | tail -1
 
     kernel.kexec_load_disabled = 1
 
-    If "kernel.kexec_load_disablede" is not set to "1" or is missing, this is a finding.
+    If "kernel.kexec_load_disabled" is not set to "1" or is missing, this is a finding.
 
 fixtext: |-
     Add or edit the following line in a system configuration file in the "/etc/sysctl.d/" directory:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/policy/stig/shared.yml
@@ -22,7 +22,7 @@ checktext: |-
     If "kernel.perf_event_paranoid" is not set to "2" or is missing, this is a finding.
     Check that the configuration files are present to enable this kernel parameter.
 
-    $  {  sudo /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F kernel.perf_event_paranoid | tail -1
+    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config  | egrep -v '^(#|;)' | grep -F kernel.perf_event_paranoid | tail -1
     kernel.perf_event_paranoid = 2
 
     If "kernel.perf_event_paranoid" is not set to "2" or is missing this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/policy/stig/shared.yml
@@ -8,11 +8,18 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} prevents privilege escalation thru the kernel by disabling access to the bpf syscall with the following commands:
 
-    $ sudo sysctl kernel.unprivileged_bpf_disabled
+    $ sysctl kernel.unprivileged_bpf_disabled
 
     kernel.unprivileged_bpf_disabled = 1
 
     If the returned line does not have a value of "1", or a line is not returned, this is a finding.
+
+    Check that the configuration files are present to enable this kernel parameter.
+
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.unprivileged_bpf_disabled | tail -1
+    kernel.unprivileged_bpf_disabled = 1
+
+    If the network parameter "ipv4.tcp_syncookies" is not equal to "1" or nothing is returned, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to prevent privilege escalation thru the kernel by disabling access to the bpf syscall by adding the following line to a file, in the "/etc/sysctl.d" directory:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/policy/stig/shared.yml
@@ -9,11 +9,18 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} restricts usage of ptrace to descendant processes with the following commands:
 
-    $ sudo sysctl kernel.yama.ptrace_scope
+    $ sysctl kernel.yama.ptrace_scope
 
     kernel.yama.ptrace_scope = 1
 
     If the returned line does not have a value of "1", or a line is not returned, this is a finding.
+
+    Check that the configuration files are present to enable this kernel parameter.
+
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.yama.ptrace_scope| tail -1
+    kernel.yama.ptrace_scope = 1
+
+    If the network parameter "kernel.yama.ptrace_scope" is not equal to "1" or nothing is returned, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to restrict usage of ptrace to descendant processes by adding the following line to a file, in the "/etc/sysctl.d" directory:

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/policy/stig/shared.yml
@@ -15,6 +15,13 @@ checktext: |-
 
     If the returned line does not have a value of "2", or a line is not returned, this is a finding.
 
+    Check that the configuration files are present to enable this kernel parameter.
+
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.core.bpf_jit_harden | tail -1
+    net.core.bpf_jit_harden = 2
+
+    If the network parameter "net.core.bpf_jit_harden" is not equal to "2" or nothing is returned, this is a finding.
+
 fixtext: |-
     Configure {{{ full_name }}} to enable hardening for the BPF JIT compiler by adding the following line to a file, in the "/etc/sysctl.d" directory:
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/policy/stig/shared.yml
@@ -10,11 +10,18 @@ checktext: |-
 
     Note: User namespaces are used primarily for Linux containers. If containers are in use, this requirement is not applicable.
 
-    $ sudo sysctl user.max_user_namespaces
+    $ sysctl user.max_user_namespaces
 
     user.max_user_namespaces = 0
 
     If the returned line does not have a value of "0", or a line is not returned, this is a finding.
+
+    Check that the configuration files are present to enable this kernel parameter.
+
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F user.max_user_namespaces | tail -1
+    user.max_user_namespaces = 0
+
+    If the network parameter "user.max_user_namespaces" is not equal to "0" or nothing is returned, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to disable the use of user namespaces by adding the following line to a file, in the "/etc/sysctl.d" directory:

--- a/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils-python-utils_installed/policy/stig/shared.yml
@@ -11,7 +11,7 @@ checktext: |-
 
     policycoreutils-python-utils.noarch     3.3-6.el9_0
 
-    If the policycoreutils-python-utils package is not installed, this is a finding.
+    If the "policycoreutils-python-utils" package is not installed, this is a finding.
 
 fixtext: |-
     Install the policycoreutils-python-utils service package (if the policycoreutils-python-utils service is not already installed) with the following command:

--- a/linux_os/guide/system/selinux/package_policycoreutils_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils_installed/policy/stig/shared.yml
@@ -13,9 +13,10 @@ checktext: |-
 
     policycoreutils.x86_64                                              3.3-6.el9_0
 
-    If the policycoreutils package is not installed, this is a finding.
+    If the "policycoreutils" package is not installed, this is a finding.
 
 fixtext: |-
     The policycoreutils package can be installed with the following command:
 
     $ sudo dnf install policycoreutils
+

--- a/linux_os/guide/system/selinux/package_policycoreutils_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/selinux/package_policycoreutils_installed/policy/stig/shared.yml
@@ -19,4 +19,3 @@ fixtext: |-
     The policycoreutils package can be installed with the following command:
 
     $ sudo dnf install policycoreutils
-

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/policy/stig/shared.yml
@@ -7,12 +7,14 @@ vuldiscussion: |-
     users cannot trivially fill partitions used for log or audit data storage.
 
 checktext: |-
-    Verify that a separate file system/partition has been created for  /home  with the following command:
+    Verify that a separate file system/partition has been created for "/home" with the following command:
 
-     $ mountpoint /home
+    $ mount | grep /home
 
+    UUID=fba5000f-2ffa-4417-90eb-8c54ae74a32f on /home type ext4 (rw,nodev,nosuid,noexec,seclabel)
 
-    If "/home is is not a mountpoint" is returned, then this is a finding.
+    If a separate entry for "/home" is not in use, this is a finding.
 
 fixtext: |-
-    Migrate the "/home" directory onto a separate file system.
+    Migrate the "/home" directory onto a separate file system/partition.
+

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_tmp/policy/stig/shared.yml
@@ -7,12 +7,13 @@ vuldiscussion: |-
     restrictive mount options, which can help protect programs which use it.
 
 checktext: |-
-    Verify that a separate file system/partition has been created for  /tmp  with the following command:
+    Verify that a separate file system/partition has been created for "/tmp" with the following command:
 
-     $ mountpoint /tmp
+    $ mount | grep /tmp
 
+    tmpfs /tmp tmpfs noatime,mode=1777 0 0
 
-    If "/tmp is is not a mountpoint" is returned, then this is a finding.
+    If a separate entry for "/tmp" is not in use, this is a finding.
 
 fixtext: |-
     Migrate the "/tmp" path onto a separate file system.

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var/policy/stig/shared.yml
@@ -9,12 +9,13 @@ vuldiscussion: |-
     world-writable directories installed by other software packages.
 
 checktext: |-
-    Verify that a separate file system/partition has been created for  /var  with the following command:
+    Verify that a separate file system/partition has been created for "/var" with the following command:
 
-     $ mountpoint /var
+    $ mount | grep /var
 
+    UUID=c274f65f-c5b5-4481-b007-bee96feb8b05 /var xfs noatime,nobarrier 1 2
 
-    If "/var is is not a mountpoint" is returned, then this is a finding.
+    If a separate entry for "/var" is not in use, this is a finding.
 
 fixtext: |-
     Migrate the "/var" path onto a separate file system.

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_log/policy/stig/shared.yml
@@ -7,12 +7,13 @@ vuldiscussion: |-
     and other files in "/var/".
 
 checktext: |-
-    Verify that a separate file system/partition has been created for  /var/log  with the following command:
+    Verify that a separate file system/partition has been created for "/var/log" with the following command:
 
-     $ mountpoint /var/log
+    $ mount | grep /var/log
 
+    UUID=c274f65f-c5b5-4486-b021-bee96feb8b21 /var/log xfs noatime,nobarrier 1 2
 
-    If "/var/log is is not a mountpoint" is returned, then this is a finding.
+    If a separate entry for "/var/log" is not in use, this is a finding.
 
 fixtext: |-
     Migrate the "/var/log" path onto a separate file system.

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_var_tmp/policy/stig/shared.yml
@@ -7,12 +7,13 @@ vuldiscussion: |-
     restrictive mount options, which can help protect programs which use it.
 
 checktext: |-
-    Verify that a separate file system/partition has been created for  /var/tmp  with the following command:
+    Verify that a separate file system/partition has been created for "/var/tmp" with the following command:
 
-     $ mountpoint /var/tmp
+    $ mount | grep /var/tmp
 
+    UUID=c274f65f-c5b5-4379-b017-bee96feb7a34 /var/log xfs noatime,nobarrier 1 2
 
-    If "/var/tmp is is not a mountpoint" is returned, then this is a finding.
+    If a separate entry for "/var/tmp" is not in use, this is a finding.
 
 fixtext: |-
     Migrate the "/var/tmp" path onto a separate file system.

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/policy/stig/shared.yml
@@ -1,0 +1,43 @@
+srg_requirement: |-
+    {{{ full_name }}} must prevent a user from overriding the disable-restart-buttons setting for the graphical user interface.
+
+vuldiscussion: |-
+    A user who is at the console can reboot the system at the login screen. If restart or shutdown buttons are pressed at the login screen, this can create the risk of short-term loss of availability of systems
+    due to reboot.
+
+checktext: |-
+    Verify {{{ full_name }}} prevents a user from overriding the disable-restart-buttons setting for graphical user interfaces.
+
+    Note: This requirement assumes the use of the {{{ full_name }}} default graphical user interface, Gnome Shell. If the system does not have any graphical user interface installed, this requirement is Not Applicable.
+
+    Determine which profile the system database is using with the following command:
+
+    $ sudo grep system-db /etc/dconf/profile/user
+
+    system-db:local
+
+    Check that graphical settings are locked from non-privileged user modification with the following command:
+
+    Note: The example below is using the database "local" for the system, so the path is "/etc/dconf/db/local.d". This path must be modified if a database other than "local" is being used.
+
+    $ grep disable-restart-buttons /etc/dconf/db/local.d/locks/*
+
+    /org/gnome/login-screen/disable-restart-buttons
+
+    If the command does not return at least the example result, this is a finding.
+
+fixtext: |-
+    Configure {{{ full_name }}} to prevent a user from overriding the disable-restart-buttons setting for graphical user interfaces.
+
+    Create a database to contain the system-wide graphical user logon settings (if it does not already exist) with the following command:
+
+    $ sudo touch /etc/dconf/db/local.d/locks/session
+
+    Add the following line to prevent non-privileged users from modifying it:
+
+    /org/gnome/login-screen/disable-restart-buttons
+
+    Run the following command to update the database:
+
+    $ sudo dconf update
+

--- a/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_login_screen/dconf_gnome_disable_restart_shutdown/policy/stig/shared.yml
@@ -40,4 +40,3 @@ fixtext: |-
     Run the following command to update the database:
 
     $ sudo dconf update
-

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/policy/stig/shared.yml
@@ -33,3 +33,4 @@ fixtext: |-
     Update the system databases:
 
     $ sudo dconf update
+

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_delay/policy/stig/shared.yml
@@ -33,4 +33,3 @@ fixtext: |-
     Update the system databases:
 
     $ sudo dconf update
-

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/policy/stig/shared.yml
@@ -41,3 +41,4 @@ fixtext: |-
     Add the following setting to prevent non-privileged users from modifying it:
 
     /org/gnome/desktop/screensaver/lock-enabled
+

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/policy/stig/shared.yml
@@ -41,4 +41,3 @@ fixtext: |-
     Add the following setting to prevent non-privileged users from modifying it:
 
     /org/gnome/desktop/screensaver/lock-enabled
-

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/policy/stig/shared.yml
@@ -41,4 +41,3 @@ fixtext: |-
     Add the following setting to prevent non-privileged users from modifying it:
 
     /org/gnome/desktop/screensaver/lock-delay
-

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_user_locks/policy/stig/shared.yml
@@ -41,3 +41,4 @@ fixtext: |-
     Add the following setting to prevent non-privileged users from modifying it:
 
     /org/gnome/desktop/screensaver/lock-delay
+

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/policy/stig/shared.yml
@@ -41,3 +41,4 @@ fixtext: |-
     Add the following setting to prevent non-privileged users from modifying it:
 
     /org/gnome/desktop/session/idle-delay
+

--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_session_idle_user_locks/policy/stig/shared.yml
@@ -41,4 +41,3 @@ fixtext: |-
     Add the following setting to prevent non-privileged users from modifying it:
 
     /org/gnome/desktop/session/idle-delay
-

--- a/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/gnome/gnome_system_settings/dconf_gnome_disable_ctrlaltdel_reboot/policy/stig/shared.yml
@@ -8,17 +8,15 @@ vuldiscussion: |-
     loss of availability of systems due to unintentional reboot.
 
 checktext: |-
-    To ensure that users cannot enable the Ctrl-Alt-Del sequence in the Gnome GUI, run the following:
+    Verify that users cannot enable the Ctrl-Alt-Del sequence in the Gnome GUI with the following command:
 
     Note: This requirement assumes the use of the {{{ full_name }}} default graphical user interface, Gnome Shell. If the system does not have any graphical user interface installed, this requirement is Not Applicable.
 
      $ grep logout /etc/dconf/db/local.d/locks/*
 
-    If properly configured, the output should be:
+    /org/gnome/settings-daemon/plugins/media-keys/logout
 
-    "/org/gnome/settings-daemon/plugins/media-keys/logout"
-
-    If Gnome can be configured to shut down when Ctrl-Alt-Del is pressed, then this is a finding.
+    If the output is not "/org/gnome/settings-daemon/plugins/media-keys/logout", the line is commented out, or the line is missing, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to disallow the user changing the Ctrl-Alt-Del sequence in the GNOME GUI, if it is installed and the system is used to host services whos availability could be impacted.

--- a/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/certified-vendor/installed_OS_is_vendor_supported/policy/stig/shared.yml
@@ -9,8 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify that the version or {{{ full_name }}} is vendor supported with the following command:
 
-    $ grep -i "red hat" /etc/redhat-release
-
+    $ cat /etc/redhat-release
 
     Red Hat Enterprise Linux release 9.0 (Plow)
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/policy/stig/shared.yml
@@ -11,9 +11,9 @@ vuldiscussion: |-
 checktext: |-
     Verify that BIND uses the system crypto policy with the following command:
 
-    If bind is not installed, this is not applicable.
+    If the "bind" package is not installed, this is not applicable.
 
-     $ sudo grep include /etc/named.conf
+    $ sudo grep include /etc/named.conf
 
     include "/etc/crypto-policies/back-ends/bind.config";'
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/policy/stig/shared.yml
@@ -9,15 +9,19 @@ vuldiscussion: |-
 checktext: |-
     Verify that the {{{ full_name }}} cryptography policy has been configured correctly with the following commands:
 
-    $ update-crypto-policies --show
+    $ sudo update-crypto-policies --show
 
     FIPS
 
-    $ update-crypto-policies --is-applied
+    If the cryptography is not set to "FIPS" and is not applied, this is a finding.
+
+    $ sudo update-crypto-policies --check
 
     The configured policy is applied.
 
-    If the cryptography is not set to "FIPS" and is not applied, this is a finding.
+    If the command does not return "The configured policy is applied.", this is a finding.
+
+
 
 fixtext: |-
     Configure the operating system to implement FIPS mode with the following command

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/policy/stig/shared.yml
@@ -7,11 +7,9 @@ vuldiscussion: |-
     fragmented.
 
 checktext: |-
-    Verify that the IPSec service uses the system crypto policy.
+    Verify that the IPSec service uses the system crypto policy with the following command:
 
-    If the ipsec service is not installed is not applicable.
-
-    Check to see if the "IPsec" service is active with the following command:
+    Note: If the ipsec service is not installed this requirement is Not Applicable.
 
     $ systemctl status ipsec
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/policy/stig/shared.yml
@@ -11,19 +11,19 @@ vuldiscussion: |-
     The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/openssl.config file.
 
 checktext: |-
-    Verify that {{{ full_name }}} OpenSSL library is configured to use only ciphers employing FIPS 140-3-approved algorithms:
-
-    Verify that system-wide crypto policies are in effect:
+    Verify that {{{ full_name }}} OpenSSL library is configured to use only ciphers employing FIPS 140-3 approved algorithms with the following command:
 
     $ sudo grep -i opensslcnf.config /etc/pki/tls/openssl.cnf
 
-    .include /etc/crypto-policies/back-ends/opensslcnf.config
+    .include = /etc/crypto-policies/back-ends/opensslcnf.config
 
     If the "opensslcnf.config" is not defined in the "/etc/pki/tls/openssl.cnf" file, this is a finding.
 
 fixtext: |-
-    Configure the {{{ full_name }}} OpenSSL library to use only ciphers employing FIPS 140-3-approved algorithms with the following command:
+    Configure the {{{ full_name }}} OpenSSL library to use the system cryptograhpic policy.
 
-    $ sudo fips-mode-setup --enable
+    Edit the "/etc/pki/tls/openssl.cnf" and add or modify the following line:
+    .include = /etc/crypto-policies/back-ends/opensslcnf.config
+
 
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/policy/stig/shared.yml
@@ -11,15 +11,7 @@ vuldiscussion: |-
     The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/openssl.config file.
 
 checktext: |-
-    Verify that {{{ full_name }}} OpenSSL library is configured to use  TLS 1.2 encryption or stronger.
-
-    Determine the version of crypto-policies that is installed on the system with the following command:
-
-    $ sudo dnf list --installed crypto-policies
-
-    crpyto-policies.noarch                20220223-1.git5203b41.el9_0.1
-
-    For version crypto-policies-20210617-1.gitc776d3e.el8.noarch and newer:
+    Verify that {{{ full_name }}} OpenSSL library is configured to use TLS 1.2 encryption or stronger with following command:
 
     $ grep -i  minprotocol /etc/crypto-policies/back-ends/opensslcnf.config
 
@@ -29,9 +21,13 @@ checktext: |-
     If the "TLS.MinProtocol" is set to anything older than "TLSv1.2" or the "DTLS.MinProtocol" is set to anything older than DTLSv1.2, this is a finding.
 
 fixtext: |-
-    Configure the {{{ full_name }}} OpenSSL library to use only DoD-approved TLS encryption by editing the following line in the "/etc/crypto-policies/back-ends/opensslcnf.config" file:
+    Reinstall the crypto-policies package to remove any modifications.
 
-    TLS.MinProtocol = TLSv1.2
-    DTLS.MinProtocol = DTLSv1.2
+    $ sudo dnf reinstall crypto-policies
 
+    Then ensure that FIPS mode is setup with the following command:
+
+    $ sudo fips-mode-setup --enable
+
+    The system must be rebooted for the changes to take effect.
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/policy/stig/shared.yml
@@ -8,20 +8,19 @@ vuldiscussion: |-
 
     Cryptographic mechanisms used for protecting the integrity of information include, for example, signed hash functions using asymmetric cryptography enabling distribution of the public key to verify the hash information while maintaining the confidentiality of the secret key used to generate the hash.
 
-    {{{ full_name }}} incorporates system-wide crypto policies by default. The SSH configuration file has no effect on the ciphers, MACs, or algorithms unless specifically defined in the /etc/sysconfig/sshd file. The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/ directory.
+    The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/openssl.config file.
 
 checktext: |-
     Verify that system-wide crypto policies are in effect:
 
-    $ sudo grep CRYPTO_POLICY /etc/sysconfig/sshd
+    $ sudo grep Include /etc/ssh/sshd_config  /etc/ssh/sshd_config.d/*
+    /etc/ssh/sshd_config:Include /etc/ssh/sshd_config.d/*.conf
+    /etc/ssh/sshd_config.d/50-redhat.conf:Include /etc/crypto-policies/back-ends/opensshserver.config
 
-    # CRYPTO_POLICY=
-
-    If a "CRYPTO_POLICY" line is found and is uncommented, this is a finding.
+    If "Include /etc/ssh/sshd_config.d/*.conf" or "Include /etc/crypto-policies/back-ends/opensshserver.config" are not included in the system sshd config or the file /etc/ssh/sshd_config.d/50-redhat.conf is missing, this is a finding
 
 fixtext: |-
-    Configure the {{{ full_name }}} SSH daemon to use system-wide crypto policies by commenting or removing the 'CRYPTO_POLICY=' line in /etc/sysconfig/sshd:
+    Configure the {{{ full_name }}} SSH daemon to use system-wide crypto policies by running the following commands:
 
-    # CRYPTO_POLICY=
-
+    $ sudo dnf reinstall openssh-server
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/policy/stig/shared.yml
@@ -11,17 +11,17 @@ vuldiscussion: |-
     {{{ full_name }}} incorporates system-wide crypto policies by default. The SSH configuration file has no effect on the ciphers, MACs, or algorithms unless specifically defined in the /etc/sysconfig/sshd file. The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/opensshserver.config file.
 
 checktext: |-
-    Verify the SSH client is configured to use only ciphers employing FIPS 140-3-approved algorithms with the following command:
+    Verify that system-wide crypto policies are in effect:
 
-    $ sudo grep -i ciphers /etc/crypto-policies/back-ends/openssh.config
+    $ sudo grep Include /etc/ssh/ssh_config  /etc/ssh/ssh_config.d/*
+    /etc/ssh/ssh_config:Include /etc/ssh/ssh_config.d/*.conf
+    /etc/ssh/ssh_config.d/50-redhat.conf:        Include /etc/crypto-policies/back-ends/openssh.config
 
-    Ciphers aes256-ctr,aes192-ctr,aes128-ctr
+    If "Include /etc/crypto-policies/back-ends/openssh.config" or "Include /etc/ssh/ssh_config.d/*.conf" are not included in the system ssh client config or the file "/etc/ssh/ssh_config.d/50-redhat.conf" is missing, this is a finding.
 
-    If the cipher entries in the "openssh.config" file have any ciphers other than "aes256-ctr,aes192-ctr,aes128-ctr", the order differs from the example above, they are missing, or commented out, this is a finding.
 
 fixtext: |-
-    Configure the {{{ full_name }}} SSH client to use only ciphers employing FIPS 140-3-approved algorithms by updating the "/etc/crypto-policies/back-ends/openssh.config" file with the following line:
+    Configure the {{{ full_name }}} SSH daemon to use system-wide crypto policies by running the following commands:
 
-    Ciphers=aes256-ctr,aes192-ctr,aes128-ctr
-
+    $ sudo dnf reinstall openssh-clients
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/policy/stig/shared.yml
@@ -24,4 +24,5 @@ fixtext: |-
     Configure the {{{ full_name }}} SSH daemon to use system-wide crypto policies by running the following commands:
 
     $ sudo dnf reinstall openssh-clients
+
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/policy/stig/shared.yml
@@ -29,4 +29,3 @@ fixtext: |-
     $ sudo fips-mode-setup --enable
 
     The system must be rebooted for the changes to take effect.
-

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} SSH server must be configured to use only Message Authentication Codes (MACs) employing FIPS 140-2 validated cryptographic hash algorithms.
+    {{{ full_name }}} SSH client must be configured to use only Message Authentication Codes (MACs) employing FIPS 140-2 validated cryptographic hash algorithms.
 
 vuldiscussion: |-
     Without cryptographic integrity protections, information can be altered by unauthorized users without detection.
@@ -11,19 +11,22 @@ vuldiscussion: |-
     {{{ full_name }}} incorporates system-wide crypto policies by default. The SSH configuration file has no effect on the ciphers, MACs, or algorithms unless specifically defined in the /etc/sysconfig/sshd file. The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/opensshserver.config file.
 
 checktext: |-
-    Verify SSH cllient is configured to use only ciphers employing FIPS 140-3-approved algorithms with the following command:
+    Verify SSH cllient is configured to use only ciphers employing FIPS 140-3 approved algorithms with the following command:
 
     $ sudo grep -i macs /etc/crypto-policies/back-ends/openssh.config
-    MACs hmac-sha2-512,hmac-sha2-256
+    MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
 
-    If the MACs entries in the "openssh.config" file have any hashes other than "hmac-sha2-512" and "hmac-sha2-256", the order differs from the example above, they are missing, or commented out, this is a finding.
-
+    If the MACs entries in the "openssh.config" file have any hashes other than  "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com", "hmac-sha2-256", "hmac-sha2-512", the order differs from the example above, they are missing, or commented out, this is a finding.
 
 fixtext: |-
-    Configure the {{{ full_name }}} SSH client to use only MACs employing FIPS 140-3-approved algorithms by updating the "/etc/crypto-policies/back-ends/openssh.config" file with the following line:
+    Reinstall the crypto-policies package to remove any modifications.
 
-    MACs hmac-sha2-512,hmac-sha2-256
+    $ sudo dnf reinstall crypto-policies
 
-    A reboot is required for the changes to take effect.
+    Then ensure that FIPS mode is setup with the following command:
+
+    $ sudo fips-mode-setup --enable
+
+    The system must be rebooted for the changes to take effect.
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/policy/stig/shared.yml
@@ -29,4 +29,3 @@ fixtext: |-
     $ sudo fips-mode-setup --enable
 
     The system must be rebooted for the changes to take effect.
-

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} must implement DoD-approved encryption ciphers to protect the confidentiality of SSH server connections.
+    {{{ full_name }}} SSH server must be configured to use only Message Authentication Codes (MACs) employing FIPS 140-2 validated cryptographic hash algorithms.
 
 vuldiscussion: |-
     Without cryptographic integrity protections, information can be altered by unauthorized users without detection.
@@ -11,13 +11,13 @@ vuldiscussion: |-
     {{{ full_name }}} incorporates system-wide crypto policies by default. The SSH configuration file has no effect on the ciphers, MACs, or algorithms unless specifically defined in the /etc/sysconfig/sshd file. The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/opensshserver.config file.
 
 checktext: |-
-    Verify the SSH server is configured to use only ciphers employing FIPS 140-3 approved algorithms with the following command:
+    Verify SSH server is configured to use only ciphers employing FIPS 140-3 approved algorithms with the following command:
 
-    $ sudo grep -i ciphers /etc/crypto-policies/back-ends/opensshserver.config
+    $ sudo grep -i macs /etc/crypto-policies/back-ends/opensshserver.config
+    MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha2-256,hmac-sha2-512
 
-    Ciphers aes256-gcm@openssh.com,aes256-ctr,aes128-gcm@openssh.com,aes128-ctr
 
-    If the cipher entries in the "opensshserver.config" file have any ciphers other than "aes256-gcm@openssh.com", "aes256-ctr", "aes128-gcm@openssh.com", "aes128-ctr", the order differs from the example above, they are missing, or commented out, this is a finding.
+    If the MACs entries in the "opensshserver.config" file have any hashes other than "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com", "hmac-sha2-256", "hmac-sha2-512", the order differs from the example above, they are missing, or commented out, this is a finding.
 
 fixtext: |-
     Reinstall the crypto-policies package to remove any modifications.
@@ -29,4 +29,4 @@ fixtext: |-
     $ sudo fips-mode-setup --enable
 
     The system must be rebooted for the changes to take effect.
-    A reboot is required for the changes to take effect.
+

--- a/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/package_crypto-policies_installed/policy/stig/shared.yml
@@ -13,7 +13,7 @@ checktext: |-
 
     crypto-policies.noarch     20220223-1.git5203b41.el9_0.1
 
-    If the crypto-policies package is not installed, this is a finding.
+    If the "crypto-policies" package is not installed, this is a finding.
 
 fixtext: |-
     Install the crypto-policies package (if the package is not already installed) with the following command:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/policy/stig/shared.yml
@@ -50,5 +50,3 @@ fixtext: |-
     /usr/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
     /usr/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
 
-
-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/policy/stig/shared.yml
@@ -49,4 +49,3 @@ fixtext: |-
     /usr/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
     /usr/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
     /usr/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
@@ -1,8 +1,8 @@
 srg_requirement: |-
-    {{{ full_name }}} mustroutinely check the baseline configuration for unauthorized changes and notify the system administrator when anomalies in the operation of any security functions are discovered.
+    {{{ full_name }}} must routinely check the baseline configuration for unauthorized changes and notify the system administrator when anomalies in the operation of any security functions are discovered.
 
 vuldiscussion: |-
-    nauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the operating system. Changes to operating system configurations can have unintended side effects, some of which may be relevant to security.
+    Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the operating system. Changes to operating system configurations can have unintended side effects, some of which may be relevant to security.
 
     Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the operating system. The operating system's Information Management Officer (IMO)/Information System Security Officer (ISSO) and System Administrators (SAs) must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.
 
@@ -34,9 +34,10 @@ checktext: |-
 fixtext: |-
     Configure the file integrity tool to run automatically on the system at least weekly and to notify designated personnel if baseline configurations are changed in an unauthorized manner. The AIDE tool can be configured to email designated personnel with the use of the cron system.
 
-    The following example output is generic. It will set cron to run AIDE daily and to send email at the completion of the
+    The following example output is generic. It will set cron to run AIDE daily and to send email at the completion of the analysis.
 
     $ sudo more /etc/cron.daily/aide
 
     #!/bin/bash
     /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
@@ -40,4 +40,3 @@ fixtext: |-
 
     #!/bin/bash
     /usr/sbin/aide --check | /bin/mail -s "$HOSTNAME - Daily aide integrity check run" root@sysname.mil
-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/policy/stig/shared.yml
@@ -20,3 +20,4 @@ fixtext: |-
     Configure the file integrity tool to check file and directory ACLs.
 
     If AIDE is installed, ensure the "acl" rule is present on all uncommented file and directory selection lists.
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/policy/stig/shared.yml
@@ -20,4 +20,3 @@ fixtext: |-
     Configure the file integrity tool to check file and directory ACLs.
 
     If AIDE is installed, ensure the "acl" rule is present on all uncommented file and directory selection lists.
-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/policy/stig/shared.yml
@@ -20,3 +20,4 @@ fixtext: |-
     Configure the file integrity tool to check file and directory extended attributes.
 
     If AIDE is installed, ensure the "xattrs" rule is present on all uncommented file and directory selection lists.
+

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/policy/stig/shared.yml
@@ -20,4 +20,3 @@ fixtext: |-
     Configure the file integrity tool to check file and directory extended attributes.
 
     If AIDE is installed, ensure the "xattrs" rule is present on all uncommented file and directory selection lists.
-

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/policy/stig/shared.yml
@@ -5,7 +5,13 @@ vuldiscussion: |-
     Without verification of the security functions, security functions may not operate correctly, and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters.
 
 checktext: |-
-    Verify that {{{ full_name }}} has the aide package installed with the following command:$sudo dnf list --installed aideaide.x86_640.16.100.el9If the aide package is not installed, this is a finding.
+    Verify that {{{ full_name }}} has the aide package installed with the following command:
+
+    $ sudo dnf list --installed aide
+
+    aide.x86_64        0.16.100.el9
+
+    If the "aide" package is not installed, this is a finding.
 
 fixtext: |-
     The aide package can be installed with the following command:

--- a/linux_os/guide/system/software/sudo/package_sudo_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/sudo/package_sudo_installed/policy/stig/shared.yml
@@ -14,7 +14,7 @@ checktext: |-
 
     sudo.x86_64    1.9.5p2-7.el9
 
-    If the sudo package is not installed, this is a finding.
+    If the "sudo" package is not installed, this is a finding.
 
 fixtext: |-
     The  sudo  package can be installed with the following command:

--- a/linux_os/guide/system/software/system-tools/package_gnutls-utils_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/system-tools/package_gnutls-utils_installed/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     gnutls-utils.x86_64        3.7.3-9.el9
 
-    If a gnutls-utils package is not installed, this is a finding.
+    If the "gnutls-utils" package is not installed, this is a finding.
 
 fixtext: |-
     The gnutls-utils package can be installed with the following command:

--- a/linux_os/guide/system/software/system-tools/package_gssproxy_removed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/system-tools/package_gssproxy_removed/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the gssproxy package is installed and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
+    If the "gssproxy" package is installed and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
 fixtext: |-
     Remove the gssproxy package with the following command:

--- a/linux_os/guide/system/software/system-tools/package_iprutils_removed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/system-tools/package_iprutils_removed/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the iprutils package is installed and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
+    If the "iprutils" package is installed and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
 fixtext: |-
     Remove the iprutils package with the following command:

--- a/linux_os/guide/system/software/system-tools/package_rng-tools_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/system-tools/package_rng-tools_installed/policy/stig/shared.yml
@@ -8,11 +8,11 @@ vuldiscussion: |-
 checktext: |-
     Verify that {{{ full_name }}} has the rng-tools package installed with the following command:
 
-    $ dnf list --installed rng-tools
+    $ sudo dnf list --installed rng-tools
 
     rng-tools.x86_64        6.14-2.git.b2b7934e.el9
 
-    If a rng-tools package is not installed, this is a finding.
+    If the "rng-tools" package is not installed, this is a finding.
 
 fixtext: |-
     The rng-tools package can be installed with the following command:

--- a/linux_os/guide/system/software/system-tools/package_subscription-manager_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/system-tools/package_subscription-manager_installed/policy/stig/shared.yml
@@ -21,7 +21,7 @@ checktext: |-
 
     subscription-manager.x86_64         1.29.26-3.el9_0
 
-    If the subscription-manager package is not installed, this is a finding.
+    If the "subscription-manager" package is not installed, this is a finding.
 
 fixtext: |-
     The  subscription-manager  package can be installed with the following command:

--- a/linux_os/guide/system/software/system-tools/package_tuned_removed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/system-tools/package_tuned_removed/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     Error: No matching Packages to list
 
-    If the tuned package is installed and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
+    If the "tuned" package is installed and is not documented with the Information System Security Officer (ISSO) as an operational requirement, this is a finding.
 
 fixtext: |-
     Remove the tuned package with the following command:

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} must check the GPG sign of locally installed packages.
+    {{{ full_name }}} must check the GPG signature of locally installed packages.
 
 vuldiscussion: |-
     Changes to any software components can have significant effects on the overall security of the operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.

--- a/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/updating/ensure_redhat_gpgkey_installed/policy/stig/shared.yml
@@ -12,7 +12,7 @@ checktext: |-
     To ensure that the GPG key is installed, run:
      $ rpm -q --queryformat "%{SUMMARY}\n" gpg-pubkey
     The command should return the string below:
-     gpg(Red Hat, Inc. (release key 2)  &lt;security@redhat.com&gt;
+     gpg(Red Hat, Inc. (release key 2)  &ltsecurity@redhat.com&gt
 
     If the Red Hat GPG Key is not installed, this is a finding.
 

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/ansible/shared.yml
@@ -9,4 +9,3 @@
     state: "latest"
   tags:
     - skip_ansible_lint # [ANSIBLE0010] Skipping lint because ANSIBLE0010 is a bad security practice
-

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/policy/stig/shared.yml
@@ -26,7 +26,7 @@ checktext: |-
 
     Typical update frequency may be overridden by Information Assurance Vulnerability Alert (IAVA) notifications from CYBERCOM.
 
-    If the system is in non-compliance with the organizational patching policy, then this is a finding.
+    If the system is in non-compliance with the organizational patching policy, this is a finding.
 
 fixtext: |-
     Install {{{ full_name }}} security patches and updates at the organizationally-defined frequency. If system updates are installed via a centralized repository that is configured on the system, you can install all updates with the following command:


### PR DESCRIPTION
#### Description:
This pull request brings in the latest RHEL 9 STIG process changes.

#### Rationale:

Sync the latest RHEL 9 STIG to the repo.

#### Review Hints:

The output (which is attached) from the `utils/srg_diff.py `  script will not be perfect. The rules that are missing (on both sides) are by design. We will have minor differences due to the need for rules like `dconf_db_up_to_date` for technical reasons. Some rules are combined in the STIG but are separate on our side. This is true in the audit and cron permission rules. Most of the rules under "Missing in Target" need to remove in later revisions when working with the compliance body.
[srg_diff.html.txt](https://github.com/ComplianceAsCode/content/files/10125343/srg_diff.html.txt)
