### PR TITLE
sshd_rekey_limit: Identify conflicting RekeyLimit configuration

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/oval/shared.xml
@@ -24,30 +24,36 @@
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="tests the value of {{{ parameter }}} setting in the file" id="test_sshd_rekey_limit" version="1">
      <ind:object object_ref="obj_sshd_rekey_limit"/>
+     <ind:state state_ref="state_sshd_rekey_limit"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_sshd_rekey_limit" version="1">
      <ind:filepath>{{{ sshd_config_path }}}</ind:filepath>
-     <ind:pattern var_ref="sshd_line_regex" operation="pattern match"></ind:pattern>
+     <ind:pattern operation="pattern match">^[\s]*{{{ parameter }}}[\s]+(.*)$</ind:pattern>
      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 
   {{%- if sshd_distributed_config == "true" %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="tests the value of {{{ parameter }}} setting in SSHD config directory" id="test_sshd_rekey_limit_config_dir" version="1">
      <ind:object object_ref="obj_sshd_rekey_limit_config_dir"/>
+     <ind:state state_ref="state_sshd_rekey_limit"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_sshd_rekey_limit_config_dir" version="1">
      <ind:path>{{{ sshd_config_dir}}}</ind:path>
      <ind:filename operation="pattern match">.*\.conf$</ind:filename>
-     <ind:pattern var_ref="sshd_line_regex" operation="pattern match"></ind:pattern>
+     <ind:pattern operation="pattern match">^[\s]*{{{ parameter }}}[\s]+(.*)$</ind:pattern>
      <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
   {{%- endif %}}
 
+  <ind:textfilecontent54_state id="state_sshd_rekey_limit" version="1">
+     <ind:subexpression operation="pattern match" var_ref="sshd_line_regex" />
+  </ind:textfilecontent54_state>
+
   <local_variable id="sshd_line_regex" datatype="string" comment="The regex of the directive" version="1">
     <concat>
-      <literal_component>^[\s]*{{{ parameter }}}[\s]+</literal_component>
+      <literal_component>^</literal_component>
       <variable_component var_ref="var_rekey_limit_size"/>
       <literal_component>[\s]+</literal_component>
       <variable_component var_ref="var_rekey_limit_time"/>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/duplicated_param.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/duplicated_param.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SSHD_PARAM="RekeyLimit"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "${SSHD_PARAM} 512M 1h" >> /etc/ssh/sshd_config
+echo "${SSHD_PARAM} 512M 1h" >> /etc/ssh/sshd_config
+

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/param_conflict.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/param_conflict.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SSHD_PARAM="RekeyLimit"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "${SSHD_PARAM} 512M 1h" >> /etc/ssh/sshd_config
+echo "${SSHD_PARAM} 1G 3h" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/param_conflict_directory.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_rekey_limit/tests/param_conflict_directory.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+SSHD_PARAM="RekeyLimit"
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+   sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "${SSHD_PARAM} 512M 1h" >> /etc/ssh/sshd_config.d/good_config.conf
+echo "${SSHD_PARAM} 1G 3h" >> /etc/ssh/sshd_config.d/bad_config.conf


### PR DESCRIPTION
#### Description:

- Add tests for conflicting `RekeyLimit` configuration
- Add test for multiple definitions of `RekeyLimit` with the same value
- Update the check so that it identifies conflicting definitions of `RekeyLimit` as `fail`

#### Rationale:

- Align SSH rule with RHEL8 STIG V1R8