### PR TITLE
Improve conditions criteria in Ansible task

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -1333,7 +1333,6 @@ Part of the grub2_bootloader_argument_absent template.
   when:
     - result_authselect_check_cmd is success
     - result_authselect_profile is not skipped
-    - result_pam_authselect_restore_features is not skipped
 {{%- endmacro %}}
 
 


### PR DESCRIPTION
#### Description:

The Ansible task to apply changes related to the custom profile creation were based on three criteria.

One criterion was if the task related to the `authselect` features restore was not skipped.
The respective task to restore `authselect` features should be usually executed in most cases because its conditions are expected to be valid.
However, the task goes through a loop based on the result of another task.
So, the list is expected be defined at this point but in some cases it can be empty.
In cases when the list is empty, it was noticed the task is skipped, even if their conditions are valid.
This behavior affects the following tasks in the Playbook by making them to also be skipped and resulting in changes not applied.

#### Rationale:

It is a tricky case because the result can change depending on the combination and even ordering of rules in a profile Playbook. We don't want this to happen. Instead, the Playbook results should be consistent regardless of its tasks.

It should fix the issue in the `testing-farm:centos-stream` CI tests related to the `accounts_password_pam_unix_remember` rule.

#### Review Hints:

Although this issue was very tricky to be identified, the solution is pretty simple.
It was basically removed one condition which doesn't affect the outcome of the Playbook in other cases which are not the one describe in the description.
In short, the task update is ensuring the desired changes are applied, like in the Bash remediation.