### PR TITLE
Update accounts_umask_interactive_users to ignore .bash_history

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -9,6 +9,8 @@
     cmd: |
       for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
         for file in $(find $dir -maxdepth 1 -type f -name ".*"); do
-          sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+          if [[ $(basename "$file") != ".bash_history" ]]; then
+            sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file
+          fi
         done
       done

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -6,6 +6,8 @@
 
 {{% call iterate_over_command_output("dir", "awk -F':' '{ if ($3 >= " ~ uid_min ~ " && $3 != 65534) print $6}' /etc/passwd") -%}}
 {{% call iterate_over_find_output("file", '$dir -maxdepth 1 -type f -name ".*"') -%}}
-sed -i 's/^\([\s]*umask\s*\)/#\1/g' "$file"
+if [[ $(basename "$file") != ".bash_history" ]]; then
+    sed -i 's/^\([\s]*umask\s*\)/#\1/g' "$file"
+fi
 {{%- endcall %}}
 {{%- endcall %}}

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
@@ -29,7 +29,14 @@
     <ind:filename operation="pattern match">^\..*</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*umask\s*</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    <filter action="exclude">state_accounts_umask_interactive_users_bash_history</filter>
   </ind:textfilecontent54_object>
+
+  <!-- ### state to filter command history -->
+  <ind:textfilecontent54_state id="state_accounts_umask_interactive_users_bash_history"
+                                comment="File name is .bash_history" version="1">
+    <ind:filename>.bash_history</ind:filename>
+  </ind:textfilecontent54_state>
 
   <!-- #### creation of test #### -->
   <ind:textfilecontent54_test id="test_accounts_umask_interactive_users" check="all"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/ignore_command_history.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/ignore_command_history.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m $USER
+
+# Artificially add command to history file
+ echo 'umask 077' >> /home/$USER/.bash_history


### PR DESCRIPTION
#### Description:

- Update `accounts_umask_interactive_users` rule's OVAL, bash and ansible to ignore bash command history

#### Rationale:

-  bash command history is stored in `.bash_history`, but this file has no effect in actual system configuration.

#### Review Hints:

- The OVAL part is tested by automatus. To validate that bash and ansible ignore `.bash_history` it could be necessary to run scripts mannually