### PR TITLE
Add note about package version and change version in spec file

### DIFF
--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -6,7 +6,7 @@
 
 Name:		scap-security-guide
 # Version placeholder. Copr build version is determined by utils/version.sh. See .packit.yaml config
-Version:	0.1.60
+Version:	0.0.1
 Release:	0%{?dist}
 Summary:	Security guidance and baselines in SCAP formats
 License:	BSD-3-Clause

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -5,6 +5,7 @@
 %global _default_patch_fuzz 2
 
 Name:		scap-security-guide
+# Version placeholder. Copr build version is determined by utils/version.sh. See .packit.yaml config
 Version:	0.1.60
 Release:	0%{?dist}
 Summary:	Security guidance and baselines in SCAP formats


### PR DESCRIPTION
#### Description:
Packit, which uses spec file for copr builds, doesn't care about version defined in the spec file. It gets current version using `utils/version.sh` script, see our Packit config https://github.com/ComplianceAsCode/content/blob/master/.packit.yaml#L6

Also change version in spec file to `0.0.1` so it looks more as placeholder.

#### Rationale:
To prevent more issues like https://github.com/ComplianceAsCode/content/issues/9841

#### Review Hints:
See `rpm-build` CI job logs, there is build log with package version.