### PR TITLE
sshd_disable_compression: Add test for paramemter conflicts

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/tests/param_conflict.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/tests/param_conflict.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SSHD_PARAM="Compression"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "${SSHD_PARAM} no" >> /etc/ssh/sshd_config
+echo "${SSHD_PARAM} yes" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/tests/param_conflict_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/tests/param_conflict_directory.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+SSHD_PARAM="Compression"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+   sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "${SSHD_PARAM} no" > /etc/ssh/sshd_config.d/good_config.conf
+echo "${SSHD_PARAM} yes" > /etc/ssh/sshd_config.d/bad_config.conf


### PR DESCRIPTION
#### Description:

- Add tests to ensure that the rule can check and remediate parameter configuration that are in conflict with each other.

#### Rationale:

- A rule behavior that is not tested is not ensured and maintained.