### PR TITLE
Update sshd_lineinfile template

### DIFF
--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -194,6 +194,21 @@ value: :code:`Setting={{ varname1 }}`
 {{% set config_dir = "/etc/ssh/sshd_config.d" %}}
 {{{ ansible_set_config_file_dir(msg, config_file="/etc/ssh/sshd_config", config_dir=config_dir, set_file=config_dir~"/"~config_basename, parameter=parameter, separator_regex="\s+", value=value, prefix_regex="(?i)^\s*", create='yes', validate='/usr/sbin/sshd -t -f %s', insert_after='', insert_before="^[#\s]*Match") }}}
 {{%- else %}}
+{{% if product in ["ol8", "ol9"] %}}
+- name: "Find sshd_config included files"
+  shell: |-
+    included_files=$(grep -oP "^\s*(?i)include.*" /etc/ssh/sshd_config | sed -e 's/Include\s*//')
+    [[ -n $included_files ]] && ls $included_files || true
+  register: sshd_config_included_files
+
+- name: "Comment conf from included files"
+  replace:
+    path: '{{ item }}'
+    regexp: '^(\s*{{{ parameter }}}.*)$'
+    replace: '# \1'
+  loop: "{{ sshd_config_included_files.stdout_lines }}"
+
+{{% endif %}}
 {{{ ansible_set_config_file(msg, "/etc/ssh/sshd_config", parameter, value=value, create="yes", prefix_regex='(?i)^\s*', validate="/usr/sbin/sshd -t -f %s", insert_before="^[#\s]*Match") }}}
 {{%- endif %}}
 {{%- endmacro %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -363,6 +363,12 @@ touch {{{ sshd_config_dir }}}/{{{ hardening_config_basename }}}
         prefix_regex=prefix_regex)
     }}}
 {{%- else %}}
