### PR TITLE
STIG Alignment for RHEL-08-020352

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -9,6 +9,8 @@
     cmd: |
       for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
         for file in $(find $dir -maxdepth 1 -type f -name ".*"); do
-          sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+          if [ "$(basename $file)" != ".bash_history" ]; then
+            sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+          fi
         done
       done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -6,6 +6,8 @@
 
 {{% call iterate_over_command_output("dir", "awk -F':' '{ if ($3 >= " ~ uid_min ~ " && $3 != 65534) print $6}' /etc/passwd") -%}}
 {{% call iterate_over_find_output("file", '$dir -maxdepth 1 -type f -name ".*"') -%}}
-sed -i 's/^\([\s]*umask\s*\)/#\1/g' "$file"
+if [ "$(basename $file)" != ".bash_history" ]; then
+    sed -i 's/^\([\s]*umask\s*\)/#\1/g' "$file"
+fi
 {{%- endcall %}}
 {{%- endcall %}}

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
@@ -29,7 +29,13 @@
     <ind:filename operation="pattern match">^\..*</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*umask\s*</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_accounts_umask_interactive_users_bash_history</filter>
   </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_accounts_umask_interactive_users_bash_history"
+    version="1">
+    <ind:filename operation="pattern match">^\.bash_history</ind:filename>
+  </ind:textfilecontent54_state>
 
   <!-- #### creation of test #### -->
   <ind:textfilecontent54_test id="test_accounts_umask_interactive_users" check="all"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/policy/stig/shared.yml
@@ -13,7 +13,7 @@ checktext: |-
 
     Note: The example is for a system that is configured to create users home directories in the "/home" directory.
 
-    # grep -ri umask /home/
+    $ sudo grep -ir ^umask --exclude=.bash_history /home
 
     /home/smithj/.bash_history:grep -i umask /etc/bashrc /etc/csh.cshrc /etc/profile
     /home/smithj/.bash_history:grep -i umask /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/bash_history_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/bash_history_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+echo "umask 022" > /home/$USER/.bash_history


### PR DESCRIPTION
#### Description:

This rule targets user files where the `umask` can be changed.
It is not the case for `.bash_history`. In addition, it should be avoided to change the `.bash_history` file by this rule remediation.

#### Rationale:

RHEL8 STIG V1R8 Alignment