### PR TITLE
Add a new rule accounts_passwords_pam_disable_nullok

### DIFF
--- a/controls/stig_rhel8.yml
+++ b/controls/stig_rhel8.yml
@@ -2765,7 +2765,9 @@ controls:
         levels:
             - high
         title: RHEL 8 must not allow blank or null passwords in the password-auth file.
-        status: pending
+        rules:
+          - accounts_passwords_pam_disable_nullok
+        status: automated
     -   id: RHEL-08-030181
         levels:
             - medium

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_disable_nullok/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_disable_nullok/oval/shared.xml
@@ -1,0 +1,22 @@
+<def-group>
+  <definition class="compliance" id="accounts_passwords_pam_disable_nullok" version="4">
+    {{{ oval_metadata("Blank or null passwords are disallowed in the PAM password-auth file.") }}}
+    <criteria>
+      <criterion test_ref="test_accounts_passwords_pam_disable_nullok"
+      comment="nullok not present in password-auth" negate="true"/>
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test id="test_accounts_passwords_pam_disable_nullok"
+  check="all" check_existence="all_exist"
+  comment="Checks that nullok is not present in password-auth" version="2">
+    <ind:object object_ref="object_accounts_passwords_pam_disable_nullok"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="object_accounts_passwords_pam_disable_nullok"
+  comment="Get the number of line containing 'nullok'" version="1">
+    <ind:filepath>/etc/pam.d/password-auth</ind:filepath>
+    <ind:pattern operation="pattern match">[\s](nullok)[\s\n]</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_disable_nullok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_disable_nullok/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+prodtype: rhel8
+
+title: 'Disallow blank or null passwords in the PAM password-auth file'
+
+description: |-
+    Remove any instances of the <tt>nullok</tt> option in the
+    <tt>/etc/pam.d/password-auth</tt> file to prevent logons with empty passwords.
+    Note: Manual changes to the listed file may be overwritten by the
+    <tt>authselect</tt> program.
+
+rationale: |-
+    If an account has an empty password, anyone could log on and run commands
+    with the privileges of that account.
+    Accounts with empty passwords should never be used in operational environments.
+
+severity: high
+
+references:
+    disa: CCI-000366
+    stigid@rhel8: RHEL-08-020332
+
+ocil_clause: 'null password are authorized'
+
+ocil: |-
+    To verify that null passwords cannot be used, run the following command:
+
+    <pre># grep -i nullok /etc/pam.d/password-auth</pre>
+
+    If output is produced, this is a finding.

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -647,6 +647,7 @@ selections:
     - no_empty_passwords
 
     # RHEL-08-020332
+    - accounts_passwords_pam_disable_nullok
 
     # RHEL-08-020340
     - display_login_attempts


### PR DESCRIPTION
#### Description:

Add a rule and an OVAL check for the DISA STIG requirement RHEL-08-020332.

#### Rationale:

"RHEL 8 must not allow blank or null passwords in the password-auth file."