### PR TITLE
Fix file name for CIS SLE15 control file in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,4 +18,4 @@
 /controls/cis_rhel8.yml @ComplianceAsCode/red-hatters
 /controls/stig_rhel8.yml @ComplianceAsCode/red-hatters
 /controls/cis_sle12.yml @ComplianceAsCode/suse-maintainers
-/controls/cis_sle_15.yml @ComplianceAsCode/suse-maintainers
+/controls/cis_sle15.yml @ComplianceAsCode/suse-maintainers


### PR DESCRIPTION
#### Description:

Fix file name for CIS SLE15 control file in CODEOWNERS

#### Rationale:

So that the CODEOWNERS functionality works correctly.

