### PR TITLE
sshd_lineinfile: Add tests for duplicated params

### DIFF
--- a/shared/templates/sshd_lineinfile/tests/duplicated_param.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param.pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*{{{ PARAMETER }}}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*{{{ PARAMETER }}}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/ssh/sshd_config
+echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/ssh/sshd_config

--- a/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*{{{ PARAMETER }}}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+    sed -i "/^\s*{{{ PARAMETER }}}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+fi
+
+echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/ssh/sshd_config.d/first.conf
+echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/ssh/sshd_config.d/second.conf


### PR DESCRIPTION


#### Description:

- Add tests to ensure that the template evaluates to pass multiple configurations of the parameter with the compliant value.
  - These tests are complementary to `param_conflict.fail.sh` and `param_conflict_directory.fail.sh`
 
#### Rationale:

- This helps ensure that the template/macro behavior is as expected.