### PR TITLE
Add tests and improve rule for firewalld open ports

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -74,7 +74,7 @@
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
-  <local_variable id="var_firewalld_active_zones" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
+  <local_variable id="var_firewalld_active_zones" version="1" comment="Firewalled ports according to firewalld configuration" datatype="string">
     <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
   </local_variable>
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -2,12 +2,16 @@
   <definition class="compliance" id="ensure_firewall_rules_for_open_ports" version="1">
     {{{ oval_metadata("Make sure firewall rules exist for all open network ports, listening on non-loopback interfaces.") }}}
     <criteria>
-      <criterion comment="Check firewall rules for udp ipv4 listening ports" test_ref="test_listening_fw_inet_ports_test" />
+      <criterion comment="Check firewall rules for udp ipv4 listening ports" test_ref="test_listening_fw_inet_ports_tcp_test" />
     </criteria>
   </definition>
 
-  <local_variable id="var_firewalled_ports" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
-    <object_component object_ref="object_firewalled_service_port" item_field="subexpression"/>
+  <local_variable id="var_firewalled_tcp_ports" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_firewalled_service_tcp_port" item_field="subexpression"/>
+  </local_variable>
+
+  <local_variable id="var_firewalled_direct_tcp_ports" version="1" comment="Directly firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_firewalled_direct_tcp_ports" item_field="subexpression"/>
   </local_variable>
 
 
@@ -22,27 +26,37 @@
     </concat>
   </local_variable>
 
+    <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1" comment="Checks local address is udp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
+  </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_test" version="1"  check="at least one" comment="Check all listening ports are firewalled">
-    <linux:object object_ref="obj_listening_inet_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_ports" />
+
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_tcp_test" version="1"  check="at least one" comment="Check all listening ports are firewalled" state_operator="OR">
+    <linux:object object_ref="obj_listening_inet_tcp_ports" />
+    <linux:state state_ref="state_firewalled_listening_inet_tcp_ports" />
+    <linux:state state_ref="state_firewalled_listening_inet_direct_tcp_ports" />
   </linux:inetlisteningservers_test>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_ports" version="1" comment="Checks listen ports has rule in firewalld">
-      <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_ports" var_check="at least one"/>
-    </linux:inetlisteningservers_state>
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_tcp_ports" version="1" comment="Checks listen ports has rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_tcp_ports" var_check="at least one"/>
+  </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_object id="obj_listening_inet_ports" version="2" comment="This object represents a listening services on the system.">
-      <linux:protocol operation="pattern match">^.*$</linux:protocol>
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_tcp_ports" version="1" comment="Checks listen ports has direct port rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_tcp_ports" var_check="at least one"/>
+  </linux:inetlisteningservers_state>
+
+    <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2" comment="This object represents a listening services on the system.">
+      <linux:protocol operation="equals">tcp</linux:protocol>
       <linux:local_address operation="not equal">^.*$</linux:local_address>
       <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
       <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
       <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
-      <filter action="include">state_not_udp_or_tcp_listening_inet_ports</filter>
+      <filter action="exclude">state_inet_foreign_port_connected</filter>
+      <filter action="include">state_tcp_listening_inet_ports</filter>
   </linux:inetlisteningservers_object>
 
-  <linux:inetlisteningservers_state id="state_not_udp_or_tcp_listening_inet_ports" version="1" comment="Checks local address is either udp or tcp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-    <linux:protocol operation="pattern match">^(tcp|udp)$</linux:protocol>
+  <linux:inetlisteningservers_state id="state_tcp_listening_inet_ports" version="1" comment="Checks local address is tcp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    <linux:protocol operation="equals">tcp</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
@@ -60,17 +74,104 @@
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
+  <local_variable id="var_firewalld_active_zones" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
+  </local_variable>
+
+  <ind:textfilecontent54_object id="object_active_firewalld_zone_cfgs" version="1">
+    <ind:path>/etc/firewalld/zones/</ind:path>
+    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*&lt;interface\s*name=.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_firewalld_zones_with_interfaces" version="1"
+                               comment="Consider only active zones (i.e. with interfaces assigned)" >
+    <ind:filename operation="equals" var_ref="var_firewalld_active_zones" var_check="at least one"/>
+  </ind:textfilecontent54_state>
+
+
   <ind:textfilecontent54_object id="object_firewalled_service" version="1">
     <ind:path>/etc/firewalld/zones/</ind:path>
     <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*&lt;service name="(\S*)".*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="include">state_firewalld_zones_with_interfaces</filter>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_firewalled_service_port" version="1">
+  <ind:textfilecontent54_object id="object_firewalled_direct_tcp_ports" version="1">
+    <ind:path>/etc/firewalld/zones/</ind:path>
+    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="include">state_firewalld_zones_with_interfaces</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_firewalled_service_tcp_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
     <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename" var_check="at least one"/>
-    <ind:pattern operation="pattern match">port="(\d+)"</ind:pattern>
+    <ind:pattern operation="pattern match">\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <!-- UDP related entities -->
+
+  <local_variable id="var_firewalled_udp_ports" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
+  </local_variable>
+
+  <local_variable id="var_firewalled_direct_udp_ports" version="1" comment="Directly firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_firewalled_direct_udp_ports" item_field="subexpression"/>
+  </local_variable>
+
+
+
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_udp_test" version="1"  check="at least one" comment="Check all listening ports are firewalled" state_operator="OR">
+    <linux:object object_ref="obj_listening_inet_udp_ports" />
+    <linux:state state_ref="state_firewalled_listening_inet_udp_ports" />
+    <linux:state state_ref="state_firewalled_listening_inet_direct_udp_ports" />
+  </linux:inetlisteningservers_test>
+
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_udp_ports" version="1" comment="Checks listen ports has rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_udp_ports" var_check="at least one"/>
+    <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
+    </linux:inetlisteningservers_state>
+
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_udp_ports" version="1" comment="Checks listen ports has direct port rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_udp_ports" var_check="at least one"/>
+    <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
+    </linux:inetlisteningservers_state>
+
+    <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2" comment="This object represents a listening services on the system.">
+      <linux:protocol operation="equals">udp</linux:protocol>
+      <linux:local_address operation="not equal">^.*$</linux:local_address>
+      <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
+      <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
+      <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
+      <filter action="exclude">state_inet_foreign_port_connected</filter>
+      <filter action="include">state_udp_listening_inet_ports</filter>
+  </linux:inetlisteningservers_object>
+
+
+  <linux:inetlisteningservers_state id="state_udp_listening_inet_ports" version="1" comment="Checks local address is udp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    <linux:protocol operation="equals">udp</linux:protocol>
+    <linux:local_address operation="pattern match">^.*$</linux:local_address>
+    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
+  </linux:inetlisteningservers_state>
+
+  <ind:textfilecontent54_object id="object_firewalled_direct_udp_ports" version="1">
+    <ind:path>/etc/firewalld/zones/</ind:path>
+    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="include">state_firewalld_zones_with_interfaces</filter>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_firewalled_service_udp_port" version="1">
+    <ind:path>/usr/lib/firewalld/services/</ind:path>
+    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename" var_check="at least one"/>
+    <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
 </def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -14,7 +14,7 @@
       </criteria>
       <criteria operator="OR">
         <criterion comment="Check if any service is listening on udp"
-          test_ref="test_listening_fw_inet_ports_udp_exist" />
+          test_ref="test_listening_inet_ports_udp_exist" />
         <criteria operator="AND">
           <criterion comment="Check there are defined udp ports in firewall"
             test_ref="test_var_firewalled_udp_ports_exists" />
@@ -25,97 +25,7 @@
     </criteria>
   </definition>
 
-  <local_variable id="var_firewalled_tcp_ports" version="1"
-    comment="Firewalled ports according to firewalld configuration" datatype="int">
-    <object_component object_ref="object_firewalled_service_tcp_port" item_field="subexpression"/>
-  </local_variable>
-
-  <local_variable id="var_firewalled_direct_tcp_ports" version="1"
-    comment="Directly firewalled ports according to firewalld configuration" datatype="int">
-    <object_component object_ref="object_firewalled_direct_tcp_ports" item_field="subexpression"/>
-  </local_variable>
-
-  <local_variable id="var_firewalled_services" version="1"
-    comment="Firewalld service names" datatype="string">
-    <object_component object_ref="object_firewalled_service" item_field="subexpression"/>
-  </local_variable>
-
-  <local_variable id="var_all_firewalled_services_desc_filename" version="1"
-    comment="Firewalld service file description" datatype="string">
-    <concat>
-      <variable_component var_ref="var_firewalled_services"/>
-      <literal_component>.xml</literal_component>
-    </concat>
-  </local_variable>
-
-  <ind:variable_object id="object_var_obj_listening_inet_tcp_ports" version="1">
-    <ind:var_ref>var_obj_listening_inet_tcp_ports</ind:var_ref>
-  </ind:variable_object>
-
-  <local_variable id="var_obj_listening_inet_tcp_ports" version="1"
-    comment="Variable with all firewalled ports" datatype="int">
-    <object_component object_ref="obj_listening_inet_tcp_ports" item_field="local_port"/>
-  </local_variable>
-
-  <local_variable id="var_object_var_firewalled_tcp_ports" version="1"
-    comment="Variable with all firewalled tcp ports" datatype="int">
-    <object_component object_ref="object_var_firewalled_tcp_ports" item_field="value"/>
-  </local_variable>
-
-  <ind:variable_object id="object_var_firewalled_tcp_ports" version="1">
-    <set>
-      <object_reference>object_var_firewalled_service_tcp_ports</object_reference>
-      <object_reference>object_var_firewalled_direct_tcp_ports</object_reference>
-    </set>
-  </ind:variable_object>
-
-  <ind:variable_object id="object_var_firewalled_service_tcp_ports" version="1">
-    <ind:var_ref>var_firewalled_tcp_ports</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_object id="object_var_firewalled_direct_tcp_ports" version="1">
-    <ind:var_ref>var_firewalled_direct_tcp_ports</ind:var_ref>
-  </ind:variable_object>
-
-  <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1"
-    comment="Checks this is a listening service not connected">
-    <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
-  </linux:inetlisteningservers_state>
-
-  <ind:variable_test id="test_listening_fw_inet_ports_tcp_test" version="1"
-    check="all" comment="Check all tcp listening ports defined are firewalled">
-    <ind:object object_ref="object_var_obj_listening_inet_tcp_ports" />
-    <ind:state state_ref="state_firewalled_listening_inet_tcp_ports" />
-  </ind:variable_test>
-
-  <ind:variable_test id="test_var_firewalled_tcp_ports_exists" check="all"
-    check_existence="at_least_one_exists" version="1"
-    comment="Check the existence of tcp port defined through services.">
-    <ind:object object_ref="object_var_firewalled_tcp_ports"/>
-  </ind:variable_test>
-
-  <ind:variable_state id="state_firewalled_listening_inet_tcp_ports" version="1"
-    comment="Checks listen ports has port rule in firewalld">
-    <ind:value datatype="int" operation="equals" var_check="at least one"
-      var_ref="var_object_var_firewalled_tcp_ports"/>
-  </ind:variable_state>
-
-  <linux:inetlisteningservers_test id="test_listening_inet_ports_tcp_exist" version="1" check="all"
-    check_existence="none_exist"
-    comment="Check if any service is listening on tcp ports">
-    <linux:object object_ref="obj_listening_inet_tcp_ports" />
-  </linux:inetlisteningservers_test>
-
-  <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
-    comment="Represents a listening services on the system.">
-    <linux:protocol operation="equals">tcp</linux:protocol>
-    <linux:local_address operation="pattern match">^.*$</linux:local_address>
-    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
-    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
-    <filter action="exclude">state_inet_foreign_port_connected</filter>
-  </linux:inetlisteningservers_object>
-
+<!-- States describing listening objects on loopback interface or established connections-->
   <linux:inetlisteningservers_state id="state_ipv4_loopback_listening_inet_ports" version="1"
     comment="Checks local address is not ipv4 loopback."
     xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
