### PR TITLE
Add Refchecker to Tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -215,6 +215,7 @@ set_tests_properties("test-create_scap_delta_tailoring_resolved" PROPERTIES FIXT
 set_tests_properties("test-create_scap_delta_tailoring_resolved" PROPERTIES DEPENDS "test-rule-dir-json")
 endif()
 
+
 if (PYTHON3_EXECUTABLE AND PYTHON_VERSION_MINOR GREATER 6)
     add_test(
         NAME "test-controleval-directory"
@@ -233,4 +234,29 @@ if (PYTHON3_EXECUTABLE AND PYTHON_VERSION_MINOR GREATER 6)
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/controleval.py" "--controls-dir" "${CMAKE_SOURCE_DIR}/tests/unit/ssg-module/data/controls_dir" "stats" "--level" "medium" "--product" "rhel8" "--id" "qrst-levels" "--output-format" "json"
     )
     set_tests_properties("test-controleval-json" PROPERTIES LABELS quick)
+endif()
+
+macro(ssg_refcheck_test PRODUCT PROFILE KEY)
+    add_test(
+        NAME "refchecker-${PRODUCT}-${PROFILE}"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/refchecker.py" --json "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" "${PRODUCT}" "${PROFILE}" "${KEY}"
+    )
+    set_tests_properties("refchecker-${PRODUCT}-${PROFILE}" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
+    set_tests_properties("refchecker-${PRODUCT}-${PROFILE}" PROPERTIES DEPENDS "test-rule-dir-json")
+    set_tests_properties("refchecker-${PRODUCT}-${PROFILE}" PROPERTIES LABELS quick)
+endmacro()
+
+if (PYTHON3_EXECUTABLE AND SSG_PRODUCT_RHEL8)
+    ssg_refcheck_test("rhel8" "cis_workstation_l1" "cis")
+    ssg_refcheck_test("rhel8" "cis_workstation_l2" "cis")
+    ssg_refcheck_test("rhel8" "cis_server_l1" "cis")
+    ssg_refcheck_test("rhel8" "cis" "cis")
+endif()
+
+
+if (PYTHON3_EXECUTABLE AND SSG_PRODUCT_RHEL7)
+    ssg_refcheck_test("rhel7" "cis_workstation_l1" "cis")
+    ssg_refcheck_test("rhel7" "cis_workstation_l2" "cis")
+    ssg_refcheck_test("rhel7" "cis_server_l1" "cis")
+    ssg_refcheck_test("rhel7" "cis" "cis")
 endif()

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -17,19 +17,22 @@ import ssg.yaml
 import ssg.utils
 
 SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+RULES_JSON = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
+BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")
+CONTROLS_DIR = os.path.join(SSG_ROOT, "controls")
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Check all rule.yml referenced in a given"
                                      "profile for a required reference identifier")
     parser.add_argument("-j", "--json", type=str, action="store",
-                        default="build/rule_dirs.json", help="File to read "
+                        default=RULES_JSON, help="File to read "
                         "json output of rule_dir_json from (defaults to "
                         "build/rule_dirs.json")
-    parser.add_argument("-c", "--build-config-yaml", default="build/build_config.yml",
+    parser.add_argument("-c", "--build-config-yaml", default=BUILD_CONFIG,
                         help="YAML file with information about the build configuration. "
                         "Defaults to build/build_config.yml")
-    parser.add_argument("--controls", default="controls",
+    parser.add_argument("--controls", default=CONTROLS_DIR,
                         help="Directory that contains control files with policy controls.")
     parser.add_argument("-p", "--profiles-root",
                         help="Override where to look for profile files.")

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -5,6 +5,7 @@ import os
 import argparse
 import json
 
+from ssg.build_cpe import ProductCPEs
 import ssg.build_profile
 import ssg.build_yaml
 import ssg.controls
@@ -63,11 +64,15 @@ def load_for_product(rule_obj, product, env_yaml=None):
 def reference_check(env_yaml, rule_dirs, profile_path, product, product_yaml, reference,
                     profiles_root, controls_manager=None):
     profile = ssg.build_yaml.ProfileWithInlinePolicies.from_yaml(profile_path, env_yaml)
+    product_cpes = ProductCPEs()
+    product_cpes.load_product_cpes(env_yaml)
+    product_cpes.load_content_cpes(env_yaml)
 
     if controls_manager:
         profile_files = ssg.products.get_profile_files_from_root(env_yaml, product_yaml)
-        all_profiles = ssg.build_profile.make_name_to_profile_mapping(profile_files, env_yaml)
-        profile.resolve(all_profiles, controls_manager)
+        all_profiles = ssg.build_profile.make_name_to_profile_mapping(profile_files, env_yaml,
+                                                                      product_cpes)
+        profile.resolve(all_profiles, rule_dirs, controls_manager)
 
     ok = True
     for rule_id in profile.selected + profile.unselected:

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -125,7 +125,7 @@ def main():
     profile_path = os.path.join(profiles_root, profile_filename)
     if not os.path.exists(profile_path):
         msg = "Unknown profile {0}: check profile, --profiles-root, and try again. "
-        msg = "Note that the '.profile' suffix shouldn't be included."
+        msg += "Note that the '.profile' suffix shouldn't be included."
         msg = msg.format(args.profile)
         raise ValueError(msg)
 


### PR DESCRIPTION
#### Description:

* Fix `utils/refchecker.py`
* Add `utils/refchecker.py` checks for RHEL7 and RHEL8 CIS profiles

#### Rationale:

* Make `utils/refchecker.py` useful
* Help find bugs sooner

#### Review Hints:
* Remove the CIS keys from a file like `linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/rule.yml`, and it should make the tests fail.