### PR TITLE
Include new maintainers teams in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,21 @@
 # Products
 
 /products/rhel*/product.yml @ComplianceAsCode/red-hatters
+/products/ol*/product.yml @ComplianceAsCode/oracle-maintainers
+/products/sle*/product.yml @ComplianceAsCode/suse-maintainers
+/products/ubuntu*/product.yml @ComplianceAsCode/ubuntu-maintainers
 
 # Product Specific Profiles
 
 /products/rhel*/profiles/ @ComplianceAsCode/red-hatters
+/products/ol*/profiles/ @ComplianceAsCode/oracle-maintainers
+/products/sle*/profiles/ @ComplianceAsCode/suse-maintainers
+/products/ubuntu*/profiles/ @ComplianceAsCode/ubuntu-maintainers
+
+# Product Specific Control Files
+
 /controls/cis_rhel7.yml @ComplianceAsCode/red-hatters
 /controls/cis_rhel8.yml @ComplianceAsCode/red-hatters
 /controls/stig_rhel8.yml @ComplianceAsCode/red-hatters
+/controls/cis_sle12.yml @ComplianceAsCode/suse-maintainers
+/controls/cis_sle_15.yml @ComplianceAsCode/suse-maintainers


### PR DESCRIPTION
#### Description:

New teams from Oracle, SUSE and Ubuntu were included in the file with the respective product specific files.

#### Rationale:

There are teams with product specific maintainers which were approved in alignment to the Governance Rules.
This PR ensure the respective teams are notified when any PR changing their respective product specific files is filed.

#### Review Hints:

About CODEOWNERS:
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

About Syntax:
- https://git-scm.com/docs/gitignore#_pattern_format