### PR TITLE
Align `service_disabled` template to `service_enabled`

### DIFF
--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -3,33 +3,17 @@
 # strategy = disable
 # complexity = low
 # disruption = low
-{{%- if init_system == "systemd" %}}
 - name: Disable service {{{ SERVICENAME }}}
   block:
+  - name: Gather the package facts
+    package_facts:
+      manager: auto
+
   - name: Disable service {{{ SERVICENAME }}}
-    systemd:
-      name: "{{{ DAEMONNAME }}}.service"
+    service:
+      name: "{{{ DAEMONNAME }}}"
       enabled: "no"
       state: "stopped"
       masked: "yes"
-    ignore_errors: 'yes'
-
-- name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
-  command: systemctl list-unit-files {{{ DAEMONNAME }}}.socket
-  args:
-    warn: False
-  register: socket_file_exists
-  changed_when: False
-  ignore_errors: True
-  check_mode: False
-
-- name: Disable socket {{{ SERVICENAME }}}
-  systemd:
-    name: "{{{ DAEMONNAME }}}.socket"
-    enabled: "no"
-    state: "stopped"
-    masked: "yes"
-  when: '"{{{ DAEMONNAME }}}.socket" in socket_file_exists.stdout_lines[1]'
-{{%- else %}}
-JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
-{{%- endif %}}
+    when:
+    - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'


### PR DESCRIPTION
#### Description:
Disable services using `service` module, similarly as `service_enabled` template does.

#### Rationale:
Current `service_disabled` template is not compatible with Ansible 2.14 where `warn` was removed.  

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/command_module.html#parameter-warn
> This feature is deprecated and will be removed in 2.14.

Causing fatal error on CentOS Stream 9 https://artifacts.dev.testing-farm.io/16b16e84-93e7-4ee4-baca-0e22ca55d5eb/