### PR TITLE
Add ANSSI and CIS ansible tests to CI

### DIFF
--- a/tests/fmf-plans/ansible-anssi.fmf
+++ b/tests/fmf-plans/ansible-anssi.fmf
@@ -1,0 +1,12 @@
+summary:
+  Destructive ANSSI BP-028 (high) profile test (Ansible)
+discover:
+  how: fmf
+  url: https://src.fedoraproject.org/tests/scap-security-guide.git
+  test:
+  - /Sanity/ansible-machine-hardening/anssi
+execute:
+  how: tmt
+adjust:
+- enabled: false
+  when: distro == fedora

--- a/tests/fmf-plans/ansible-cis.fmf
+++ b/tests/fmf-plans/ansible-cis.fmf
@@ -1,0 +1,12 @@
+summary:
+  Destructive CIS Server Level 2 profile test (Ansible)
+discover:
+  how: fmf
+  url: https://src.fedoraproject.org/tests/scap-security-guide.git
+  test:
+  - /Sanity/ansible-machine-hardening/cis
+execute:
+  how: tmt
+adjust:
+- enabled: false
+  when: distro == fedora


### PR DESCRIPTION
#### Description:
Extend existing `ansible-machine-hardening` CI test with ANSSI High and CIS Server Level 2 profiles.

#### Rationale:
Increase ansible CI test coverage.

#### Review Hints:
See `testing-farm:centos-stream-*` checks.