@@ -132,17 +42,23 @@
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
-  <local_variable id="var_firewalld_active_zones" version="1"
-    comment="Firewalled ports according to firewalld configuration" datatype="string">
-    <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
-  </local_variable>
+  <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1"
+    comment="Checks this is a listening service not connected">
+    <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
+  </linux:inetlisteningservers_state>
 
+  <!-- Objects and variables describing the firewalld configuration -->
   <ind:textfilecontent54_object id="object_active_firewalld_zone_cfgs" version="1">
     <ind:path>/etc/firewalld/zones/</ind:path>
     <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*&lt;interface\s*name=.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+
+  <local_variable id="var_firewalld_active_zones" version="1"
+    comment="Firewalled ports according to firewalld configuration" datatype="string">
+    <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
+  </local_variable>
 
   <ind:textfilecontent54_state id="state_firewalld_zones_with_interfaces" version="1"
     comment="Consider only active zones (i.e. with interfaces assigned)" >
@@ -157,13 +73,40 @@
     <filter action="include">state_firewalld_zones_with_interfaces</filter>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_object id="object_firewalled_direct_tcp_ports" version="1">
-    <ind:path>/etc/firewalld/zones/</ind:path>
-    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*.*$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="include">state_firewalld_zones_with_interfaces</filter>
-  </ind:textfilecontent54_object>
+  <local_variable id="var_firewalled_services" version="1"
+    comment="Firewalld service names" datatype="string">
+    <object_component object_ref="object_firewalled_service" item_field="subexpression"/>
+  </local_variable>
+
+  <local_variable id="var_all_firewalled_services_desc_filename" version="1"
+    comment="Firewalld service file description" datatype="string">
+    <concat>
+      <variable_component var_ref="var_firewalled_services"/>
+      <literal_component>.xml</literal_component>
+    </concat>
+  </local_variable>
+
+  <!-- TCP related entities -->
+
+  <!-- Objects and variables describing the listening TCP service on the system -->
+  <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
+    comment="Represents a listening services on the system.">
+    <linux:protocol operation="equals">tcp</linux:protocol>
+    <linux:local_address operation="pattern match">^.*$</linux:local_address>
+    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
+    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_inet_foreign_port_connected</filter>
+  </linux:inetlisteningservers_object>
+
+  <local_variable id="var_obj_listening_inet_tcp_ports" version="1"
+    comment="Variable with all firewalled ports" datatype="int">
+    <object_component object_ref="obj_listening_inet_tcp_ports" item_field="local_port"/>
+  </local_variable>
+
+  <ind:variable_object id="object_var_obj_listening_inet_tcp_ports" version="1">
+    <ind:var_ref>var_obj_listening_inet_tcp_ports</ind:var_ref>
+  </ind:variable_object>
 
   <ind:textfilecontent54_object id="object_firewalled_service_tcp_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
@@ -173,20 +116,116 @@
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
+  <local_variable id="var_firewalled_service_tcp_ports" version="1"
+    comment="Firewalled ports according to firewalld configuration per service" datatype="int">
+    <object_component object_ref="object_firewalled_service_tcp_port" item_field="subexpression"/>
+  </local_variable>
+
+  <ind:variable_object id="object_var_firewalled_service_tcp_ports" version="1">
+    <ind:var_ref>var_firewalled_service_tcp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- States objects and variables describing the Firewalled ports stated with port numbers -->
+  <ind:textfilecontent54_object id="object_firewalled_direct_tcp_ports" version="1">
+    <ind:path>/etc/firewalld/zones/</ind:path>
+    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="include">state_firewalld_zones_with_interfaces</filter>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_firewalled_direct_tcp_ports" version="1"
+    comment="Directly firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_firewalled_direct_tcp_ports" item_field="subexpression"/>
+  </local_variable>
+
+  <ind:variable_object id="object_var_firewalled_direct_tcp_ports" version="1">
+    <ind:var_ref>var_firewalled_direct_tcp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Object defining firewalled  services and ports -->
+  <ind:variable_object id="object_var_firewalled_tcp_ports" version="1">
+    <set>
+      <object_reference>object_var_firewalled_service_tcp_ports</object_reference>
+      <object_reference>object_var_firewalled_direct_tcp_ports</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <local_variable id="var_object_var_firewalled_tcp_ports" version="1"
+    comment="Variable with all firewalled tcp ports" datatype="int">
+    <object_component object_ref="object_var_firewalled_tcp_ports" item_field="value"/>
+  </local_variable>
+
+  <ind:variable_test id="test_var_firewalled_tcp_ports_exists" check="all"
+    check_existence="at_least_one_exists" version="1"
+    comment="Check the existence of tcp port defined through services.">
+    <ind:object object_ref="object_var_firewalled_tcp_ports"/>
+  </ind:variable_test>
+
+  <linux:inetlisteningservers_test id="test_listening_inet_ports_tcp_exist" version="1" check="all"
+    check_existence="none_exist"
+    comment="Check if any service is listening on tcp ports">
+    <linux:object object_ref="obj_listening_inet_tcp_ports" />
+  </linux:inetlisteningservers_test>
+
+  <ind:variable_state id="state_firewalled_listening_inet_tcp_ports" version="1"
+    comment="Checks listen ports has port rule in firewalld">
+    <ind:value datatype="int" operation="equals" var_check="at least one"
+      var_ref="var_object_var_firewalled_tcp_ports"/>
+  </ind:variable_state>
+
+  <ind:variable_test id="test_listening_fw_inet_ports_tcp_test" version="1"
+    check="all" comment="Check all tcp listening ports defined are firewalled">
+    <ind:object object_ref="object_var_obj_listening_inet_tcp_ports" />
+    <ind:state state_ref="state_firewalled_listening_inet_tcp_ports" />
+  </ind:variable_test>
+
   <!-- UDP related entities -->
-  <local_variable id="var_firewalled_udp_ports" version="1"
-    comment="Firewalled ports according to firewalld configuration" datatype="int">
-    <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
+
+  <!-- Objects and variables describing the listening TCP service on the system -->
+  <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
+    comment="This object represents a listening services on the system.">
+    <linux:protocol operation="equals">udp</linux:protocol>
+    <linux:local_address operation="pattern match">^.*$</linux:local_address>
+    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
+    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_inet_foreign_port_connected</filter>
+  </linux:inetlisteningservers_object>
+
+  <local_variable id="var_obj_listening_inet_udp_ports" version="1" datatype="int"
+    comment="Variable with all firewalled ports">
+    <object_component object_ref="obj_listening_inet_udp_ports" item_field="local_port"/>
   </local_variable>
 
   <ind:variable_object id="object_var_obj_listening_inet_udp_ports" version="1">
     <ind:var_ref>var_obj_listening_inet_udp_ports</ind:var_ref>
   </ind:variable_object>
 
-  <local_variable id="var_obj_listening_inet_udp_ports" version="1" datatype="int"
-    comment="Variable with all firewalled ports">
-    <object_component object_ref="obj_listening_inet_udp_ports" item_field="local_port"/>
+  <ind:textfilecontent54_object id="object_firewalled_service_udp_port" version="1">
+    <ind:path>/usr/lib/firewalld/services/</ind:path>
+    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
+      var_check="at least one"/>
+    <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_firewalled_service_udp_ports" version="1"
+    comment="Firewalled ports according to firewalld configuration" datatype="int">
+    <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
   </local_variable>
+
+  <ind:variable_object id="object_var_firewalled_service_udp_ports" version="1">
+    <ind:var_ref>var_firewalled_service_udp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:textfilecontent54_object id="object_firewalled_direct_udp_ports" version="1">
+    <ind:path>/etc/firewalld/zones/</ind:path>
+    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
+    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*.*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+    <filter action="include">state_firewalld_zones_with_interfaces</filter>
+  </ind:textfilecontent54_object>
 
   <local_variable id="var_firewalled_direct_udp_ports" version="1"
     comment="Directly firewalled ports according to firewalld configuration"
@@ -199,9 +238,6 @@
     <object_component object_ref="object_var_firewalled_udp_ports" item_field="value"/>
   </local_variable>
 
-  <ind:variable_object id="object_var_firewalled_service_udp_ports" version="1">
-    <ind:var_ref>var_firewalled_udp_ports</ind:var_ref>
-  </ind:variable_object>
   <ind:variable_object id="object_var_firewalled_direct_udp_ports" version="1">
     <ind:var_ref>var_firewalled_direct_udp_ports</ind:var_ref>
   </ind:variable_object>
@@ -213,17 +249,16 @@
     </set>
   </ind:variable_object>
 
-    <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
+  <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
       check_existence="at_least_one_exists" version="1"
       comment="Check the existence of udp port defined through services.">
     <ind:object object_ref="object_var_firewalled_udp_ports"/>
   </ind:variable_test>
 
-  <ind:variable_test id="test_listening_fw_inet_ports_udp_test" version="1" check="at least one"
-    comment="Check listening ports defined by service are firewalled" state_operator="OR">
-    <ind:object object_ref="object_var_obj_listening_inet_udp_ports" />
-    <ind:state state_ref="state_firewalled_listening_inet_udp_ports" />
-  </ind:variable_test>
+  <linux:inetlisteningservers_test id="test_listening_inet_ports_udp_exist" version="1" check="all"
+      check_existence="none_exist" comment="Check if any service is listening on udp ports">
+    <linux:object object_ref="obj_listening_inet_udp_ports" />
+  </linux:inetlisteningservers_test>
 
   <ind:variable_state id="state_firewalled_listening_inet_udp_ports" version="1"
     comment="Checks listen ports has rule in firewalld">
@@ -231,41 +266,10 @@
       var_check="at least one"/>
   </ind:variable_state>
 
