### PR TITLE
Improve service_disabled template

### DIFF
--- a/shared/templates/service_disabled/bash.template
+++ b/shared/templates/service_disabled/bash.template
@@ -11,7 +11,7 @@ SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
 "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
 # Disable socket activation if we have a unit file for it
-if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+if "$SYSTEMCTL_EXEC" -q list-unit-files {{{ DAEMONNAME }}}.socket; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
     "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
 fi

--- a/shared/templates/service_disabled/tests/service_disabled.pass.sh
+++ b/shared/templates/service_disabled/tests/service_disabled.pass.sh
@@ -4,13 +4,13 @@
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 # Some services use <name>@.service style that is not meant to be activated at all,
 # and only used via socket activation.
-if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.service' | grep -q '^{{{ DAEMONNAME }}}.service'; then
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.service'; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
     "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
     "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
 fi
 # Disable socket activation if we have a unit file for it
-if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.socket' | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.socket'; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
     "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
 fi

--- a/shared/templates/service_disabled/tests/service_disabled.pass.sh
+++ b/shared/templates/service_disabled/tests/service_disabled.pass.sh
@@ -2,11 +2,15 @@
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
-"$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.service' | grep -q '^{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" disable '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.service'
+fi
 # Disable socket activation if we have a unit file for it
-if "$SYSTEMCTL_EXEC" list-unit-files | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.socket' | grep -q '^{{{ DAEMONNAME }}}.socket'; then
     "$SYSTEMCTL_EXEC" stop '{{{ DAEMONNAME }}}.socket'
     "$SYSTEMCTL_EXEC" mask '{{{ DAEMONNAME }}}.socket'
 fi

--- a/shared/templates/service_disabled/tests/service_enabled.fail.sh
+++ b/shared/templates/service_disabled/tests/service_enabled.fail.sh
@@ -4,13 +4,13 @@
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
 # Some services use <name>@.service style that is not meant to be activated at all,
 # and only used via socket activation.
-if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.service' | grep -q '^{{{ DAEMONNAME }}}.service'; then
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.service'; then
     "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
     "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
     "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
 fi
-# Disable socket activation if we have a unit file for it
-if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.socket' | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+# Enable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" -q list-unit-files '{{{ DAEMONNAME }}}.socket'; then
     "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.socket'
     "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.socket'
 fi

--- a/shared/templates/service_disabled/tests/service_enabled.fail.sh
+++ b/shared/templates/service_disabled/tests/service_enabled.fail.sh
@@ -2,9 +2,18 @@
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'
-"$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
-"$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+# Some services use <name>@.service style that is not meant to be activated at all,
+# and only used via socket activation.
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.service' | grep -q '^{{{ DAEMONNAME }}}.service'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.service'
+    "$SYSTEMCTL_EXEC" enable '{{{ DAEMONNAME }}}.service'
+fi
+# Disable socket activation if we have a unit file for it
+if "$SYSTEMCTL_EXEC" list-unit-files '{{{ DAEMONNAME }}}.socket' | grep -q '^{{{ DAEMONNAME }}}.socket'; then
+    "$SYSTEMCTL_EXEC" unmask '{{{ DAEMONNAME }}}.socket'
+    "$SYSTEMCTL_EXEC" start '{{{ DAEMONNAME }}}.socket'
+fi
 
 # The service may not be running because it has been started and failed,
 # so let's reset the state so OVAL checks pass.


### PR DESCRIPTION
#### Description:

This rule is a rebase for the #9468 plus some additional improvements in conditionals.
In alignment to the remediation, conditionals for systemd units were included in the two test scenario scripts by the initial PR.

After the rebase, I improved the conditionals in test scenarios and bash remediation to remove unnecessary `grep` from the command.

#### Rationale:

Better alignment between remediation and test scenarios.
Simpler conditionals with faster commands.

#### Review Hints:

For testing this changes I chose some random rules which uses the `service_disabled` template.
This should be enough for testing the changes.