### PR TITLE
Add new rule ensure_apparmor_enforce_or_complain

### DIFF
--- a/linux_os/guide/system/apparmor/ensure_apparmor_enforce_or_complain/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/ensure_apparmor_enforce_or_complain/bash/shared.sh
@@ -1,0 +1,15 @@
+# platform = multi_platform_ubuntu
+# reboot = true
+# disruption = high
+
+{{{ bash_instantiate_variables("var_set_apparmor_mode") }}}
+aa_mode=${var_set_apparmor_mode}
+
+{{{ bash_package_install("apparmor") }}}
+{{{ bash_package_install("apparmor-utils") }}}
+
+if [ -z "${aa_mode}" ] || [ "${aa_mode}" == "complain" ]; then
+    aa-complain /etc/apparmor.d/*
+else
+    aa-enforce /etc/apparmor.d/*
+fi

--- a/linux_os/guide/system/apparmor/ensure_apparmor_enforce_or_complain/oval/shared.xml
+++ b/linux_os/guide/system/apparmor/ensure_apparmor_enforce_or_complain/oval/shared.xml
@@ -1,0 +1,32 @@
+<def-group>
+  <definition class="compliance" id="ensure_apparmor_enforce_or_complain" version="1">
+    {{{ oval_metadata("Ensure all AppArmor Profiles are in var_set_apparmor_mode") }}}
+    <criteria comment="Either all profiles are set to complain or enforce" operator="OR">
+      <criterion comment="All profiles are set to complain mode" test_ref="test_profiles_in_complain_mode" />
+      <criterion comment="All profiles are set to enforce mode" test_ref="test_profiles_in_enforce_mode" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_profiles_in_complain_mode" check="all" version="1"
+  comment="Check for complain in /sys/kernel/security/apparmor/profiles">
+    <ind:object object_ref="object_profiles_complain_mode" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_profiles_complain_mode" version="1">
+    <ind:filepath>/sys/kernel/security/apparmor/profiles</ind:filepath>
+    <ind:pattern operation="pattern match">^.*\s+\(complain\)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_profiles_in_enforce_mode" check="all" version="1"
+  comment="Check for complain in /sys/kernel/security/apparmor/profiles">
+    <ind:object object_ref="object_profiles_enforce_mode" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_profiles_enforce_mode" version="1">
+    <ind:filepath>/sys/kernel/security/apparmor/profiles</ind:filepath>
+    <ind:pattern operation="pattern match">^.*\s+\(enforce\)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+</def-group>

--- a/linux_os/guide/system/apparmor/ensure_apparmor_enforce_or_complain/rule.yml
+++ b/linux_os/guide/system/apparmor/ensure_apparmor_enforce_or_complain/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure all AppArmor Profiles are in enforce or complain mode'
+
+description: |-
+    AppArmor profiles define what resources applications are able to access.
+
+rationale: |-
+    Security configuration requirements vary from site to site. Some sites
+    may mandate a policy that is stricter than the default policy, which is
+    perfectly acceptable. This item is intended to ensure that any policies
+    that exist on the system are activated.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 1.7.1.3
+    cis@ubuntu2204: 1.6.1.3
+

--- a/linux_os/guide/system/apparmor/var_set_apparmor_mode.var
+++ b/linux_os/guide/system/apparmor/var_set_apparmor_mode.var
@@ -1,0 +1,22 @@
+documentation_complete: true
+
+title: 'Select AppArmor mode for rule ensure_apparmor_enforce_or_complain'
+
+description: |-
+    Rule ensure_apparmor_enforce_or_complain will select which AppArmor mode will be set based
+    on this variable value.
+    default - Default sets mode to complain.
+    <br />enforce - AppArmor mode set to Enforce.
+    <br />complain - AppArmor mode set to Complain.
+
+type: boolean
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "complain"
+    "enforce": "enforce"
+    "complain": "complain"
+

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -157,7 +157,8 @@ selections:
     # NEEDS RULE
 
     #### 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
-    # NEEDS RULE
+    - var_set_apparmor_mode=complain
+    - ensure_apparmor_enforce_or_complain
 
     #### 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
     # Skip due to being Level 2

--- a/products/ubuntu2204/profiles/cis_level2_server.profile
+++ b/products/ubuntu2204/profiles/cis_level2_server.profile
@@ -31,6 +31,8 @@ selections:
     - partition_for_home
 
     #### 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
+    - var_set_apparmor_mode=enforce
+    - ensure_apparmor_enforce_or_complain
 
     ### 1.8.1 Ensure GNOME Display Manager is removed (Automated)
     - package_gdm_removed


### PR DESCRIPTION
#### Description:

- This is a new rule to satisfy CIS items: 
   - 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode
   - 1.6.1.4 Ensure all AppArmor Profiles are enforcing
- For that a new variable was created var_set_apparmor_mode, so we could re-use the same rule for both items.
- @teacup-on-rockingchair I think this is also needed for SLE15.

#### Rationale:

- Security configuration requirements vary from site to site. Some sites may mandate a
policy that is stricter than the default policy, which is perfectly acceptable. This item is
intended to ensure that any policies that exist on the system are activated.

#### Review Hints:

Run the following command and verify that profiles are loaded, and are in either enforce
or complain mode:
`# apparmor_status | grep profiles`

Review output and ensure that profiles are loaded, and in either enforce or complain mode:
```
37 profiles are loaded.
35 profiles are in enforce mode.
2 profiles are in complain mode.
4 processes have profiles defined.
```

Run the following command and verify no processes are unconfined
`# apparmor_status | grep processes`

Review the output and ensure no processes are unconfined:
```
4 processes have profiles defined.
4 processes are in enforce mode.
0 processes are in complain mode.
0 processes are unconfined but have a profile defined.
```