### PR TITLE
Do not remove blank lines when building profile playbook

### DIFF
--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -40,13 +40,6 @@ def add_minimum_version(ansible_src):
     return ansible_src.replace(" - hosts: all", pre_task, 1)
 
 
-def remove_multiple_blank_lines(ansible_src):
-    """
-    Removes multiple blank lines in an Ansible script
-    """
-    return re.sub(r'\n\s*\n', '\n\n', ansible_src)
-
-
 def remove_trailing_whitespace(ansible_src):
     """
     Removes trailing whitespace in an Ansible script

--- a/ssg/build_profile_remediations.py
+++ b/ssg/build_profile_remediations.py
@@ -5,8 +5,7 @@ import os
 import sys
 from collections import namedtuple
 
-from .ansible import add_minimum_version, remove_multiple_blank_lines, \
-                     remove_trailing_whitespace
+from .ansible import add_minimum_version, remove_trailing_whitespace
 from .shims import subprocess_check_output, Queue
 from .build_guides import _is_blacklisted_profile
 from .xccdf import get_profile_short_id

--- a/ssg/build_profile_remediations.py
+++ b/ssg/build_profile_remediations.py
@@ -134,7 +134,6 @@ def builder(queue):
             if extension == "yml" and \
                template == "urn:xccdf:fix:script:ansible":
                 src = add_minimum_version(src)
-                src = remove_multiple_blank_lines(src)
                 src = remove_trailing_whitespace(src)
             with open(path, "wb") as _file:
                 _file.write(src.encode("utf-8"))


### PR DESCRIPTION
#### Description:
Removal of blank lines breaks remediations when working with exact string.
For example [audit_ospp_general rule](https://github.com/ComplianceAsCode/content/blob/master/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml#L7)

#### Rationale:
Fixes #9808 

Fixes CS8 Testing farm https://artifacts.dev.testing-farm.io/3c424748-3e5f-42a7-b147-b8ac92e4fc0d/work-ansible-osppnCOL9l/tests/fmf-plans/ansible-ospp/execute/data/Sanity/ansible-machine-hardening/ospp/output.txt