### PR TITLE
Add Ubuntu 22.04 to Gating

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -103,6 +103,25 @@ jobs:
         run: ctest -j2 --output-on-failure -E unique-stigids
         working-directory: ./build
 
+  validate-ubuntu-22-04:
+    name: Build, Test on Ubuntu 22.04
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install Deps
+        uses: mstksg/get-package@master
+        with:
+          apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml python3-setuptools ansible-lint python3-github bats python3-pytest python3-pytest-cov shellcheck
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |-
+          ./build_product \
+              ubuntu2004 \
+              ubuntu2204
+      - name: Test
+        run: ctest -j2 --output-on-failure -E unique-stigids
+        working-directory: ./build
+
   validate-fedora:
     name: Build, Test on Fedora Latest (Container)
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### Description:
Adds Ubuntu 22.04 to the gating checks.

#### Rationale:

We have CIS now for Ubuntu 22.04. So the (Ubuntu part) of the project should build on Ubuntu 22.04. It seems that OpenSCAP 1.2.17 (what ships with Ubuntu 22.04) can't build the whole project so I limited this new gating test to just Ubuntu products.
