### PR TITLE
Sort conditional remediation platform checks

### DIFF
--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -218,10 +218,10 @@ class BashRemediation(Remediation):
         if stripped_fix_text == "":
             return result
 
-        inherited_conditionals = super(
-            BashRemediation, self).get_inherited_conditionals("bash", cpe_platforms)
-        rule_specific_conditionals = super(
-            BashRemediation, self).get_rule_specific_conditionals("bash", cpe_platforms)
+        inherited_conditionals = sorted(super(
+            BashRemediation, self).get_inherited_conditionals("bash", cpe_platforms))
+        rule_specific_conditionals = sorted(super(
+            BashRemediation, self).get_rule_specific_conditionals("bash", cpe_platforms))
         if inherited_conditionals or rule_specific_conditionals:
             wrapped_fix_text = ["# Remediation is applicable only in certain platforms"]
 
@@ -361,10 +361,10 @@ class AnsibleRemediation(Remediation):
 
     def update_when_from_rule(self, to_update, cpe_platforms):
         additional_when = []
-        inherited_conditionals = super(
-            AnsibleRemediation, self).get_inherited_conditionals("ansible", cpe_platforms)
-        rule_specific_conditionals = super(
-            AnsibleRemediation, self).get_rule_specific_conditionals("ansible", cpe_platforms)
+        inherited_conditionals = sorted(super(
+            AnsibleRemediation, self).get_inherited_conditionals("ansible", cpe_platforms))
+        rule_specific_conditionals = sorted(super(
+            AnsibleRemediation, self).get_rule_specific_conditionals("ansible", cpe_platforms))
         # Remove conditionals related to package CPEs if the updated task collects package facts
         if "package_facts" in to_update:
             inherited_conditionals = filter(


### PR DESCRIPTION


#### Description:
- Sort conditional remediation platform checks.
  - Make them output the same string always.

#### Rationale:

- An attempt to make things more consistent and not produce huge diffs as seen in: https://github.com/ComplianceAsCode/content/pull/9816#issuecomment-1313856769
- Related with: https://github.com/ComplianceAsCode/content/pull/9779
  - This PR removed the `sorted` function from the conditionals (for example: [this line deletion](https://github.com/ComplianceAsCode/content/pull/9779/files#diff-48b8aad934e3b158dcc1a3d770c6daa02fe69278848f16a0911baa8c3694125bL199)), but not only that it may changed how things were stored and even the putting back the sorted function in place was not enough but definitely improved many of the cases.
  - @vojtapolasek please take a look on this one and give your opinion.
  - This should bring the state of remediation conditionals closer to what we had previously.
  - I'm not entirely sure how this affects the stabilization branch for v0.1.65.