### PR TITLE
Refactor CPE AL

### DIFF
--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -12,15 +12,6 @@ SPEC_SYMBOLS = ['<', '>', '=', '!', ',', '[', ']']
 
 VERSION_SYMBOLS = ['.', '-', '_', '*']
 
-SPEC_OP_ID_TRANSLATION = {
-    '==': 'eq',
-    '!=': 'ne',
-    '>': 'gt',
-    '<': 'le',
-    '>=': 'gt_or_eq',
-    '<=': 'le_or_eq',
-}
-
 
 class Function(boolean.Function):
     """
@@ -32,7 +23,7 @@ class Function(boolean.Function):
     Provides `is_and`, `is_or` and `is_not` methods to distinguish instances
     between different boolean functions.
 
-    The `as_id` method will generate an unique string identifier usable as
+    The `as_id` method will generate a unique string identifier usable as
     an XML id based on the properties of the entity.
     """
 
@@ -63,7 +54,7 @@ class Symbol(boolean.Symbol):
     Sub-class it and pass to the `Algebra` as `symbol_cls` to enrich
     expression elements with domain-specific methods.
 
-    The `as_id` method will generate an unique string identifier usable as
+    The `as_id` method will generate a unique string identifier usable as
     an XML id based on the properties of the entity.
     """
 
@@ -77,10 +68,6 @@ class Symbol(boolean.Symbol):
         if self.arg:
             full_name += '[' + self.arg + ']'
         val = kwargs.get(full_name, False)
-        if len(self.version_definitions):
-            if type(val) is str:
-                return val in self.requirement
-            return False
         return bool(val)
 
     def __lt__(self, other):
@@ -88,8 +75,6 @@ class Symbol(boolean.Symbol):
 
     def as_id(self):
         id_str = self.name
-        for (op, ver) in self.version_definitions:
-            id_str += '_{0}_{1}'.format(SPEC_OP_ID_TRANSLATION.get(op, 'unknown_spec_op'), ver)
         if self.arg:
             id_str += '_' + self.arg
         return id_str
@@ -103,10 +88,6 @@ class Symbol(boolean.Symbol):
     @property
     def arg(self):
         return self.requirement.extras[0] if self.requirement.extras else None
-
-    @property
-    def version_definitions(self):
-        return self.requirement.specs
 
     @property
     def name(self):

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -253,7 +253,7 @@ class CPEALLogicalTest(Function):
         return cond
 
 
-class CPEALFactRef (Symbol):
+class CPEALFactRef(Symbol):
 
     prefix = "cpe-lang"
     ns = PREFIX_TO_NS[prefix]

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -333,7 +333,7 @@ def enum(*args):
     return type('Enum', (), enums)
 
 
-def apply_formatting_on_dict_values(source_dict, string_dict, ignored_keys=[]):
+def apply_formatting_on_dict_values(source_dict, string_dict, ignored_keys=frozenset()):
     """
     Uses Python built-in string replacement.
     It replaces strings marked by {token} if "token" is a key in the string_dict parameter.

--- a/tests/unit/ssg-module/test_boolean_expressions.py
+++ b/tests/unit/ssg-module/test_boolean_expressions.py
@@ -1,90 +1,49 @@
 import pytest
 
 from ssg import boolean_expression
-from xml.dom import expatbuilder
-
-
-class PlatformFunction(boolean_expression.Function):
-    def as_cpe_lang_xml(self):
-        return '<cpe-lang:logical-test negate="' + ('true' if self.is_not() else 'false') + \
-               '" operator="' + ('OR' if self.is_or() else 'AND') + '">' + \
-               ''.join([arg.as_cpe_lang_xml() for arg in self.args]) + "</cpe-lang:logical-test>"
-
-
-class PlatformSymbol(boolean_expression.Symbol):
-    def as_cpe_lang_xml(self):
-        return '<cpe-lang:fact-ref name="cpe:/a:' + self.name + ':' + ':'.join([v for (op, v) in self.version_definitions]) + '"/>'
-
-
-class PlatformAlgebra(boolean_expression.Algebra):
-    def __init__(self):
-        super(PlatformAlgebra, self).__init__(symbol_cls=PlatformSymbol, function_cls=PlatformFunction)
-
-    @staticmethod
-    def as_cpe_lang_xml(expr):
-        s = '<cpe-lang:platform id="' + expr.as_id() + '">' + expr.as_cpe_lang_xml() + '</cpe-lang:platform>'
-        # A primitive but simple way to pretty-print an XML string
-        return expatbuilder.parseString(s, False).toprettyxml()
 
 
 @pytest.fixture
 def algebra():
-    return PlatformAlgebra()
+    return boolean_expression.Algebra(
+        symbol_cls=boolean_expression.Symbol, function_cls=boolean_expression.Function)
 
 
 @pytest.fixture
 def expression1(algebra):
