### PR TITLE
Recognize 64bit architectures in Ansible remediations

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -14,12 +14,18 @@
 #
 - name: Set architecture for audit tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
 # set list of syscalls based on rhel version
 {{% set audit_syscalls = ["init_module", "delete_module", "finit_module"] %}}
 
-- name: Perform remediation of Audit rules for kernel module loading for x86 platform
+- name: Perform remediation of Audit rules for kernel module loading for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -38,7 +44,7 @@
       syscall_grouping=audit_syscalls,
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for kernel module loading for x86_64 platform
+- name: Perform remediation of Audit rules for kernel module loading for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/ansible/shared.yml
@@ -8,9 +8,15 @@
 
 - name: Set architecture for audit finit_module tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for finit_module for x86 platform
+- name: Perform remediation of Audit rules for finit_module for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -29,7 +35,7 @@
       syscall_grouping=[],
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for finit_module for x86_64 platform
+- name: Perform remediation of Audit rules for finit_module for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/ansible/shared.yml
@@ -14,9 +14,15 @@
 
 - name: Set architecture for audit delete_module tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for delete_module for x86 platform
+- name: Perform remediation of Audit rules for delete_module for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -35,7 +41,7 @@
       syscall_grouping=[],
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for delete_module for x86_64 platform
+- name: Perform remediation of Audit rules for delete_module for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/ansible/shared.yml
@@ -14,7 +14,13 @@
 
 - name: Set architecture for audit finit_module tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
 - name: Perform remediation of Audit rules for finit_module for x86 platform
   block:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/ansible/shared.yml
@@ -14,9 +14,15 @@
 
 - name: Set architecture for audit init_module tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for init_module for x86 platform
+- name: Perform remediation of Audit rules for init_module for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -35,7 +41,7 @@
       syscall_grouping=["init_module","finit_module"],
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for init_module for x86_64 platform
+- name: Perform remediation of Audit rules for init_module for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/ansible/shared.yml
@@ -9,9 +9,15 @@
 #
 - name: Set architecture for audit tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Remediate audit rules for network configuration for x86
+- name: Remediate audit rules for network configuration for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +36,7 @@
       syscall_grouping=["sethostname", "setdomainname"],
       )|indent(4) }}}
 
-- name: Remediate audit rules for network configuration for x86_64
+- name: Remediate audit rules for network configuration for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_adjtimex/ansible/shared.yml
@@ -6,9 +6,15 @@
 
 - name: Set architecture for audit tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for adjtimex for x86 platform
+- name: Perform remediation of Audit rules for adjtimex for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -27,7 +33,7 @@
       syscall_grouping=["adjtimex", "settimeofday", "stime"],
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for adjtimex for x86_64 platform
+- name: Perform remediation of Audit rules for adjtimex for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_clock_settime/ansible/shared.yml
@@ -8,9 +8,15 @@
 #
 - name: Set architecture for audit tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for clock_settime for x86 platform
+- name: Perform remediation of Audit rules for clock_settime for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -29,7 +35,7 @@
       syscall_grouping=[],
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for clock_settime for x86_64 platform
+- name: Perform remediation of Audit rules for clock_settime for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_time_rules/audit_rules_time_settimeofday/ansible/shared.yml
@@ -6,9 +6,15 @@
 
 - name: Set architecture for audit tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for settimeofday for x86 platform
+- name: Perform remediation of Audit rules for settimeofday for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -27,7 +33,7 @@
       syscall_grouping=["adjtimex", "settimeofday", "stime"],
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for settimeofday for x86_64 platform
+- name: Perform remediation of Audit rules for settimeofday for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/ansible/shared.yml
@@ -8,9 +8,21 @@
 {{% if "rhel" not in product and product != "fedora" %}}
 
 # What architecture are we on?
-- name: Set architecture for kernel exec-shield tasks
+# By default, set 32bit
+- name: Set 32bit architecture for kernel exec-shield tasks
   set_fact:
-    kexec_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    kexec_arch: "b32"
+
+# If needed, change to 64bit
+- name: Set 64bit architecture for kernel exec-shield tasks
+  set_fact:
+    kexec_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
 - name: Ensure sysctl kernel.exec-shield is set to 1
   sysctl:

