### PR TITLE
Make Ansible remediation less prone to fatal errors

### DIFF
--- a/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/ansible/shared.yml
@@ -4,19 +4,40 @@
 # complexity = low
 # disruption = low
 
-- name: Find /etc/grub.d/ files
-  find:
+- name: "{{{ rule_title }}} - Find /etc/grub.d/ files"
+  ansible.builtin.find:
     paths:
       - /etc/grub.d/
-    follow: yes
-  register: grub
+    follow: true
+  register: result_grub_d
 
-
-- name: Ensure SELinux Not Disabled in grub files
-  replace:
+- name: "{{{ rule_title }}} - Ensure SELinux Not Disabled in /etc/grub.d/ files"
+  ansible.builtin.replace:
     dest: "{{ item.path }}"
     regexp: (selinux|enforcing)=0
   with_items:
-    - "{{ grub.files }}"
-    - { path: /etc/grub2.cfg }
-    - { path: /etc/default/grub }
+    - "{{ result_grub_d.files }}"
+
+- name: "{{{ rule_title }}} - Check if /etc/grub2.cfg exists"
+  ansible.builtin.stat:
+    path: /etc/grub2.cfg
+  register: result_grub2_cfg_present
+
+- name: "{{{ rule_title }}} - Check if /etc/default/grub exists"
+  ansible.builtin.stat:
+    path: /etc/default/grub
+  register: result_default_grub_present
+
+- name: "{{{ rule_title }}} - Ensure SELinux Not Disabled in /etc/grub2.cfg"
+  ansible.builtin.replace:
+    dest: "/etc/grub2.cfg"
+    regexp: (selinux|enforcing)=0
+  when:
+    - result_grub2_cfg_present.stat.exists
+
+- name: "{{{ rule_title }}} - Ensure SELinux Not Disabled in /etc/default/grub"
+  ansible.builtin.replace:
+    dest: "/etc/default/grub"
+    regexp: (selinux|enforcing)=0
+  when:
+    - result_default_grub_present.stat.exists

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/oval/shared.xml
@@ -1,53 +1,55 @@
 <def-group>
