### PR TITLE
Improve the arguments for Ansible command module

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -6,8 +6,8 @@
 {{{ ansible_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
 - name: Collect users with not correct maximum time period between password changes
-  ansible.builtin.command: >
-    awk -F: '$5 > {{ var_accounts_maximum_age_login_defs }} || $5 == "" {print $1}' /etc/shadow
+  ansible.builtin.command:
+    cmd: awk -F':' '$5 > {{ var_accounts_maximum_age_login_defs }} || $5 == "" {print $1}' /etc/shadow
   register: user_names
 
 - name: Change the maximum time period between password changes
@@ -16,8 +16,8 @@
     user: '{{ item }}'
     password_expire_max: '{{ var_accounts_maximum_age_login_defs }}'
 {{% else %}}
-  ansible.builtin.command: >
-    chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
+  ansible.builtin.command:
+    cmd: chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
 {{% endif %}}
   with_items: '{{ user_names.stdout_lines }}'
   when: user_names.stdout_lines | length > 0


### PR DESCRIPTION
#### Description:

It was used the `awk` command in a task and the delimiter character was `:`.
This was not quoted and making it prone to be interpreted as a module parameter.
This has likely been worked around in the past, but not in the most compatible way, causing the Playbook a fatal error on some systems with different versions of Ansible. Relevant tasks have been improved to be more robust and compatible.

#### Rationale:

Avoid fatal errors on Ansible Playbooks