### PR TITLE
accounts_tmout: Handle conflicting and duplicate values, plus /etc/bashrc on rhel7

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,7 +5,7 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_tmout") }}}
 
-{{% if product in ["rhel7"] %}}
+{{% if product in ["ol7", "rhel7"] %}}
 - name: Correct any occurrence of TMOUT in /etc/bashrc
   replace:
     path: /etc/bashrc
@@ -23,4 +23,4 @@
   register: profile_replaced
 
 {{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}',
-    create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ['rhel7']) }}}
+    create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ["ol7", "rhel7"]) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,6 +5,22 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_tmout") }}}
 
-{{{ ansible_lineinfile("", "/etc/bashrc", regex='TMOUT=', create='no', state='absent') }}}
-{{{ ansible_lineinfile("", "/etc/profile", regex='TMOUT=', create='no', state='absent') }}}
-{{{ ansible_only_lineinfile(path='/etc/profile.d/tmout.sh', line_regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}', create='yes') }}}
+{{% if product in ["rhel7"] %}}
+- name: Correct any occurrence of TMOUT in /etc/bashrc
+  replace:
+    path: /etc/bashrc
+    regexp: '^[^#].*TMOUT=.*'
+    replace: declare -xr TMOUT={{ var_accounts_tmout }}
+  register: bashrc_replaced
+
+{{% endif %}}
+
+- name: Correct any occurrence of TMOUT in /etc/profile
+  replace:
+    path: /etc/profile
+    regexp: '^[^#].*TMOUT=.*'
+    replace: declare -xr TMOUT={{ var_accounts_tmout }}
+  register: profile_replaced
+
+{{{ ansible_lineinfile("", "/etc/profile.d/tmout.sh", regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}',
+    create='yes', state='present', when="profile_replaced is defined and not profile_replaced.changed" + " and bashrc_replaced is defined and not bashrc_replaced.changed" if product in ['rhel7']) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -5,4 +5,6 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_accounts_tmout") }}}
 
+{{{ ansible_lineinfile("", "/etc/bashrc", regex='TMOUT=', create='no', state='absent') }}}
+{{{ ansible_lineinfile("", "/etc/profile", regex='TMOUT=', create='no', state='absent') }}}
 {{{ ansible_only_lineinfile(path='/etc/profile.d/tmout.sh', line_regex='TMOUT=', new_line='declare -xr TMOUT={{ var_accounts_tmout }}', create='yes') }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -3,16 +3,21 @@
 # strategy = restrict
 # complexity = low
 # disruption = low
+
 {{{ ansible_instantiate_variables("var_accounts_tmout") }}}
 
+{{% set system_configuration_using_etc_bashrc_expected = false %}}
 {{% if product in ["ol7", "rhel7"] %}}
+  {{% set system_configuration_using_etc_bashrc_expected = true %}}
+{{% endif %}}
+
+{{% if system_configuration_using_etc_bashrc_expected %}}
 - name: Correct any occurrence of TMOUT in /etc/bashrc
   replace:
     path: /etc/bashrc
     regexp: '^[^#].*TMOUT=.*'
     replace: declare -xr TMOUT={{ var_accounts_tmout }}
   register: bashrc_replaced
-
 {{% endif %}}
 
 - name: Correct any occurrence of TMOUT in /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -6,8 +6,8 @@
 tmout_found=0
 
 for f in /etc/profile /etc/profile.d/*.sh; do
-    if grep --silent '^\s*TMOUT' $f; then
-        sed -i -E "s/^(\s*)TMOUT\s*=\s*(\w|\$)*(.*)$/declare -xr TMOUT=$var_accounts_tmout\3/g" $f
+    if grep --silent '^[^#].*TMOUT' $f; then
+        sed -i -E "s/^(.*)TMOUT\s*=\s*(\w|\$)*(.*)$/declare -xr TMOUT=$var_accounts_tmout\3/g" $f
         tmout_found=1
     fi
 done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -1,11 +1,16 @@
 # platform = multi_platform_all
+{{% set system_configuration_using_etc_bashrc_expected = false -%}}
+
+{{% if product in ["ol7", "rhel7"] %}}
+  {{% set system_configuration_using_etc_bashrc_expected = true -%}}
+{{%- endif -%}}
 
 {{{ bash_instantiate_variables("var_accounts_tmout") }}}
 
 # if 0, no occurence of tmout found, if 1, occurence found
 tmout_found=0
 
-{{%- if product in ["ol7", "rhel7"] %}}
+{{% if system_configuration_using_etc_bashrc_expected %}}
 for f in /etc/profile /etc/profile.d/*.sh /etc/bashrc; do
 {{% else %}}
 for f in /etc/profile /etc/profile.d/*.sh; do

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -5,7 +5,7 @@
 # if 0, no occurence of tmout found, if 1, occurence found
 tmout_found=0
 
-{{%- if product in ["rhel7"] %}}
+{{%- if product in ["ol7", "rhel7"] %}}
 for f in /etc/profile /etc/profile.d/*.sh /etc/bashrc; do
 {{% else %}}
 for f in /etc/profile /etc/profile.d/*.sh; do

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/bash/shared.sh
@@ -5,7 +5,11 @@
 # if 0, no occurence of tmout found, if 1, occurence found
 tmout_found=0
 
+{{%- if product in ["rhel7"] %}}
+for f in /etc/profile /etc/profile.d/*.sh /etc/bashrc; do
+{{% else %}}
 for f in /etc/profile /etc/profile.d/*.sh; do
+{{% endif %}}
     if grep --silent '^[^#].*TMOUT' $f; then
         sed -i -E "s/^(.*)TMOUT\s*=\s*(\w|\$)*(.*)$/declare -xr TMOUT=$var_accounts_tmout\3/g" $f
         tmout_found=1

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -58,14 +58,19 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_accounts_tmout_partial_tmout_instances" version="1">
-  {{% else %}}
-  <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
-  {{% endif %}}
     <set>
       <object_reference>object_etc_profile_tmout</object_reference>
       <object_reference>object_etc_profiled_tmout</object_reference>
     </set>
   </ind:textfilecontent54_object>
+  {{% else %}}
+  <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
+    <set>
+      <object_reference>object_etc_profile_tmout</object_reference>
+      <object_reference>object_etc_profiled_tmout</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+  {{% endif %}}
 
   <local_variable id="variable_count_of_tmout_instances" comment="Count of TMOUT instances" datatype="int" version="1">
     <count>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -30,7 +30,7 @@
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*declare[\s]+-xr[\s]+TMOUT=([\w$]+).*$</ind:pattern>
     {{% endif %}}
-    <ind:instance datatype="int">1</ind:instance>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   {{% endmacro %}}
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -1,3 +1,8 @@
+{{% set system_configuration_using_etc_bashrc_expected = false -%}}
+
+{{% if product in ["ol7", "rhel7"] -%}}
+  {{% set system_configuration_using_etc_bashrc_expected = true %}}
+{{%- endif -%}}
 <def-group>
   <definition class="compliance" id="accounts_tmout" version="3">
     {{{ oval_metadata("Checks interactive shell timeout") }}}
@@ -5,7 +10,7 @@
       <criterion comment="TMOUT value in /etc/profile &lt;= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
       <criterion comment="TMOUT value in /etc/profile.d/*.sh &lt;= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
       <criterion comment="At least one config file has TMOUT defined" test_ref="test_accounts_tmout_defined" />
-      {{% if product in ["ol7", "rhel7"] %}}
+      {{% if system_configuration_using_etc_bashrc_expected %}}
       <criterion comment="TMOUT value in /etc/bashrc &lt;= var_accounts_tmout" test_ref="test_etc_bashrc_tmout" />
       {{% endif %}}
     </criteria>
@@ -44,12 +49,12 @@
   {{{ test_tmout(  test_stem="etc_profiled_tmout", files="/etc/profile.d/*.sh") }}}
   {{{ object_tmout(test_stem="etc_profiled_tmout", path="/etc/profile.d", filename="^.*\.sh$") }}}
 
-  {{% if product in ["ol7", "rhel7"] %}}
+  {{% if system_configuration_using_etc_bashrc_expected %}}
   {{{ test_tmout(  test_stem="etc_bashrc_tmout", files="/etc/bashrc") }}}
   {{{ object_tmout(test_stem="etc_bashrc_tmout", filepath="/etc/bashrc") }}}
   {{% endif %}}
 
-  {{% if product in ["ol7", "rhel7"] %}}
+  {{% if system_configuration_using_etc_bashrc_expected %}}
   <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
     <set>
       <object_reference>object_etc_bashrc_tmout</object_reference>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -5,6 +5,9 @@
       <criterion comment="TMOUT value in /etc/profile &lt;= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
       <criterion comment="TMOUT value in /etc/profile.d/*.sh &lt;= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
       <criterion comment="At least one config file has TMOUT defined" test_ref="test_accounts_tmout_defined" />
+      {{% if product in ["rhel7"] %}}
+      <criterion comment="TMOUT value in /etc/bashrc &lt;= var_accounts_tmout" test_ref="test_etc_bashrc_tmout" />
+      {{% endif %}}
     </criteria>
   </definition>
 
@@ -41,7 +44,23 @@
   {{{ test_tmout(  test_stem="etc_profiled_tmout", files="/etc/profile.d/*.sh") }}}
   {{{ object_tmout(test_stem="etc_profiled_tmout", path="/etc/profile.d", filename="^.*\.sh$") }}}
 
+  {{% if product in ["rhel7"] %}}
+  {{{ test_tmout(  test_stem="etc_bashrc_tmout", files="/etc/bashrc") }}}
+  {{{ object_tmout(test_stem="etc_bashrc_tmout", filepath="/etc/bashrc") }}}
+  {{% endif %}}
+
+  {{% if product in ["rhel7"] %}}
   <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
+    <set>
+      <object_reference>object_etc_bashrc_tmout</object_reference>
+      <object_reference>object_accounts_tmout_partial_tmout_instances</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_accounts_tmout_partial_tmout_instances" version="1">
+  {{% else %}}
+  <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
+  {{% endif %}}
     <set>
       <object_reference>object_etc_profile_tmout</object_reference>
       <object_reference>object_etc_profiled_tmout</object_reference>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -4,6 +4,7 @@
     <criteria operator="AND">
       <criterion comment="TMOUT value in /etc/profile &lt;= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
       <criterion comment="TMOUT value in /etc/profile.d/*.sh &lt;= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
+      <criterion comment="At least one config file has TMOUT defined" test_ref="test_accounts_tmout_defined" />
     </criteria>
   </definition>
 
@@ -39,6 +40,30 @@
 
   {{{ test_tmout(  test_stem="etc_profiled_tmout", files="/etc/profile.d/*.sh") }}}
   {{{ object_tmout(test_stem="etc_profiled_tmout", path="/etc/profile.d", filename="^.*\.sh$") }}}
+
+  <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
+    <set>
+      <object_reference>object_etc_profile_tmout</object_reference>
+      <object_reference>object_etc_profiled_tmout</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="variable_count_of_tmout_instances" comment="Count of TMOUT instances" datatype="int" version="1">
+    <count>
+      <object_component object_ref="object_accounts_tmout_all_tmout_instances" item_field="text" />
+    </count>
+  </local_variable>
+
+  <ind:variable_test check="all" check_existence="all_exist" id="test_accounts_tmout_defined" comment="Check that at least one TMOUT is defined" version="1">
+    <ind:object object_ref="object_accounts_tmout_defined" />
+    <ind:state state_ref="state_accounts_tmout_defined" />
+  </ind:variable_test>
+  <ind:variable_object id="object_accounts_tmout_defined" version="1">
+    <ind:var_ref>variable_count_of_tmout_instances</ind:var_ref>
+  </ind:variable_object>
+  <ind:variable_state id="state_accounts_tmout_defined" version="1">
+    <ind:value operation="greater than or equal" datatype="int">1</ind:value>
+  </ind:variable_state>
 
   <ind:textfilecontent54_state id="state_etc_profile_tmout" version="2">
     <ind:subexpression datatype="int" operation="less than or equal" var_check="all" var_ref="var_accounts_tmout" />

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -1,14 +1,14 @@
 <def-group>
   <definition class="compliance" id="accounts_tmout" version="3">
     {{{ oval_metadata("Checks interactive shell timeout") }}}
-    <criteria operator="OR">
+    <criteria operator="AND">
       <criterion comment="TMOUT value in /etc/profile &lt;= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
       <criterion comment="TMOUT value in /etc/profile.d/*.sh &lt;= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
     </criteria>
   </definition>
 
   {{% macro test_tmout(test_stem, files) %}}
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="TMOUT in {{{ files }}}" id="test_{{{ test_stem }}}" version="2">
+  <ind:textfilecontent54_test check="all" check_existence="any_exist" comment="TMOUT in {{{ files }}}" id="test_{{{ test_stem }}}" version="2">
     <ind:object object_ref="object_{{{ test_stem }}}" />
     <ind:state state_ref="state_etc_profile_tmout" />
   </ind:textfilecontent54_test>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/oval/shared.xml
@@ -5,7 +5,7 @@
       <criterion comment="TMOUT value in /etc/profile &lt;= var_accounts_tmout" test_ref="test_etc_profile_tmout" />
       <criterion comment="TMOUT value in /etc/profile.d/*.sh &lt;= var_accounts_tmout" test_ref="test_etc_profiled_tmout" />
       <criterion comment="At least one config file has TMOUT defined" test_ref="test_accounts_tmout_defined" />
-      {{% if product in ["rhel7"] %}}
+      {{% if product in ["ol7", "rhel7"] %}}
       <criterion comment="TMOUT value in /etc/bashrc &lt;= var_accounts_tmout" test_ref="test_etc_bashrc_tmout" />
       {{% endif %}}
     </criteria>
@@ -44,12 +44,12 @@
   {{{ test_tmout(  test_stem="etc_profiled_tmout", files="/etc/profile.d/*.sh") }}}
   {{{ object_tmout(test_stem="etc_profiled_tmout", path="/etc/profile.d", filename="^.*\.sh$") }}}
 
-  {{% if product in ["rhel7"] %}}
+  {{% if product in ["ol7", "rhel7"] %}}
   {{{ test_tmout(  test_stem="etc_bashrc_tmout", files="/etc/bashrc") }}}
   {{{ object_tmout(test_stem="etc_bashrc_tmout", filepath="/etc/bashrc") }}}
   {{% endif %}}
 
-  {{% if product in ["rhel7"] %}}
+  {{% if product in ["ol7", "rhel7"] %}}
   <ind:textfilecontent54_object id="object_accounts_tmout_all_tmout_instances" version="1">
     <set>
       <object_reference>object_etc_bashrc_tmout</object_reference>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -15,7 +15,8 @@ description: |-
     readonly TMOUT
     export TMOUT
     {{% else %}}
-    setting in a file loaded by <tt>/etc/profile</tt>, e.g.
+    setting in a file loaded by <tt>/etc/profile</tt>
+    {{{- "or <tt>/etc/bashrc</tt>" if product == "rhel7" }}}, e.g.
     <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
     <pre>declare -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/rule.yml
@@ -16,7 +16,7 @@ description: |-
     export TMOUT
     {{% else %}}
     setting in a file loaded by <tt>/etc/profile</tt>
-    {{{- "or <tt>/etc/bashrc</tt>" if product == "rhel7" }}}, e.g.
+    {{{- "or <tt>/etc/bashrc</tt>" if product in ["ol7", "rhel7"] }}}, e.g.
     <tt>/etc/profile.d/tmout.sh</tt> should read as follows:
     <pre>declare -xr TMOUT={{{ xccdf_value("var_accounts_tmout") }}}</pre>
     {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_diff_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_diff_file.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
+
+echo "declare -xr TMOUT=700" >> /etc/profile
+echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_same_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/conflicting_values_same_file.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
+
+echo "declare -xr TMOUT=700" >> /etc/profile
+echo "declare -xr TMOUT=800" >> /etc/profile

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_bashrc.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/correct_value_bashrc.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# platform = Red Hat Enterprise Linux 7
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
+
+echo "declare -xr TMOUT=700" >> /etc/bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_diff_files.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_diff_files.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh
+
+echo "declare -xr TMOUT=700" >> /etc/profile
+echo "declare -xr TMOUT=700" >> /etc/profile.d/tmout.sh

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile.pass.sh
@@ -6,8 +6,8 @@ sed -i "/.*TMOUT.*/d" /etc/profile.d/*.sh
 
 if grep -q "TMOUT" /etc/profile; then
 	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile
-	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 else
 	echo "declare -xr TMOUT=700" >> /etc/profile
-	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/duplicate_correct_value_profile_d.pass.sh
@@ -6,8 +6,8 @@ sed -i "/.*TMOUT.*/d" /etc/profile
 
 if grep -q "TMOUT" /etc/profile.d/tmout.sh; then
 	sed -i "s/.*TMOUT.*/declare -xr TMOUT=700/" /etc/profile.d/tmout.sh
-	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 else
 	echo "declare -xr TMOUT=700" >> /etc/profile.d/tmout.sh
-	echo "declare -xr TMOUT=800" >> /etc/profile.d/tmout.sh
+	echo "declare -xr TMOUT=600" >> /etc/profile.d/tmout.sh
 fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_bashrc.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/tests/wrong_value_bashrc.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# platform = Red Hat Enterprise Linux 7
+# variables = var_accounts_tmout=700
+
+sed -i "/.*TMOUT.*/d" /etc/profile /etc/profile.d/*.sh /etc/bashrc
+
+echo "declare -xr TMOUT=800" >> /etc/bashrc


### PR DESCRIPTION
#### Description:

- Change the check and remediations so that the rule can:
  - check all occurrences of TMOUT (only the first one was being checked)
  - identify conflicting values of TMOUT among all relevant config files
  - remediations can correct any duplicate value of TMOUT
  - identify that a TMOUT value exists in one of the config files and not add it again in `/etc/profile.d/tmout.sh`
  - Check for and remediate `/etc/bashrc` on RHEL7 and OL7 systems, aligning the rule with RHEL7 STIG V3R9 and OL7 STIG V2R9.

#### Rationale:
- Improve check of duplicate and conflicting values
- Align rule with RHEL7 STIG V3R9
- Align rule with OL7 STIG V2R9

#### Review Hints:
- Check the commit messages for more details
- `python3  tests/automatus.py rule --libvirt qemu:///session rhel79 --datastream build/ssg-rhel7-ds.xml --remediate-using ansible  accounts_tmout`