### PR TITLE
Update rules to limit password reuse

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -372,8 +372,10 @@ controls:
     - accounts_passwords_pam_faillock_unlock_time
 
     # Do not reuse last two passwords
-    - var_password_pam_unix_remember=2
-    - accounts_password_pam_unix_remember
+    - var_password_pam_remember=2
+    - var_password_pam_remember_control_flag=requisite
+    - accounts_password_pam_pwhistory_remember_password_auth
+    - accounts_password_pam_pwhistory_remember_system_auth
 
   - id: R19
     levels:

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -42,6 +42,7 @@ identifiers:
     cce@rhel9: CCE-86354-8
 
 references:
+    anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
     cis@alinux2: 5.3.3
     cis@alinux3: 5.5.3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/rule.yml
@@ -42,6 +42,7 @@ identifiers:
     cce@rhel9: CCE-89176-2
 
 references:
+    anssi: BP28(R18)
     cis-csc: 1,12,15,16,5
     cis@alinux2: 5.3.3
     cis@alinux3: 5.5.3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember.var
@@ -12,6 +12,10 @@ interactive: false
 
 options:
     "0": "0"
+    1: 1
+    2: 2
+    3: 3
+    4: 4
     5: 5
     6: 6
     7: 7


### PR DESCRIPTION
#### Description:

The ANSSI profile was using the `accounts_password_pam_unix_remember` rule to limit the reuse of passwords. However, there are more updated rules which better identify the proper PAM module to be used and make the changes in a more granular way.

#### Rationale:

Using more granular rules, in alignment to other profiles.
The new rules are also more intuitive since they explicitly mention the proper PAM module used to limite password reuse.
