### PR TITLE
Ensure pwquality.conf.d dir exists on test scenarios

### DIFF
--- a/shared/templates/accounts_password/tests/conflicting_values_directory.fail.sh
+++ b/shared/templates/accounts_password/tests/conflicting_values_directory.fail.sh
@@ -7,5 +7,6 @@ truncate -s 0 /etc/security/pwquality.conf
 
 echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf
 
-echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" \
->> /etc/security/pwquality.conf.d/test_file.conf
+config_dir="/etc/security/pwquality.conf.d"
+mkdir -p $config_dir
+echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" >> $config_dir/test_file.conf

--- a/shared/templates/accounts_password/tests/correct_value_directory.pass.sh
+++ b/shared/templates/accounts_password/tests/correct_value_directory.pass.sh
@@ -8,5 +8,6 @@
 
 truncate -s 0 /etc/security/pwquality.conf
 
-echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" \
->> /etc/security/pwquality.conf.d/test_file.conf
+config_dir="/etc/security/pwquality.conf.d"
+mkdir -p $config_dir
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> $config_dir/test_file.conf

--- a/shared/templates/accounts_password/tests/multiple_correct_value.pass.sh
+++ b/shared/templates/accounts_password/tests/multiple_correct_value.pass.sh
@@ -7,5 +7,6 @@ truncate -s 0 /etc/security/pwquality.conf
 
 echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf
 
-echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" \
->> /etc/security/pwquality.conf.d/test_file.conf
+config_dir="/etc/security/pwquality.conf.d"
+mkdir -p $config_dir
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> $config_dir/test_file.conf

--- a/shared/templates/accounts_password/tests/wrong_value_directory.fail.sh
+++ b/shared/templates/accounts_password/tests/wrong_value_directory.fail.sh
@@ -7,5 +7,6 @@
 
 truncate -s 0 /etc/security/pwquality.conf
 
-echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" \
->> /etc/security/pwquality.conf.d/test_file.conf
+config_dir="/etc/security/pwquality.conf.d"
+mkdir -p $config_dir
+echo "{{{ VARIABLE }}} = {{{ TEST_WRONG_VALUE }}}" >> $config_dir/test_file.conf


### PR DESCRIPTION
#### Description:

Ensure `pwquality.conf.d` dir exists on test scenarios.

#### Rationale:

- Fixes #9774