### PR TITLE
Produce an understanable error when remediation collections goes wrong

### DIFF
--- a/build-scripts/collect_remediations.py
+++ b/build-scripts/collect_remediations.py
@@ -111,8 +111,14 @@ def collect_remediations(
         if fix_path is None:
             # neither static nor templated remediation found
             continue
-        process_remediation(
-            rule, fix_path, lang, output_dirs, expected_file_name, env_yaml, cpe_platforms)
+        try:
+            process_remediation(
+                rule, fix_path, lang, output_dirs, expected_file_name, env_yaml, cpe_platforms)
+        except Exception as exc:
+            msg = (
+                "Failed to dispatch {lang} remediation for {rule_id}: {error}"
+                .format(lang=lang, rule_id=rule.id_, error=str(exc)))
+            raise RuntimeError(msg)
 
 
 def main():


### PR DESCRIPTION
At least name the rule and the remediation type.


#### Review Hints:

If you run the build of e.g. `sle15` product on a Python2 system, you will get an encoding error that will point you out to the file that contains a non-ASCII character. Generally, you can introduce any fatal error to the remediation s.a. non-matching Jinja control characters, and you will see the improved error handling in action. (although in case of Jinja errors, there would already be a pointer given by Jinja, but there are other things that can go wrong that crash without telling details).