-    <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_udp_ports" version="1"
-      comment="Checks listen ports has direct port rule in firewalld">
-      <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_udp_ports"
-        var_check="at least one"/>
-      <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
-    </linux:inetlisteningservers_state>
+  <ind:variable_test id="test_listening_fw_inet_ports_udp_test" version="1" check="at least one"
+    comment="Check listening ports defined by service are firewalled" state_operator="OR">
+    <ind:object object_ref="object_var_obj_listening_inet_udp_ports" />
+    <ind:state state_ref="state_firewalled_listening_inet_udp_ports" />
+  </ind:variable_test>
 
-    <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_udp_exist" version="1" check="all"
-      check_existence="none_exist" comment="Check if any service is listening on udp ports">
-    <linux:object object_ref="obj_listening_inet_udp_ports" />
-  </linux:inetlisteningservers_test>
-
-  <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
-    comment="This object represents a listening services on the system.">
-    <linux:protocol operation="equals">udp</linux:protocol>
-    <linux:local_address operation="pattern match">^.*$</linux:local_address>
-    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
-    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
-    <filter action="exclude">state_inet_foreign_port_connected</filter>
-  </linux:inetlisteningservers_object>
-
-  <ind:textfilecontent54_object id="object_firewalled_direct_udp_ports" version="1">
-    <ind:path>/etc/firewalld/zones/</ind:path>
-    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*.*$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="include">state_firewalld_zones_with_interfaces</filter>
-  </ind:textfilecontent54_object>
-
-  <ind:textfilecontent54_object id="object_firewalled_service_udp_port" version="1">
-    <ind:path>/usr/lib/firewalld/services/</ind:path>
-    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
-      var_check="at least one"/>
-    <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -1,52 +1,44 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("Make sure firewall rules exist for all open network ports, listening on non-loopback interfaces.") }}}
+    {{{ oval_metadata("Make sure firewall rules exist for all open network ports,listening on non-loopback interfaces.") }}}
     <criteria operator="AND">
       <criteria operator="OR">
         <criterion comment="Check if any service is listening on tcp"
-                   test_ref="test_listening_fw_inet_ports_tcp_exist" />
+                   test_ref="test_listening_inet_ports_tcp_exist" />
         <criteria operator="AND">
-          <criterion comment="Check there are defined tcp service ports in firewall"
+          <criterion comment="Check there are tcp service ports in firewall"
                      test_ref="test_var_firewalled_tcp_ports_exists" />
           <criterion comment="Check firewall rules for tcp listening ports"
-                     test_ref="test_listening_fw_inet_service_ports_tcp_test" />
-        </criteria>
-        <criteria operator="AND">
-          <criterion comment="Check there are defined direct tcp ports in firewall"
-                     test_ref="test_var_firewalled_direct_tcp_ports_exists" />
-          <criterion comment="Check firewall rules for directly-defined tcp listening ports"
-                     test_ref="test_listening_fw_inet_direct_ports_tcp_test" />
+                     test_ref="test_listening_fw_inet_ports_tcp_test" />
         </criteria>
       </criteria>
       <criteria operator="OR">
         <criterion comment="Check if any service is listening on udp"
                    test_ref="test_listening_fw_inet_ports_udp_exist" />
         <criteria operator="AND">
-          <criterion comment="Check there are defined udp service ports in firewall"
+          <criterion comment="Check there are defined udp ports in firewall"
                      test_ref="test_var_firewalled_udp_ports_exists" />
           <criterion comment="Check firewall rules for udp listening ports"
-                     test_ref="test_listening_fw_inet_service_ports_udp_test" />
-        </criteria>
-        <criteria operator="AND">
-          <criterion comment="Check there are defined udp direct ports in firewall"
-                     test_ref="test_var_firewalled_direct_udp_ports_exists" />
-          <criterion comment="Check firewall rules for directly-defined udp listening ports"
-                     test_ref="test_listening_fw_inet_direct_ports_udp_test" />
+                     test_ref="test_listening_fw_inet_ports_udp_test" />
         </criteria>
       </criteria>
     </criteria>
   </definition>
 
-  <local_variable id="var_firewalled_tcp_ports" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
+  <local_variable id="var_firewalled_tcp_ports" version="1"
+                  comment="Firewalled ports according to firewalld configuration" datatype="int">
     <object_component object_ref="object_firewalled_service_tcp_port" item_field="subexpression"/>
   </local_variable>
 
-  <local_variable id="var_firewalled_direct_tcp_ports" version="1" comment="Directly firewalled ports according to firewalld configuration" datatype="int">
+  <local_variable id="var_firewalled_direct_tcp_ports" version="1"
+                  comment="Directly firewalled ports according to firewalld configuration"
+                  datatype="int">
     <object_component object_ref="object_firewalled_direct_tcp_ports" item_field="subexpression"/>
   </local_variable>
 
 
-  <local_variable id="var_firewalled_services" version="1" comment="Firewalld service names" datatype="string">
+  <local_variable id="var_firewalled_services" version="1" comment="Firewalld service names"
+                  datatype="string">
     <object_component object_ref="object_firewalled_service" item_field="subexpression"/>
   </local_variable>
 
@@ -58,7 +50,28 @@
     </concat>
   </local_variable>
 
+  <ind:variable_object id="object_var_obj_listening_inet_tcp_ports" version="1">
+    <ind:var_ref>var_obj_listening_inet_tcp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable id="var_obj_listening_inet_tcp_ports" version="1" datatype="int"
+                  comment="Variable with all firewalled ports">
+      <object_component object_ref="obj_listening_inet_tcp_ports" item_field="local_port"/>
+  </local_variable>
+
+  <local_variable id="var_object_var_firewalled_tcp_ports" version="1" datatype="int"
+                  comment="Variable with all firewalled tcp ports">
+      <object_component object_ref="object_var_firewalled_tcp_ports" item_field="value"/>
+  </local_variable>
+
   <ind:variable_object id="object_var_firewalled_tcp_ports" version="1">
+    <set>
+      <object_reference>object_var_firewalled_service_tcp_ports</object_reference>
+      <object_reference>object_var_firewalled_direct_tcp_ports</object_reference>
+    </set>
+  </ind:variable_object>
+
+  <ind:variable_object id="object_var_firewalled_service_tcp_ports" version="1">
     <ind:var_ref>var_firewalled_tcp_ports</ind:var_ref>
   </ind:variable_object>
 
@@ -67,30 +80,17 @@
   </ind:variable_object>
 
   <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1"
-                                    comment="Checks this is a listening service not connected"
-                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+                                    comment="Checks this is a listening service not connected">
     <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
   </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_service_ports_tcp_test" version="1"
-                                   check="at least one"
-                                   comment="Check all listening ports defined directly are firewalled">
-    <linux:object object_ref="obj_listening_inet_tcp_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_direct_tcp_ports" />
-  </linux:inetlisteningservers_test>
-
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_direct_ports_tcp_test" version="1"
-                                   check="at least one"
-                                   comment="Check all listening ports defined by service are firewalled">
-    <linux:object object_ref="obj_listening_inet_tcp_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_tcp_ports" />
-  </linux:inetlisteningservers_test>
-
-  <ind:variable_test id="test_var_firewalled_direct_tcp_ports_exists" check="all"
-                     check_existence="at_least_one_exists" version="1"
-                     comment="Check the existence of direct tcp port definitions.">
-    <ind:object object_ref="object_var_firewalled_direct_tcp_ports"/>
+  <ind:variable_test id="test_listening_fw_inet_ports_tcp_test" version="1"
+                                   check="all"
+                                   comment="Check all tcp listening ports defined are firewalled">
+    <ind:object object_ref="object_var_obj_listening_inet_tcp_ports" />
+    <ind:state state_ref="state_firewalled_listening_inet_tcp_ports" />
   </ind:variable_test>
+
 
   <ind:variable_test id="test_var_firewalled_tcp_ports_exists" check="all"
                      check_existence="at_least_one_exists" version="1"
@@ -98,19 +98,14 @@
     <ind:object object_ref="object_var_firewalled_tcp_ports"/>
   </ind:variable_test>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_tcp_ports" version="1"
-                                    comment="Checks listen ports has rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_tcp_ports"
-                      var_check="at least one"/>
-  </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_tcp_ports" version="1"
-                                    comment="Checks listen ports has direct port rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_tcp_ports"
-                      var_check="at least one"/>
-  </linux:inetlisteningservers_state>
+  <ind:variable_state id="state_firewalled_listening_inet_tcp_ports" version="1"
+                      comment="Checks listen ports has port rule in firewalld">
+    <ind:value datatype="int" operation="equals"  var_ref="var_object_var_firewalled_tcp_ports"
+               var_check="at least one"/>
+  </ind:variable_state>
 
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_tcp_exist" version="1" check="all"
+  <linux:inetlisteningservers_test id="test_listening_inet_ports_tcp_exist" version="1" check="all"
                                    check_existence="none_exist"
                                    comment="Check if any service is listening on tcp ports">
     <linux:object object_ref="obj_listening_inet_tcp_ports" />
@@ -118,12 +113,12 @@
 
   <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
                                      comment="Represents a listening services on the system.">
-      <linux:protocol operation="equals">tcp</linux:protocol>
-      <linux:local_address operation="pattern match">^.*$</linux:local_address>
-      <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-      <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
-      <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
-      <filter action="exclude">state_inet_foreign_port_connected</filter>
+    <linux:protocol operation="equals">tcp</linux:protocol>
+    <linux:local_address operation="pattern match">^.*$</linux:local_address>
+    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
+    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_inet_foreign_port_connected</filter>
   </linux:inetlisteningservers_object>
 
   <linux:inetlisteningservers_state id="state_ipv4_loopback_listening_inet_ports" version="1"
@@ -148,7 +143,8 @@
   </local_variable>
 
   <ind:textfilecontent54_object id="object_active_firewalld_zone_cfgs" version="1">
-    <ind:path>/etc/firewalld/zones/</ind:path>
+    <ind:path>/etc/firewalld/zones/
+    </ind:path>
     <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*&lt;interface\s*name=.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
@@ -180,7 +176,7 @@
     <ind:path>/usr/lib/firewalld/services/</ind:path>
     <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
                   var_check="at least one"/>
-    <ind:pattern operation="pattern match">\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*</ind:pattern>
+    <ind:pattern operation="pattern match">\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s* </ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -190,61 +186,65 @@
     <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
   </local_variable>
 
+  <ind:variable_object id="object_var_obj_listening_inet_udp_ports" version="1">
+    <ind:var_ref>var_obj_listening_inet_udp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <local_variable id="var_obj_listening_inet_udp_ports" version="1" datatype="int"
+                  comment="Variable with all firewalled ports">
+      <object_component object_ref="obj_listening_inet_udp_ports" item_field="local_port"/>
+  </local_variable>
+
   <local_variable id="var_firewalled_direct_udp_ports" version="1"
                   comment="Directly firewalled ports according to firewalld configuration"
                   datatype="int">
     <object_component object_ref="object_firewalled_direct_udp_ports" item_field="subexpression"/>
   </local_variable>
 