-    return algebra.parse(u'(oranges==2.0 | banana) and not ~apple + !pie', simplify=True)
+    return algebra.parse(u'(oranges | banana) and not ~apple + !pie', simplify=True)
 
 
-def test_dyn():
-    alg = boolean_expression.Algebra(symbol_cls=PlatformSymbol, function_cls=PlatformFunction)
+def test_dynamic_algebra():
+    alg = boolean_expression.Algebra(
+        symbol_cls=boolean_expression.Symbol, function_cls=boolean_expression.Function)
     exp = alg.parse('not banana and not apple or anything')
     assert str(exp) == '(~banana&~apple)|anything'
     assert str(exp.simplify()) == 'anything|(~apple&~banana)'
 
 
-def test_id(expression1):
-    assert str(expression1.as_id()) == 'apple_and_banana_or_oranges_eq_2.0_or_not_pie'
+def test_compare_expressions(algebra):
+    exp1 = algebra.parse('banana1 and apple1')
+    exp2 = algebra.parse('apple1 and banana1')
+    assert exp1 == exp2
 
 
 def test_cnf(algebra, expression1):
-    assert str(algebra.cnf(expression1)) == '(apple|~pie)&(banana|oranges==2.0|~pie)'
+    assert str(algebra.cnf(expression1)) == '(apple|~pie)&(banana|oranges|~pie)'
 
 
 def test_dnf(algebra, expression1):
-    assert str(algebra.dnf(expression1)) == '(apple&banana)|(apple&oranges==2.0)|~pie'
-
-
-def test_as_cpe_xml(algebra, expression1):
-    xml = algebra.as_cpe_lang_xml(algebra.dnf(expression1))
-    assert xml == """<?xml version="1.0" ?>
-<cpe-lang:platform id="apple_and_banana_or_apple_and_oranges_eq_2.0_or_not_pie">
-\t<cpe-lang:logical-test negate="false" operator="OR">
-\t\t<cpe-lang:logical-test negate="false" operator="AND">
-\t\t\t<cpe-lang:fact-ref name="cpe:/a:apple:"/>
-\t\t\t<cpe-lang:fact-ref name="cpe:/a:banana:"/>
-\t\t</cpe-lang:logical-test>
-\t\t<cpe-lang:logical-test negate="false" operator="AND">
-\t\t\t<cpe-lang:fact-ref name="cpe:/a:apple:"/>
-\t\t\t<cpe-lang:fact-ref name="cpe:/a:oranges:2.0"/>
-\t\t</cpe-lang:logical-test>
-\t\t<cpe-lang:logical-test negate="true" operator="AND">
-\t\t\t<cpe-lang:fact-ref name="cpe:/a:pie:"/>
-\t\t</cpe-lang:logical-test>
-\t</cpe-lang:logical-test>
-</cpe-lang:platform>
-"""
+    assert str(algebra.dnf(expression1)) == '(apple&banana)|(apple&oranges)|~pie'
 
 
 def test_underscores_and_dashes_in_name(algebra):
     exp = algebra.parse(u'not_s390x_arch and dashed-name')
     assert exp(**{'not_s390x_arch': True, 'dashed-name': True})
 
+
 def test_expression_with_parameter(algebra):
     exp = algebra.parse(u'package[test] and os_release[rhel]')
     assert exp(**{"package[test]": True, "os_release[rhel]": True})
-
 
 
 def test_evaluate_simple_boolean_ops(algebra):
@@ -93,45 +52,8 @@ def test_evaluate_simple_boolean_ops(algebra):
     assert not exp(**{'oranges': True, 'apple': False, 'pie': True})
 
 
-def test_evaluate_simple_version_ops(algebra):
-    exp = algebra.parse(u'oranges==2')
-    assert exp(**{'oranges': '2'})
-    assert exp(**{'oranges': '2.0'})
-    assert exp(**{'oranges': '2.0.0'})
-    assert not exp(**{'oranges': '2.0.1'})
-    assert not exp(**{'oranges': '3.0'})
+def test_args(algebra):
+    exp = algebra.parse(u'oranges[aaa] | oranges[bbb]')
+    assert exp(**{'oranges[aaa]': True, 'oranges[bbb]': True})
+    assert not exp(**{'oranges[zzz]': True})
     assert not exp(**{'oranges': True})
