### PR TITLE
Platforms can accept parameters and pass them to underlying CPE items

### DIFF
--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -73,7 +73,10 @@ class Symbol(boolean.Symbol):
         self.obj = self.spec
 
     def __call__(self, **kwargs):
-        val = kwargs.get(self.name, False)
+        full_name = self.name
+        if self.spec.extras:
+            full_name += '[' + self.spec.extras[0] + ']'
+        val = kwargs.get(full_name, False)
         if len(self.spec.specs):
             if type(val) is str:
                 return val in self.spec
@@ -87,15 +90,27 @@ class Symbol(boolean.Symbol):
         id_str = self.name
         for (op, ver) in self.spec.specs:
             id_str += '_{0}_{1}'.format(SPEC_OP_ID_TRANSLATION.get(op, 'unknown_spec_op'), ver)
+        if self.spec.extras:
+            id_str += '_' + self.spec.extras[0]
         return id_str
 
+    def as_dict(self):
+        res = {'id': self.as_id(), 'name': self.name, 'arg': ''}
+        if self.spec.extras:
+            res['arg'] = self.spec.extras[0]
+        return res
+
     @property
-    def name(self):
-        return self.spec.project_name
+    def arg(self):
+        return self.spec.extras[0] if self.spec.extras else None
 
     @property
     def specs(self):
         return self.spec.specs
+
+    @property
+    def name(self):
+        return self.spec.project_name
 
 
 class Algebra(boolean.BooleanAlgebra):

--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -69,17 +69,17 @@ class Symbol(boolean.Symbol):
 
     def __init__(self, obj):
         super(Symbol, self).__init__(obj)
-        self.spec = pkg_resources.Requirement.parse(obj)
-        self.obj = self.spec
+        self.requirement = pkg_resources.Requirement.parse(obj)
+        self.obj = self.requirement
 
     def __call__(self, **kwargs):
         full_name = self.name
-        if self.spec.extras:
-            full_name += '[' + self.spec.extras[0] + ']'
+        if self.arg:
+            full_name += '[' + self.arg + ']'
         val = kwargs.get(full_name, False)
-        if len(self.spec.specs):
+        if len(self.version_definitions):
             if type(val) is str:
-                return val in self.spec
+                return val in self.requirement
             return False
         return bool(val)
 
@@ -88,29 +88,29 @@ class Symbol(boolean.Symbol):
 
     def as_id(self):
         id_str = self.name
-        for (op, ver) in self.spec.specs:
+        for (op, ver) in self.version_definitions:
             id_str += '_{0}_{1}'.format(SPEC_OP_ID_TRANSLATION.get(op, 'unknown_spec_op'), ver)
-        if self.spec.extras:
-            id_str += '_' + self.spec.extras[0]
+        if self.arg:
+            id_str += '_' + self.arg
         return id_str
 
     def as_dict(self):
         res = {'id': self.as_id(), 'name': self.name, 'arg': ''}
-        if self.spec.extras:
-            res['arg'] = self.spec.extras[0]
+        if self.arg:
+            res['arg'] = self.arg
         return res
 
     @property
     def arg(self):
-        return self.spec.extras[0] if self.spec.extras else None
+        return self.requirement.extras[0] if self.requirement.extras else None
 
     @property
-    def specs(self):
-        return self.spec.specs
+    def version_definitions(self):
+        return self.requirement.specs
 
     @property
     def name(self):
-        return self.spec.project_name
+        return self.requirement.project_name
 
 
 class Algebra(boolean.BooleanAlgebra):

--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -137,6 +137,7 @@ class Algebra(boolean.BooleanAlgebra):
                                       Symbol_class=symbol_cls,
                                       NOT_class=not_cls, AND_class=and_cls, OR_class=or_cls)
 
