### PR TITLE
Revert `service_disabled` alignment and make `service_disabled` Ansible 2.14 compatible

### DIFF
--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -16,8 +16,6 @@
 
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
   command: systemctl list-unit-files {{{ DAEMONNAME }}}.socket
-  args:
-    warn: False
   register: socket_file_exists
   changed_when: False
   ignore_errors: True

--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -3,17 +3,33 @@
 # strategy = disable
 # complexity = low
 # disruption = low
+{{%- if init_system == "systemd" %}}
 - name: Disable service {{{ SERVICENAME }}}
   block:
-  - name: Gather the package facts
-    package_facts:
-      manager: auto
-
   - name: Disable service {{{ SERVICENAME }}}
-    service:
-      name: "{{{ DAEMONNAME }}}"
+    systemd:
+      name: "{{{ DAEMONNAME }}}.service"
       enabled: "no"
       state: "stopped"
       masked: "yes"
-    when:
-    - '"{{{ PACKAGENAME }}}" in ansible_facts.packages'
+    ignore_errors: 'yes'
+
+- name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
+  command: systemctl list-unit-files {{{ DAEMONNAME }}}.socket
+  args:
+    warn: False
+  register: socket_file_exists
+  changed_when: False
+  ignore_errors: True
+  check_mode: False
+
+- name: Disable socket {{{ SERVICENAME }}}
+  systemd:
+    name: "{{{ DAEMONNAME }}}.socket"
+    enabled: "no"
+    state: "stopped"
+    masked: "yes"
+  when: '"{{{ DAEMONNAME }}}.socket" in socket_file_exists.stdout_lines[1]'
+{{%- else %}}
+JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
+{{%- endif %}}


### PR DESCRIPTION
#### Description:
`service_disabled` update didn't consider disabling sockets. This PR reverts the update back and removes `warn` parameter to make it compatible with Ansible 2.14 where the parameter is removed.

#### Rationale:
Fixes #9815 