### PR TITLE
Fix the file param in rule_dir_json

### DIFF
--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -177,7 +177,7 @@ def handle_remediations(product_list, product_yamls, rule_obj):
 
 def quiet_print(msg, quiet, file):
     if not quiet:
-        print(msg, file)
+        print(msg, file=file)
 
 
 def main():


### PR DESCRIPTION
#### Description:

Minor fix to the `quiet_print` function in `utils/rule_dir_json.py`.

#### Rationale:
Fix issues like this.

```
Product ubuntu1804 has multiple remediations of the same type in rule rsyslog_remote_access_monitoring: shared.sh,shared.yml,ubuntu.sh <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
Product ubuntu1604 has multiple remediations of the same type in rule rsyslog_remote_access_monitoring: shared.sh,shared.yml,ubuntu.sh <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
Product ubuntu2204 has multiple remediations of the same type in rule rsyslog_remote_access_monitoring: shared.sh,shared.yml,ubuntu.sh <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
Product ubuntu2004 has multiple remediations of the same type in rule rsyslog_remote_access_monitoring: shared.sh,shared.yml,ubuntu.sh <_io.TextIOWrapper name='<stderr>' mode='w' encoding='utf-8'>
```