### PR TITLE
Rewrite remediations for rsyslog_remote_tls

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -5,21 +5,27 @@
 # disruption = low
 {{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
-- name: "Get omfwd configuration directive"
-  shell: sed -e '/^action\s*(\s*type\s*=\s*"omfwd"/,/)/!d' /etc/rsyslog.conf /etc/rsyslog.d/*.conf || true
-  register: include_omfwd_config_output
+- name: "{{{ rule_title }}}: Find all files matching /etc/rsyslog.d/*.conf"
+  find:
+    paths: "/etc/rsyslog.d/"
+    pattern: "*.conf"
+  register: rsyslog_includes
 
-- name: "Get include files directives"
-  shell: >
-    set -o pipefail
-    echo \"{{ include_omfwd_config_output.stdout }}\"|grep  'StreamDriver=\"gtls\"'
-  register: include_omfwd_gtls_config_output
-  when: (include_omfwd_config_output.stdout_lines| length > 0)
+- name: "{{{ rule_title }}}: Retrieve list of Rsyslog config files"
+  set_fact:
+    rsyslog_files: "{{ rsyslog_includes.files | map(attribute='path') | list + ['/etc/rsyslog.conf'] }}"
 
-- name: "Set rsyslog omfwd to use TLS"
+- name: "{{{ rule_title }}}: Fix existing omfwd directives"
+  replace:
+    path: "{{ item }}"
+    regexp: '^(action\s*\(\s*type\s*=\s*"omfwd"(.*(?!.*StreamDriver\s*=\s*"gtls".*)))\)$'
+    replace: '\1 StreamDriver="gtls")'
+  register: existing_directive_fixed
+  loop: "{{ rsyslog_files }}"
+
+- name: "{{{ rule_title }}}: Add missing rsyslog directive"
   lineinfile:
     dest: /etc/rsyslog.conf
     line: "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"
     create: yes
-  when: (include_omfwd_gtls_config_output is skipped ) or
-        ("gtls" not in include_omfwd_gtls_config_output.stdout)
+  when: not existing_directive_fixed.changed

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -6,17 +6,17 @@
 {{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
 - name: "{{{ rule_title }}}: Find all files matching /etc/rsyslog.d/*.conf"
-  find:
+  ansible.builtin.find:
     paths: "/etc/rsyslog.d/"
     pattern: "*.conf"
   register: rsyslog_includes
 
 - name: "{{{ rule_title }}}: Retrieve list of Rsyslog config files"
-  set_fact:
+  ansible.builtin.set_fact:
     rsyslog_files: "{{ rsyslog_includes.files | map(attribute='path') | list + ['/etc/rsyslog.conf'] }}"
 
 - name: "{{{ rule_title }}}: Fix existing omfwd directives"
-  replace:
+  ansible.builtin.replace:
     path: "{{ item }}"
     regexp: '^(action\s*\(\s*type\s*=\s*"omfwd"(.*(?!.*StreamDriver\s*=\s*"gtls".*)))\)$'
     replace: '\1 StreamDriver="gtls")'
@@ -24,7 +24,7 @@
   loop: "{{ rsyslog_files }}"
 
 - name: "{{{ rule_title }}}: Add missing rsyslog directive"
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/rsyslog.conf
     line: "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"
     create: yes

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -70,7 +70,6 @@
         path: "{{ item[0] }}"
         regexp: '(?i)^(\s*action\s*\(\s*type\s*=\s*"omfwd"[\s\S]*)({{ item[1][0] | regex_escape() }}\s*=\s*"\S*")([\s\S]*\))$'
         replace: '\1{{ item[1][0] }}="{{ item[1][1] }}"\3'
-      register: existing_directive_value_fixed
       loop: "{{ rsyslog_files | product (rsyslog_parameters_to_replace_if_wrong_value | zip(rsyslog_values_to_replace_if_wrong_value)) | list }}"
 
     - name: "{{{ rule_title }}}: Fix existing omfwd directives by adding parameter and value"
@@ -78,10 +77,8 @@
         path: "{{ item[0] }}"
         regexp: '(?i)^(\s*action\s*\(\s*type\s*=\s*"omfwd"(?:[\s\S](?!{{ item[1][0] | regex_escape() }}))*.)(\))$'
         replace: '\1 {{ item[1][0] }}="{{ item[1][1] }}" \2'
-      register: existing_directive_fixed
       loop: "{{ rsyslog_files | product (rsyslog_parameters_to_add_if_missing | zip(rsyslog_values_to_add_if_missing)) | list }}"
   when: rsyslog_includes_with_directive.matched or rsyslog_main_file_with_directive.matched
-
 
 - name: "{{{ rule_title }}}: Add missing rsyslog directive"
   ansible.builtin.lineinfile:

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -5,27 +5,87 @@
 # disruption = low
 {{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
-- name: "{{{ rule_title }}}: Find all files matching /etc/rsyslog.d/*.conf"
+- name: "{{{ rule_title }}}: search for omfwd action directive in rsyslog include files"
   ansible.builtin.find:
     paths: "/etc/rsyslog.d/"
     pattern: "*.conf"
-  register: rsyslog_includes
+    contains: '^\s*action\s*\(\s*type\s*=\s*"omfwd".*'
+  register: rsyslog_includes_with_directive
 
-- name: "{{{ rule_title }}}: Retrieve list of Rsyslog config files"
+- name: "{{{ rule_title }}}: search for omfwd action directive in rsyslog main config file"
+  ansible.builtin.find:
+    paths: "/etc"
+    pattern: "rsyslog.conf"
+    contains: '^\s*action\s*\(\s*type\s*=\s*"omfwd".*'
+  register: rsyslog_main_file_with_directive
+
+- name: "{{{ rule_title }}}: declare Rsyslog option parameters to be inserted inf entirely missing"
   ansible.builtin.set_fact:
-    rsyslog_files: "{{ rsyslog_includes.files | map(attribute='path') | list + ['/etc/rsyslog.conf'] }}"
+    rsyslog_parameters_to_add_if_missing:
+      - "protocol"
+      - "target"
+      - "port"
+      - "StreamDriver"
+      - "StreamDriverMode"
+      - "StreamDriverAuthMode"
+      - "streamdriver.CheckExtendedKeyPurpose"
 
-- name: "{{{ rule_title }}}: Fix existing omfwd directives"
-  ansible.builtin.replace:
-    path: "{{ item }}"
-    regexp: '^(action\s*\(\s*type\s*=\s*"omfwd"(.*(?!.*StreamDriver\s*=\s*"gtls".*)))\)$'
-    replace: '\1 StreamDriver="gtls")'
-  register: existing_directive_fixed
-  loop: "{{ rsyslog_files }}"
+- name: "{{{ rule_title }}}: declare Rsyslog option values to be inserted if entirely missing"
+  ansible.builtin.set_fact:
+    rsyslog_values_to_add_if_missing:
+      - "tcp"
+      - "{{ rsyslog_remote_loghost_address }}"
+      - "6514"
+      - "gtls"
+      - "1"
+      - "x509/name"
+      - "on"
+
+- name: "{{{ rule_title }}}: declare Rsyslog option parameters to be replaced if defined with wrong values"
+  ansible.builtin.set_fact:
+    rsyslog_parameters_to_replace_if_wrong_value:
+      - "protocol"
+      - "StreamDriver"
+      - "StreamDriverMode"
+      - "StreamDriverAuthMode"
+      - "streamdriver.CheckExtendedKeyPurpose"
+
+- name: "{{{ rule_title }}}: declare Rsyslog option values to be replaced when having wrong value"
+  ansible.builtin.set_fact:
+    rsyslog_values_to_replace_if_wrong_value:
+      - "tcp"
+      - "gtls"
+      - "1"
+      - "x509/name"
+      - "on"
+
+- name: "{{{ rule_title }}}: assemble list of files with existing directives"
+  ansible.builtin.set_fact:
+    rsyslog_files: "{{ rsyslog_includes_with_directive.files | map(attribute='path') | list + rsyslog_main_file_with_directive.files | map(attribute='path') | list }}"
+
+- name: "{{{ rule_title }}}: try to fix existing directives"
+  block:
+    - name: "{{{ rule_title }}}: Fix existing omfwd directives by adjusting the value"
+      ansible.builtin.replace:
+        path: "{{ item[0] }}"
+        regexp: '(?i)^(\s*action\s*\(\s*type\s*=\s*"omfwd"[\s\S]*)({{ item[1][0] | regex_escape() }}\s*=\s*"\S*")([\s\S]*\))$'
+        replace: '\1 {{ item[1][0] }}="{{ item[1][1] }}"\3'
+      register: existing_directive_value_fixed
+      loop: "{{ rsyslog_files | product (rsyslog_parameters_to_replace_if_wrong_value | zip(rsyslog_values_to_replace_if_wrong_value)) | list }}"
+
+    - name: "{{{ rule_title }}}: Fix existing omfwd directives by adding parameter and value"
+      ansible.builtin.replace:
+        path: "{{ item[0] }}"
+        regexp: '(?i)^(\s*action\s*\(\s*type\s*=\s*"omfwd"(?:[\s\S](?!{{ item[1][0] | regex_escape() }}))*.)(\))$'
+        replace: '\1 {{ item[1][0] }}="{{ item[1][1] }}" \2'
+      register: existing_directive_fixed
+      loop: "{{ rsyslog_files | product (rsyslog_parameters_to_add_if_missing | zip(rsyslog_values_to_add_if_missing)) | list }}"
+  when: rsyslog_includes_with_directive.matched or rsyslog_main_file_with_directive.matched
+
 
 - name: "{{{ rule_title }}}: Add missing rsyslog directive"
   ansible.builtin.lineinfile:
     dest: /etc/rsyslog.conf
-    line: "action(type=\"omfwd\" protocol=\"tcp\" Target=\"{{ rsyslog_remote_loghost_address }}\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"
+    line: 'action(type="omfwd" protocol="tcp" Target="{{ rsyslog_remote_loghost_address }}" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")'
     create: yes
-  when: not existing_directive_fixed.changed
+  when: not rsyslog_includes_with_directive.matched and not rsyslog_main_file_with_directive.matched

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/ansible/shared.yml
@@ -19,7 +19,7 @@
     contains: '^\s*action\s*\(\s*type\s*=\s*"omfwd".*'
   register: rsyslog_main_file_with_directive
 
-- name: "{{{ rule_title }}}: declare Rsyslog option parameters to be inserted inf entirely missing"
+- name: "{{{ rule_title }}}: declare Rsyslog option parameters to be inserted if entirely missing"
   ansible.builtin.set_fact:
     rsyslog_parameters_to_add_if_missing:
       - "protocol"
@@ -69,7 +69,7 @@
       ansible.builtin.replace:
         path: "{{ item[0] }}"
         regexp: '(?i)^(\s*action\s*\(\s*type\s*=\s*"omfwd"[\s\S]*)({{ item[1][0] | regex_escape() }}\s*=\s*"\S*")([\s\S]*\))$'
-        replace: '\1 {{ item[1][0] }}="{{ item[1][1] }}"\3'
+        replace: '\1{{ item[1][0] }}="{{ item[1][1] }}"\3'
       register: existing_directive_value_fixed
       loop: "{{ rsyslog_files | product (rsyslog_parameters_to_replace_if_wrong_value | zip(rsyslog_values_to_replace_if_wrong_value)) | list }}"
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/bash/shared.sh
@@ -4,20 +4,24 @@
 # complexity = low
 # disruption = low
 
-{{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
+ {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
+params_to_add_if_missing=("protocol" "target" "port" "StreamDriver" "StreamDriverMode" "StreamDriverAuthMode" "streamdriver.CheckExtendedKeyPurpose")
+values_to_add_if_missing=("tcp" "$rsyslog_remote_loghost_address" "6514" "gtls" "1" "x509/name" "on")
+params_to_replace_if_wrong_value=("protocol" "StreamDriver" "StreamDriverMode" "StreamDriverAuthMode" "streamdriver.CheckExtendedKeyPurpose")
+values_to_replace_if_wrong_value=("tcp" "gtls" "1" "x509/name" "on")
 
-# Get omfwd configuration directive
-OMFWD_CONFIG_OUTPUT=`grep -Pzo '^(?s)action\s*\(\s*type\s*=\s*"omfwd".*\)' /etc/rsyslog.conf /etc/rsyslog.d/*.conf`
-OMFWD_CONFIG=`echo "$OMFWD_CONFIG_OUTPUT"| awk 'BEGIN {FS=":"; RS=")\n"}; {print $2}'`
-OMFWD_CONFIG_FILE=`echo "$OMFWD_CONFIG_OUTPUT"| awk 'BEGIN {FS=":"; RS=")\n"}; {print $1}'`
-if ! [ -z "$OMFWD_CONFIG" ]; then
-    OMFWD_TLS_STREAM=`echo "$OMFWD_CONFIG"|grep  'StreamDriver="gtls"'`
-    if ! [ -z "${OMFWD_TLS_STREAM}" ]; then
-        exit 0
-    else
-        # insert TLS stream param
-        sed -i 's/action\s*(\s*type\s*=\s*"omfwd"/action(type="omfwd"\ StreamDriver="gtls"\ /' $OMFWD_CONFIG_FILE
-    fi
+files_containing_omfwd=("$(grep -ilE '^[^#]*\s*action\s*\(\s*type\s*=\s*"omfwd".*' /etc/rsyslog.conf /etc/rsyslog.d/*.conf)")
+if [ -n "${files_containing_omfwd[*]}" ]; then
+    for file in "${files_containing_omfwd[@]}"; do
+        for ((i=0; i<${#params_to_replace_if_wrong_value[@]}; i++)); do
+            sed -i -E -e 'H;$!d;x;s/^\n//' -e "s|(\s*action\s*\(\s*type\s*=\s*[\"]omfwd[\"].*?)${params_to_replace_if_wrong_value[$i]}\s*=\s*[\"]\S*[\"](.*\))|\1${params_to_replace_if_wrong_value[$i]}=\"${values_to_replace_if_wrong_value[$i]}\"\2|gI" "$file"
+        done
+        for ((i=0; i<${#params_to_add_if_missing[@]}; i++)); do
+            if ! grep -qPzi "(?s)\s*action\s*\(\s*type\s*=\s*[\"]omfwd[\"].*?${params_to_add_if_missing[$i]}.*?\).*" "$file"; then
+                sed -i -E -e 'H;$!d;x;s/^\n//' -e "s|(\s*action\s*\(\s*type\s*=\s*[\"]omfwd[\"])|\1\n${params_to_add_if_missing[$i]}=\"${values_to_add_if_missing[$i]}\"|gI" "$file"
+            fi
+        done
+    done
 else
     echo "action(type=\"omfwd\" protocol=\"tcp\" Target=\"$rsyslog_remote_loghost_address\" port=\"6514\" StreamDriver=\"gtls\" StreamDriverMode=\"1\" StreamDriverAuthMode=\"x509/name\" streamdriver.CheckExtendedKeyPurpose=\"on\")"  >> /etc/rsyslog.conf
 fi

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cat >> /etc/rsyslog.conf <<EOF
-action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")
+action(type="omfwd" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on" protocol="tcp")
 EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_include_file.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_include_file.pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-mkdir /etc/rsyslog.d
+if [ ! -d /etc/rsyslog.d/ ]; then
+    mkdir /etc/rsyslog.d
+fi
+
 cat >> /etc/rsyslog.d/test.conf <<EOF
 action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")
 EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_include_file.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_include_file.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+mkdir /etc/rsyslog.d
+cat >> /etc/rsyslog.d/test.conf <<EOF
+action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")
+EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_EKU.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_EKU.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd"

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd"

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# remediation = none
+
+mkdir /etc/rsyslog.d
+cat >> /etc/rsyslog.d/test.conf <<EOF
+action(type="omfwd"
+       protocol="tcp"
+       Target="remote.system.com"
+       port="6514"
+       StreamDriver="gtls"
+       StreamDriverMode="1")
+EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 
 mkdir /etc/rsyslog.d
 cat >> /etc/rsyslog.d/test.conf <<EOF

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-mkdir /etc/rsyslog.d
+if [ ! -d /etc/rsyslog.d/ ]; then
+    mkdir /etc/rsyslog.d
+fi
+
 cat >> /etc/rsyslog.d/test.conf <<EOF
 action(type="omfwd"
        protocol="tcp"

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/wrong_multiline.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/wrong_multiline.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# remediation = none
 
 cat >> /etc/rsyslog.conf <<EOF
 action(type="omfwd"


### PR DESCRIPTION
#### Description:


- add few tests to test also files in /etc/rsyslog.d
- completely rewrite Bash and Ansible remediations
- now remediations try to file the omfwd line in tact as much as possible. They first try to correct wrong config options and also add missing config options to the omfwd directive.
- If no omfwd directive is found, they create a new one.

#### Rationale:

Fixes: #9621 