+{{% if product in ["ol8", "ol9"] %}}
+included_files=$(grep -oP "^\s*(?i)include.*" /etc/ssh/sshd_config | sed -e 's/Include\s*//')
+for included_file in ${included_files} ; do
+    {{{ lineinfile_absent("$included_file", "^\s*" ~ parameter, insensitive=true) | indent(4) }}}
+done
+{{% endif %}}
 {{{ bash_sshd_config_set(parameter=parameter, value=value) }}}
 {{%- endif %}}
 {{%- endmacro %}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -107,18 +107,23 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type missing_parameter_pass: bool
 :param id_stem: The first suffix of tests, objects etc. that ensures uniqueness of the particular OVAL entity ID. Defaults to the rule ID.
 :type id_stem: str
+:param avoid_conflicting: If true, the check will only pass in case all (if any) configurations found are compliant
+:type avoid_conflicting: bool
 
 #}}
-{{%- macro oval_line_in_file_criterion(path='', parameter='', missing_parameter_pass=false, comment='', id_stem='') -%}}
+{{%- macro oval_line_in_file_criterion(path='', parameter='', missing_parameter_pass=false, comment='', id_stem='', avoid_conflicting=false) -%}}
 {{%- set id_stem = id_stem or rule_id -%}}
 {{%- set suffix_id = "" -%}}
 {{%- set prefix_text = "Check the" -%}}
+{{%- set suffix_text = "" -%}}
 {{%- if missing_parameter_pass %}}
 {{%- set suffix_id = suffix_id_default_not_overriden -%}}
 {{%- set prefix_text = prefix_text + " absence of" -%}}
+{{%- elif avoid_conflicting -%}}
+{{%- set suffix_text = "if any" -%}}
 {{%- endif %}}
 {{%- if not comment -%}}
-{{%- set comment = prefix_text ~ " " ~ parameter ~ " in " ~ path -%}}
+{{%- set comment = prefix_text ~ " " ~ parameter ~ " in " ~ path ~ suffix_text -%}}
 {{%- endif -%}}
 <criterion comment="{{{ comment }}}"
   test_ref="test_{{{ id_stem }}}{{{ suffix_id }}}" />
@@ -137,13 +142,18 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 :type id_stem: str
 
 #}}
-{{%- macro oval_line_in_file_test(path='', parameter='', missing_parameter_pass=false, id_stem='') -%}}
+{{%- macro oval_line_in_file_test(path='', parameter='', missing_parameter_pass=false, id_stem='', avoid_conflicting=false) -%}}
 {{%- set id_stem = id_stem or rule_id -%}}
 {{%- set suffix_id = "" -%}}
+{{%- set suffix_text = "" -%}}
 {{%- if missing_parameter_pass %}}
 {{%- set check_existence = "none_exist" -%}}
 {{%- set prefix_text = "absence" -%}}
 {{%- set suffix_id = suffix_id_default_not_overriden -%}}
+{{%- elif  avoid_conflicting -%}}
+{{%- set check_existence = "any_exist" -%}}
+{{%- set prefix_text = "value" -%}}
+{{%- set suffix_text = "if any" -%}}
 {{%- else %}}
 {{%- set check_existence = "all_exist" -%}}
 {{%- set prefix_text = "value" -%}}
@@ -258,12 +268,12 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 </ind:textfilecontent54_state>
 {{%- endmacro %}}
 
-{{%- macro oval_line_in_directory_criterion(path='', parameter='', missing_parameter_pass=false) -%}}
-{{{- oval_line_in_file_criterion(path, parameter, missing_parameter_pass, id_stem=rule_id ~ "_config_dir") -}}}
+{{%- macro oval_line_in_directory_criterion(path='', parameter='', missing_parameter_pass=false, avoid_conflicting=false) -%}}
+{{{- oval_line_in_file_criterion(path, parameter, missing_parameter_pass, id_stem=rule_id ~ "_config_dir", avoid_conflicting=avoid_conflicting) -}}}
 {{%- endmacro %}}
 
-{{%- macro oval_line_in_directory_test(path='', parameter='', missing_parameter_pass=false) -%}}
-{{{ oval_line_in_file_test(path, parameter, missing_parameter_pass, id_stem=rule_id ~ "_config_dir") }}}
+{{%- macro oval_line_in_directory_test(path='', parameter='', missing_parameter_pass=false, avoid_conflicting=false) -%}}
+{{{ oval_line_in_file_test(path, parameter, missing_parameter_pass, id_stem=rule_id ~ "_config_dir", avoid_conflicting=avoid_conflicting) }}}
 {{%- endmacro %}}
 
 {{%- macro oval_line_in_directory_object(path='', section='', prefix_regex='^[ \\t]*', parameter='', separator_regex='[ \\t]+', missing_parameter_pass=false, multi_value=false) -%}}
@@ -879,42 +889,76 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
           definition_ref="sshd_required_or_unset" />
         <extend_definition comment="rpm package openssh-server installed"
           definition_ref="package_openssh-server_installed" />
-        <criteria comment="sshd is configured correctly" operator="OR">
-          {{{- oval_line_in_file_criterion(sshd_config_path, parameter) | indent(8) }}}
-          {{%- if missing_parameter_pass %}}
-          <criteria comment="sshd is not configured incorrectly" operator="AND">
-          {{{- oval_line_in_file_criterion(sshd_config_path, parameter, missing_parameter_pass) | indent(10)}}}
-          {{%- if config_is_distributed == "true" %}}
-          {{{- oval_line_in_directory_criterion(sshd_config_dir, parameter, missing_parameter_pass) | indent(10) }}}
-          {{%- endif %}}
+        <criteria comment="sshd is configured correctly" operator="AND">
+          <criteria comment="the configuration is correct if it exists" operator="AND">
+            {{{- oval_line_in_file_criterion(sshd_config_path, parameter, avoid_conflicting=true) | indent(10)}}}
+            {{%- if config_is_distributed == "true" %}}
+            {{{- oval_line_in_directory_criterion(sshd_config_dir, parameter, avoid_conflicting=true) | indent(10) }}}
+            {{%- endif %}}
+            {{% if product in ["ol8", "ol9"] %}}
+            {{{- oval_line_in_file_criterion("sshd_config included", parameter, id_stem=rule_id ~ "_sshd_included_files", avoid_conflicting=true) | indent(10)}}}
+            {{% endif %}}
           </criteria>
-          {{%- endif %}}
-          {{%- if config_is_distributed == "true" %}}
-          {{{- oval_line_in_directory_criterion(sshd_config_dir, parameter) | indent(8) }}}
-          {{%- endif %}}
+          {{%- if not missing_parameter_pass %}}
+          <criterion comment="the configuraton exists" test_ref="test_{{{ parameter }}}_present_{{{ rule_id }}}" />
+          {{% endif %}}
         </criteria>
       </criteria>
     </criteria>
   </definition>
-  {{{ oval_line_in_file_test(sshd_config_path, parameter) | indent (2) }}}
+
+  {{% if product in ["ol8", "ol9"] %}}
+  {{{ oval_line_in_file_object(sshd_config_path, parameter="include", id_stem="sshd_include_value_" ~ rule_id, ** case_insensitivity_kwargs)| indent (2) }}}
+  <local_variable id="var_sshd_config_included_files_{{{ rule_id }}}" datatype="string" version="1"
+  comment="Include value converted to regex">
+    <unique>
+      <glob_to_regex>
+        <object_component item_field="subexpression" object_ref="obj_sshd_include_value_{{{ rule_id }}}" />
+      </glob_to_regex>
+    </unique>
+  </local_variable>
+
+  {{{ oval_line_in_file_test("sshd_config included", parameter, id_stem=rule_id ~ "_sshd_included_files", avoid_conflicting=true ) | indent (2) }}}
+
+  <ind:textfilecontent54_object id="obj_{{{ rule_id }}}_sshd_included_files" version="1">
+    <ind:filepath operation="pattern match" var_ref="var_sshd_config_included_files_{{{ rule_id }}}" />
+    <ind:pattern operation="pattern match">^[ \t]*(?i){{{ parameter }}}(?-i)[ \t]+(.+?)[ \t]*(?:$|#)</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  {{{ oval_line_in_file_state(value, id_stem=rule_id ~ "_sshd_included_files") | indent (2) }}}
+
+  {{% endif %}}
+
+  {{{ oval_line_in_file_test(sshd_config_path, parameter, avoid_conflicting=true ) | indent (2) }}}
   {{{ oval_line_in_file_object(sshd_config_path, parameter=parameter, ** case_insensitivity_kwargs)| indent (2) }}}
   {{{ oval_line_in_file_state(value) | indent (2) }}}
 
-  {{%- if missing_parameter_pass %}}
-  {{{ oval_line_in_file_test(sshd_config_path, parameter, missing_parameter_pass) | indent(2) }}}
-  {{{ oval_line_in_file_object(sshd_config_path, parameter=parameter, missing_parameter_pass=missing_parameter_pass, ** case_insensitivity_kwargs) | indent(2) }}}
-  {{%- endif %}}
-
   {{%- if config_is_distributed == "true" %}}
-  {{{ oval_line_in_directory_test(sshd_config_dir, parameter) | indent (2) }}}
+  {{{ oval_line_in_directory_test(sshd_config_dir, parameter, avoid_conflicting=true) | indent (2) }}}
   {{{ oval_line_in_directory_object(sshd_config_dir, parameter=parameter, ** case_insensitivity_kwargs) | indent (2) }}}
   {{{ oval_line_in_directory_state(value) | indent (2) }}}
+  {{%- endif %}}
 
-  {{%- if missing_parameter_pass %}}
-  {{{ oval_line_in_directory_test(sshd_config_dir, parameter, missing_parameter_pass) | indent(2) }}}
-  {{{ oval_line_in_directory_object(sshd_config_dir, parameter=parameter, missing_parameter_pass=missing_parameter_pass, ** case_insensitivity_kwargs) | indent(2) }}}
-  {{%- endif %}}
-  {{%- endif %}}
+  {{% if not missing_parameter_pass %}}
+  <ind:textfilecontent54_object comment="All confs collection" id="obj_collection_obj_{{{ rule_id }}}" version="1">
+    <set>
+      <object_reference>obj_{{{ rule_id }}}</object_reference>
+      {{%- if config_is_distributed == "true" %}}
+      <object_reference>obj_{{{ rule_id }}}_config_dir</object_reference>
+      {{% elif product in ["ol8", "ol9"] %}}
+      <object_reference>obj_{{{ rule_id }}}_sshd_included_files</object_reference>
+      {{%- endif %}}
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_{{{ parameter }}}_present_{{{ rule_id }}}" version="1"
+                              check="all" check_existence="at_least_one_exists"
+                              comment="Verify that the value of {{{ parameter }}} is present">
+    <ind:object object_ref="obj_collection_obj_{{{ rule_id }}}" />
+  </ind:textfilecontent54_test>
+
+  {{% endif %}}
 </def-group>
 {{%- endmacro %}}
 

--- a/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 9
 
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
+
+{{% if product in ["ol8", "ol9"] %}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{% endif %}}
 
 {{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=true) -}}}

