### PR TITLE
Add Timezone contributors script

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -18,7 +18,7 @@ and ultimately allows the release process to happen while development continues 
 - Update the contributors list by accessing the root folder of Content repository, in the
 **stabilization** branch, and executing the following command:
     ```
-    PYTHONPATH=. utils/generate_contributors.py`
+    PYTHONPATH=. utils/generate_contributors.py
     ```
     - De-duplicate names if necessary.
     - Make a commit send the a PR.

--- a/ssg/contributors.py
+++ b/ssg/contributors.py
@@ -10,8 +10,8 @@ from .shims import subprocess_check_output
 
 
 MANUAL_EDIT_WARNING = """This file is generated using the %s script. DO NOT MANUALLY EDIT!!!!
-Last Modified: %s
-""" % (os.path.basename(__file__), datetime.datetime.now().strftime("%Y-%m-%d %H:%M"))
+Last Modified: %s UTC
+""" % (os.path.basename(__file__), datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M"))
 
 ignored_emails = (
     # No idea / ignore


### PR DESCRIPTION
#### Description:

- Add UTC date to contributors script
- Fix a small bug in the docs for running the contributors script

#### Rationale:

Using UTC helps communicate the date to a more global audience.