### PR TITLE
Packit COPR build on EPEL7 and TF testing on CentOS 7

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -15,6 +15,7 @@ jobs:
   metadata:
     targets:
     - fedora-all-x86_64
+    - epel-7-x86_64
     - centos-stream-8-x86_64
     - centos-stream-9-x86_64
 

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,7 +23,8 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-    - fedora-latest-stable
-    - centos-7
-    - centos-stream-8
-    - centos-stream-9
+      fedora-latest-stable: {}
+      epel-7:
+        distros: [centos-7]
+      centos-stream-8: {}
+      centos-stream-9: {}

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -24,5 +24,6 @@ jobs:
   metadata:
     targets:
     - fedora-latest-stable
+    - centos-7
     - centos-stream-8
     - centos-stream-9

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -63,19 +63,28 @@ present in %{name} package.
 
 mkdir -p build
 %build
-%if 0%{?centos} == 8
+%if 0%{?centos} == 7 || 0%{?centos} == 8
 cd build
 %cmake %{cmake_defines_common} %{cmake_defines_specific} ../
 %else
 %cmake %{cmake_defines_common} %{cmake_defines_specific}
 %endif
+
+%if 0%{?centos} == 7
+make %{?_smp_mflags}
+%else
 %cmake_build
+%endif
 
 %install
-%if 0%{?centos} == 8
+%if 0%{?centos} == 7 || 0%{?centos} == 8
 cd build
 %endif
+%if 0%{?centos} == 7
+%make_install
+%else
 %cmake_install
+%endif
 rm %{buildroot}/%{_docdir}/%{name}/README.md
 rm %{buildroot}/%{_docdir}/%{name}/Contributors.md
 

--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -14,16 +14,11 @@ URL:		https://github.com/ComplianceAsCode/content/
 Source0:	https://github.com/ComplianceAsCode/content/releases/download/v%{version}/scap-security-guide-%{version}.tar.bz2
 BuildArch:	noarch
 
-BuildRequires:	libxslt
-BuildRequires:	expat
-BuildRequires:	openscap-scanner >= 1.2.5
-BuildRequires:	cmake >= 2.8
-# To get python3 inside the buildroot require its path explicitly in BuildRequires
-BuildRequires: /usr/bin/python3
-BuildRequires:	python%{python3_pkgversion}
-BuildRequires:	python%{python3_pkgversion}-jinja2
-BuildRequires:	python%{python3_pkgversion}-PyYAML
-BuildRequires:	python%{python3_pkgversion}-setuptools
+%if 0%{?centos} == 7
+BuildRequires:  libxslt, expat, openscap-scanner >= 1.2.5, cmake >= 2.8, python, python-jinja2, PyYAML, python-setuptools
+%else
+BuildRequires:  libxslt, expat, openscap-scanner >= 1.2.5, cmake >= 2.8, /usr/bin/python3, python%{python3_pkgversion}, python%{python3_pkgversion}-jinja2, python%{python3_pkgversion}-PyYAML, python%{python3_pkgversion}-setuptools
+%endif
 Requires:	xml-common, openscap-scanner >= 1.2.5
 
 %description

--- a/tests/fmf-plans/ansible-anssi.fmf
+++ b/tests/fmf-plans/ansible-anssi.fmf
@@ -10,3 +10,7 @@ execute:
 adjust:
 - enabled: false
   when: distro == fedora
+  continue: false
+- enabled: false
+  when: distro <= centos-7
+  continue: false

--- a/tests/fmf-plans/bash-anssi.fmf
+++ b/tests/fmf-plans/bash-anssi.fmf
@@ -10,3 +10,7 @@ execute:
 adjust:
 - enabled: false
   when: distro == fedora
+  continue: false
+- enabled: false
+  when: distro <= centos-7
+  continue: false


### PR DESCRIPTION
#### Description:
Extend existing CI with building and testing on CentOS 7.

According to `copr-cli`, CentOS7 is not available, but EPEL7 is there and it can be used for building:
> epel-7-x86_64                                                                                                                                                                                                                                 
    Builds are done against CentOS 7 + EPEL 7. 

On Testing Farm, CentOS 7 image is available for testing.

Spec file had to be extended with CentOS 7 specific conditions.
ANSSI test is disable on CentOS 7 for now, because RHEL7 doesn't have ANSSI BP-028 profile. The test will need to be extended to ANSSI NT-028 for this case.

#### Rationale:
Adds build on EPEL 7, where python2 is used.
Adds test coverage for CentOS 7 where profiles are noticeably different than on COS8/COS9.

#### Review Hints:
See Github Actions in this PR.