-  <ind:variable_object id="object_var_firewalled_udp_ports" version="1">
+  <local_variable id="var_object_var_firewalled_udp_ports" version="1" datatype="int"
+                  comment="Variable with all udp firewalled ports">
+    <object_component object_ref="object_var_firewalled_udp_ports" item_field="value"/>
+  </local_variable>
+
+  <ind:variable_object id="object_var_firewalled_service_udp_ports" version="1">
     <ind:var_ref>var_firewalled_udp_ports</ind:var_ref>
   </ind:variable_object>
-
   <ind:variable_object id="object_var_firewalled_direct_udp_ports" version="1">
     <ind:var_ref>var_firewalled_direct_udp_ports</ind:var_ref>
   </ind:variable_object>
 
-  <ind:variable_test id="test_var_firewalled_direct_udp_ports_exists" check="all"
-                     check_existence="at_least_one_exists" version="1"
-                     comment="Check the existence of direct udp port definitions.">
-    <ind:object object_ref="object_var_firewalled_direct_udp_ports"/>
-  </ind:variable_test>
+  <ind:variable_object id="object_var_firewalled_udp_ports" version="1">
+    <set>
+      <object_reference>object_var_firewalled_service_udp_ports</object_reference>
+      <object_reference>object_var_firewalled_direct_udp_ports</object_reference>
+    </set>
+  </ind:variable_object>
 
-  <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
+    <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
                      check_existence="at_least_one_exists" version="1"
                      comment="Check the existence of udp port defined through services.">
     <ind:object object_ref="object_var_firewalled_udp_ports"/>
   </ind:variable_test>
 
-
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_direct_ports_udp_test" version="1"
-                                   check="at least one"
-                                   comment="Check listening ports directly defined are firewalled"
-                                   state_operator="OR">
-    <linux:object object_ref="obj_listening_inet_udp_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_direct_udp_ports" />
-  </linux:inetlisteningservers_test>
-
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_service_ports_udp_test" version="1"
+  <ind:variable_test id="test_listening_fw_inet_ports_udp_test" version="1"
                                    check="at least one"
                                    comment="Check listening ports defined by service are firewalled"
                                    state_operator="OR">
-    <linux:object object_ref="obj_listening_inet_udp_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_udp_ports" />
-  </linux:inetlisteningservers_test>
+    <ind:object object_ref="object_var_obj_listening_inet_udp_ports" />
+    <ind:state state_ref="state_firewalled_listening_inet_udp_ports" />
+  </ind:variable_test>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_udp_ports" version="1"
-                                    comment="Checks listen ports has rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_udp_ports"
-                      var_check="at least one"/>
-    <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
-    </linux:inetlisteningservers_state>
+  <ind:variable_state id="state_firewalled_listening_inet_udp_ports" version="1"
+                      comment="Checks listen ports has rule in firewalld">
+    <ind:value datatype="int" operation="equals"  var_ref="var_object_var_firewalled_udp_ports"
+               var_check="at least one"/>
+  </ind:variable_state>
 
     <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_udp_ports" version="1"
                                       comment="Checks listen ports has direct port rule in firewalld">
       <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_udp_ports"
                         var_check="at least one"/>
-    <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
+      <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
     </linux:inetlisteningservers_state>
 
     <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_udp_exist" version="1" check="all"
@@ -255,12 +255,12 @@
 
   <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
                                        comment="This object represents a listening services on the system.">
-      <linux:protocol operation="equals">udp</linux:protocol>
-      <linux:local_address operation="pattern match">^.*$</linux:local_address>
-      <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-      <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
-      <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
-      <filter action="exclude">state_inet_foreign_port_connected</filter>
+    <linux:protocol operation="equals">udp</linux:protocol>
+    <linux:local_address operation="pattern match">^.*$</linux:local_address>
+    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
+    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
+    <filter action="exclude">state_inet_foreign_port_connected</filter>
   </linux:inetlisteningservers_object>
 
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -1,27 +1,20 @@
+{{% set inet_protos = ['tcp', 'udp'] %}}
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Make sure firewall rules exist for all open network ports,listening on non-loopback interfaces.") }}}
     <criteria operator="AND">
+{{% for proto in inet_protos %}}
       <criteria operator="OR">
-        <criterion comment="Check if any service is listening on tcp"
-          test_ref="test_listening_inet_ports_tcp_exist" />
+        <criterion comment="Check if any service is listening on {{{ proto }}}"
+          test_ref="test_listening_inet_ports_{{{ proto }}}_exist" />
         <criteria operator="AND">
-          <criterion comment="Check there are tcp service ports in firewall"
-            test_ref="test_var_firewalled_tcp_ports_exists" />
-          <criterion comment="Check firewall rules for tcp listening ports"
-            test_ref="test_listening_fw_inet_ports_tcp_test" />
+          <criterion comment="Check there are {{{ proto }}} service ports in firewall"
+            test_ref="test_var_firewalled_{{{ proto }}}_ports_exists" />
+          <criterion comment="Check firewall rules for {{{ proto }}} listening ports"
+            test_ref="test_listening_fw_inet_ports_{{{ proto }}}_test" />
         </criteria>
       </criteria>
-      <criteria operator="OR">
-        <criterion comment="Check if any service is listening on udp"
-          test_ref="test_listening_inet_ports_udp_exist" />
-        <criteria operator="AND">
-          <criterion comment="Check there are defined udp ports in firewall"
-            test_ref="test_var_firewalled_udp_ports_exists" />
-          <criterion comment="Check firewall rules for udp listening ports"
-            test_ref="test_listening_fw_inet_ports_udp_test" />
-        </criteria>
-      </criteria>
+{{% endfor %}}
     </criteria>
   </definition>
 
@@ -56,7 +49,7 @@
   </ind:textfilecontent54_object>
 
   <local_variable id="var_firewalld_active_zones" version="1"
-    comment="Firewalled ports according to firewalld configuration" datatype="string">
+    comment="Firewalld zones configuration filenames" datatype="string">
     <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
   </local_variable>
 
@@ -86,7 +79,6 @@
     </concat>
   </local_variable>
 
-{{% set inet_protos = ['tcp', 'udp'] %}}
 {{% for proto in inet_protos %}}
 
 <linux:inetlisteningservers_object id="obj_listening_inet_{{{ proto }}}_ports" version="2"

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -1,8 +1,35 @@
 <def-group>
   <definition class="compliance" id="ensure_firewall_rules_for_open_ports" version="1">
     {{{ oval_metadata("Make sure firewall rules exist for all open network ports, listening on non-loopback interfaces.") }}}
-    <criteria>
-      <criterion comment="Check firewall rules for udp ipv4 listening ports" test_ref="test_listening_fw_inet_ports_tcp_test" />
+    <criteria operator="AND">
+      <criteria operator="OR">
+        <criteria operator="AND">
+          <criterion comment="Check there are defined tcp service ports in firewall"
+                     test_ref="test_var_firewalled_tcp_ports_exists" />
+          <criterion comment="Check firewall rules for tcp listening ports"
+                     test_ref="test_listening_fw_inet_service_ports_tcp_test" />
+        </criteria>
+        <criteria operator="AND">
+          <criterion comment="Check there are defined direct tcp ports in firewall"
+                     test_ref="test_var_firewalled_direct_tcp_ports_exists" />
+          <criterion comment="Check firewall rules for directly-defined tcp listening ports"
+                     test_ref="test_listening_fw_inet_direct_ports_tcp_test" />
+        </criteria>
+      </criteria>
+      <criteria operator="OR">
+        <criteria operator="AND">
+          <criterion comment="Check there are defined udp service ports in firewall"
+                     test_ref="test_var_firewalled_udp_ports_exists" />
+          <criterion comment="Check firewall rules for udp listening ports"
+                     test_ref="test_listening_fw_inet_service_ports_udp_test" />
+        </criteria>
+        <criteria operator="AND">
+          <criterion comment="Check there are defined udp direct ports in firewall"
+                     test_ref="test_var_firewalled_direct_udp_ports_exists" />
+          <criterion comment="Check firewall rules for directly-defined udp listening ports"
+                     test_ref="test_listening_fw_inet_direct_ports_udp_test" />
+        </criteria>
+      </criteria>
     </criteria>
   </definition>
 
@@ -19,33 +46,68 @@
     <object_component object_ref="object_firewalled_service" item_field="subexpression"/>
   </local_variable>
 
-  <local_variable id="var_all_firewalled_services_desc_filename" version="1" comment="Firewalld service file description" datatype="string">
+  <local_variable id="var_all_firewalled_services_desc_filename" version="1"
+                  comment="Firewalld service file description" datatype="string">
     <concat>
       <variable_component var_ref="var_firewalled_services"/>
       <literal_component>.xml</literal_component>
     </concat>
   </local_variable>
 
-    <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1" comment="Checks local address is udp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+  <ind:variable_object id="object_var_firewalled_tcp_ports" version="1">
+    <ind:var_ref>var_firewalled_tcp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_object id="object_var_firewalled_direct_tcp_ports" version="1">
+    <ind:var_ref>var_firewalled_direct_tcp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1"
+                                    comment="Checks local address is udp."
+                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
   </linux:inetlisteningservers_state>
-
-
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_tcp_test" version="1"  check="at least one" comment="Check all listening ports are firewalled" state_operator="OR">
+  
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_service_ports_tcp_test" version="1"
+                                   check="at least one"
+                                   comment="Check all listening ports defined directly are firewalled">
     <linux:object object_ref="obj_listening_inet_tcp_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_tcp_ports" />
     <linux:state state_ref="state_firewalled_listening_inet_direct_tcp_ports" />
   </linux:inetlisteningservers_test>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_tcp_ports" version="1" comment="Checks listen ports has rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_tcp_ports" var_check="at least one"/>
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_direct_ports_tcp_test" version="1"
+                                   check="at least one"
+                                   comment="Check all listening ports defined by service are firewalled">
+    <linux:object object_ref="obj_listening_inet_tcp_ports" />
+    <linux:state state_ref="state_firewalled_listening_inet_tcp_ports" />
+  </linux:inetlisteningservers_test>
+
+  <ind:variable_test id="test_var_firewalled_direct_tcp_ports_exists" check="all"
+                     check_existence="at_least_one_exists" version="1"
+                     comment="Check the existence of direct tcp port definitions.">
+    <ind:object object_ref="object_var_firewalled_direct_tcp_ports"/>
+  </ind:variable_test>
+
+  <ind:variable_test id="test_var_firewalled_tcp_ports_exists" check="all"
+                     check_existence="at_least_one_exists" version="1"
+                     comment="Check the existence of tcp port defined through services.">
+    <ind:object object_ref="object_var_firewalled_tcp_ports"/>
+  </ind:variable_test>
+
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_tcp_ports" version="1"
+                                    comment="Checks listen ports has rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_tcp_ports"
+                      var_check="at least one"/>
   </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_tcp_ports" version="1" comment="Checks listen ports has direct port rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_tcp_ports" var_check="at least one"/>
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_tcp_ports" version="1"
+                                    comment="Checks listen ports has direct port rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_tcp_ports"
+                      var_check="at least one"/>
   </linux:inetlisteningservers_state>
 
