### PR TITLE
Fix config file path in dconf_gnome_screensaver_lock_locked yaml file

### DIFF
--- a/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
+++ b/linux_os/guide/system/software/gnome/gnome_screen_locking/dconf_gnome_screensaver_lock_locked/rule.yml
@@ -7,7 +7,7 @@ title: 'Ensure Users Cannot Change GNOME3 Screensaver Lock After Idle Period'
 description: |-
     If not already configured, ensure that users cannot change GNOME3 screensaver lock settings
     by adding <pre>/org/gnome/desktop/screensaver/lock-enabled</pre>
-    to <tt>/etc/dconf/db/local.d/00-security-settings</tt>.
+    to <tt>/etc/dconf/db/local.d/locks/00-security-settings</tt>.
     For example:
     <pre>/org/gnome/desktop/screensaver/lock-enabled</pre>
     After the settings have been set, run <tt>dconf update</tt>.


### PR DESCRIPTION
#### Description:

- Added `locks/` to the config file path for the screensaver lock

#### Rationale:

- This fixes rule description, to have the correct file path

#### Review Hints:

- This new path now matches the one present in OCIL section