+
 def get_base_name_of_parametrized_platform(name):
     """
     If given a parametrized platform name such as package[test],

--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -136,3 +136,10 @@ class Algebra(boolean.BooleanAlgebra):
         super(Algebra, self).__init__(allowed_in_token=VERSION_SYMBOLS+SPEC_SYMBOLS,
                                       Symbol_class=symbol_cls,
                                       NOT_class=not_cls, AND_class=and_cls, OR_class=or_cls)
+
+def get_base_name_of_parametrized_platform(name):
+    """
+    If given a parametrized platform name such as package[test],
+    it returns the package part only.
+    """
+    return pkg_resources.Requirement.parse(name).project_name

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -9,11 +9,12 @@ import sys
 
 from .constants import oval_namespace
 from .constants import PREFIX_TO_NS
-from .utils import required_key
+from .utils import required_key, apply_formatting_on_dict_values
 from .xml import ElementTree as ET
 from .boolean_expression import Algebra, Symbol, Function
 from .entities.common import XCCDFEntity
 from .yaml import convert_string_to_bool
+import pkg_resources
 
 
 class CPEDoesNotExist(Exception):
@@ -87,6 +88,9 @@ class ProductCPEs(object):
             if self._is_name(ref):
                 return self.cpes_by_name[ref]
             else:
+                # in case we get parametrized item in form ref[parameter]
+                # get only the ref part
+                ref = pkg_resources.Requirement.parse(ref).project_name
                 return self.cpes_by_id[ref]
         except KeyError:
             raise CPEDoesNotExist("CPE %s is not defined" % (ref))
@@ -177,6 +181,7 @@ class CPEItem(XCCDFEntity):
             cpe_item.is_product_cpe = convert_string_to_bool(cpe_item.is_product_cpe)
         return cpe_item
 
+
 class CPEALLogicalTest(Function):
 
     prefix = "cpe-lang"
@@ -197,6 +202,10 @@ class CPEALLogicalTest(Function):
     def enrich_with_cpe_info(self, cpe_products):
         for arg in self.args:
             arg.enrich_with_cpe_info(cpe_products)
+
+    def pass_parameters(self, product_cpes):
+        for arg in self.args:
+            arg.pass_parameters(product_cpes)
 
     def to_bash_conditional(self):
         child_bash_conds = [
@@ -257,10 +266,20 @@ class CPEALFactRef (Symbol):
         self.ansible_conditional = cpe_products.get_cpe(self.cpe_name).ansible_conditional
         self.cpe_name = cpe_products.get_cpe_name(self.cpe_name)
 
+    def pass_parameters(self, product_cpes):
+        if self.arg:
+            associated_cpe_item_as_dict = product_cpes.get_cpe(self.cpe_name).represent_as_dict()
+            new_associated_cpe_item_as_dict = apply_formatting_on_dict_values(
+                associated_cpe_item_as_dict, self.as_dict())
+            new_associated_cpe_item_as_dict["id_"] = self.as_id()
+            new_associated_cpe_item = CPEItem.get_instance_from_full_dict(
+                new_associated_cpe_item_as_dict)
+            product_cpes.add_cpe_item(new_associated_cpe_item)
+            self.cpe_name = new_associated_cpe_item.name
+
     def to_xml_element(self):
         cpe_factref = ET.Element("{%s}fact-ref" % CPEALFactRef.ns)
         cpe_factref.set('name', self.cpe_name)
-
         return cpe_factref
 
     def to_bash_conditional(self):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -1610,6 +1610,7 @@ class Platform(XCCDFEntity):
         id = test.as_id()
         platform = cls(id)
         platform.test = test
+        platform.test.pass_parameters(product_cpes)
         platform.test.enrich_with_cpe_info(product_cpes)
         platform.name = id
         platform.original_expression = expression

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -219,6 +219,7 @@ def read_file_list(path):
     with open(path, 'r') as f:
         return split_string_content(f.read())
 
+
 def split_string_content(content):
     """
     Split the string content and returns as a list.
@@ -326,6 +327,28 @@ def check_conflict_regex_directory(data):
                 "specify a directory. Append '/' to the filepath or remove the "
                 "'file_regex' key.".format(data["_rule_id"], f))
 
+
 def enum(*args):
     enums = dict(zip(args, range(len(args))))
     return type('Enum', (), enums)
+
+
+def apply_formatting_on_dict_values(source_dict, string_dict, ignored_keys=[]):
+    """
+    Uses Python built-in string replacement.
+    It replaces strings marked by {token} if "token" is a key in the string_dict parameter.
+    It skips keys in source_dict which are listed in ignored_keys parameter.
+    This works only for dictionaries whose values are dicts or strings
+    """
+    new_dict = {}
+    for k, v in source_dict.items():
+        if k not in ignored_keys:
+            if isinstance(v, dict):
+                new_dict[k] = apply_formatting_on_dict_values(v, string_dict, ignored_keys)
+            elif isinstance(v, str):
+                new_dict[k] = v.format(**string_dict)
+            else:
+                new_dict[k] = v
+        else:
+            new_dict[k] = v
+    return new_dict

--- a/tests/unit/ssg-module/data/applicability/package.yml
+++ b/tests/unit/ssg-module/data/applicability/package.yml
@@ -1,0 +1,3 @@
+name: "cpe:/a:{arg}"
+title: "Package {arg} is installed"
+check_id: installed_env_has_{arg}_package

--- a/tests/unit/ssg-module/test_boolean_expressions.py
+++ b/tests/unit/ssg-module/test_boolean_expressions.py
@@ -13,7 +13,7 @@ class PlatformFunction(boolean_expression.Function):
 
 class PlatformSymbol(boolean_expression.Symbol):
     def as_cpe_lang_xml(self):
-        return '<cpe-lang:fact-ref name="cpe:/a:' + self.name + ':' + ':'.join([v for (op, v) in self.specs]) + '"/>'
+        return '<cpe-lang:fact-ref name="cpe:/a:' + self.name + ':' + ':'.join([v for (op, v) in self.version_definitions]) + '"/>'
 
 
 class PlatformAlgebra(boolean_expression.Algebra):

--- a/tests/unit/ssg-module/test_boolean_expressions.py
+++ b/tests/unit/ssg-module/test_boolean_expressions.py
@@ -81,6 +81,11 @@ def test_underscores_and_dashes_in_name(algebra):
     exp = algebra.parse(u'not_s390x_arch and dashed-name')
     assert exp(**{'not_s390x_arch': True, 'dashed-name': True})
 
