### PR TITLE
Use F36 in Ansible Lint Github action job.

### DIFF
--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -4,10 +4,10 @@ on:
     branches: [ 'master' ]
 jobs:
   validate-fedora-ar:
-    name: Build, Lint Ansible Roles on Fedora Latest (Container)
+    name: Build, Lint Ansible Roles on Fedora 36 (Container)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:36
     steps:
       - name: Install Deps
         run: dnf install -y cmake make ninja-build openscap-utils python3-pyyaml python3-setuptools python3-jinja2 python3-pygithub ansible ansible-lint expat libxslt git


### PR DESCRIPTION
#### Rationale:

- Latest F36 seems to have a newer version of the ansible lint that is failing with current content. Let's switch back to the older version until we figure out what the actual problems with the newer version are.