-    <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2" comment="This object represents a listening services on the system.">
+  <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
+                                     comment="Represents a listening services on the system.">
       <linux:protocol operation="equals">tcp</linux:protocol>
       <linux:local_address operation="not equal">^.*$</linux:local_address>
       <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
@@ -55,26 +117,33 @@
       <filter action="include">state_tcp_listening_inet_ports</filter>
   </linux:inetlisteningservers_object>
 
-  <linux:inetlisteningservers_state id="state_tcp_listening_inet_ports" version="1" comment="Checks local address is tcp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+  <linux:inetlisteningservers_state id="state_tcp_listening_inet_ports" version="1"
+                                    comment="Checks local address is tcp."
+                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="equals">tcp</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
 
-  <linux:inetlisteningservers_state id="state_ipv4_loopback_listening_inet_ports" version="1" comment="Checks local address is not ipv4 loopback." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+  <linux:inetlisteningservers_state id="state_ipv4_loopback_listening_inet_ports" version="1"
+                                    comment="Checks local address is not ipv4 loopback."
+                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="pattern match">^.*$</linux:protocol>
     <linux:local_address operation="equals">127.0.0.1</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_state id="state_ipv6_loopback_listening_inet_ports" version="1" comment="Checks local address is not ipv6 loopback." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+  <linux:inetlisteningservers_state id="state_ipv6_loopback_listening_inet_ports" version="1"
+                                    comment="Checks local address is not ipv6 loopback."
+                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="pattern match">^.*$</linux:protocol>
     <linux:local_address operation="equals">::1</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
-  <local_variable id="var_firewalld_active_zones" version="1" comment="Firewalled ports according to firewalld configuration" datatype="string">
+  <local_variable id="var_firewalld_active_zones" version="1"
+                  comment="Firewalled ports according to firewalld configuration" datatype="string">
     <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
   </local_variable>
 
@@ -109,39 +178,77 @@
 
   <ind:textfilecontent54_object id="object_firewalled_service_tcp_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
-    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename" var_check="at least one"/>
+    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
+                  var_check="at least one"/>
     <ind:pattern operation="pattern match">\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- UDP related entities -->
-  <local_variable id="var_firewalled_udp_ports" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
+  <local_variable id="var_firewalled_udp_ports" version="1"
+                  comment="Firewalled ports according to firewalld configuration" datatype="int">
     <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
   </local_variable>
 
-  <local_variable id="var_firewalled_direct_udp_ports" version="1" comment="Directly firewalled ports according to firewalld configuration" datatype="int">
+  <local_variable id="var_firewalled_direct_udp_ports" version="1"
+                  comment="Directly firewalled ports according to firewalld configuration"
+                  datatype="int">
     <object_component object_ref="object_firewalled_direct_udp_ports" item_field="subexpression"/>
   </local_variable>
 
+  <ind:variable_object id="object_var_firewalled_udp_ports" version="1">
+    <ind:var_ref>var_firewalled_udp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_object id="object_var_firewalled_direct_udp_ports" version="1">
+    <ind:var_ref>var_firewalled_direct_udp_ports</ind:var_ref>
+  </ind:variable_object>
+
+  <ind:variable_test id="test_var_firewalled_direct_udp_ports_exists" check="all"
+                     check_existence="at_least_one_exists" version="1"
+                     comment="Check the existence of direct udp port definitions.">
+    <ind:object object_ref="object_var_firewalled_direct_udp_ports"/>
+  </ind:variable_test>
+
+  <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
+                     check_existence="at_least_one_exists" version="1"
+                     comment="Check the existence of udp port defined through services.">
+    <ind:object object_ref="object_var_firewalled_udp_ports"/>
+  </ind:variable_test>
 
 
-  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_udp_test" version="1"  check="at least one" comment="Check all listening ports are firewalled" state_operator="OR">
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_direct_ports_udp_test" version="1"
+                                   check="at least one"
+                                   comment="Check listening ports directly defined are firewalled"
+                                   state_operator="OR">
     <linux:object object_ref="obj_listening_inet_udp_ports" />
-    <linux:state state_ref="state_firewalled_listening_inet_udp_ports" />
     <linux:state state_ref="state_firewalled_listening_inet_direct_udp_ports" />
   </linux:inetlisteningservers_test>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_udp_ports" version="1" comment="Checks listen ports has rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_udp_ports" var_check="at least one"/>
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_service_ports_udp_test" version="1"
+                                   check="at least one"
+                                   comment="Check listening ports defined by service are firewalled"
+                                   state_operator="OR">
+    <linux:object object_ref="obj_listening_inet_udp_ports" />
+    <linux:state state_ref="state_firewalled_listening_inet_udp_ports" />
+  </linux:inetlisteningservers_test>
+
+  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_udp_ports" version="1"
+                                    comment="Checks listen ports has rule in firewalld">
+    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_udp_ports"
+                      var_check="at least one"/>
     <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
     </linux:inetlisteningservers_state>
 
-  <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_udp_ports" version="1" comment="Checks listen ports has direct port rule in firewalld">
-    <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_udp_ports" var_check="at least one"/>
+    <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_udp_ports" version="1"
+                                      comment="Checks listen ports has direct port rule in firewalld">
+      <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_udp_ports"
+                        var_check="at least one"/>
     <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
     </linux:inetlisteningservers_state>
 
-    <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2" comment="This object represents a listening services on the system.">
+    <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
+                                       comment="This object represents a listening services on the system.">
       <linux:protocol operation="equals">udp</linux:protocol>
       <linux:local_address operation="not equal">^.*$</linux:local_address>
       <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
@@ -151,7 +258,9 @@
       <filter action="include">state_udp_listening_inet_ports</filter>
   </linux:inetlisteningservers_object>
 
-  <linux:inetlisteningservers_state id="state_udp_listening_inet_ports" version="1" comment="Checks local address is udp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+  <linux:inetlisteningservers_state id="state_udp_listening_inet_ports" version="1"
+                                    comment="Checks local address is udp."
+                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="equals">udp</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
@@ -167,7 +276,8 @@
 
   <ind:textfilecontent54_object id="object_firewalled_service_udp_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
-    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename" var_check="at least one"/>
+    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
+                  var_check="at least one"/>
     <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -151,7 +151,6 @@
       <filter action="include">state_udp_listening_inet_ports</filter>
   </linux:inetlisteningservers_object>
 
-
   <linux:inetlisteningservers_state id="state_udp_listening_inet_ports" version="1" comment="Checks local address is udp." xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="equals">udp</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -4,46 +4,44 @@
     <criteria operator="AND">
       <criteria operator="OR">
         <criterion comment="Check if any service is listening on tcp"
-                   test_ref="test_listening_inet_ports_tcp_exist" />
+          test_ref="test_listening_inet_ports_tcp_exist" />
         <criteria operator="AND">
           <criterion comment="Check there are tcp service ports in firewall"
-                     test_ref="test_var_firewalled_tcp_ports_exists" />
+            test_ref="test_var_firewalled_tcp_ports_exists" />
           <criterion comment="Check firewall rules for tcp listening ports"
-                     test_ref="test_listening_fw_inet_ports_tcp_test" />
+            test_ref="test_listening_fw_inet_ports_tcp_test" />
         </criteria>
       </criteria>
       <criteria operator="OR">
         <criterion comment="Check if any service is listening on udp"
-                   test_ref="test_listening_fw_inet_ports_udp_exist" />
+          test_ref="test_listening_fw_inet_ports_udp_exist" />
         <criteria operator="AND">
           <criterion comment="Check there are defined udp ports in firewall"
-                     test_ref="test_var_firewalled_udp_ports_exists" />
+            test_ref="test_var_firewalled_udp_ports_exists" />
           <criterion comment="Check firewall rules for udp listening ports"
-                     test_ref="test_listening_fw_inet_ports_udp_test" />
+            test_ref="test_listening_fw_inet_ports_udp_test" />
         </criteria>
       </criteria>
     </criteria>
   </definition>
 
   <local_variable id="var_firewalled_tcp_ports" version="1"
-                  comment="Firewalled ports according to firewalld configuration" datatype="int">
+    comment="Firewalled ports according to firewalld configuration" datatype="int">
     <object_component object_ref="object_firewalled_service_tcp_port" item_field="subexpression"/>
   </local_variable>
 
   <local_variable id="var_firewalled_direct_tcp_ports" version="1"
-                  comment="Directly firewalled ports according to firewalld configuration"
-                  datatype="int">
+    comment="Directly firewalled ports according to firewalld configuration" datatype="int">
     <object_component object_ref="object_firewalled_direct_tcp_ports" item_field="subexpression"/>
   </local_variable>
 
-
-  <local_variable id="var_firewalled_services" version="1" comment="Firewalld service names"
-                  datatype="string">
+  <local_variable id="var_firewalled_services" version="1"
+    comment="Firewalld service names" datatype="string">
     <object_component object_ref="object_firewalled_service" item_field="subexpression"/>
   </local_variable>
 
   <local_variable id="var_all_firewalled_services_desc_filename" version="1"
-                  comment="Firewalld service file description" datatype="string">
+    comment="Firewalld service file description" datatype="string">
     <concat>
       <variable_component var_ref="var_firewalled_services"/>
       <literal_component>.xml</literal_component>
@@ -54,14 +52,14 @@
     <ind:var_ref>var_obj_listening_inet_tcp_ports</ind:var_ref>
   </ind:variable_object>
 
-  <local_variable id="var_obj_listening_inet_tcp_ports" version="1" datatype="int"
-                  comment="Variable with all firewalled ports">
-      <object_component object_ref="obj_listening_inet_tcp_ports" item_field="local_port"/>
+  <local_variable id="var_obj_listening_inet_tcp_ports" version="1"
+    comment="Variable with all firewalled ports" datatype="int">
+    <object_component object_ref="obj_listening_inet_tcp_ports" item_field="local_port"/>
   </local_variable>
 
-  <local_variable id="var_object_var_firewalled_tcp_ports" version="1" datatype="int"
-                  comment="Variable with all firewalled tcp ports">
-      <object_component object_ref="object_var_firewalled_tcp_ports" item_field="value"/>
+  <local_variable id="var_object_var_firewalled_tcp_ports" version="1"
+    comment="Variable with all firewalled tcp ports" datatype="int">
+    <object_component object_ref="object_var_firewalled_tcp_ports" item_field="value"/>
   </local_variable>
 
   <ind:variable_object id="object_var_firewalled_tcp_ports" version="1">
@@ -80,39 +78,36 @@
   </ind:variable_object>
 
   <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1"
-                                    comment="Checks this is a listening service not connected">
+    comment="Checks this is a listening service not connected">
     <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
   </linux:inetlisteningservers_state>
 
   <ind:variable_test id="test_listening_fw_inet_ports_tcp_test" version="1"
