### PR TITLE
Resolve issue #9812 with pipes

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
@@ -2,7 +2,7 @@
 
 MOUNT_OPTION="nodev"
 # Create array of local non-root partitions
-readarray -t partitions_records < <(findmnt --mtab --raw --evaluate | grep "^/\w" | grep "\s/dev/\w")
+findmnt --mtab --raw --evaluate | grep "^/\w" | grep "\s/dev/\w" | readarray -t partitions_records
 
 for partition_record in "${partitions_records[@]}"; do
     # Get all important information for fstab


### PR DESCRIPTION
PR for the confimed/tested fix as suggested by @rossengeorgiev

#### Description:

- There was an issue / odd development decision in this script's original format to use `<` versus pipes, which can cause some issues when the remediation script is ran through an emulated terminal (e.g. Azure RunCommand), or if POSIX flags or Bash pragma is not honored by the shell runner. 

#### Rationale:

- Pipes work, alleviating this issue, and arguably this script could & should have been written that way originally. It appears in line with other scripts within the linux OS Guides for remediation that do use pipes.

- Fixes #9812.

#### Review Hints:

- Change suggested by @rossengeorgiev, and tested by myself in the environment in which I was experiencing the issue.