### PR TITLE
CI ansible hardening and rename of existing Bash hardening

### DIFF
--- a/tests/fmf-plans/ansible-ospp.fmf
+++ b/tests/fmf-plans/ansible-ospp.fmf
@@ -1,0 +1,12 @@
+summary:
+  Destructive OSPP profile test (Ansible)
+discover:
+  how: fmf
+  url: https://src.fedoraproject.org/tests/scap-security-guide.git
+  test:
+  - /Sanity/ansible-machine-hardening/ospp
+execute:
+  how: tmt
+adjust:
+- enabled: false
+  when: distro == fedora

--- a/tests/fmf-plans/bash-anssi.fmf
+++ b/tests/fmf-plans/bash-anssi.fmf
@@ -1,10 +1,10 @@
 summary:
-  Destructive CIS Server Level 2 profile test
+  Destructive ANSSI-BP-028 (high) profile test (Bash)
 discover:
   how: fmf
   url: https://src.fedoraproject.org/tests/scap-security-guide.git
   test:
-  - /Sanity/machine-hardening/cis
+  - /Sanity/machine-hardening/anssi_bp28_high
 execute:
   how: tmt
 adjust:

--- a/tests/fmf-plans/bash-cis.fmf
+++ b/tests/fmf-plans/bash-cis.fmf
@@ -1,10 +1,10 @@
 summary:
-  Destructive ANSSI-BP-028 (high) profile test
+  Destructive CIS Server Level 2 profile test (Bash)
 discover:
   how: fmf
   url: https://src.fedoraproject.org/tests/scap-security-guide.git
   test:
-  - /Sanity/machine-hardening/anssi_bp28_high
+  - /Sanity/machine-hardening/cis
 execute:
   how: tmt
 adjust:

--- a/tests/fmf-plans/bash-ospp.fmf
+++ b/tests/fmf-plans/bash-ospp.fmf
@@ -1,5 +1,5 @@
 summary:
-  Destructive OSPP profile test
+  Destructive OSPP profile test (Bash)
 discover:
   how: fmf
   url: https://src.fedoraproject.org/tests/scap-security-guide.git

--- a/tests/fmf-plans/bash-stig.fmf
+++ b/tests/fmf-plans/bash-stig.fmf
@@ -1,5 +1,5 @@
 summary:
-  Destructive STIG profile test
+  Destructive STIG profile test (Bash)
 discover:
   how: fmf
   url: https://src.fedoraproject.org/tests/scap-security-guide.git


### PR DESCRIPTION
#### Description:
Update existing `machine-hardening` Testing Farm tests to explicitly mention they are testing Bash - update their description and test case name.

Add `ansible-machine-hardening` Testing Farm test - the test is very similar to existing `machine-hardening` test but hardens using `ansible-playbook`.
Test case was introduced in https://src.fedoraproject.org/tests/scap-security-guide/pull-request/20 and this PR references it.

#### Rationale:
Extend CI with Ansible tests.

#### Review Hints:
See `testing-farm:centos-stream-*` checks.