### PR TITLE
Install NetworkManager as part of `wireless_disable_interfaces` remediation

### DIFF
--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/ansible/shared.yml
@@ -4,14 +4,12 @@
 # complexity = low
 # disruption = medium
 
-- name: Check if NetworkManager is installed
-  ansible.builtin.package_facts:
-    manager: "auto"
-
-- name: Error message when NetworkManager not installed
-  fail:
-    msg: "NetworkManager package not installed"
-  when: "'NetworkManager' not in ansible_facts.packages"
+- name: Ensure NetworkManager is installed
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - NetworkManager
 
 - name: Deactivate Wireless Network Interfaces
   command: nmcli radio wifi off

--- a/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/wireless_disable_interfaces/bash/shared.sh
@@ -1,9 +1,5 @@
 # platform = multi_platform_all
 
-if 
-    rpm -q NetworkManager
-then
-    nmcli radio all off
-else
-    echo "NetworkManager package not installed" >&2     
-fi
+{{{ bash_package_install("NetworkManager") }}}
+
+nmcli radio all off


### PR DESCRIPTION
#### Description:
NetworkManager is needed for remediation as it uses `nmcli`. Install it, don't fail - same approach as [firewalld_sshd_port_enabled](https://github.com/ComplianceAsCode/content/tree/master/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled)

#### Rationale:
CentOS 7 doesn't have NetworkManager installed by default and it aborts ansible-playbook:
```
TASK [Deactivate Wireless Network Interfaces] **********************************
fatal: [localhost]: FAILED! => {"changed": true, "cmd": ["nmcli", "radio", "wifi", "off"], "delta": "0:00:00.013661", "end": "2023-01-02 09:16:34.337236", "msg": "non-zero return code", "rc": 8, "start": "2023-01-02 09:16:34.323575", "stderr": "Error: NetworkManager is not running.", "stderr_lines": ["Error: NetworkManager is not running."], "stdout": "", "stdout_lines": []}
```