### PR TITLE
SRG Export XLSX in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ option(SSG_JINJA2_CACHE_ENABLED "If enabled, the jinja2 templating files will be
 option(SSG_BATS_TESTS_ENABLED "If enabled, bats will be used to run unit-tests of bash remediations." TRUE)
 option(SSG_BUILD_DISA_DELTA_FILES "If enabled, If the product has automated content from DISA for its STIG a tailoring file will be created with rules not covered by DISA's content enabled." TRUE)
 option(SSG_SCE_ENABLED "If enabled, additional SCE audit content will be enabled alongside OVAL-based auditing." FALSE)
+option(SSG_SRG_XLSX_EXPORT "If enabled, an XLSX of SRG Export will be ceated." FALSE)
 set(SSG_JINJA2_CACHE_DIR "${CMAKE_BINARY_DIR}/jinja2_cache" CACHE PATH "Where the jinja2 cached bytecode should be stored. This speeds up builds at the expense of disk space. You can use one location for multiple SSG builds for performance improvements.")
 
 # SSG_PRODUCT_DEFAULT modifies the behavior of all other options. Products

--- a/products/rhel9/CMakeLists.txt
+++ b/products/rhel9/CMakeLists.txt
@@ -11,6 +11,10 @@ ssg_build_html_cce_table(${PRODUCT})
 
 ssg_build_html_srgmap_tables(${PRODUCT})
 
+if (SSG_SRG_XLSX_EXPORT)
+    ssg_build_xlsx_srg_export(${PRODUCT} "srg_gpos")
+endif()
+
 # ssg_build_html_stig_tables(${PRODUCT} "stig")
 
 #ssg_build_html_stig_tables(${PRODUCT} "ospp")

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -27,6 +27,7 @@ def parse_args():
                    help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
     parser.add_argument("-o", "--output", type=str, action="store", default=BUILD_OUTPUT,
                    help="File to write json output to (defaults to build/rule_dirs.json)")
+    parser.add_argument("-q", "--quiet", action="store_true", help="Hides output from the script, just creates the file.")
 
     return parser.parse_args()
 
@@ -173,6 +174,11 @@ def handle_remediations(product_list, product_yamls, rule_obj):
     return rule_remediations, r_products
 
 
+def quiet_print(msg, quiet, file):
+    if not quiet:
+        print(msg, file)
+
+
 def main():
     args = parse_args()
 
@@ -201,7 +207,8 @@ def main():
                 all_ovals = ','.join(oval_products[key])
                 msg = "Product {0} has multiple ovals in rule {1}: {2}"
                 msg = msg.format(key, rule_id, all_ovals)
-                print(msg, file=sys.stderr)
+                if not args.quiet:
+                    print(msg, file=sys.stderr)
 
         rule_obj['oval_products'] = oval_products
 
@@ -215,7 +222,8 @@ def main():
                     msg = "Product {0} has multiple remediations of the same type "
                     msg += "in rule {1}: {2}"
                     msg = msg.format(key, rule_id, all_fixes)
-                    print(msg, file=sys.stderr)
+                    if not args.quiet:
+                        print(msg, file=sys.stderr)
 
         rule_obj['remediation_products'] = r_products
 

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -8,7 +8,6 @@ import sys
 from collections import defaultdict
 
 import json
-from typing import TextIO
 
 import ssg.build_yaml
 import ssg.oval

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -8,6 +8,7 @@ import sys
 from collections import defaultdict
 
 import json
+from typing import TextIO
 
 import ssg.build_yaml
 import ssg.oval
@@ -27,7 +28,8 @@ def parse_args():
                    help="Path to SSG root directory (defaults to %s)" % SSG_ROOT)
     parser.add_argument("-o", "--output", type=str, action="store", default=BUILD_OUTPUT,
                    help="File to write json output to (defaults to build/rule_dirs.json)")
-    parser.add_argument("-q", "--quiet", action="store_true", help="Hides output from the script, just creates the file.")
+    parser.add_argument("-q", "--quiet", action="store_true",
+                        help="Hides output from the script, just creates the file.")
 
     return parser.parse_args()
 
@@ -207,8 +209,7 @@ def main():
                 all_ovals = ','.join(oval_products[key])
                 msg = "Product {0} has multiple ovals in rule {1}: {2}"
                 msg = msg.format(key, rule_id, all_ovals)
-                if not args.quiet:
-                    print(msg, file=sys.stderr)
+                quiet_print(msg, args.quiet, sys.stderr)
 
         rule_obj['oval_products'] = oval_products
 
@@ -222,8 +223,7 @@ def main():
                     msg = "Product {0} has multiple remediations of the same type "
                     msg += "in rule {1}: {2}"
                     msg = msg.format(key, rule_id, all_fixes)
-                    if not args.quiet:
-                        print(msg, file=sys.stderr)
+                    quiet_print(msg, args.quiet, sys.stderr)
 
         rule_obj['remediation_products'] = r_products
 


### PR DESCRIPTION
#### Description:

This PR adds the ability to create the XLSX files from `utils/create_srg_export` from the build system.

#### Rationale:

This PR makes using the `utils/srg_diff.py` script much easier. Instead of running a four-step process (building, creating rule_dir_json, creating the SRG export, then creating the SRG Diff HTML report), this PR brings it to two steps (building the product and creating the SRG Diff HTML report).
#### Review Hints:

* To activate the new build option, run a command like `ADDITIONAL_CMAKE_OPTIONS="-DSSG_SRG_XLSX_EXPORT=ON" ./build_product -j9 rhel9`