--- a/shared/templates/audit_rules_dac_modification/ansible.template
+++ b/shared/templates/audit_rules_dac_modification/ansible.template
@@ -9,9 +9,15 @@
 #
 - name: Set architecture for audit {{{ ATTR | join(", ") }}} tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for {{{ ATTR | join(", ") }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ ATTR | join(", ") }}} for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -48,7 +54,7 @@
       )|indent(4) }}}
 {{%- endif %}}
 
-- name: Perform remediation of Audit rules for {{{ ATTR | join(", ") }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ ATTR | join(", ") }}} for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_file_deletion_events/ansible.template
+++ b/shared/templates/audit_rules_file_deletion_events/ansible.template
@@ -9,9 +9,15 @@
 #
 - name: Set architecture for audit {{{ NAME | join(", ") }}} tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +36,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_path_syscall/ansible.template
+++ b/shared/templates/audit_rules_path_syscall/ansible.template
@@ -9,9 +9,15 @@
 #
 - name: Set architecture for audit {{{ SYSCALL | join(", ") }}} tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
-- name: Perform remediation of Audit rules for {{{ SYSCALL | join(", ") }}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ SYSCALL | join(", ") }}} for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -30,7 +36,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for {{{ SYSCALL | join(", ") }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ SYSCALL | join(", ") }}} for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",

--- a/shared/templates/audit_rules_syscall_events/ansible.template
+++ b/shared/templates/audit_rules_syscall_events/ansible.template
@@ -9,7 +9,13 @@
 #
 - name: Set architecture for audit {{{ ATTR }}} tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
 #
 # Inserts/replaces the rule in /etc/audit/rules.d
@@ -34,29 +40,29 @@
       - "{{ find_{{{ ATTR }}}.files | map(attribute='path') | list | first }}"
   when: find_{{{ ATTR }}}.matched is defined and find_{{{ ATTR }}}.matched > 0
 
-- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86
+- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on 32bit
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     create: yes
 
-- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on x86_64
+- name: Inserts/replaces the {{{ ATTR }}} rule in rules.d when on 64bit
   lineinfile:
     path: "{{ all_files[0] }}"
     line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     create: yes
   when: audit_arch is defined and audit_arch == 'b64'
-#   
+#
 # Inserts/replaces the rule in /etc/audit/audit.rules
 #
-- name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/rules.d/audit.rules when on x86
+- name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/rules.d/audit.rules when on 32bit
   lineinfile:
     line: "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     state: present
     dest: /etc/audit/rules.d/audit.rules
     create: yes
 
-- name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/rules.d/audit.rules when on x86_64
+- name: Inserts/replaces the {{{ ATTR }}} rule in /etc/audit/rules.d/audit.rules when on 64bit
   lineinfile:
     line: "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ auid }}} -F auid!=4294967295 -F key=perm_mod"
     state: present

--- a/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/ansible.template
@@ -9,10 +9,16 @@
 #
 - name: Set architecture for audit {{{ NAME | join(", ") }}} tasks
   set_fact:
-    audit_arch: "b{{ ansible_architecture | regex_replace('.*(\\d\\d$)','\\1') }}"
+    audit_arch: "b64"
+  when:
+  - ansible_architecture == "aarch64" or
+    ansible_architecture == "ppc64" or
+    ansible_architecture == "ppc64le" or
+    ansible_architecture == "s390x" or
+    ansible_architecture == "x86_64"
 
 {{% for EXIT_CODE in ["EACCES","EPERM"] %}}
-- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE}}} for x86 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE}}} for 32bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b32",
@@ -31,7 +37,7 @@
       syscall_grouping=SYSCALL_GROUPING,
       )|indent(4) }}}
 
-- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE }}} for x86_64 platform
+- name: Perform remediation of Audit rules for {{{ NAME | join(", ") }}} {{{ EXIT_CODE }}} for 64bit platform
   block:
     {{{ ansible_audit_augenrules_add_syscall_rule(
       action_arch_filters="-a always,exit -F arch=b64",


### PR DESCRIPTION
#### Description:
Change identifying 64bit architectures - use exact architecture names and don't do some regex_replaces, because that doesn't work for architectures like `s390x`.

#### Rationale:
Fixes #9856 

#### Review Hints:
You can do x86_64 testing on Automatus, but for the rest architectures I recommend having the machine with non-x86_64 arch (ideally s390x or ppc64le) and testing it right on it.