### PR TITLE
Update sudo_require_reauthentication

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/ansible/shared.yml
@@ -9,20 +9,20 @@
   find:
     path: "/etc/sudoers.d"
     patterns: "*"
-    contains: '^[\s]*Defaults\s.*\btimestamp_timeout=.*'
+    contains: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=.*'
   register: sudoers_d_defaults_timestamp_timeout
 
 - name: "Remove found occurrences of 'Defaults timestamp_timeout' from /etc/sudoers.d/* files"
   lineinfile:
     path: "{{ item.path }}"
-    regexp: '^[\s]*Defaults\s.*\btimestamp_timeout=.*'
+    regexp: '^[\s]*Defaults\s.*\btimestamp_timeout[\s]*=.*'
     state: absent
   with_items: "{{ sudoers_d_defaults_timestamp_timeout.files }}"
 
 - name: Ensure timestamp_timeout is enabled with the appropriate value in /etc/sudoers
   lineinfile:
     path: /etc/sudoers
-    regexp: '^[\s]*Defaults\s(.*)\btimestamp_timeout=[-]?\w+\b(.*)$'
+    regexp: '^[\s]*Defaults\s(.*)\btimestamp_timeout[\s]*=[\s]*[-]?\w+\b(.*)$'
     line: 'Defaults \1timestamp_timeout={{ var_sudo_timestamp_timeout }}\2'
     validate: /usr/sbin/visudo -cf %s
     backrefs: yes

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/bash/shared.sh
@@ -7,20 +7,20 @@
 
 {{{ bash_instantiate_variables("var_sudo_timestamp_timeout") }}}
 
-if grep -x '^[\s]*Defaults.*\btimestamp_timeout=.*' /etc/sudoers.d/*; then
-    find /etc/sudoers.d/ -type f -exec sed -i "/^[\s]*Defaults.*\btimestamp_timeout=.*/d" {} \;
+if grep -Px '^[\s]*Defaults.*timestamp_timeout[\s]*=.*' /etc/sudoers.d/*; then
+    find /etc/sudoers.d/ -type f -exec sed -Ei "/^[[:blank:]]*Defaults.*timestamp_timeout[[:blank:]]*=.*/d" {} \;
 fi
 
 if /usr/sbin/visudo -qcf /etc/sudoers; then
     cp /etc/sudoers /etc/sudoers.bak
-    if ! grep -P '^[\s]*Defaults.*\btimestamp_timeout=[-]?\w+\b\b.*$' /etc/sudoers; then
+    if ! grep -P '^[\s]*Defaults.*timestamp_timeout[\s]*=[\s]*[-]?\w+.*$' /etc/sudoers; then
         # sudoers file doesn't define Option timestamp_timeout
         echo "Defaults timestamp_timeout=${var_sudo_timestamp_timeout}" >> /etc/sudoers
     else
         # sudoers file defines Option timestamp_timeout, remediate if appropriate value is not set
-        if ! grep -P "^[\s]*Defaults.*\btimestamp_timeout=${var_sudo_timestamp_timeout}\b.*$" /etc/sudoers; then
+        if ! grep -P "^[\s]*Defaults.*timestamp_timeout[\s]*=[\s]*${var_sudo_timestamp_timeout}.*$" /etc/sudoers; then
             
-            sed -Ei "s/(^[\s]*Defaults.*\btimestamp_timeout=)[-]?\w+(\b.*$)/\1${var_sudo_timestamp_timeout}\2/" /etc/sudoers
+            sed -Ei "s/(^[[:blank:]]*Defaults.*timestamp_timeout[[:blank:]]*=)[[:blank:]]*[-]?\w+(.*$)/\1${var_sudo_timestamp_timeout}\2/" /etc/sudoers
         fi
     fi
     

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/oval/shared.xml
@@ -6,14 +6,14 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists" comment="check correct configuration in /etc/sudoers" id="test_sudo_timestamp_timeout" version="1">
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists" comment="check correct configuration in /etc/sudoers" id="test_sudo_timestamp_timeout" version="1">
     <ind:object object_ref="obj_sudo_timestamp_timeout"/>
     <ind:state state_ref="state_sudo_timestamp_timeout" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_sudo_timestamp_timeout" version="1">
     <ind:filepath operation="pattern match">^/etc/sudoers(\.d/.*)?$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]+timestamp_timeout=([-]?[\d]+)$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*Defaults[\s]+timestamp_timeout[\s]*=[\s]*([-]?[\d]+)$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -60,4 +60,6 @@ fixtext: |-
 
     Defaults timestamp_timeout={{{ xccdf_value("var_sudo_timestamp_timeout") }}}
 
+    Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files. 
+
 srg_requirement: '{{{ full_name }}} must require re-authentication when using the "sudo" command.'

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sudo
 
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i 's/.*timestamp_timeout.*/Defaults timestamp_timeout=3/' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_with_spaces.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/correct_value_with_spaces.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# packages = sudo
+
+if grep -q 'timestamp_timeout' /etc/sudoers; then
+	sed -i 's/.*timestamp_timeout.*/Defaults timestamp_timeout = 3/' /etc/sudoers
+else
+	echo "Defaults timestamp_timeout = 3" >> /etc/sudoers
+fi

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/missing_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/missing_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sudo
 
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i '/.*timestamp_timeout.*/d' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/multiple_conflicting_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/multiple_conflicting_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# packages = sudo
 
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i 's/.*timestamp_timeout.*/Defaults timestamp_timeout=3/' /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/multiple_correct_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/multiple_correct_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+# packages = sudo
 
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i 's/.*timestamp_timeout.*/Defaults timestamp_timeout=3/' /etc/sudoers
@@ -7,4 +7,4 @@ else
 	echo "Defaults timestamp_timeout=3" >> /etc/sudoers
 fi
 
-echo "Defaults timestamp_timeout=3" > /etc/sudoers.d/00-complianceascode-test.conf
+echo "Defaults timestamp_timeout = 3" > /etc/sudoers.d/00-complianceascode-test.conf

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/tests/wrong_value.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = sudo
 
 if grep -q 'timestamp_timeout' /etc/sudoers; then
 	sed -i 's/.*timestamp_timeout.*/Defaults timestamp_timeout=-1/' /etc/sudoers


### PR DESCRIPTION
#### Description:

- Update OVAL checks to fail if more than one config entry is found and update tests accordingly.
- Also update ansible and bash remediations to allow whitespace surrounding 'timestamp_timeout'.
- Update rule yaml to mention the removal of duplicated config entries on the fixtext.

#### Rationale:

- DISA added the following statement to the requirement this rule implements: "_Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files._"

#### Review Hints:

- I am a bit unsure about failing the scan if more than one config entry is found since DISA does not explicitly says this is a finding.