### PR TITLE
Small Ol7 updates, rule additions, and incorporation in JINJA statements

### DIFF
--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left/rule.yml
@@ -39,7 +39,6 @@ references:
     nist@sle12: AU-5(1)
     pcidss: Req-10.7
     srg: SRG-OS-000343-GPOS-00134
-    stigid@ol7: OL07-00-030330
     stigid@sle12: SLES-12-020030
     stigid@sle15: SLES-15-030700
     vmmsrg: SRG-OS-000343-VMM-001240

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_percentage/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,ol9,rhel7,rhel8,rhel9,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,ubuntu2004,ubuntu2204
 
 title: 'Configure auditd space_left on Low Disk Space'
 
@@ -35,6 +35,7 @@ references:
     nist-csf: DE.AE-3,DE.AE-5,PR.DS-4,PR.PT-1,RS.AN-1,RS.AN-4
     pcidss: Req-10.7
     srg: SRG-OS-000343-GPOS-00134
+    stigid@ol7: OL07-00-030330
     stigid@ol8: OL08-00-030730
     stigid@rhel7: RHEL-07-030330
     stigid@rhel8: RHEL-08-030730

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_password/oval/shared.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("The grub2 boot loader should have password protection enabled.") }}}
 
     <criteria operator="OR">
-      {{% if product in ["ol8", "rhel8"] %}}
+      {{% if product in ["ol7","ol8", "rhel8"] %}}
       <criterion comment="make sure a password is defined in {{{ grub2_boot_path }}}/user.cfg" test_ref="test_grub2_password_usercfg" />
       {{% else %}}
       <criteria operator="AND">
@@ -17,7 +17,7 @@
     </criteria>
   </definition>
 
