### PR TITLE
scap-security-guide.spec: update the version to the latest version v0.1.64

### DIFF
--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -5,7 +5,7 @@
 %global _default_patch_fuzz 2
 
 Name:		scap-security-guide
-Version:	0.1.60
+Version:	0.1.64
 Release:	0%{?dist}
 Summary:	Security guidance and baselines in SCAP formats
 License:	BSD-3-Clause

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -18,7 +18,7 @@ BuildRequires:	expat
 BuildRequires:	openscap-scanner >= 1.2.5
 BuildRequires:	cmake >= 2.8
 # To get python3 inside the buildroot require its path explicitly in BuildRequires
-BuildRequires: /usr/bin/python3
+BuildRequires:	/usr/bin/python3
 BuildRequires:	python%{python3_pkgversion}
 BuildRequires:	python%{python3_pkgversion}-jinja2
 BuildRequires:	python%{python3_pkgversion}-PyYAML


### PR DESCRIPTION
#### Description:

- Obviously, the version in [scap-security-guide.spec](https://github.com/ComplianceAsCode/content/blob/master/scap-security-guide.spec#L8) is 0.1.60 rather than the latest 0.1.64, so we need to update it for testing and rpm-building.
- Fixes #9841 