### PR TITLE
add correct CIS id

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
@@ -30,7 +30,7 @@ references:
     cis-csc: 11,14,3,9
     cis@rhel7: 3.5.1.5
     cis@rhel8: 3.4.1.5
-    cis@sle15: 3.5.1.5
+    cis@sle15: 3.5.1.4
     cjis: 5.10.1
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS05.02,DSS05.05,DSS06.06
     cui: 3.1.3,3.4.7,3.13.6


### PR DESCRIPTION
#### Description:

- Rule set firewalld default zone for CIS at SLE 15 SP2 corrected CIS ID.

