### PR TITLE
Update instructions for TLS cipher suite algorithms

### DIFF
--- a/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cipher_suites/rule.yml
@@ -52,7 +52,7 @@ ocil_clause: "TLS cipher suite configuration is not configured or contains insec
 
 ocil: |-
     Run the following command on the kubelet node(s):
-    <pre>$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | grep tlsCipherSuites; done</pre>
+    <pre>$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1" | .tlsCipherSuites'; done</pre>
     Verify that the set of ciphers contains only the following:
     <pre>
     TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,


### PR DESCRIPTION
The instructions for checking the TLS cipher suites piped the output
into grep, which didn't actually output the kubelet algorithms.

This commit updates the instructions to output the actual values used by
each kubelet so it's easier for users to compare the values across a set
of kubelets.

Fixes OCPBUGS-3017
