### PR TITLE
RHEL 9 STIG Import

### DIFF
--- a/linux_os/guide/services/base/service_kdump_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/services/base/service_kdump_disabled/policy/stig/shared.yml
@@ -40,4 +40,3 @@ fixtext: |-
     To mask the kdump service run the following command:
 
     $ sudo systemctl mask --now kdump
-    $ sudo systemctl mask --now kdump

--- a/linux_os/guide/services/cron_and_at/file_permissions_crontab/policy/stig/shared.yml
+++ b/linux_os/guide/services/cron_and_at/file_permissions_crontab/policy/stig/shared.yml
@@ -19,4 +19,3 @@ fixtext: |-
     Configure the {{{ full_name }}} file /etc/crontab with mode 600.
 
     $ sudo chmod 0600 /etc/crontab
-    chmod 0600 /etc/crontab

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/policy/stig/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_servers/use_kerberos_security_all_exports/policy/stig/shared.yml
@@ -22,4 +22,3 @@ fixtext: |-
     Update the "/etc/fstab" file so the option "sec" is defined for each NFS mounted file system and the "sec" option does not have the "sys" setting.
 
     Ensure the "sec" option is defined as "krb5p:krb5i:krb5".
-

--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-utils_removed/policy/stig/shared.yml
@@ -21,4 +21,3 @@ fixtext: |-
     Remove the nfs-utils package with the following command:
 
     $ sudo dnf remove nfs-utils
-

--- a/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/policy/stig/shared.yml
+++ b/linux_os/guide/services/obsolete/telnet/package_telnet-server_removed/policy/stig/shared.yml
@@ -31,4 +31,3 @@ fixtext: |-
     Remove the telnet-server package with the following command:
 
     $ sudo dnf remove telnet-server
-

--- a/linux_os/guide/services/ssh/package_openssh-server_installed/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/package_openssh-server_installed/policy/stig/shared.yml
@@ -21,4 +21,3 @@ fixtext: |-
     The  openssh-server  package can be installed with the following command:
 
     $ sudo dnf install openssh-server
-

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/policy/stig/shared.yml
@@ -22,7 +22,7 @@ fixtext: |-
 
     Modify or append the following lines in the "/etc/ssh/sshd_config" file:
 
-    ClientAliveCountMax {{{ xccdf_value("var_sshd_set_keepalive") }}}
+    ClientAliveCountMax 0
 
     In order for the changes to take effect, the SSH daemon must be restarted.
 

--- a/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/policy/stig/shared.yml
+++ b/linux_os/guide/services/usbguard/configure_usbguard_auditbackend/policy/stig/shared.yml
@@ -35,4 +35,3 @@ fixtext: |-
     Add or edit the following line in /etc/usbguard/usbguard-daemon.conf
 
     AuditBackend=LinuxAudit
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ grep -i remember /etc/pam.d/password-auth
 
-    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3
+    password requisite pam_pwhistory.so use_authtok remember=5 retry=3
 
     If the line containing "pam_pwhistory.so" does not have the "remember" module argument set, is commented out, or the value of the "remember" module argument is set to less than "5", this is a finding.
 
@@ -24,4 +24,4 @@ fixtext: |-
 
     Add the following line in "/etc/pam.d/password-auth" (or modify the line to have the required value):
 
-    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3
+    password required pam_pwhistory.so use_authtok remember=5 retry=3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_system_auth/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ grep -i remember /etc/pam.d/system-auth
 
-    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3
+    password requisite pam_pwhistory.so use_authtok remember=5 retry=3
 
     If the line containing "pam_pwhistory.so" does not have the "remember" module argument set, is commented out, or the value of the "remember" module argument is set to less than "5", this is a finding.
 
@@ -24,4 +24,4 @@ fixtext: |-
 
     Add the following line in "/etc/pam.d/system-auth" (or modify the line to have the required value):
 
-    password {{{ xccdf_value("var_password_pam_remember_control_flag") }}} pam_pwhistory.so use_authtok remember=5 retry=3
+    password required pam_pwhistory.so use_authtok remember=5 retry=3

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_deny_root/policy/stig/shared.yml
@@ -25,4 +25,3 @@ fixtext: |-
 
       add or uncomment the following line:
      even_deny_root
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/policy/stig/shared.yml
@@ -21,4 +21,3 @@ fixtext: |-
     Change the UID of any account on the system, other than root, that has a UID of "0".
 
     If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/policy/stig/shared.yml
