### PR TITLE
Fix PAM control flag for pam_pwhistory.so

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1956,7 +1956,7 @@ controls:
       https://bugzilla.redhat.com/show_bug.cgi?id=1778929
     rules:
     - var_password_pam_remember=5
-    - var_password_pam_remember_control_flag=required
+    - var_password_pam_remember_control_flag=requisite
     - accounts_password_pam_pwhistory_remember_system_auth
     - accounts_password_pam_pwhistory_remember_password_auth
 

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -2245,7 +2245,7 @@ controls:
     rules:
       - accounts_password_pam_pwhistory_remember_password_auth
       - accounts_password_pam_pwhistory_remember_system_auth
-      - var_password_pam_remember_control_flag=required
+      - var_password_pam_remember_control_flag=requisite
       - var_password_pam_remember=5
 
   - id: 5.5.4

--- a/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
+++ b/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
@@ -5,7 +5,7 @@ controls:
         title: {{{ full_name }}} must prohibit password reuse for a minimum of five generations.
         rules:
             - var_password_pam_remember=5
-            - var_password_pam_remember_control_flag=required
+            - var_password_pam_remember_control_flag=requisite
             - accounts_password_pam_pwhistory_remember_password_auth
             - accounts_password_pam_pwhistory_remember_system_auth
         status: automated

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ grep -i remember /etc/pam.d/password-auth
 
-    password required pam_pwhistory.so use_authtok remember=5 retry=3
+    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3
 
     If the line containing "pam_pwhistory.so" does not have the "remember" module argument set, is commented out, or the value of the "remember" module argument is set to less than "5", this is a finding.
 
@@ -24,4 +24,4 @@ fixtext: |-
 
     Add the following line in "/etc/pam.d/password-auth" (or modify the line to have the required value):
 
-    password required pam_pwhistory.so use_authtok remember=5 retry=3
+    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel7_correct_value_cis_l2.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/tests/rhel7_correct_value_cis_l2.pass.sh
@@ -4,7 +4,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
 remember_cnt=5
-control_flag='required'
+control_flag='requisite'
 
 config_file=/etc/pam.d/password-auth
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ grep -i remember /etc/pam.d/system-auth
 
-    password required pam_pwhistory.so use_authtok remember=5 retry=3
+    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3
 
     If the line containing "pam_pwhistory.so" does not have the "remember" module argument set, is commented out, or the value of the "remember" module argument is set to less than "5", this is a finding.
 
@@ -24,4 +24,4 @@ fixtext: |-
 
     Add the following line in "/etc/pam.d/system-auth" (or modify the line to have the required value):
 
-    password required pam_pwhistory.so use_authtok remember=5 retry=3
+    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel7_correct_value_cis_l2.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/tests/rhel7_correct_value_cis_l2.pass.sh
@@ -4,7 +4,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
 remember_cnt=5
-control_flag='required'
+control_flag='requisite'
 
 config_file=/etc/pam.d/system-auth
 

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -38,7 +38,7 @@ selections:
     - var_accounts_minimum_age_login_defs=1
     - var_accounts_max_concurrent_login_sessions=10
     - var_password_pam_remember=5
-    - var_password_pam_remember_control_flag=required
+    - var_password_pam_remember_control_flag=requisite
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted
     - var_password_pam_unix_rounds=5000

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -849,7 +849,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 :param pwhistory_var_name:  Literal variable name.
 
 #}}
-{{%- macro ansible_pam_pwhistory_parameter_value(pam_file, parameter, pwhistory_value_var='') -%}}
+{{%- macro ansible_pam_pwhistory_parameter_value(pam_file, parameter, pwhistory_var_name='') -%}}
 - name: '{{{ rule_title }}} - Check the presence of /etc/security/pwhistory.conf file'
   ansible.builtin.stat:
     path: /etc/security/pwhistory.conf
@@ -865,7 +865,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
         line: {{{ parameter }}}
         {{%- else %}}
         regexp: ^\s*{{{ parameter }}}\s*=
