### PR TITLE
Build all profiles on all CentOS and CentOS Streams

### DIFF
--- a/build-scripts/enable_derivatives.py
+++ b/build-scripts/enable_derivatives.py
@@ -94,8 +94,8 @@ def main():
         raise RuntimeError("No Benchmark found!")
 
     for namespace, benchmark in benchmarks:
-        if args[1] != "cs9" and args[1] != "centos8":
-            # In CentOS Stream 8 and 9, profiles are kept because they are systems
+        if args[1] != "cs9" and not args[1].startswith("centos"):
+            # In all CentOS and CentOS Streams, profiles are kept because they are systems
             # intended to test content that will get into RHEL
             ssg.build_derivatives.profile_handling(benchmark, namespace)
         if not ssg.build_derivatives.add_cpes(benchmark, namespace, mapping):


### PR DESCRIPTION
#### Description:
Enable building all RHEL profiles in CentOS 7.

#### Rationale:
To be able to test all profiles with CentOS 7 datastream.

#### Review Hints:
`./build_product rhel7 --derivatives` and then check if all expected profiles are there.