### PR TITLE
Fixing bootloader password for RHEL8 kickstart

### DIFF
--- a/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
+++ b/products/rhel8/kickstart/ssg-rhel8-cis-ks.cfg
@@ -74,7 +74,7 @@ timezone --utc America/New_York
 # Plaintext password is: password
 # Refer to e.g. https://pykickstart.readthedocs.io/en/latest/commands.html#rootpw to see how to create
 # encrypted password form for different plaintext password
-bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=$6$zCPaBARiNlBYUAS7$40phthWpqvaPVz3QUeIK6n5qoazJDJD5Nlc9OKy5SyYoX9Rt4jFaLjzqJCwpgR4RVAEFSADsqQot0WKs5qNto0
+bootloader --location=mbr --append="crashkernel=auto rhgb quiet" --password=grub.pbkdf2.sha512.10000.45912D32B964BA58B91EAF9847F3CCE6F4C962638922543AFFAEE4D29951757F4336C181E6FC9030E07B7D9874DAD696A1B18978D995B1D7F27AF9C38159FDF3.99F65F3896012A0A3D571A99D6E6C695F3C51BE5343A01C1B6907E1C3E1373CB7F250C2BC66C44BB876961E9071F40205006A05189E51C2C14770C70C723F3FD --iscrypted
 
 # Initialize (format) all disks (optional)
 zerombr


### PR DESCRIPTION
Fixing bootloader password

#### Description:

Bootloader password must be in Grub PBKDF2 format and also parameter `--iscrypted` must be provided. See https://pykickstart.readthedocs.io/en/latest/commands.html#bootloader

#### Rationale:

- Password was wrong in kickstart

#### Review Hints:

- Install RHEL8 with kickstart and try to edit GRUB line