-  {{% if product not in ["ol8", "rhel8"] %}}
+  {{% if product not in ["ol7","ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="superuser is defined in {{{ grub2_boot_path }}}/grub.cfg files." id="test_bootloader_superuser" version="2">
     <ind:object object_ref="object_bootloader_superuser" />
   </ind:textfilecontent54_test>
@@ -37,7 +37,7 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  {{% if product not in ["ol8", "rhel8"] %}}
+  {{% if product not in ["ol7","ol8", "rhel8"] %}}
   <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="make sure a password is defined in {{{ grub2_boot_path }}}/grub.cfg" id="test_grub2_password_grubcfg" version="1">
     <ind:object object_ref="object_grub2_password_grubcfg" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/package_firewalld_installed/rule.yml
@@ -37,6 +37,7 @@ references:
     nist@sle15: CM-7,CM-7.1(iii),CM-7(b),AC-17(1)
     ospp: FMT_SMF_EXT.1
     srg: SRG-OS-000096-GPOS-00050,SRG-OS-000297-GPOS-00115,SRG-OS-000298-GPOS-00116,SRG-OS-000480-GPOS-00227,SRG-OS-000480-GPOS-00232
+    stigid@ol7: OL07-00-040520
     stigid@ol8: OL08-00-040100
     stigid@rhel8: RHEL-08-040100
     stigid@sle15: SLES-15-010220

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configure_firewalld_rate_limiting/rule.yml
@@ -33,7 +33,6 @@ references:
     disa: CCI-002385
     nist: SC-5,SC-5(1),SC-5(2),SC-5(3)(a),CM-6(a)
     srg: SRG-OS-000420-GPOS-00186
-    stigid@ol7: OL07-00-040510
     stigid@rhel7: RHEL-07-040510
     vmmsrg: SRG-OS-000420-VMM-001690
 

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nodev/rule.yml
@@ -42,7 +42,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
-    stigid@ol7: OL07-00-021022
+    stigid@ol7: OL07-00-021024
     stigid@ol8: OL08-00-040120
     stigid@rhel7: RHEL-07-021024
     stigid@rhel8: RHEL-08-040120

--- a/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_dev_shm_nosuid/rule.yml
@@ -42,7 +42,7 @@ references:
     nist: CM-7(a),CM-7(b),CM-6(a),AC-6,AC-6(1),MP-7
     nist-csf: PR.IP-1,PR.PT-2,PR.PT-3
     srg: SRG-OS-000368-GPOS-00154
-    stigid@ol7: OL07-00-021023
+    stigid@ol7: OL07-00-021024
     stigid@ol8: OL08-00-040121
     stigid@rhel7: RHEL-07-021024
     stigid@rhel8: RHEL-08-040121

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -250,6 +250,7 @@ selections:
     - sshd_disable_compression
     - chronyd_or_ntpd_set_maxpoll
     - service_firewalld_enabled
+    - package_firewalld_installed
     - display_login_attempts
     - no_user_host_based_files
     - no_host_based_files

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -47,6 +47,7 @@ selections:
     - sysctl_net_ipv4_conf_default_accept_redirects_value=disabled
     - sysctl_net_ipv6_conf_all_accept_source_route_value=disabled
     - sysctl_net_ipv4_conf_all_accept_redirects_value=disabled
+    - sysctl_net_ipv4_tcp_invalid_ratelimit_value=five_hundred
     - rpm_verify_permissions
     - rpm_verify_ownership
     - rpm_verify_hashes
@@ -248,7 +249,6 @@ selections:
     - sshd_use_priv_separation
     - sshd_disable_compression
     - chronyd_or_ntpd_set_maxpoll
-    - configure_firewalld_rate_limiting
     - service_firewalld_enabled
     - display_login_attempts
     - no_user_host_based_files
@@ -262,6 +262,7 @@ selections:
     - sysctl_net_ipv4_conf_all_send_redirects
     - sysctl_net_ipv4_conf_all_rp_filter
     - sysctl_net_ipv4_conf_default_rp_filter
+    - sysctl_net_ipv4_tcp_invalid_ratelimit
     - network_sniffer_disabled
     - postfix_prevent_unrestricted_relay
     - package_vsftpd_removed

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -33,6 +33,7 @@ selections:
     - var_removable_partition=dev_cdrom
     - var_auditd_action_mail_acct=root
     - var_auditd_space_left_action=email
+    - var_auditd_space_left_percentage=25pc
     - var_accounts_user_umask=077
     - var_password_pam_retry=3
     - var_accounts_max_concurrent_login_sessions=10
@@ -159,7 +160,7 @@ selections:
     - auditd_audispd_encrypt_sent_records
     - auditd_audispd_disk_full_action
     - auditd_name_format
-    - auditd_data_retention_space_left
+    - auditd_data_retention_space_left_percentage
     - auditd_data_retention_space_left_action
     - auditd_data_retention_action_mail_acct
     - audit_rules_dac_modification_chown

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -17,7 +17,7 @@
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
       comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
       {{% endif %}}
-{{% if "ubuntu" not in product and "rhel" not in product%}}
+{{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product%}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
 {{% endif %}}
 
@@ -68,7 +68,7 @@
   </ind:textfilecontent54_object>
 {{% endif %}}
 
-{{% if "ubuntu" not in product and "rhel" not in product %}}
+{{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product %}}
   <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" version="1" check="all"
   comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf">
     <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf" />


### PR DESCRIPTION
#### Description:

- Update OL7 STIG Ids in `mount_option_dev_shm_nodev` & `mount_option_dev_shm_nosuid`
- Update `grub2_password` rule for OL7 to only check configuration in user.cfg, as done in ol8
- Update `kernel_module_disabled` template for OL products, so OVAL doesn't check `modprobe.conf`
- Replace the rule `auditd_data_retention_space_left` with `auditd_data_retention_space_left_percentage` in OL7 STIG profile
- Replace `configure_firewalld_rate_limiting` rule with `sysctl_net_ipv4_tcp_invalid_ratelimit` in OL7 STIG profile
- Add rule `package_firewalld_installed` to OL7 STIG profile

#### Rationale:

- All this with the intention to align better OL7 STIG profile with DISA's requirements

#### Review Hints:

- All this changes just take advantage of existing content. So I don't see much potential to break something