### PR TITLE
Wait for buffer flushes to finish writes

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -121,6 +121,7 @@ macro(ssg_build_xccdf_oval_ocil PRODUCT)
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_xccdf.py" --resolved-base "${CMAKE_CURRENT_BINARY_DIR}" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" --xccdf "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml" --oval "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml" --ocil "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-ocil.xml"
+        COMMAND sync
         DEPENDS ${PRODUCT}-compile-all
         DEPENDS generate-internal-${PRODUCT}-all-fixes
         DEPENDS generate-internal-${PRODUCT}-oval-unlinked.xml


### PR DESCRIPTION
The compile_all script writes hundreds of small files. As there may be latency between dispatching writes and actual writes, it makes sense to manually make sure that this step of the build is considered complete only after all disk operations are physically executed.

This could fix issue #9829. At the same time, our lack of ability to reproduce the issue as well as the constructed explanation don't give that much hope, and the issue should remain open, closing it only if it doesn't occur for a couple of weeks.