### PR TITLE
Fix typo in test platforms

### DIFF
--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/missing_blacklist.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/missing_blacklist.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_ol
 
 rm -f /etc/modprobe.d/dccp-blacklist.conf
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf

--- a/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/missing_blacklist.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform multi_platform_rhel,multi_platform_ol
+# platform = multi_platform_rhel,multi_platform_ol
 
 echo > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf


### PR DESCRIPTION
#### Description:

- Some tests had a typo  (missing '=') in the platform entry which was making the test run on all platforms instead.