@@ -39,4 +39,3 @@ fixtext: |-
     $ sudo usermod --shell /sbin/nologin &ltuser&gt
 
     Do not perform the steps in this section on the root account. Doing so will cause the system to become inaccessible.
-

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/policy/stig/shared.yml
@@ -25,4 +25,3 @@ fixtext: |-
     $ sed '/^[[:space:]]*#[[:space:]]*auth[[:space:]]\+required[[:space:]]\+pam_wheel\.so[[:space:]]\+use_uid$/s/^[[:space:]]*#//' -i /etc/pam.d/su
 
     If necessary, create a "wheel" group and add administrative users to the group.
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/policy/stig/shared.yml
@@ -25,4 +25,3 @@ fixtext: |-
     -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt=1000 -F auid!=unset -F key=privileged
 
     The audit daemon must be restarted for the changes to take effect.
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers/policy/stig/shared.yml
@@ -21,5 +21,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/sudoers".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/sudoers -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_sudoers_d/policy/stig/shared.yml
@@ -21,5 +21,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/sudoers.d/".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/sudoers.d/ -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/policy/stig/shared.yml
@@ -31,5 +31,4 @@ fixtext: |-
     -a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k execpriv
     -a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k execpriv
 
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/policy/stig/shared.yml
@@ -19,5 +19,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/group".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/group -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/policy/stig/shared.yml
@@ -19,5 +19,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/gshadow -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/policy/stig/shared.yml
@@ -19,5 +19,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/security/opasswd -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/policy/stig/shared.yml
@@ -19,5 +19,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/passwd -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/policy/stig/shared.yml
@@ -19,5 +19,4 @@ fixtext: |-
     Configure {{{ full_name }}} to generate audit records for all account creations, modifications, disabling, and termination events that affect "/etc/shadow".
     Add or update the following file system rule to "/etc/audit/rules.d/audit.rules":
     -w /etc/shadow -p wa -k identity
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_local_events/policy/stig/shared.yml
@@ -20,5 +20,4 @@ fixtext: |-
 
     local_events = yes
 
-
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_atm_disabled/policy/stig/shared.yml
@@ -17,4 +17,5 @@ checktext: |-
 fixtext: |-
     To configure the system to prevent the atm kernel module from being loaded, add the following line to the file  /etc/modprobe.d/atm.conf (or create atm.conf if it does not exist):
 
+    install atm /bin/true
     blacklist atm

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_can_disabled/policy/stig/shared.yml
@@ -16,4 +16,5 @@ checktext: |-
 fixtext: |-
     To configure the system to prevent the can kernel module from being loaded, add the following line to the file  /etc/modprobe.d/can.conf (or create atm.conf if it does not exist):
 
+    install can /bin/true
     blacklist can

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_tipc_disabled/policy/stig/shared.yml
@@ -20,4 +20,5 @@ checktext: |-
 fixtext: |-
     To configure the system to prevent the tipc kernel module from being loaded, add the following line to the file  /etc/modprobe.d/tipc.conf (or create tipc.conf if it does not exist):
 
+    install tipc /bin/true
     blacklist tipc

--- a/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-wireless/wireless_software/kernel_module_bluetooth_disabled/policy/stig/shared.yml
@@ -17,6 +17,7 @@ fixtext: |-
 
     Create or modify the "/etc/modprobe.d/bluetooth.conf" file with the following line:
 
+    install bluetooth /bin/true
     blacklist bluetooth
 
     Reboot the system for the settings to take effect.

--- a/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/file_permissions_etc_audit_auditd/policy/stig/shared.yml
@@ -22,4 +22,3 @@ fixtext: |-
     Set the mode of /etc/audit/auditd.conf file to 0640 with the command:
 
     $ sudo chmod 0640 /etc/audit/auditd.conf
-

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_owner_backup_etc_group/policy/stig/shared.yml
@@ -19,4 +19,3 @@ fixtext: |-
     Change the owner of the file /etc/group- to root by running the following command:
 
     $ sudo chown root /etc/group-
-

--- a/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_cramfs_disabled/policy/stig/shared.yml
@@ -20,4 +20,5 @@ checktext: |-
 fixtext: |-
     To configure the system to prevent the cramfs kernel module from being loaded, add the following line to the file /etc/modprobe.d/blacklist.conf (or create blacklist.conf if it does not exist):
 
