### PR TITLE
Raise exception when parametrized platforms receives invalid argument

### DIFF
--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -210,7 +210,13 @@ class CPEItem(XCCDFEntity, Templatable):
             if not self.versioned:
                 raise ValueError("CPE entity '{0}' does not support version specifiers: "
                                  "{1}".format(self.id_, fact_ref.cpe_name))
-        resolved_parameters = self.args[fact_ref.arg]
+        try:
+            resolved_parameters = self.args[fact_ref.arg]
+        except KeyError:
+            raise KeyError(
+                "The {0} CPE item does not support the argument {1}. "
+                "Following arguments are supported: {2}".format(
+                    self.id_, fact_ref.arg, [a for a in self.args.keys()]))
         resolved_parameters.update(fact_ref.as_dict())
         cpe_item_as_dict = self.represent_as_dict()
         cpe_item_as_dict["args"] = None

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -379,6 +379,10 @@ def test_parametrized_platform(product_cpes):
     assert cpe_item.title == "Package ntp is installed"
     assert cpe_item.check_id == "installed_env_has_ntp_package"
 
+def test_parametrized_platform_with_invalid_argument(product_cpes):
+    with pytest.raises(KeyError):
+        platform = ssg.build_yaml.Platform.from_text("package[nonexisting_argument]", product_cpes)
+
 
 def test_derive_id_from_file_name():
     assert ssg.entities.common.derive_id_from_file_name("rule.yml") == "rule"


### PR DESCRIPTION
#### Description:

- when a parametrized platform receives an argumend which is not defined in corresponding shared/applicability/*.yml file, it now raises more descriptive exception
- it also displays list of valid arguments

#### Rationale:

Make usage more user friendly.