### PR TITLE
Stabilization: Fix indentation in Ansible shell module parameter

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -8,6 +8,7 @@
   shell: |
     set -o pipefail
     find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null
+  args:
     executable: /bin/bash
   check_mode: no
   register: find_result


### PR DESCRIPTION
#### Description:

The Ansible task using the shell module intended to define the executable parameter.
However, due to wrong indentation it was interpreted as part of the shell command.

#### Rationale:

Copy of #9851 to stabilization branch.
Fix Ansible task.