-  <definition class="compliance" id="grub2_enable_selinux" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("
         Check if selinux=0 OR enforcing=0 within the GRUB2 configuration files, fail if found.
       ") }}}
     <criteria operator="AND">
-      <criterion comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found" test_ref="test_selinux_default_grub" />
-      <criterion comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found" test_ref="test_selinux_grub2_cfg" />
-      <criterion comment="check value selinux|enforcing=0 in /etc/grub.d, fail if found" test_ref="test_selinux_grub_dir" />
+      <criterion test_ref="test_selinux_default_grub"
+        comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found"/>
+      <criterion test_ref="test_selinux_grub2_cfg"
+        comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found"/>
+      <criterion test_ref="test_selinux_grub_dir"
+        comment="check value selinux|enforcing=0 in /etc/grub.d, fail if found"/>
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found"
-  id="test_selinux_default_grub" version="1">
-    <ind:object object_ref="object_selinux_default_grub" />
+  <ind:textfilecontent54_test id="test_selinux_default_grub" version="1"
+    check="all" check_existence="none_exist"
+    comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found">
+    <ind:object object_ref="object_selinux_default_grub"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_selinux_default_grub"
-  comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found"
-  version="1">
+
+  <ind:textfilecontent54_object id="object_selinux_default_grub" version="1"
+    comment="check value selinux|enforcing=0 in /etc/default/grub, fail if found">
     <ind:filepath>/etc/default/grub</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*GRUB_CMDLINE_LINUX.*(selinux|enforcing)=0.*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found"
-  id="test_selinux_grub2_cfg" version="1">
-    <ind:object object_ref="object_selinux_grub2_cfg" />
+  <ind:textfilecontent54_test id="test_selinux_grub2_cfg" version="1"
+    check="all" check_existence="none_exist"
+    comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found">
+    <ind:object object_ref="object_selinux_grub2_cfg"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_selinux_grub2_cfg" 
-  comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found"
-  version="1">
+
+  <ind:textfilecontent54_object id="object_selinux_grub2_cfg" version="1"
+    comment="check value selinux|enforcing=0 in /etc/grub2.cfg, fail if found">
     <ind:filepath>/etc/grub2.cfg</ind:filepath>
     <ind:pattern operation="pattern match">^.*(selinux|enforcing)=0.*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="check value selinux|enforcing=0 in /etc/grub.d fail if found"
-  id="test_selinux_grub_dir" version="1">
-    <ind:object object_ref="object_selinux_grub_dir" />
+  <ind:textfilecontent54_test id="test_selinux_grub_dir" version="1"
+    check="all" check_existence="none_exist"
+    comment="check value selinux|enforcing=0 in /etc/grub.d fail if found">
+    <ind:object object_ref="object_selinux_grub_dir"/>
   </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_selinux_grub_dir"
-  comment="check value selinux|enforcing=0 in /etc/grub.d, fail if found"
-  version="1">
+
+  <ind:textfilecontent54_object id="object_selinux_grub_dir" version="1"
+    comment="check value selinux|enforcing=0 in /etc/grub.d, fail if found">
     <ind:path>/etc/grub.d</ind:path>
     <ind:filename operation="pattern match">^.*$</ind:filename>
     <ind:pattern operation="pattern match">^.*(selinux|enforcing)=0.*$</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
-
 </def-group>

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/rule.yml
@@ -42,6 +42,8 @@ references:
     nist-csf: DE.AE-1,ID.AM-3,PR.AC-4,PR.AC-5,PR.AC-6,PR.DS-5,PR.PT-1,PR.PT-3,PR.PT-4
     vmmsrg: SRG-OS-000445-VMM-001780
 
+platform: grub2
+
 ocil_clause: 'SELinux is disabled at boot time'
 
 ocil: |-

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_default_grub.fail.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_default_grub.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "GRUB_CMDLINE_LINUX=selinux=0 enforcing=0 audit=1" >> /etc/default/grub
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/grub2.cfg /etc/grub.d/*
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/grub2.cfg /etc/grub.d/*

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_default_grub_missing.pass.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_default_grub_missing.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+rm -f /etc/default/grub
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/grub2.cfg /etc/grub.d/*
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/grub2.cfg /etc/grub.d/*

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_everywhere.fail.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_everywhere.fail.sh
@@ -4,5 +4,4 @@ echo "GRUB_CMDLINE_LINUX=selinux=0 enforcing=0 audit=1" >> /etc/default/grub
 echo "selinux=0" >> /etc/grub2.cfg
 echo "enforcing=0" >> /etc/grub2.cfg
 echo "selinux=0" > /etc/grub.d/tmp_file
-echo "rubbish=0" >> /etc/grub.d/tmp_file
 echo "enforcing=0" >> /etc/grub.d/tmp_file

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_grub_cfg.fail.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_grub_cfg.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "selinux=0" >> /etc/grub2.cfg
+echo "enforcing=0" >> /etc/grub2.cfg
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub.d/*
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub.d/*

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_grub_d.fail.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_disabled_grub_d.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+echo "selinux=0" > /etc/grub.d/tmp_file
+echo "enforcing=0" >> /etc/grub.d/tmp_file
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg

--- a/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_enable_similar_line.pass.sh
+++ b/linux_os/guide/system/selinux/grub2_enable_selinux/tests/selinux_enable_similar_line.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "rubbish=0" >> /etc/grub.d/tmp_file
+sed -i --follow-symlinks "s/selinux=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*
+sed -i --follow-symlinks "s/enforcing=0//gI" /etc/default/grub /etc/grub2.cfg /etc/grub.d/*


### PR DESCRIPTION
#### Description:

There are cases where the systems don't have one or more of the grub files intended to be checked. If this is the case, the former task in the Ansible playbook would result in a fatal error. Now, the files existences are firstly ensured before checking their contents.

#### Rationale:

Avoids fatal errors when executing the Ansible Playbook.

#### Review Hints:

This PR is was initially merged in stabilization: #9911 