### PR TITLE
Update kmod audit rule for OL7

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -1,9 +1,7 @@
-{{%- if product in ["rhel7", "rhel8", "rhel9"] %}}
+{{%- if product in ["ol7", "rhel7", "rhel8", "rhel9"] %}}
     {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" %}}
 {{%- elif product in ["ubuntu2004", "ubuntu2204"] %}}
     {{%- set kmod_audit="-w /bin/kmod -p x -k modules" %}}
-{{%- elif product in ["ol7"] %}}
-    {{%- set kmod_audit="-w /usr/bin/kmod -p x -F auid!=unset -k modules" %}}
 {{%- else %}}
     {{%- set kmod_audit="-w /usr/bin/kmod -p x -k modules" %}}
 {{%- endif %}}


### PR DESCRIPTION
#### Description:

- Update the audit_rules_privileged_commands_kmod yaml file for OL7 to be in sync with OVAL and remediation content.

#### Rationale:

- OL7 DISA STIG profile efforts