### PR TITLE
Fix Variable in CTest for srg-export-rhel9

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,7 +160,7 @@ if (PY_MYPY)
      )
 endif()
 
-if (PYTHON_VERSION_MAJOR GREATER 2 AND PY_OPENPYXL AND PY_PANDAS AND SRG_PRODUCT_RHEL9)
+if (PYTHON_VERSION_MAJOR GREATER 2 AND PY_OPENPYXL AND PY_PANDAS AND SSG_PRODUCT_RHEL9)
     add_test(
         NAME "srg-export-rhel9"
         COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/create_srg_export.py" --root "${CMAKE_SOURCE_DIR}" --json "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" --control "${CMAKE_SOURCE_DIR}/controls/srg_gpos.yml" --product rhel9 --out-format xlsx --output "${CMAKE_BINARY_DIR}/cac_stig_output.xlsx" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml"


### PR DESCRIPTION
#### Description:

`SRG_PRODUCT_RHEL9` to `SSG_PRODUCT_RHEL9`

#### Rationale:

Fix the issue found [here](https://github.com/ComplianceAsCode/content/pull/9962#discussion_r1047095626).