-                                   check="all"
-                                   comment="Check all tcp listening ports defined are firewalled">
+    check="all" comment="Check all tcp listening ports defined are firewalled">
     <ind:object object_ref="object_var_obj_listening_inet_tcp_ports" />
     <ind:state state_ref="state_firewalled_listening_inet_tcp_ports" />
   </ind:variable_test>
 
-
   <ind:variable_test id="test_var_firewalled_tcp_ports_exists" check="all"
-                     check_existence="at_least_one_exists" version="1"
-                     comment="Check the existence of tcp port defined through services.">
+    check_existence="at_least_one_exists" version="1"
+    comment="Check the existence of tcp port defined through services.">
     <ind:object object_ref="object_var_firewalled_tcp_ports"/>
   </ind:variable_test>
 
-
   <ind:variable_state id="state_firewalled_listening_inet_tcp_ports" version="1"
-                      comment="Checks listen ports has port rule in firewalld">
-    <ind:value datatype="int" operation="equals"  var_ref="var_object_var_firewalled_tcp_ports"
-               var_check="at least one"/>
+    comment="Checks listen ports has port rule in firewalld">
+    <ind:value datatype="int" operation="equals" var_check="at least one"
+      var_ref="var_object_var_firewalled_tcp_ports"/>
   </ind:variable_state>
 
   <linux:inetlisteningservers_test id="test_listening_inet_ports_tcp_exist" version="1" check="all"
-                                   check_existence="none_exist"
-                                   comment="Check if any service is listening on tcp ports">
+    check_existence="none_exist"
+    comment="Check if any service is listening on tcp ports">
     <linux:object object_ref="obj_listening_inet_tcp_ports" />
   </linux:inetlisteningservers_test>
 
   <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
-                                     comment="Represents a listening services on the system.">
+    comment="Represents a listening services on the system.">
     <linux:protocol operation="equals">tcp</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
@@ -122,39 +117,37 @@
   </linux:inetlisteningservers_object>
 
   <linux:inetlisteningservers_state id="state_ipv4_loopback_listening_inet_ports" version="1"
-                                    comment="Checks local address is not ipv4 loopback."
-                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    comment="Checks local address is not ipv4 loopback."
+    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="pattern match">^.*$</linux:protocol>
     <linux:local_address operation="equals">127.0.0.1</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
   <linux:inetlisteningservers_state id="state_ipv6_loopback_listening_inet_ports" version="1"
-                                    comment="Checks local address is not ipv6 loopback."
-                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
+    comment="Checks local address is not ipv6 loopback."
+    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:protocol operation="pattern match">^.*$</linux:protocol>
     <linux:local_address operation="equals">::1</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
   </linux:inetlisteningservers_state>
 
   <local_variable id="var_firewalld_active_zones" version="1"
-                  comment="Firewalled ports according to firewalld configuration" datatype="string">
+    comment="Firewalled ports according to firewalld configuration" datatype="string">
     <object_component object_ref="object_active_firewalld_zone_cfgs" item_field="filename"/>
   </local_variable>
 
   <ind:textfilecontent54_object id="object_active_firewalld_zone_cfgs" version="1">
-    <ind:path>/etc/firewalld/zones/
-    </ind:path>
+    <ind:path>/etc/firewalld/zones/</ind:path>
     <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
     <ind:pattern operation="pattern match">^[\s]*&lt;interface\s*name=.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_firewalld_zones_with_interfaces" version="1"
-                               comment="Consider only active zones (i.e. with interfaces assigned)" >
+    comment="Consider only active zones (i.e. with interfaces assigned)" >
     <ind:filename operation="equals" var_ref="var_firewalld_active_zones" var_check="at least one"/>
   </ind:textfilecontent54_state>
-
 
   <ind:textfilecontent54_object id="object_firewalled_service" version="1">
     <ind:path>/etc/firewalld/zones/</ind:path>
@@ -175,14 +168,14 @@
   <ind:textfilecontent54_object id="object_firewalled_service_tcp_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
     <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
-                  var_check="at least one"/>
+      var_check="at least one"/>
     <ind:pattern operation="pattern match">\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s* </ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- UDP related entities -->
   <local_variable id="var_firewalled_udp_ports" version="1"
-                  comment="Firewalled ports according to firewalld configuration" datatype="int">
+    comment="Firewalled ports according to firewalld configuration" datatype="int">
     <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
   </local_variable>
 
@@ -191,18 +184,18 @@
   </ind:variable_object>
 
   <local_variable id="var_obj_listening_inet_udp_ports" version="1" datatype="int"
-                  comment="Variable with all firewalled ports">
-      <object_component object_ref="obj_listening_inet_udp_ports" item_field="local_port"/>
+    comment="Variable with all firewalled ports">
+    <object_component object_ref="obj_listening_inet_udp_ports" item_field="local_port"/>
   </local_variable>
 
   <local_variable id="var_firewalled_direct_udp_ports" version="1"
-                  comment="Directly firewalled ports according to firewalld configuration"
-                  datatype="int">
+    comment="Directly firewalled ports according to firewalld configuration"
+    datatype="int">
     <object_component object_ref="object_firewalled_direct_udp_ports" item_field="subexpression"/>
   </local_variable>
 
   <local_variable id="var_object_var_firewalled_udp_ports" version="1" datatype="int"
-                  comment="Variable with all udp firewalled ports">
+    comment="Variable with all udp firewalled ports">
     <object_component object_ref="object_var_firewalled_udp_ports" item_field="value"/>
   </local_variable>
 
@@ -221,40 +214,37 @@
   </ind:variable_object>
 
     <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
-                     check_existence="at_least_one_exists" version="1"
-                     comment="Check the existence of udp port defined through services.">
+      check_existence="at_least_one_exists" version="1"
+      comment="Check the existence of udp port defined through services.">
     <ind:object object_ref="object_var_firewalled_udp_ports"/>
   </ind:variable_test>
 
-  <ind:variable_test id="test_listening_fw_inet_ports_udp_test" version="1"
-                                   check="at least one"
-                                   comment="Check listening ports defined by service are firewalled"
-                                   state_operator="OR">
+  <ind:variable_test id="test_listening_fw_inet_ports_udp_test" version="1" check="at least one"
+    comment="Check listening ports defined by service are firewalled" state_operator="OR">
     <ind:object object_ref="object_var_obj_listening_inet_udp_ports" />
     <ind:state state_ref="state_firewalled_listening_inet_udp_ports" />
   </ind:variable_test>
 
   <ind:variable_state id="state_firewalled_listening_inet_udp_ports" version="1"
-                      comment="Checks listen ports has rule in firewalld">
-    <ind:value datatype="int" operation="equals"  var_ref="var_object_var_firewalled_udp_ports"
-               var_check="at least one"/>
+    comment="Checks listen ports has rule in firewalld">
+    <ind:value datatype="int" operation="equals" var_ref="var_object_var_firewalled_udp_ports"
+      var_check="at least one"/>
   </ind:variable_state>
 
     <linux:inetlisteningservers_state id="state_firewalled_listening_inet_direct_udp_ports" version="1"
-                                      comment="Checks listen ports has direct port rule in firewalld">
+      comment="Checks listen ports has direct port rule in firewalld">
       <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_udp_ports"
-                        var_check="at least one"/>
+        var_check="at least one"/>
       <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
     </linux:inetlisteningservers_state>
 
     <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_udp_exist" version="1" check="all"
-                                     check_existence="none_exist"
-                                     comment="Check if any service is listening on udp ports">
+      check_existence="none_exist" comment="Check if any service is listening on udp ports">
     <linux:object object_ref="obj_listening_inet_udp_ports" />
   </linux:inetlisteningservers_test>
 
   <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
-                                       comment="This object represents a listening services on the system.">
+    comment="This object represents a listening services on the system.">
     <linux:protocol operation="equals">udp</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
@@ -262,7 +252,6 @@
     <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
     <filter action="exclude">state_inet_foreign_port_connected</filter>
   </linux:inetlisteningservers_object>
-
 
   <ind:textfilecontent54_object id="object_firewalled_direct_udp_ports" version="1">
     <ind:path>/etc/firewalld/zones/</ind:path>
@@ -275,7 +264,7 @@
   <ind:textfilecontent54_object id="object_firewalled_service_udp_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
     <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
-                  var_check="at least one"/>
+      var_check="at least one"/>
     <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -86,12 +86,12 @@
     </concat>
   </local_variable>
 
-  <!-- TCP related entities -->
+{{% set inet_protos = ['tcp', 'udp'] %}}
+{{% for proto in inet_protos %}}
 
-  <!-- Objects and variables describing the listening TCP service on the system -->
-  <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
+<linux:inetlisteningservers_object id="obj_listening_inet_{{{ proto }}}_ports" version="2"
     comment="Represents a listening services on the system.">
-    <linux:protocol operation="equals">tcp</linux:protocol>
+    <linux:protocol operation="equals">{{{ proto }}}</linux:protocol>
     <linux:local_address operation="pattern match">^.*$</linux:local_address>
     <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
     <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
@@ -99,177 +99,85 @@
     <filter action="exclude">state_inet_foreign_port_connected</filter>
   </linux:inetlisteningservers_object>
 
-  <local_variable id="var_obj_listening_inet_tcp_ports" version="1"
+  <local_variable id="var_obj_listening_inet_{{{ proto }}}_ports" version="1"
     comment="Variable with all firewalled ports" datatype="int">
-    <object_component object_ref="obj_listening_inet_tcp_ports" item_field="local_port"/>
+    <object_component object_ref="obj_listening_inet_{{{ proto }}}_ports" item_field="local_port"/>
   </local_variable>
 
-  <ind:variable_object id="object_var_obj_listening_inet_tcp_ports" version="1">
-    <ind:var_ref>var_obj_listening_inet_tcp_ports</ind:var_ref>
+  <ind:variable_object id="object_var_obj_listening_inet_{{{ proto }}}_ports" version="1">
+    <ind:var_ref>var_obj_listening_inet_{{{ proto }}}_ports</ind:var_ref>
   </ind:variable_object>
 
-  <ind:textfilecontent54_object id="object_firewalled_service_tcp_port" version="1">
+  <ind:textfilecontent54_object id="object_firewalled_service_{{{ proto }}}_port" version="1">
     <ind:path>/usr/lib/firewalld/services/</ind:path>
     <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
       var_check="at least one"/>
-    <ind:pattern operation="pattern match">\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s* </ind:pattern>
+    <ind:pattern operation="pattern match">\s*(?:(?:protocol="{{{ proto }}}")|)\s*port="(\d+)"\s*(?:(?:protocol="{{{ proto }}}")|)\s*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_firewalled_service_tcp_ports" version="1"
+  <local_variable id="var_firewalled_service_{{{ proto }}}_ports" version="1"
     comment="Firewalled ports according to firewalld configuration per service" datatype="int">
