### PR TITLE
sysctl: Make template aware of /usr/local/lib/sysctl.d

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -9,12 +9,15 @@
     paths:
       - "/etc/sysctl.d/"
       - "/run/sysctl.d/"
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+      - "/usr/lib/sysctl.d/"
+{{% endif %}}
     contains: '^[\s]*{{{ SYSCTLVAR }}}.*$'
     patterns: "*.conf"
     file_type: any
   register: find_sysctl_d
 
-- name: Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
+- name: Comment out any occurrences of {{{ SYSCTLVAR }}} from config files
   replace:
     path: "{{ item.path }}"
     regexp: '^[\s]*{{{ SYSCTLVAR }}}'

--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -9,6 +9,7 @@
     paths:
       - "/etc/sysctl.d/"
       - "/run/sysctl.d/"
+      - "/usr/local/lib/sysctl.d/"
 {{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
       - "/usr/lib/sysctl.d/"
 {{% endif %}}

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -6,9 +6,9 @@
 
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
-for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}
-for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf; do
+for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf; do
 {{% endif %}}
   matching_list=$(grep -P '^(?!#).*[\s]*{{{ SYSCTLVAR }}}.*$' $f | uniq )
   if ! test -z "$matching_list"; then

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -138,6 +138,8 @@
           <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /usr/lib/sysctl.d/*.conf"
                     test_ref="test_{{{ rule_id }}}_static_usr_lib_sysctld"/>
 {{% endif %}}
+          <criterion comment="kernel static parameter {{{ SYSCTLVAR }}} set to {{{ COMMENT_VALUE }}} in /usr/local/lib/sysctl.d/*.conf"
+                    test_ref="test_{{{ rule_id }}}_static_usr_local_lib_sysctld"/>
         </criteria>
         <criterion comment="Check that {{{ SYSCTLID }}} is defined in at least one file" test_ref="test_{{{ rule_id }}}_not_defined"
                    negate="true"/>
@@ -181,6 +183,13 @@
   </ind:textfilecontent54_test>
 {{% endif %}}
 
+  <ind:textfilecontent54_test id="test_{{{ rule_id }}}_static_usr_local_lib_sysctld" version="1"
+                          check_existence="any_exist"
+                          check="all"
+                          comment="{{{ SYSCTLVAR }}} static configuration in /usr/local/lib/sysctl.d/*.conf" state_operator="OR">
+    {{{ state_static_sysctld("usr_local_lib_sysctld") }}}
+  </ind:textfilecontent54_test>
+
   <local_variable comment="List of conf files" datatype="string" id="local_var_conf_files_{{{ rule_id }}}" version="1">
     <object_component object_ref="object_{{{ rule_id }}}_static_set_sysctls_unfiltered" item_field="filepath" />
   </local_variable>
@@ -190,7 +199,7 @@
   <ind:textfilecontent54_object id="object_{{{ rule_id }}}_static_set_sysctls_unfiltered" version="1">
     <set>
       <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
-      <object_reference>object_static_run_usr_sysctls_{{{ rule_id }}}</object_reference>
+      <object_reference>object_static_run_usr_local_sysctls_{{{ rule_id }}}</object_reference>
     </set>
   </ind:textfilecontent54_object>
 
@@ -198,6 +207,13 @@
     <set>
       <object_reference>object_static_sysctl_{{{ rule_id }}}</object_reference>
       <object_reference>object_static_etc_sysctld_{{{ rule_id }}}</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_run_usr_local_sysctls_{{{ rule_id }}}" version="1">
+    <set>
+      <object_reference>object_static_usr_local_lib_sysctld_{{{ rule_id }}}</object_reference>
+      <object_reference>object_static_run_usr_sysctls_{{{ rule_id }}}</object_reference>
     </set>
   </ind:textfilecontent54_object>
 
@@ -223,6 +239,12 @@
 
   <ind:textfilecontent54_object id="object_static_run_sysctld_{{{ rule_id }}}" version="1">
     <ind:path>/run/sysctl.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{{ sysctl_match() }}}
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_usr_local_lib_sysctld_{{{ rule_id }}}" version="1">
+    <ind:path>/usr/local/lib/sysctl.d</ind:path>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>

--- a/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+{{% if SYSCTLVAL == "" %}}
+# variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
+{{% endif %}}
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /usr/local/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
+mkdir /usr/local/lib/sysctl.d/
+echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /usr/local/lib/sysctl.d/correct.conf
+
+# set correct runtime value to check if the filesystem configuration is evaluated properly
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"

--- a/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+{{% if SYSCTLVAL == "" %}}
+# variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
+{{% endif %}}
+
+# Clean sysctl config directories
+rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+
+sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
+mkdir /usr/local/lib/sysctl.d/
+echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /usr/local/lib/sysctl.d/wrong.conf
+
+# Setting correct runtime value
+sysctl -w {{{ SYSCTLVAR }}}="{{{ SYSCTL_CORRECT_VALUE }}}"


### PR DESCRIPTION
#### Description:

- Update `sysctl` template so that I:
  - checks for sysctl options in `/usr/local/lib/sysctl.d/'
  - comments out any sysctl option defined in `/usr/local/lib/sysctl.d/` in favor settings in `/etc/sysctl.conf`

#### Rationale:

- This directory doesn't exist by default, but it can still contain configs that are loaded and used by the sysctla