### PR TITLE
Add set_firewalld_default_zone rule to PCI DSS profile for sle15

### DIFF
--- a/controls/pcidss_3.yml
+++ b/controls/pcidss_3.yml
@@ -219,8 +219,9 @@ controls:
       employee-owned devices.
   levels:
   - base
-  status: pending
-  rules: []
+  status: partial
+  rules:
+    - set_firewalld_default_zone
 
 - id: Req-1.5
   title: 1.5 Ensure that security policies and operational procedures for managing

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
@@ -24,6 +24,7 @@ identifiers:
     cce@rhel7: CCE-27349-0
     cce@rhel8: CCE-80890-7
     cce@rhel9: CCE-84023-1
+    cce@sle15: CCE-91410-1
 
 references:
     cis-csc: 11,14,3,9
@@ -41,6 +42,7 @@ references:
     nist: CA-3(5),CM-7(b),SC-7(23),CM-6(a)
     nist-csf: PR.IP-1,PR.PT-3
     ospp: FMT_MOF_EXT.1
+    pcidss: Req-1.4
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040810
     stigid@rhel7: RHEL-07-040810


### PR DESCRIPTION
#### Description:

- Add set_firewalld_default_zone rule to PCI DSS profile for sle15

#### Rationale:

- Add set_firewalld_default_zone rule to PCI DSS control file and also add SLE15 CCE id and PCI-DSS reference id to the rule