-    <object_component object_ref="object_firewalled_service_tcp_port" item_field="subexpression"/>
+    <object_component object_ref="object_firewalled_service_{{{ proto }}}_port" item_field="subexpression"/>
   </local_variable>
 
-  <ind:variable_object id="object_var_firewalled_service_tcp_ports" version="1">
-    <ind:var_ref>var_firewalled_service_tcp_ports</ind:var_ref>
+  <ind:variable_object id="object_var_firewalled_service_{{{ proto }}}_ports" version="1">
+    <ind:var_ref>var_firewalled_service_{{{ proto }}}_ports</ind:var_ref>
   </ind:variable_object>
 
   <!-- States objects and variables describing the Firewalled ports stated with port numbers -->
-  <ind:textfilecontent54_object id="object_firewalled_direct_tcp_ports" version="1">
+  <ind:textfilecontent54_object id="object_firewalled_direct_{{{ proto }}}_ports" version="1">
     <ind:path>/etc/firewalld/zones/</ind:path>
     <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="tcp")|)\s*port="(\d+)"\s*(?:(?:protocol="tcp")|)\s*.*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="{{{ proto }}}")|)\s*port="(\d+)"\s*(?:(?:protocol="{{{ proto }}}")|)\s*.*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="include">state_firewalld_zones_with_interfaces</filter>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_firewalled_direct_tcp_ports" version="1"
+  <local_variable id="var_firewalled_direct_{{{ proto }}}_ports" version="1"
     comment="Directly firewalled ports according to firewalld configuration" datatype="int">
-    <object_component object_ref="object_firewalled_direct_tcp_ports" item_field="subexpression"/>
+    <object_component object_ref="object_firewalled_direct_{{{ proto }}}_ports" item_field="subexpression"/>
   </local_variable>
 
-  <ind:variable_object id="object_var_firewalled_direct_tcp_ports" version="1">
-    <ind:var_ref>var_firewalled_direct_tcp_ports</ind:var_ref>
+  <ind:variable_object id="object_var_firewalled_direct_{{{ proto }}}_ports" version="1">
+    <ind:var_ref>var_firewalled_direct_{{{ proto }}}_ports</ind:var_ref>
   </ind:variable_object>
 
   <!-- Object defining firewalled  services and ports -->
-  <ind:variable_object id="object_var_firewalled_tcp_ports" version="1">
+  <ind:variable_object id="object_var_firewalled_{{{ proto }}}_ports" version="1">
     <set>
-      <object_reference>object_var_firewalled_service_tcp_ports</object_reference>
-      <object_reference>object_var_firewalled_direct_tcp_ports</object_reference>
+      <object_reference>object_var_firewalled_service_{{{ proto }}}_ports</object_reference>
+      <object_reference>object_var_firewalled_direct_{{{ proto }}}_ports</object_reference>
     </set>
   </ind:variable_object>
 
-  <local_variable id="var_object_var_firewalled_tcp_ports" version="1"
-    comment="Variable with all firewalled tcp ports" datatype="int">
-    <object_component object_ref="object_var_firewalled_tcp_ports" item_field="value"/>
+  <local_variable id="var_object_var_firewalled_{{{ proto }}}_ports" version="1"
+    comment="Variable with all firewalled {{{ proto }}} ports" datatype="int">
+    <object_component object_ref="object_var_firewalled_{{{ proto }}}_ports" item_field="value"/>
   </local_variable>
 
-  <ind:variable_test id="test_var_firewalled_tcp_ports_exists" check="all"
+  <ind:variable_test id="test_var_firewalled_{{{ proto }}}_ports_exists" check="all"
     check_existence="at_least_one_exists" version="1"
-    comment="Check the existence of tcp port defined through services.">
-    <ind:object object_ref="object_var_firewalled_tcp_ports"/>
+    comment="Check the existence of {{{ proto }}} port defined through services.">
+    <ind:object object_ref="object_var_firewalled_{{{ proto }}}_ports"/>
   </ind:variable_test>
 
-  <linux:inetlisteningservers_test id="test_listening_inet_ports_tcp_exist" version="1" check="all"
+  <linux:inetlisteningservers_test id="test_listening_inet_ports_{{{ proto }}}_exist" version="1" check="all"
     check_existence="none_exist"
-    comment="Check if any service is listening on tcp ports">
-    <linux:object object_ref="obj_listening_inet_tcp_ports" />
+    comment="Check if any service is listening on {{{ proto }}} ports">
+    <linux:object object_ref="obj_listening_inet_{{{ proto }}}_ports" />
   </linux:inetlisteningservers_test>
 
-  <ind:variable_state id="state_firewalled_listening_inet_tcp_ports" version="1"
+  <ind:variable_state id="state_firewalled_listening_inet_{{{ proto }}}_ports" version="1"
     comment="Checks listen ports has port rule in firewalld">
     <ind:value datatype="int" operation="equals" var_check="at least one"
-      var_ref="var_object_var_firewalled_tcp_ports"/>
+      var_ref="var_object_var_firewalled_{{{ proto }}}_ports"/>
   </ind:variable_state>
 
-  <ind:variable_test id="test_listening_fw_inet_ports_tcp_test" version="1"
-    check="all" comment="Check all tcp listening ports defined are firewalled">
-    <ind:object object_ref="object_var_obj_listening_inet_tcp_ports" />
-    <ind:state state_ref="state_firewalled_listening_inet_tcp_ports" />
+  <ind:variable_test id="test_listening_fw_inet_ports_{{{ proto }}}_test" version="1"
+    check="all" comment="Check all {{{ proto }}} listening ports defined are firewalled">
+    <ind:object object_ref="object_var_obj_listening_inet_{{{ proto }}}_ports" />
+    <ind:state state_ref="state_firewalled_listening_inet_{{{ proto }}}_ports" />
   </ind:variable_test>
-
-  <!-- UDP related entities -->
-
-  <!-- Objects and variables describing the listening TCP service on the system -->
-  <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
-    comment="This object represents a listening services on the system.">
-    <linux:protocol operation="equals">udp</linux:protocol>
-    <linux:local_address operation="pattern match">^.*$</linux:local_address>
-    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-    <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
-    <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
-    <filter action="exclude">state_inet_foreign_port_connected</filter>
-  </linux:inetlisteningservers_object>
-
-  <local_variable id="var_obj_listening_inet_udp_ports" version="1" datatype="int"
-    comment="Variable with all firewalled ports">
-    <object_component object_ref="obj_listening_inet_udp_ports" item_field="local_port"/>
-  </local_variable>
-
-  <ind:variable_object id="object_var_obj_listening_inet_udp_ports" version="1">
-    <ind:var_ref>var_obj_listening_inet_udp_ports</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:textfilecontent54_object id="object_firewalled_service_udp_port" version="1">
-    <ind:path>/usr/lib/firewalld/services/</ind:path>
-    <ind:filename operation="pattern match" var_ref="var_all_firewalled_services_desc_filename"
-      var_check="at least one"/>
-    <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <local_variable id="var_firewalled_service_udp_ports" version="1"
-    comment="Firewalled ports according to firewalld configuration" datatype="int">
-    <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
-  </local_variable>
-
-  <ind:variable_object id="object_var_firewalled_service_udp_ports" version="1">
-    <ind:var_ref>var_firewalled_service_udp_ports</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:textfilecontent54_object id="object_firewalled_direct_udp_ports" version="1">
-    <ind:path>/etc/firewalld/zones/</ind:path>
-    <ind:filename operation="pattern match">^.+\.xml$</ind:filename>
-    <ind:pattern operation="pattern match">^[\s]*&lt;port\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*.*$</ind:pattern>
-    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="include">state_firewalld_zones_with_interfaces</filter>
-  </ind:textfilecontent54_object>
-
-  <local_variable id="var_firewalled_direct_udp_ports" version="1"
-    comment="Directly firewalled ports according to firewalld configuration"
-    datatype="int">
-    <object_component object_ref="object_firewalled_direct_udp_ports" item_field="subexpression"/>
-  </local_variable>
-
-  <local_variable id="var_object_var_firewalled_udp_ports" version="1" datatype="int"
-    comment="Variable with all udp firewalled ports">
-    <object_component object_ref="object_var_firewalled_udp_ports" item_field="value"/>
-  </local_variable>
-
-  <ind:variable_object id="object_var_firewalled_direct_udp_ports" version="1">
-    <ind:var_ref>var_firewalled_direct_udp_ports</ind:var_ref>
-  </ind:variable_object>
-
-  <ind:variable_object id="object_var_firewalled_udp_ports" version="1">
-    <set>
-      <object_reference>object_var_firewalled_service_udp_ports</object_reference>
-      <object_reference>object_var_firewalled_direct_udp_ports</object_reference>
-    </set>
-  </ind:variable_object>
-
-  <ind:variable_test id="test_var_firewalled_udp_ports_exists" check="all"
-      check_existence="at_least_one_exists" version="1"
-      comment="Check the existence of udp port defined through services.">
-    <ind:object object_ref="object_var_firewalled_udp_ports"/>
-  </ind:variable_test>
-
-  <linux:inetlisteningservers_test id="test_listening_inet_ports_udp_exist" version="1" check="all"
-      check_existence="none_exist" comment="Check if any service is listening on udp ports">
-    <linux:object object_ref="obj_listening_inet_udp_ports" />
-  </linux:inetlisteningservers_test>
-
-  <ind:variable_state id="state_firewalled_listening_inet_udp_ports" version="1"
-    comment="Checks listen ports has rule in firewalld">
-    <ind:value datatype="int" operation="equals" var_ref="var_object_var_firewalled_udp_ports"
-      var_check="at least one"/>
-  </ind:variable_state>
-
-  <ind:variable_test id="test_listening_fw_inet_ports_udp_test" version="1" check="at least one"
-    comment="Check listening ports defined by service are firewalled" state_operator="OR">
-    <ind:object object_ref="object_var_obj_listening_inet_udp_ports" />
-    <ind:state state_ref="state_firewalled_listening_inet_udp_ports" />
-  </ind:variable_test>
-
+{{% endfor %}}
 </def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -67,7 +67,7 @@
   </ind:variable_object>
 
   <linux:inetlisteningservers_state id="state_inet_foreign_port_connected" version="1"
-                                    comment="Checks local address is udp."
+                                    comment="Checks this is a listening service not connected"
                                     xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
   </linux:inetlisteningservers_state>
@@ -119,22 +119,12 @@
   <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
                                      comment="Represents a listening services on the system.">
       <linux:protocol operation="equals">tcp</linux:protocol>
-      <linux:local_address operation="not equal">^.*$</linux:local_address>
+      <linux:local_address operation="pattern match">^.*$</linux:local_address>
       <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
       <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
       <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
       <filter action="exclude">state_inet_foreign_port_connected</filter>
-      <filter action="include">state_tcp_listening_inet_ports</filter>
   </linux:inetlisteningservers_object>