+    install tipc /bin/true
     blacklist cramfs

--- a/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/mounting/kernel_module_usb-storage_disabled/policy/stig/shared.yml
@@ -16,4 +16,5 @@ checktext: |-
 fixtext: |-
     To configure the system to prevent the  usb-storage kernel module from being loaded, add the following line to the file  /etc/modprobe.d/usb-storage.conf (or create usb-storage.conf if it does not exist):
 
+    install usb-storage /bin/true
     blacklist usb-storage

--- a/linux_os/guide/system/software/disk_partitioning/partition_for_home/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/disk_partitioning/partition_for_home/policy/stig/shared.yml
@@ -17,4 +17,3 @@ checktext: |-
 
 fixtext: |-
     Migrate the "/home" directory onto a separate file system/partition.
-

--- a/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_crypto_policy/policy/stig/shared.yml
@@ -21,8 +21,6 @@ checktext: |-
 
     If the command does not return "The configured policy is applied.", this is a finding.
 
-
-
 fixtext: |-
     Configure the operating system to implement FIPS mode with the following command
 

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_crypto_policy/policy/stig/shared.yml
@@ -25,5 +25,4 @@ fixtext: |-
     Edit the "/etc/pki/tls/openssl.cnf" and add or modify the following line:
     .include = /etc/crypto-policies/back-ends/opensslcnf.config
 
-
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_openssl_tls_crypto_policy/policy/stig/shared.yml
@@ -21,13 +21,9 @@ checktext: |-
     If the "TLS.MinProtocol" is set to anything older than "TLSv1.2" or the "DTLS.MinProtocol" is set to anything older than DTLSv1.2, this is a finding.
 
 fixtext: |-
-    Reinstall the crypto-policies package to remove any modifications.
+    Configure the {{{ full_name }}} OpenSSL library to use only DoD-approved TLS encryption by editing the following line in the "/etc/crypto-policies/back-ends/opensslcnf.config" file:
 
-    $ sudo dnf reinstall crypto-policies
+    TLS.MinProtocol = TLSv1.2
+    DTLS.MinProtocol = DTLSv1.2
 
-    Then ensure that FIPS mode is setup with the following command:
-
-    $ sudo fips-mode-setup --enable
-
-    The system must be rebooted for the changes to take effect.
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/configure_ssh_crypto_policy/policy/stig/shared.yml
@@ -2,13 +2,19 @@ srg_requirement: |-
     The {{{ full_name }}} SSH daemon must be configured to use system-wide crypto policies.
 
 vuldiscussion: |-
-    Without cryptographic integrity protections, information can be altered by unauthorized users without detection.
+    Without cryptographic integrity protections, information can be altered
+    by unauthorized users without detection.
 
-    Remote access (e.g., RDP) is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+    Remote access (e.g., RDP) is access to DoD nonpublic information systems
+     by an authorized user (or an information system) communicating through
+    an external, non-organization-controlled network. Remote access methods
+    include, for example, dial-up, broadband, and wireless.
 
-    Cryptographic mechanisms used for protecting the integrity of information include, for example, signed hash functions using asymmetric cryptography enabling distribution of the public key to verify the hash information while maintaining the confidentiality of the secret key used to generate the hash.
-
-    The employed algorithms can be viewed in the /etc/crypto-policies/back-ends/openssl.config file.
+    Cryptographic mechanisms used for protecting the integrity of
+    information include, for example, signed hash functions using asymmetric
+     cryptography enabling distribution of the public key to verify the hash
+     information while maintaining the confidentiality of the secret key
+    used to generate the hash.
 
 checktext: |-
     Verify that system-wide crypto policies are in effect:
@@ -23,4 +29,5 @@ fixtext: |-
     Configure the {{{ full_name }}} SSH daemon to use system-wide crypto policies by running the following commands:
 
     $ sudo dnf reinstall openssh-server
+
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_openssh_conf_crypto_policy/policy/stig/shared.yml
@@ -19,7 +19,6 @@ checktext: |-
 
     If "Include /etc/crypto-policies/back-ends/openssh.config" or "Include /etc/ssh/ssh_config.d/*.conf" are not included in the system ssh client config or the file "/etc/ssh/ssh_config.d/50-redhat.conf" is missing, this is a finding.
 
