### PR TITLE
Add audit_rules_kernel_module_loading_create to OL7 STIG profile

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: ol7,rhel7
 
 title: 'Ensure auditd Collects Information on Kernel Module Unloading - create_module'
 
@@ -29,6 +29,7 @@ identifiers:
 references:
     disa: CCI-000172
     srg: SRG-OS-000471-GPOS-00216,SRG-OS-000477-GPOS-00222
+    stigid@ol7: OL07-00-030819
     stigid@rhel7: RHEL-07-030819
 
 {{{ complete_ocil_entry_audit_syscall(syscall="create_module") }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/tests/default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_create/tests/default.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = audit
 # remediation = bash
 
 rm -f /etc/audit/rules.d/*

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -205,6 +205,7 @@ selections:
     - audit_rules_privileged_commands_ssh_keysign
     - audit_rules_privileged_commands_crontab
     - audit_rules_privileged_commands_pam_timestamp_check
+    - audit_rules_kernel_module_loading_create
     - audit_rules_kernel_module_loading_init
     - audit_rules_kernel_module_loading_finit
     - audit_rules_kernel_module_loading_delete


### PR DESCRIPTION
#### Description:

- Add `audit_rules_kernel_module_loading_create` rule to OL7 STIG
- Add `# packages = audit` header to test

#### Rationale:

- This covers `OL07-00-030819`
- OL7 doesn't have by default `/etc/audit/rules.d/*` only when audit package is installed

#### Review Hints:

- This doesn't change existing content, only adds it to OL7. 