-
-
-def test_evaluate_advanced_version_ops(algebra):
-    exp = algebra.parse(u'oranges>=1.0,<3.0 and oranges!=2.6')
-    assert exp(**{'oranges': '2'})
-    assert exp(**{'oranges': '2.9'})
-    assert exp(**{'oranges': '2.0.1'})
-    assert exp(**{'oranges': '2.9.0-rc'})
-    assert not exp(**{'oranges': '3.0'})
-    assert not exp(**{'oranges': '0.9.999'})
-    assert not exp(**{'oranges': '0.9.999_beta_2'})
-    assert not exp(**{'oranges': '2.6.0'})
-
-def test_as_id(algebra):
-    exp1 = algebra.parse(u'package')
-    exp2 = algebra.parse(u'package[test]')
-    assert exp1.as_id() == "package"
-    assert exp2.as_id() == "package_test"
-
-def test_as_dict(algebra):
-    exp1 = algebra.parse(u'package')
-    exp1_dict = {
-        "arg": "",
-        "id": "package",
-        "name": "package"
-    }
-    exp2 = algebra.parse(u'package[test]')
-    exp2_dict = {
-        "arg": "test",
-        "id": "package_test",
-        "name": "package"
-    }
-    assert exp1.as_dict() == exp1_dict
-    assert exp2.as_dict() == exp2_dict

--- a/tests/unit/ssg-module/test_platform_expressions.py
+++ b/tests/unit/ssg-module/test_platform_expressions.py
@@ -1,0 +1,91 @@
+import pytest
+
+from ssg import boolean_expression
+from xml.dom import expatbuilder
+
+
+class PlatformFunction(boolean_expression.Function):
+    def as_cpe_lang_xml(self):
+        return '<cpe-lang:logical-test negate="' + ('true' if self.is_not() else 'false') + \
+               '" operator="' + ('OR' if self.is_or() else 'AND') + '">' + \
+               ''.join([arg.as_cpe_lang_xml() for arg in self.args]) + "</cpe-lang:logical-test>"
+
+
+class PlatformSymbol(boolean_expression.Symbol):
+    def as_cpe_lang_xml(self):
+        return '<cpe-lang:fact-ref name="cpe:/a:' + self.name + ':' + '"/>'
+
+
+class PlatformAlgebra(boolean_expression.Algebra):
+    def __init__(self):
+        super(PlatformAlgebra, self).__init__(symbol_cls=PlatformSymbol, function_cls=PlatformFunction)
+
+    @staticmethod
+    def as_cpe_lang_xml(expr):
+        s = '<cpe-lang:platform id="' + expr.as_id() + '">' + expr.as_cpe_lang_xml() + '</cpe-lang:platform>'
+        # A primitive but simple way to pretty-print an XML string
+        return expatbuilder.parseString(s, False).toprettyxml()
+
+
+@pytest.fixture
+def algebra():
+    return PlatformAlgebra()
+
+
+@pytest.fixture
+def expression1(algebra):
+    return algebra.parse(u'(oranges | banana) and not ~apple + !pie', simplify=True)
+
+
+def test_id(expression1):
+    assert str(expression1.as_id()) == 'apple_and_banana_or_oranges_or_not_pie'
+
+
+def test_as_cpe_xml(algebra, expression1):
+    xml = algebra.as_cpe_lang_xml(algebra.dnf(expression1))
+    assert xml == """<?xml version="1.0" ?>
+<cpe-lang:platform id="apple_and_banana_or_apple_and_oranges_or_not_pie">
+\t<cpe-lang:logical-test negate="false" operator="OR">
+\t\t<cpe-lang:logical-test negate="false" operator="AND">
+\t\t\t<cpe-lang:fact-ref name="cpe:/a:apple:"/>
+\t\t\t<cpe-lang:fact-ref name="cpe:/a:banana:"/>
+\t\t</cpe-lang:logical-test>
+\t\t<cpe-lang:logical-test negate="false" operator="AND">
+\t\t\t<cpe-lang:fact-ref name="cpe:/a:apple:"/>
+\t\t\t<cpe-lang:fact-ref name="cpe:/a:oranges:"/>
+\t\t</cpe-lang:logical-test>
+\t\t<cpe-lang:logical-test negate="true" operator="AND">
+\t\t\t<cpe-lang:fact-ref name="cpe:/a:pie:"/>
+\t\t</cpe-lang:logical-test>
+\t</cpe-lang:logical-test>
+</cpe-lang:platform>
+"""
+
+
+def test_expression_with_parameter(algebra):
+    exp = algebra.parse(u'package[test] and os_release[rhel]')
+    assert exp(**{"package[test]": True, "os_release[rhel]": True})
+
+
+def test_as_id(algebra):
+    exp1 = algebra.parse(u'package')
+    exp2 = algebra.parse(u'package[test]')
+    assert exp1.as_id() == "package"
+    assert exp2.as_id() == "package_test"
+
+
+def test_as_dict(algebra):
+    exp1 = algebra.parse(u'package')
+    exp1_dict = {
+        "arg": "",
+        "id": "package",
+        "name": "package"
+    }
+    exp2 = algebra.parse(u'package[test]')
+    exp2_dict = {
+        "arg": "test",
+        "id": "package_test",
+        "name": "package"
+    }
+    assert exp1.as_dict() == exp1_dict
+    assert exp2.as_dict() == exp2_dict


### PR DESCRIPTION
Remove version specifications.

Split boolean expression tests into generic and platform-related. 

Fix mutable default argument value.