### PR TITLE
Drop CIS reference in no_legacy_plus_entries_etc_group rule for SLE15

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_legacy_plus_entries_etc_group/rule.yml
@@ -22,7 +22,6 @@ identifiers:
 
 references:
     cis@rhel7: 6.2.4
-    cis@sle15: 6.2.5
 
 ocil_clause: 'the file contains legacy lines'
 


### PR DESCRIPTION


#### Description:

The reference to the CIS SLE benchmark is not correct.

#### Rationale:

As far as I could track in history those references were added in PR #5807, where the author stated that he has no access to enterprise linux benchmarks and used the distribution independant benchmark, in which context the references are more or less valid. BTW the rhel7 reference also looks incorrect to me, but if did not want to change it without feedback from RedHat's team member.

#### Review Hints:

- Please someone(@marcusburghardt , @ggbecker , @yuumasato  from RH team can you double check if cis@rhel7 reference and I guess the CCEs should also be dropped as irrelevant?