### PR TITLE
Update accounts_password template for OL due to precedence confs

### DIFF
--- a/shared/templates/accounts_password/ansible.template
+++ b/shared/templates/accounts_password/ansible.template
@@ -5,8 +5,32 @@
 # disruption = low
 - (xccdf-var var_password_pam_{{{ VARIABLE }}})
 
-- name: Ensure PAM variable {{{ VARIABLE }}} is set accordingly
-  lineinfile:
+{{% if product == "ol8" %}}
+- name: {{{ rule_title }}} - Find pwquality.conf.d files
+  ansible.builtin.find::
+    paths: /etc/security/pwquality.conf.d/
+    patterns: "*.conf"
+  register: pwquality_conf_d_files
+
+- name: {{{ rule_title }}} - Ensure {{{ VARIABLE }}} is not set in pwquality.conf.d
+  ansible.builtin.lineinfile:
+    path: "{{ item.path }}"
+    regexp: '^\s*\b{{{ VARIABLE }}}\b.*'
+    state: absent
+  with_items: "{{ pwquality_conf_d_files.files }}"
+{{% endif %}}
+
+{{% if "ol" in product %}}
+{{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{% endif %}}
+
+- name: {{{ rule_title }}} - Ensure PAM variable {{{ VARIABLE }}} is set accordingly
+  ansible.builtin.lineinfile:
     create: yes
     dest: "/etc/security/pwquality.conf"
     regexp: '^#?\s*{{{ VARIABLE }}}'

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -12,4 +12,13 @@ if grep -sq {{{ VARIABLE }}} /etc/security/pwquality.conf.d/*.conf ; then
 fi
 {{% endif %}}
 
+{{% if "ol" in product %}}
+{{{ bash_remove_pam_module_option_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  '',
+                                  'pam_pwquality.so',
+                                  VARIABLE)
+}}}
+{{% endif %}}
+
 {{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' ~ VARIABLE , '$var_password_pam_' ~ VARIABLE , '%s = %s') }}}

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -11,8 +11,28 @@
       <criteria operator="OR">
         <criterion comment="pwquality.conf" test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}" />
       </criteria>
+      {{% if "ol" in product %}}
+      <criterion comment="{{{ VARIABLE }}} is not overwritten in system-auth"
+      test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten"/>
+      {{% endif %}}
     </criteria>
   </definition>
+
+  {{% if "ol" in product %}}
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+  comment="check the configuration of /etc/pam.d/system-auth doens't override pwquality.conf"
+  id="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten" version="1">
+    <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten"
+  version="1">
+    <ind:filepath>/etc/pam.d/system-auth</ind:filepath>
+    <ind:pattern
+    operation="pattern match">^\s*password.*pam_pwquality\.so.*\b{{{ VARIABLE }}}\b</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  {{% endif %}}
 
   <ind:textfilecontent54_test check="all" state_operator="AND"
   comment="check the configuration of /etc/security/pwquality.conf"

--- a/shared/templates/accounts_password/oval.template
+++ b/shared/templates/accounts_password/oval.template
@@ -13,15 +13,15 @@
       </criteria>
       {{% if "ol" in product %}}
       <criterion comment="{{{ VARIABLE }}} is not overwritten in system-auth"
-      test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten"/>
+        test_ref="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten"/>
       {{% endif %}}
     </criteria>
   </definition>
 
   {{% if "ol" in product %}}
   <ind:textfilecontent54_test check="all" check_existence="none_exist"
-  comment="check the configuration of /etc/pam.d/system-auth doens't override pwquality.conf"
-  id="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten" version="1">
+    comment="check the configuration of /etc/pam.d/system-auth doens't override pwquality.conf"
+    id="test_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten" version="1">
     <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}_not_overwritten" />
   </ind:textfilecontent54_test>
 
@@ -35,8 +35,8 @@
   {{% endif %}}
 
   <ind:textfilecontent54_test check="all" state_operator="AND"
-  comment="check the configuration of /etc/security/pwquality.conf"
-  id="test_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
+    comment="check the configuration of /etc/security/pwquality.conf"
+    id="test_password_pam_pwquality_{{{ VARIABLE }}}" version="3">
     <ind:object object_ref="obj_password_pam_pwquality_{{{ VARIABLE }}}" />
     <ind:state state_ref="state_password_pam_{{{ VARIABLE }}}" />
   {{%- if ZERO_COMPARISON_OPERATION %}}

--- a/shared/templates/accounts_password/tests/system_auth_overwritten.fail.sh
+++ b/shared/templates/accounts_password/tests/system_auth_overwritten.fail.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This test only applies to platforms that check system-auth to not override
+# the value in pwquality.conf
+# platform = multi_platform_ol
+# variables = var_password_pam_{{{ VARIABLE }}}={{{ TEST_VAR_VALUE }}}
+
+truncate -s 0 /etc/security/pwquality.conf
+
+echo "{{{ VARIABLE }}} = {{{ TEST_CORRECT_VALUE }}}" >> /etc/security/pwquality.conf
+
+{{{
+    bash_ensure_pam_module_configuration('/etc/pam.d/system-auth',
+                                  'password',
+                                  'required',
+                                  'pam_pwquality.so',
+                                  VARIABLE,
+                                  TEST_CORRECT_VALUE)
+}}}


### PR DESCRIPTION
#### Description:

- Update accounts_password OVAL for OL to check/remove the configuration in `system-auth`. Since that one could override the configuration present in pwquality.conf
- Update remediations for OL8 to remove confs in `/etc/security/pwquality.conf.d/` to ensure there aren't non compliant configurations there

#### Rationale:

- This manages better the system behavior due to configuration precedences

#### Review Hints:

- Automatus test should be enough to validate this new behavior