-
 fixtext: |-
     Configure the {{{ full_name }}} SSH daemon to use system-wide crypto policies by running the following commands:
 

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_ciphers_opensshserver_conf_crypto_policy/policy/stig/shared.yml
@@ -20,13 +20,8 @@ checktext: |-
     If the cipher entries in the "opensshserver.config" file have any ciphers other than "aes256-gcm@openssh.com", "aes256-ctr", "aes128-gcm@openssh.com", "aes128-ctr", the order differs from the example above, they are missing, or commented out, this is a finding.
 
 fixtext: |-
-    Reinstall the crypto-policies package to remove any modifications.
+    Configure the {{{ full_name }}} SSH client to use only ciphers employing FIPS 140-3 approved algorithms by updating the "/etc/crypto-policies/back-ends/openssh.config" file with the following line:
 
-    $ sudo dnf reinstall crypto-policies
+    Ciphers aes256-ctr,aes192-ctr,aes128-ctr
 
-    Then ensure that FIPS mode is setup with the following command:
-
-    $ sudo fips-mode-setup --enable
-
-    The system must be rebooted for the changes to take effect.
     A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_openssh_conf_crypto_policy/policy/stig/shared.yml
@@ -20,12 +20,8 @@ checktext: |-
     If the MACs entries in the "openssh.config" file have any hashes other than  "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com", "hmac-sha2-256", "hmac-sha2-512", the order differs from the example above, they are missing, or commented out, this is a finding.
 
 fixtext: |-
-    Reinstall the crypto-policies package to remove any modifications.
+    Configure the {{{ full_name }}} SSH client to use only MACs employing FIPS 140-3 approved algorithms by updating the "/etc/crypto-policies/back-ends/openssh.config" file with the following line:
 
-    $ sudo dnf reinstall crypto-policies
+    MACs hmac-sha2-512,hmac-sha2-256
 
-    Then ensure that FIPS mode is setup with the following command:
-
-    $ sudo fips-mode-setup --enable
-
-    The system must be rebooted for the changes to take effect.
+    A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/crypto/harden_sshd_macs_opensshserver_conf_crypto_policy/policy/stig/shared.yml
@@ -20,12 +20,8 @@ checktext: |-
     If the MACs entries in the "opensshserver.config" file have any hashes other than "hmac-sha2-256-etm@openssh.com", "hmac-sha2-512-etm@openssh.com", "hmac-sha2-256", "hmac-sha2-512", the order differs from the example above, they are missing, or commented out, this is a finding.
 
 fixtext: |-
-    Reinstall the crypto-policies package to remove any modifications.
+    Configure the {{{ full_name }}} SSH client to use only MACs employing FIPS 140-3 approved algorithms by updating the "/etc/crypto-policies/back-ends/openssh.config" file with the following line:
 
-    $ sudo dnf reinstall crypto-policies
+    MACs hmac-sha2-512,hmac-sha2-256
 
-    Then ensure that FIPS mode is setup with the following command:
-
-    $ sudo fips-mode-setup --enable
-
-    The system must be rebooted for the changes to take effect.
+    A reboot is required for the changes to take effect.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/policy/stig/shared.yml
@@ -1,5 +1,5 @@
 srg_requirement: |-
-    {{{ full_name }}} must routinely check the baseline configuration for unauthorized changes and notify the system administrator when anomalies in the operation of any security functions are discovered.
+    {{{ full_name }}} mustroutinely check the baseline configuration for unauthorized changes and notify the system administrator when anomalies in the operation of any security functions are discovered.
 
 vuldiscussion: |-
     Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the operating system. Changes to operating system configurations can have unintended side effects, some of which may be relevant to security.
@@ -34,7 +34,7 @@ checktext: |-
 fixtext: |-
     Configure the file integrity tool to run automatically on the system at least weekly and to notify designated personnel if baseline configurations are changed in an unauthorized manner. The AIDE tool can be configured to email designated personnel with the use of the cron system.
 
-    The following example output is generic. It will set cron to run AIDE daily and to send email at the completion of the analysis.
+    The following example output is generic. It will set cron to run AIDE daily and to send email at the completion of the analysis
 
     $ sudo more /etc/cron.daily/aide
 


### PR DESCRIPTION
#### Description:

RHEL 9 STIG import from November 2022.

#### Rationale:
Keeping the repositories up to date with the process. 