### PR TITLE
accounts_password_pam_retry: Add test for dupes and conflicts

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_conflicting_values.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_conflicting_values.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# variables = var_password_pam_retry=3
+
+source common.sh
+
+CONF_FILE="/etc/security/pwquality.conf"
+retry_cnt=3
+
+truncate -s 0 $CONF_FILE
+
+echo "retry = 3" >> $CONF_FILE
+echo "retry = 4" >> $CONF_FILE

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_duplicate_values.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/tests/pwquality_conf_duplicate_values.pass.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# variables = var_password_pam_retry=3
+
+source common.sh
+
+CONF_FILE="/etc/security/pwquality.conf"
+retry_cnt=3
+
+truncate -s 0 $CONF_FILE
+
+echo "retry = 3" >> $CONF_FILE
+echo "retry = 3" >> $CONF_FILE


### PR DESCRIPTION
#### Description:

- Add tests to ensure that the rule can check and remediate parameter configuration that are in conflict with each other or duplicate each other.

#### Rationale:

- A rule behavior that is not tested is not ensured and maintained.