+def test_expression_with_parameter(algebra):
+    exp = algebra.parse(u'package[test] and os_release[rhel]')
+    assert exp(**{"package[test]": True, "os_release[rhel]": True})
+
+
 
 def test_evaluate_simple_boolean_ops(algebra):
     exp = algebra.parse(u'(oranges | banana) and not not apple or !pie')
@@ -108,3 +113,25 @@ def test_evaluate_advanced_version_ops(algebra):
     assert not exp(**{'oranges': '0.9.999'})
     assert not exp(**{'oranges': '0.9.999_beta_2'})
     assert not exp(**{'oranges': '2.6.0'})
+
+def test_as_id(algebra):
+    exp1 = algebra.parse(u'package')
+    exp2 = algebra.parse(u'package[test]')
+    assert exp1.as_id() == "package"
+    assert exp2.as_id() == "package_test"
+
+def test_as_dict(algebra):
+    exp1 = algebra.parse(u'package')
+    exp1_dict = {
+        "arg": "",
+        "id": "package",
+        "name": "package"
+    }
+    exp2 = algebra.parse(u'package[test]')
+    exp2_dict = {
+        "arg": "test",
+        "id": "package_test",
+        "name": "package"
+    }
+    assert exp1.as_dict() == exp1_dict
+    assert exp2.as_dict() == exp2_dict

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -367,6 +367,17 @@ def test_platform_get_invalid_conditional_language(product_cpes):
     with pytest.raises(AttributeError):
         assert platform.get_remediation_conditional("foo")
 
+def test_parametrized_platform(product_cpes):
+    platform = ssg.build_yaml.Platform.from_text("package[test]", product_cpes)
+    assert platform.test.cpe_name != "cpe:/a:{arg}"
+    assert platform.test.cpe_name == "cpe:/a:test"
+    cpe_item = product_cpes.get_cpe(platform.test.cpe_name)
+    assert cpe_item.name == "cpe:/a:test"
+    assert cpe_item.title == "Package test is installed"
+    assert cpe_item.check_id == "installed_env_has_test_package"
+
+
+
 
 def test_derive_id_from_file_name():
     assert ssg.entities.common.derive_id_from_file_name("rule.yml") == "rule"

--- a/tests/unit/ssg-module/test_utils.py
+++ b/tests/unit/ssg-module/test_utils.py
@@ -87,3 +87,40 @@ def test_subset_dict():
     assert ssg.utils.subset_dict(_dict, ["red fish"]) == {"red fish": "blue fish"}
     assert ssg.utils.subset_dict(_dict, [1, "red fish"]) == _dict
     assert ssg.utils.subset_dict(_dict, []) == dict()
+
+def test_apply_formatting_on_dict_values():
+    embedded_dict = {
+        "nothing to replace": "test",
+        "replace": "some text {arg}",
+    }
+    source_dict = {
+        "nothing to replace": "test",
+        "replace everything": "{arg}",
+        "replace only part": "{arg} and some text",
+        "multiple replaces": "test1 {arg} test2 {arg}",
+        "integer": 42,
+        "float": 3.14,
+        "list": [1, "2"],
+        "embedded dictionary": embedded_dict,
+        "ignored key": "{arg}"
+    }
+    dict_with_replacements = {
+        "arg": "replaced"
+    }
+    ignored_keys = ["ignored key"]
+    result = ssg.utils.apply_formatting_on_dict_values(source_dict, dict_with_replacements, ignored_keys)
+    assert result["nothing to replace"] == "test"
+    assert result["replace everything"] == "replaced"
+    assert result["replace only part"] == "replaced and some text"
+    assert result["multiple replaces"] == "test1 replaced test2 replaced"
+    assert result["integer"] == 42
+    assert result["float"] == 3.14
+    assert result["list"] == [1, "2"]
+    assert result["ignored key"] == "{arg}"
+    res_embedded_dict = result["embedded dictionary"]
+    assert res_embedded_dict["nothing to replace"] == "test"
+    assert res_embedded_dict["replace"] == "some text replaced"
+
+
+
+


### PR DESCRIPTION
#### Description:

This PR adds a mechanism which allows platforms to be specified as
```
platform_name[parameter]
```
If such a platform is encountered, the following happens:
1. The platform is created normally. The CPE item with name platform_name must exist. This CPE item can't be used on its own because it has placeholders marked with {} which are later replaced by the parameter.
2. During platform initialization, there is a new CPE item created based on the previous one. In this case, the CPE item would be named platform_name_parameter. This CPE item has all occurences of {arg} replaced with the string "parameter".

If the platform does not have parameter in [], no change to the processing should happen.

Note that the functionality is not used in the content. But it is demonstrated in unit tests.

See commit messages as well.

#### Rationale:

This is aprt of an initiative which should allow content authors to pass parameters to platform definitions, therefore creating multiple platforms with common base attributes but with slight deviations.
