### PR TITLE
Add automatic detection of platform_package_overrides when using automatus 

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/commented.fail.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu,multi_platform_rhel
-{{% if "ubuntu" in product %}}
-# packages = libpam-pkcs11
-{{% elif "rhel7" == product %}}
-# packages = pam_pkcs11
-{{% else %}}
 # packages = openssl-pkcs11
-{{% endif %}}
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/correct.pass.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
-{{% if "ubuntu" in product %}}
-# packages = libpam-pkcs11
-{{% elif product in ["ol7", "rhel7"] %}}
-# packages = pam_pkcs11
-{{% else %}}
 # packages = openssl-pkcs11
-{{% endif %}}
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/missing_ocsp.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/tests/missing_ocsp.fail.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel,multi_platform_ubuntu
-{{% if "ubuntu" in product %}}
-# packages = libpam-pkcs11
-{{% elif product in ["ol7", "rhel7"] %}}
-# packages = pam_pkcs11
-{{% else %}}
 # packages = openssl-pkcs11
-{{% endif %}}
 
 if [ ! -f /etc/pam_pkcs11/pam_pkcs11.conf ]; then
     cp /usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/rules_not_there.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/rules_not_there.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules\

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 {{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "-a always,exit -F arch=b32 -S finit_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/default.fail.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # remediation = bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 {{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 echo "-a always,exit -F arch=b32 -S init_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/default.fail.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # remediation = bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product %}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_default_file.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_default_file.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product %}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/correct_value_non-root_group.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product %}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 # platform = multi_platform_rhel
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product %}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value_default_file.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value_default_file.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product %}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value_non-root_group.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/wrong_value_non-root_group.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product %}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 # platform = multi_platform_rhel
 
 if grep -iwq "log_file" /etc/audit/auditd.conf; then

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/wrong_value.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_multiple_possible.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_multiple_possible.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 # variables = var_auditd_disk_full_action=action1|action2|action3
 
 source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_one_possible.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_and_wrong_value_one_possible.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 # variables = var_auditd_disk_full_action=action1
 
 source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_multiple_possible.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_multiple_possible.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 # variables = var_auditd_disk_full_action=action1|action2|action3
 
 source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_one_possible.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/correct_value_one_possible.pass.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 # variables = var_auditd_disk_full_action=halt
 
 source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/no_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/no_value.fail.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/wrong_value.fail.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
-{{% if "ubuntu" in product%}}
-# packages = auditd
-{{% else %}}
 # packages = audit
-{{% endif %}}
 
 source common.sh
 

--- a/products/ol7/product.yml
+++ b/products/ol7/product.yml
@@ -37,6 +37,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"
+  openssl-pkcs11: "pam_pkcs11"
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/oracle_linux/'

--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -58,6 +58,7 @@ cpes:
 # Mapping of CPE platform to package
 platform_package_overrides:
   login_defs: "shadow-utils"
+  openssl-pkcs11: "pam_pkcs11"
 
 centos_pkg_release: "53a7ff4b"
 centos_pkg_version: "f4a80eb5"

--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -28,6 +28,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1604
 
 platform_package_overrides:
+  audit: auditd
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp
@@ -35,6 +36,7 @@ platform_package_overrides:
   pam: libpam-runtime
   shadow: login
   sssd: sssd-common
+  openssl-pkcs11: libpam-pkcs11
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/ubuntu_linux/'

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -27,6 +27,7 @@ cpes:
       check_id: installed_OS_is_ubuntu1804
 
 platform_package_overrides:
+  audit: auditd
   gdm: gdm3
   grub2: grub2-common
   net-snmp: snmp
@@ -34,6 +35,7 @@ platform_package_overrides:
   pam: libpam-runtime
   shadow: login
   sssd: sssd-common
+  openssl-pkcs11: libpam-pkcs11
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/ubuntu_linux/'

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -35,6 +35,7 @@ platform_package_overrides:
   pam: libpam-runtime
   shadow: login
   sssd: sssd-common
+  openssl-pkcs11: libpam-pkcs11
 
 reference_uris:
   cis: 'https://www.cisecurity.org/benchmark/ubuntu_linux/'

--- a/tests/README.md
+++ b/tests/README.md
@@ -165,7 +165,11 @@ test runs. After the header, arbitrary Bash commands can follow.
 
 The header consists of comments (starting by `#`). Possible keys are:
 
-- `packages` is a comma-separated list of packages to install.
+- `packages` is a comma-separated list of packages to install. Note that each
+  package can be overridden by its platform-specific alternative if listed
+  under `platform_package_overrides` in the product YAML. You should use
+  the most common package names in this field and provide an alternative
+  for any platform-specific names in the `platform_package_overrides` field.
 - `platform` is a comma-separated list of platforms where the test scenario can
   be run. This is similar to `platform` used in our remediations. Examples of
   values: `multi_platform_rhel`, `Red Hat Enterprise Linux 7`,


### PR DESCRIPTION
#### Description:

- Enable the use of `platform_package_overrides` product section when using automatus for rule testing.

#### Rationale:

- Before performing the install step when testing a rule, ensure that the package is not listed under `platform_package_overrides`. In case it is, replace the package to install with the one specified in `platform_package_overrides`.

- Fixes #9869

#### Review Hints:

- A conversation about implementing the solution with macros was discussed in issue #9869. I tested the proposed solution there and it works as expected. 
- Nevertheless, in PR #7295, it was discussed that it would be better to handle package overrides on the level of the test framework and I also prefer this approach to avoid adding the macro for all tests, which is why I implemented the solution based on this other approach. 