### PR TITLE
Handle polyinstantiated directories/mount points

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/bash/shared.sh
@@ -4,12 +4,22 @@ MOUNT_OPTION="nodev"
 # Create array of local non-root partitions
 readarray -t partitions_records < <(findmnt --mtab --raw --evaluate | grep "^/\w" | grep "\s/dev/\w")
 
+# Create array of polyinstantiated directories, in case one of them is found in mtab
+readarray -t polyinstantiated_dirs < \
+    <(grep -oP "^\s*[^#\s]+\s+\S+" /etc/security/namespace.conf | grep -oP "(?<=\s)\S+?(?=/?\$)")
+
+
 for partition_record in "${partitions_records[@]}"; do
     # Get all important information for fstab
     mount_point="$(echo ${partition_record} | cut -d " " -f1)"
     device="$(echo ${partition_record} | cut -d " " -f2)"
     device_type="$(echo ${partition_record} | cut -d " " -f3)"
-    # device and device_type will be used only in case when the device doesn't have fstab record
-    {{{ bash_ensure_mount_option_in_fstab("$mount_point", "$MOUNT_OPTION", "$device", "$device_type") }}}
-    {{{ bash_ensure_partition_is_mounted("$mount_point") }}}
+    if ! printf '%s\0' "${polyinstantiated_dirs[@]}" | grep -qxzF "$mount_point"; then
+        # device and device_type will be used only in case when the device doesn't have fstab record
+        {{{ bash_ensure_mount_option_in_fstab("$mount_point",
+                                              "$MOUNT_OPTION",
+                                              "$device",
+                                              "$device_type") | indent(8) }}}
+        {{{ bash_ensure_partition_is_mounted("$mount_point") | indent(8)}}}
+    fi
 done


### PR DESCRIPTION
#### Description:

- Look into namespace.conf for polyinstantiated directories, so the remediation in rule `mount_option_nodev_nonroot_local_partitions` works properly

#### Rationale:

- The rule `mount_option_nodev_nonroot_local_partitions` was setting unexpected entries in fstab when the system was using polyinstantiation for /tmp or /var/tmp for example, when those directories are separate partitions

#### Review Hints:

- Without this changes, the issue was reproducible from ansible high profile. specifically running remdediations for:
  -  `accounts_polyinstantiated_tmp`
  -  `accounts_polyinstantiated_var_tmp`
  - `sebool_polyinstantiation_enabled`
- And then `mount_option_nodev_nonroot_local_partitions`. This would cause unexpected entries in fstab and the system wouldn't be able to boot