### PR TITLE
accounts_password_pam_unix_remember minor alignments

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/ansible/shared.yml
@@ -11,4 +11,3 @@
 {{% else %}}
 {{{ ansible_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '^password.*requisite.*pam_pwquality\.so') }}}
 {{% endif %}}
-{{{ ansible_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', '{{ var_password_pam_unix_remember }}', '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/shared.sh
@@ -7,4 +7,3 @@
 {{% else %}}
 {{{ bash_ensure_pam_module_configuration('/etc/pam.d/system-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '^password.*requisite.*pam_pwquality\.so') }}}
 {{% endif %}}
-{{{ bash_ensure_pam_module_configuration('/etc/pam.d/password-auth', 'password', 'requisite', 'pam_pwhistory.so', 'remember', "$var_password_pam_unix_remember", '^password.*requisite.*pam_pwquality\.so') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -33,7 +33,7 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_password_pam_pwhistory_remember" version="1">
-{{% if product in [ "sle15" ] %}}
+{{% if product in [ "sle12", "sle15" ] %}}
     <ind:filepath>/etc/pam.d/common-password</ind:filepath>
 {{% else %}}
     <ind:filepath>/etc/pam.d/system-auth</ind:filepath>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/oval/shared.xml
@@ -1,17 +1,21 @@
 <def-group>
-  <definition class="compliance" id="accounts_password_pam_unix_remember" version="2">
+  <definition class="compliance" id="{{{ rule_id }}}" version="2">
     {{{ oval_metadata("The passwords to remember should be set correctly.") }}}
-    <criteria comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly" operator="OR">
-      <criterion comment="remember parameter of pam_unix.so is set correctly" test_ref="test_accounts_password_pam_unix_remember" />
-      <criterion comment="remember parameter of pam_pwhistory.so is set correctly" test_ref="test_accounts_password_pam_pwhistory_remember" />
+    <criteria operator="OR"
+      comment="remember parameter of pam_unix.so or pam_pwhistory.so is set correctly">
+      <criterion test_ref="test_accounts_password_pam_unix_remember"
+        comment="remember parameter of pam_unix.so is set correctly"/>
+      <criterion test_ref="test_accounts_password_pam_pwhistory_remember"
+        comment="remember parameter of pam_pwhistory.so is set correctly"/>
     </criteria>
   </definition>
 
   <!-- Check the pam_unix.so remember case -->
-  <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember" check="all" check_existence="all_exist"
-  comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth" version="1">
-    <ind:object object_ref="object_accounts_password_pam_unix_remember" />
-    <ind:state state_ref="state_accounts_password_pam_unix_remember" />
+  <ind:textfilecontent54_test id="test_accounts_password_pam_unix_remember" version="1"
+    check="all" check_existence="all_exist"
+    comment="Test if remember attribute of pam_unix.so is set correctly in /etc/pam.d/system-auth">
+    <ind:object object_ref="object_accounts_password_pam_unix_remember"/>
+    <ind:state state_ref="state_accounts_password_pam_unix_remember"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_password_pam_unix_remember" version="1">
@@ -21,8 +25,9 @@
   </ind:textfilecontent54_object>
 
   <!-- Check the pam_pwhistory.so remember case -->
-  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember" check="all" check_existence="all_exist"
-  comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth" version="1">
+  <ind:textfilecontent54_test id="test_accounts_password_pam_pwhistory_remember" version="1"
+    check="all" check_existence="all_exist"
+    comment="Test if remember attribute of pam_pwhistory.so is set correctly in /etc/pam.d/system-auth">
     <ind:object object_ref="object_accounts_password_pam_pwhistory_remember" />
     <ind:state state_ref="state_accounts_password_pam_unix_remember" />
   </ind:textfilecontent54_test>
@@ -39,9 +44,10 @@
 
   <!-- Common state - shared by both of 'remember' tests above -->
   <ind:textfilecontent54_state id="state_accounts_password_pam_unix_remember" version="1">
-    <ind:subexpression datatype="int" operation="greater than or equal" var_ref="var_password_pam_unix_remember" />
+    <ind:subexpression datatype="int" operation="greater than or equal"
+      var_ref="var_password_pam_unix_remember"/>
   </ind:textfilecontent54_state>
 
-  <external_variable comment="number of passwords that should be remembered" datatype="int" id="var_password_pam_unix_remember" version="1" />
-
+  <external_variable id="var_password_pam_unix_remember" version="1"
+    datatype="int" comment="number of passwords that should be remembered"/>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_correct_value.pass.sh
@@ -8,12 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $custom_pam_file); then
-        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $custom_pam_file
-    else
-        sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $custom_pam_file
-    fi
-done
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
+else
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_SYSTEM_AUTH
+fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_argument.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_argument.fail.sh
@@ -7,12 +7,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $custom_pam_file); then
-        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so use_authtok" $custom_pam_file
-    else
-        sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $custom_pam_file
-    fi
-done
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so use_authtok" $CUSTOM_SYSTEM_AUTH
+else
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*\)remember=[[:digit:]]\+\s\(.*\)/\1 \2/g" $CUSTOM_SYSTEM_AUTH
+fi
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_line.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_missing_line.fail.sh
@@ -7,8 +7,5 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $custom_pam_file
-done
+sed -i --follow-symlinks '/.*pam_pwhistory\.so/d' $CUSTOM_SYSTEM_AUTH
 authselect apply-changes -b

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/tests/authselect_wrong_value.fail.sh
@@ -8,12 +8,9 @@ authselect create-profile hardening -b sssd
 CUSTOM_PROFILE="custom/hardening"
 authselect select $CUSTOM_PROFILE --force
 CUSTOM_SYSTEM_AUTH="/etc/authselect/$CUSTOM_PROFILE/system-auth"
-CUSTOM_PASSWORD_AUTH="/etc/authselect/$CUSTOM_PROFILE/password-auth"
-for custom_pam_file in $CUSTOM_SYSTEM_AUTH $CUSTOM_PASSWORD_AUTH; do
-    if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $custom_pam_file); then
-        sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $custom_pam_file
-    else
-        sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $custom_pam_file
-    fi
-done
+if ! $(grep -q "^[^#].*pam_pwhistory\.so.*remember=" $CUSTOM_SYSTEM_AUTH); then
+    sed -i --follow-symlinks "/^password.*requisite.*pam_pwquality\.so/a password    requisite     pam_pwhistory.so remember=$remember_cnt use_authtok" $CUSTOM_SYSTEM_AUTH
+else
+    sed -i --follow-symlinks "s/\(.*pam_pwhistory\.so.*remember=\)[[:digit:]]\+\s\(.*\)/\1$remember_cnt \2/g" $CUSTOM_SYSTEM_AUTH
+fi
 authselect apply-changes -b


### PR DESCRIPTION
#### Description:

While investigating an issue it was noticed some misalignment in the `accounts_password_pam_unix_remember` rule.
Basically the remediation was also changing the `password-auth` file while the rule description and OVAL are only considering the `system-auth` or the `common-auth`, depending on the distro.

#### Rationale:

Improve alignment in remediation.