-
-  <linux:inetlisteningservers_state id="state_tcp_listening_inet_ports" version="1"
-                                    comment="Checks local address is tcp."
-                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-    <linux:protocol operation="equals">tcp</linux:protocol>
-    <linux:local_address operation="pattern match">^.*$</linux:local_address>
-    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-  </linux:inetlisteningservers_state>
-
 
   <linux:inetlisteningservers_state id="state_ipv4_loopback_listening_inet_ports" version="1"
                                     comment="Checks local address is not ipv4 loopback."
@@ -266,21 +256,13 @@
   <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
                                        comment="This object represents a listening services on the system.">
       <linux:protocol operation="equals">udp</linux:protocol>
-      <linux:local_address operation="not equal">^.*$</linux:local_address>
+      <linux:local_address operation="pattern match">^.*$</linux:local_address>
       <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
       <filter action="exclude">state_ipv4_loopback_listening_inet_ports</filter>
       <filter action="exclude">state_ipv6_loopback_listening_inet_ports</filter>
       <filter action="exclude">state_inet_foreign_port_connected</filter>
-      <filter action="include">state_udp_listening_inet_ports</filter>
   </linux:inetlisteningservers_object>
 
-  <linux:inetlisteningservers_state id="state_udp_listening_inet_ports" version="1"
-                                    comment="Checks local address is udp."
-                                    xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
-    <linux:protocol operation="equals">udp</linux:protocol>
-    <linux:local_address operation="pattern match">^.*$</linux:local_address>
-    <linux:local_port datatype="int" operation="greater than or equal">0</linux:local_port>
-  </linux:inetlisteningservers_state>
 
   <ind:textfilecontent54_object id="object_firewalled_direct_udp_ports" version="1">
     <ind:path>/etc/firewalld/zones/</ind:path>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -1,5 +1,5 @@
 <def-group>
-  <definition class="compliance" id="ensure_firewall_rules_for_open_ports" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Make sure firewall rules exist for all open network ports, listening on non-loopback interfaces.") }}}
     <criteria operator="AND">
       <criteria operator="OR">

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -3,6 +3,8 @@
     {{{ oval_metadata("Make sure firewall rules exist for all open network ports, listening on non-loopback interfaces.") }}}
     <criteria operator="AND">
       <criteria operator="OR">
+        <criterion comment="Check if any service is listening on tcp"
+                   test_ref="test_listening_fw_inet_ports_tcp_exist" />
         <criteria operator="AND">
           <criterion comment="Check there are defined tcp service ports in firewall"
                      test_ref="test_var_firewalled_tcp_ports_exists" />
@@ -17,6 +19,8 @@
         </criteria>
       </criteria>
       <criteria operator="OR">
+        <criterion comment="Check if any service is listening on udp"
+                   test_ref="test_listening_fw_inet_ports_udp_exist" />
         <criteria operator="AND">
           <criterion comment="Check there are defined udp service ports in firewall"
                      test_ref="test_var_firewalled_udp_ports_exists" />
@@ -67,7 +71,7 @@
                                     xmlns="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux">
     <linux:foreign_port datatype="int" operation="not equal">0</linux:foreign_port>
   </linux:inetlisteningservers_state>
-  
+
   <linux:inetlisteningservers_test id="test_listening_fw_inet_service_ports_tcp_test" version="1"
                                    check="at least one"
                                    comment="Check all listening ports defined directly are firewalled">
@@ -105,6 +109,12 @@
     <linux:local_port datatype="int" operation="equals"  var_ref="var_firewalled_direct_tcp_ports"
                       var_check="at least one"/>
   </linux:inetlisteningservers_state>
+
+  <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_tcp_exist" version="1" check="all"
+                                   check_existence="none_exist"
+                                   comment="Check if any service is listening on tcp ports">
+    <linux:object object_ref="obj_listening_inet_tcp_ports" />
+  </linux:inetlisteningservers_test>
 
   <linux:inetlisteningservers_object id="obj_listening_inet_tcp_ports" version="2"
                                      comment="Represents a listening services on the system.">
@@ -247,7 +257,13 @@
     <linux:foreign_port datatype="int" operation="equals">0</linux:foreign_port>
     </linux:inetlisteningservers_state>
 
-    <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
+    <linux:inetlisteningservers_test id="test_listening_fw_inet_ports_udp_exist" version="1" check="all"
+                                     check_existence="none_exist"
+                                     comment="Check if any service is listening on udp ports">
+    <linux:object object_ref="obj_listening_inet_udp_ports" />
+  </linux:inetlisteningservers_test>
+
+  <linux:inetlisteningservers_object id="obj_listening_inet_udp_ports" version="2"
                                        comment="This object represents a listening services on the system.">
       <linux:protocol operation="equals">udp</linux:protocol>
       <linux:local_address operation="not equal">^.*$</linux:local_address>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -171,5 +171,4 @@
     <ind:pattern operation="pattern match">\s*(?:(?:protocol="udp")|)\s*port="(\d+)"\s*(?:(?:protocol="udp")|)\s*</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-
 </def-group>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/oval/shared.xml
@@ -115,7 +115,6 @@
   </ind:textfilecontent54_object>
 
   <!-- UDP related entities -->
-
   <local_variable id="var_firewalled_udp_ports" version="1" comment="Firewalled ports according to firewalld configuration" datatype="int">
     <object_component object_ref="object_firewalled_service_udp_port" item_field="subexpression"/>
   </local_variable>

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/common.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/common.sh
@@ -1,0 +1,33 @@
+
+listening_ports() {
+    protocol=$1
+
+    # list all listending ports
+    listening_ports=()
+    IFS=' ' read -r -a listening_v4_ports <<< "$(ss -H4${protocol}ln |grep -vP '127.0.0.1' |grep -oP '[\.\d]+\:\d+'|awk -F ":" '{print $NF}')"
+    IFS=' ' read -r -a listening_v6_ports <<<"$(ss -H6${protocol}ln |grep -vP '::1' |grep -oP '\[[\:\d]+\]+\:\d+'|awk -F ":" '{print $NF}')"
+    listening_ports=(${listening_v6_ports[@]}  ${listening_v4_ports[@]})
+    # only unique ports
+    listening_ports=($(for port in "${listening_ports[@]}"; do echo $port; done|sort -u))
+    echo "${listening_ports[@]}"
+}
+
+get_default_firewalld_zone_cfg() {
+    zone_name=$(grep -rIn DefaultZone /etc/firewalld/firewalld.conf|awk -F '=' '{print $2}')
+    echo "/etc/firewalld/zones/${zone_name}.xml"
+}
+
+zone_cfg_begin() {
+    echo "<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<zone>
+  <short>Public</short>
+  <description>For use in public areas. You do not trust the other computers on networks to not harm your computer. Only selected incoming connections are accepted.</description>
+"
+}
+
+zone_cfg_end() {
+    echo "
+  <interface name=\"eth0\"/>
+  <interface name=\"eth1\"/>
+</zone>"
+}

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/common.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/common.sh
@@ -1,4 +1,3 @@
-
 listening_ports() {
     protocol=$1
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct-portnum.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct-portnum.pass.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# packages = firewalld
+
+source common.sh
+
+# check if ssh started
+is_sshd_active=$(systemctl status sshd|grep Active|awk '{print $2}')
+if [ "${is_sshd_active}" != "active" ]; then
+    # start ssh if not - to have for sure at least one network service running
+    systemctl start sshd
+fi
+
+listening_tcp_ports=($(listening_ports "t"))
+listening_udp_ports=($(listening_ports "u"))
+# add all listening ports to firewalld
+zone_cfg_template=$(zone_cfg_begin)
+for port in "${listening_tcp_ports[@]}"; do
+    zone_cfg_template+="
+    <port port=\"${port}\" protocol=\"tcp\"/>"
+done
+
+for port in "${listening_udp_ports[@]}"; do
+    zone_cfg_template+="
+    <port port=\"${port}\" protocol=\"udp\"/>" 
+done
+zone_cfg_template+=$(zone_cfg_end)
+echo "${zone_cfg_template}" > $(get_default_firewalld_zone_cfg)

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct.pass.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# packages = firewalld
+source common.sh
+
+# check if ssh started
+is_sshd_active=$(systemctl status sshd|grep Active|awk '{print $2}')
+if [ "${is_sshd_active}" != "active" ]; then
+# start ssh if not - to have for sure at least one network service running
+    systemctl start sshd
+fi
+
+listening_tcp_ports=($(listening_ports "t"))
+listening_udp_ports=($(listening_ports "u"))
+# add all listening ports to firewalld
+zone_cfg_template=$(zone_cfg_begin)
+for port in "${listening_tcp_ports[@]}"; do
+    if [ "${port}" == "22" ];then
+        zone_cfg_template+="
+        <service name=\"ssh\"/>"
+    else
+        zone_cfg_template+="
+        <port port=\"${port}\" protocol=\"tcp\"/>"
+    fi
+done
+
+for port in "${listening_udp_ports[@]}"; do
+    zone_cfg_template+="
+    <port port=\"${port}\" protocol=\"udp\"/>" 
+done
+zone_cfg_template+=$(zone_cfg_end)
+echo "${zone_cfg_template}" > $(get_default_firewalld_zone_cfg)

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct.pass.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = firewalld
+
 source common.sh
 
 # check if ssh started

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct.pass.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/correct.pass.sh
@@ -6,7 +6,7 @@ source common.sh
 # check if ssh started
 is_sshd_active=$(systemctl status sshd|grep Active|awk '{print $2}')
 if [ "${is_sshd_active}" != "active" ]; then
-# start ssh if not - to have for sure at least one network service running
+    # start ssh if not - to have for sure at least one network service running
     systemctl start sshd
 fi
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/wrong.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/wrong.fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# packages = firewalld
+source common.sh
+
+# check if ssh started
+is_sshd_active=$(systemctl status sshd|grep Active|awk '{print $2}')
+if [ "${is_sshd_active}" != "active" ]; then
+# start ssh if not - to have for sure at least one network service running
+    systemctl start sshd
+fi
+
+# add no listening ports to firewalld
+zone_cfg_template=$(zone_cfg_begin)
+zone_cfg_template+=$(zone_cfg_end)
+echo "${zone_cfg_template}" > $(get_default_firewalld_zone_cfg)

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/wrong.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/wrong.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = firewalld
+# remediation = none
 
 source common.sh
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/wrong.fail.sh
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/ensure_firewall_rules_for_open_ports/tests/wrong.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # packages = firewalld
+
 source common.sh
 
 # check if ssh started


### PR DESCRIPTION
#### Description:

- Add two simple tests for the new rule and thanks to that improve the rule

#### Rationale:

- add simple pass and fail test cases for filtering ssh service and a port number, and also no filtering at all
 - split the logic for UDP and TCP services for more accurate comparison between firewall-ed and listening ports
 - add filter to ignore listen object with foreign port different than zero
 - include support for direct port filtering firewalld definitions, not only for service-based
 - make sure to inspect zone files for only active zones, i.e. such with set interfaces
