### PR TITLE
Add config for Ansible lint

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,0 +1,11 @@
+skip_list:
+  - fqcn-builtins # We should be using fqcn
+warn_list:
+  - name[missing]  # Rule for checking task and play names.
+  - template-instead-of-copy  # Templated files should use template instead of copy
+  - yaml[empty-lines]  # Violations reported by yamllint.
+  - yaml[indentation]  # Violations reported by yamllint.
+  - yaml[line-length]  # Violations reported by yamllint.
+  - jinja[spacing]  # Rule that looks inside jinja2 templates.
+  - name[casing]  # Rule for checking task and play names.
+


### PR DESCRIPTION
#### Description:
Adds an Ansible lint config to the project.

#### Rationale:

To better match the old Ansible lint.

In the future, we should fix some of the things like using fully quality module names. 

Alternative to #9837