--- a/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 9
 
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
+
+{{% if product in ["ol8", "ol9"] %}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{% endif %}}
 
 if grep -q "^\s*{{{ PARAMETER }}}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
     sed -i "/^\s*{{{ PARAMETER }}}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_file_with_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_file_with_directory.fail.sh
@@ -16,5 +16,5 @@ if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; t
 	sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
 fi
 
-echo "${SSHD_PARAM} ${SSHD_VAL}" > /etc/ssh/sshd_config.d/good_config.conf
+echo "${SSHD_PARAM} ${SSHD_VAL}" >> /etc/ssh/sshd_config
 echo "${SSHD_PARAM} bad_val" > /etc/ssh/sshd_config.d/bad_config.conf

--- a/shared/templates/sshd_lineinfile/tests/wrong_value_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/wrong_value_directory.fail.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
 
-# platform = multi_platform_fedora,Red Hat Enterprise Linux 9
+# platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 9
 
 SSHD_PARAM={{{ PARAMETER }}}
 SSHD_VAL="bad_val"
 
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
+
+{{% if product in ["ol8", "ol9"] %}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{% endif %}}
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
 	sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*


### PR DESCRIPTION
#### Description:

- Add the ability to look into the included files from sshd_config files

#### Rationale:

- This ensures no conflicting configurations are allowed, previously if there was a correct configuration in main sshd_config file, but a wrong one in other valid file it would pass, also in the opposite situation.
- And adds the possibility to use the keyword Include, as done by default in OL9 and available in OL8

#### Review Hints:

- Review that the parameter `avoid_conflicting` makes sense and can't interact with `missing_parameter_pass`
- Automatus tests were updated/added to validate this new behavior