### PR TITLE
Stabilization: Unselect nfs-utils removal rule as GUI installation reqires the package

### DIFF
--- a/products/rhel9/profiles/stig_gui.profile
+++ b/products/rhel9/profiles/stig_gui.profile
@@ -43,3 +43,6 @@ selections:
     # SRG-OS-000480-GPOS-00227
     - '!package_gdm_removed'
     - '!package_xorg-x11-server-common_removed'
+
+    # SRG-OS-000095-GPOS-00049
+    - '!package_nfs-utils_removed'


### PR DESCRIPTION
#### Description:
Unselect package_nfs-utils_removed rule for STIG with GUI RHEL9 profile.

See #9860 