-        line: {{{ parameter }}} = {{{ pwhistory_value_var }}}
+        line: {{{ parameter }}} = {{{ pwhistory_var_name }}}
         {{%- endif %}}
         state: present
 
@@ -878,7 +878,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 - name: '{{{ rule_title }}} - pam_pwhistory.so parameters are configured in PAM files'
   block:
     {{{ ansible_ensure_pam_facts_and_authselect_profile(pam_file) | indent(4) }}}
-    {{{ ansible_ensure_pam_module_option('{{ pam_file_path }}', 'password', 'requisite', 'pam_pwhistory.so', parameter, pwhistory_value_var, '') | indent(4) }}}
+    {{{ ansible_ensure_pam_module_option('{{ pam_file_path }}', 'password', 'requisite', 'pam_pwhistory.so', parameter, pwhistory_var_name, '') | indent(4) }}}
     {{{ ansible_apply_authselect_changes() | indent(4) }}}
       when:
         - result_authselect_present.stat.exists

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1074,7 +1074,7 @@ PAM_FILE_PATH="/etc/authselect/$CURRENT_PROFILE/$PAM_FILE_NAME"
                         the beginning of the file: "BOF"
 
 #}}
-{{%- macro bash_pam_pwhistory_enable(pam_file, control, module, after_match='') -%}}
+{{%- macro bash_pam_pwhistory_enable(pam_file, control, after_match='') -%}}
 if [ -f /usr/bin/authselect ]; then
     if authselect list-features minimal | grep -q with-pwhistory; then
         {{{ bash_enable_authselect_feature('with-pwhistory') | indent(8) }}}

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -1,4 +1,3 @@
-title: DISA STIG for Red Hat Enterprise Linux 8
 description: 'This profile contains configuration checks that align to the
 
     DISA STIG for Red Hat Enterprise Linux 8 V1R8.
@@ -431,7 +430,7 @@ selections:
 - var_accounts_minimum_age_login_defs=1
 - var_accounts_max_concurrent_login_sessions=10
 - var_password_pam_remember=5
-- var_password_pam_remember_control_flag=required
+- var_password_pam_remember_control_flag=requisite
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_password_pam_unix_rounds=5000
@@ -474,4 +473,5 @@ platforms: !!set {}
 cpe_names: !!set {}
 platform: null
 filter_rules: ''
+title: DISA STIG for Red Hat Enterprise Linux 8
 documentation_complete: true

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -1,4 +1,3 @@
-title: DISA STIG with GUI for Red Hat Enterprise Linux 8
 description: 'This profile contains configuration checks that align to the
 
     DISA STIG with GUI for Red Hat Enterprise Linux 8 V1R8.
@@ -439,7 +438,7 @@ selections:
 - var_accounts_minimum_age_login_defs=1
 - var_accounts_max_concurrent_login_sessions=10
 - var_password_pam_remember=5
-- var_password_pam_remember_control_flag=required
+- var_password_pam_remember_control_flag=requisite
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_password_pam_unix_rounds=5000
@@ -482,4 +481,5 @@ platforms: !!set {}
 cpe_names: !!set {}
 platform: null
 filter_rules: ''
+title: DISA STIG with GUI for Red Hat Enterprise Linux 8
 documentation_complete: true


### PR DESCRIPTION
#### Description:

Newer versions of RHEL8 and RHEL9 are using authselect for PAM configurations.
When the feature `with_pwhistory` for pam_pwhistory is available, it uses `requisite` as control flag for `pam_pwhistory.so` module instead of `required`.

#### Rationale:

Although the man for `pam_pwhistory.so` contains examples to configure the module using `required` control flag, this is not the default control flag in RHEL8 and RHEL9 when using authselect.
For RHEL7 there is no authselect. However, it makes sense to keep it aligned.

In practical, changing from `required` to `requisite` has no technical impact for this case but only user experience impact since using the `requisite` control flag the user will be informed immediately.

- Fixes #10019 
