### PR TITLE
Ansible and bash remediations for set_ipv6_loopback_traffic

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/ansible/shared.yml
@@ -1,0 +1,22 @@
+# platform = multi_platform_sle
+
+- name: Allow incoming traffic on the loopback interface
+  ansible.builtin.iptables:
+    ipv6: yes
+    chain: INPUT
+    in_interface: lo
+    jump: ACCEPT
+
+- name: Allow outgoing traffic on the loopback interface
+  ansible.builtin.iptables:
+    ipv6: yes
+    chain: OUTPUT
+    out_interface: lo
+    jump: ACCEPT
+
+- name: Drop incoming traffic from the localhost
+  ansible.builtin.iptables:
+    ipv6: yes
+    chain: INPUT
+    source: "::1"
+    jump: DROP

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/bash/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/bash/shared.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_sle
 
-iptables -A INPUT -i lo -j ACCEPT
-iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A INPUT -s 127.0.0.0/8 -j DROP
+ip6tables -A INPUT -i lo -j ACCEPT
+ip6tables -A OUTPUT -o lo -j ACCEPT
+ip6tables -A INPUT -s ::1 -j DROP 


### PR DESCRIPTION
#### Description:

- Adds ansible and bash remediations for the rule "set_ipv6_loopback_traffic"

#### Rationale:

- Bash remediation was wrong, ansible remediation missing