### PR TITLE
Fix typing import in `create_srg_export.py`

### DIFF
--- a/utils/create_srg_export.py
+++ b/utils/create_srg_export.py
@@ -11,7 +11,7 @@ import sys
 import string
 
 import yaml
-from typing.io import TextIO
+from typing import TextIO
 import xml.etree.ElementTree as ET
 
 import convert_srg_export_to_xlsx


### PR DESCRIPTION
#### Description:

Import `TextIO` directly from `typing`.

#### Rationale:
Fix deprecation warning in `utils/create_srg_export.py`.

