### PR TITLE
macros: Fix load order of `ocil_fix_srg_privileged_command`

### DIFF
--- a/docs/jinja_macros/20-rules.rst
+++ b/docs/jinja_macros/20-rules.rst
@@ -1,0 +1,5 @@
+Rule macros
+=========
+Contains macros for rules that leverage multiple macros from other files
+
+    .. autojinja:: shared/macros/20-rules.jinja

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1121,15 +1121,6 @@ Part of the grub2_bootloader_argument(_absent) templates.
 {{{ grub_helper_executable }}} {{{ " ".join(grub_helper_args) }}}
 {{%- endmacro %}}
 
-{{% macro ocil_fix_srg_privileged_command(cmd, path_prefix="/usr/bin/", key="") %}}
-{{{ complete_ocil_entry_audit_privileged_commands(cmd, path_prefix, key) }}}
-
-fixtext: |-
-    {{{ fixtext_audit_rules_privileged_commands(cmd, path_prefix, key) | indent(4) }}}
-
-srg_requirement: '{{{ srg_requirement_audit_command(cmd) }}}'
-{{%- endmacro %}}
-
 {{%- macro audit_remediation_unsuccessful_file_modification_detailed_audit_file_content() -%}}
 ## This content is a section of an Audit config snapshot recommended for linux systems that target OSPP compliance.
 ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules

--- a/shared/macros/20-rules.jinja
+++ b/shared/macros/20-rules.jinja
@@ -1,0 +1,20 @@
+{{#
+
+    Adds an OCIL, fixtex and SRG requirement to audit_privileged_command rules.
+
+:param cmd: The command to audit
+:type cmd: str
+:param path_prefix: Prefix of the command to audit
+:type path_prefix: str
+:param key: The key to use in the audit rule
+:type key: str
+
+#}}
+{{% macro ocil_fix_srg_privileged_command(cmd, path_prefix="/usr/bin/", key="") %}}
+{{{ complete_ocil_entry_audit_privileged_commands(cmd, path_prefix, key) }}}
+
+fixtext: |-
+    {{{ fixtext_audit_rules_privileged_commands(cmd, path_prefix, key) | indent(4) }}}
+
+srg_requirement: '{{{ srg_requirement_audit_command(cmd) }}}'
+{{%- endmacro %}}


### PR DESCRIPTION

#### Description:

- Relocate the `ocil_fix_srg_privileged_command`  macro so that it is loaded later, it needs other macros that need to be loaded before it.
- This is broken since introduction of `ocil_fix_srg_privileged_command` in https://github.com/ComplianceAsCode/content/pull/8807

#### Rationale:

- Macros that use other macros need to be loaded after them.

#### Review Hints:

- Try to automatus a rule that uses the macro:
```
python3  tests/automatus.py rule --libvirt qemu:///session rhel8 --datastream build/ssg-rhel8-ds.xml audit_rules_privileged_commands_kmod
Setting console output to log level INFO
INFO - The base image option has not been specified, choosing libvirt-based test environment.
INFO - Logging into /home/wsato/git/content/logs/rule-custom-2022-11-21-1511/test_suite.log
ERROR - Terminating due to error: Error loading a Rule from /home/wsato/git/content/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml: 'complete_ocil_entry_audit_privileged_commands' is undefined.
WARNING - Nothing has been tested!
```