### PR TITLE
Add rule to OL7 stig profile

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,ol9,rhel7,rhel8,rhel9,rhv4
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4
 
 title: "Set PAM''s Password Hashing Algorithm - password-auth"
 
@@ -57,6 +57,7 @@ references:
     nist-csf: PR.AC-1,PR.AC-6,PR.AC-7
     pcidss: Req-8.2.1
     srg: SRG-OS-000073-GPOS-00041,SRG-OS-000120-GPOS-00061
+    stigid@ol7: OL07-00-010200
     stigid@ol8: OL08-00-010160
     stigid@rhel7: RHEL-07-010200
     stigid@rhel8: RHEL-08-010160

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -71,6 +71,7 @@ selections:
     - accounts_password_pam_maxrepeat
     - accounts_password_pam_maxclassrepeat
     - set_password_hashing_algorithm_systemauth
+    - set_password_hashing_algorithm_passwordauth
     - set_password_hashing_algorithm_logindefs
     - set_password_hashing_algorithm_libuserconf
     - accounts_minimum_age_login_defs


### PR DESCRIPTION
#### Description:

- Add the set_password_hashing_algorithm_passwordauth rule to the OL7 stig profile.
- Add OL7 stigid and prodtype to this rule as well.

#### Rationale:

- OL7 DISA STIG efforts