### PR TITLE
Fix `--datastream-only` in `./build_product`

### DIFF
--- a/build_product
+++ b/build_product
@@ -297,7 +297,7 @@ set_no_derivatives_options() {
 set_explict_build_targets() {
 	if test "$_arg_datastream_only" = on ; then
 		for chosen_product in "${_arg_product[@]}"; do
-			EXPLICIT_BUILD_TARGETS+=("generate-ssg-${chosen_product}-ds.xml")
+			EXPLICIT_BUILD_TARGETS+=("generate-ssg-$(to_lowercase "$chosen_product")-ds.xml")
 		done
 	fi
 }


### PR DESCRIPTION
#### Description:

Fixes `--datastream-only`.

#### Rationale:
Allow use of `--datastream-only` .

#### Review Hints:
If run `./build_product --datastream-only` on master (772d932d1401095b36c0c1b9514f343d3f45bbe0) you should get 

`make: *** No rule to make target 'generate-ssg-ALINUX2-ds.xml'.  Stop.`