### PR TITLE
Add sanity tests for compare_disa_xml.py

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -260,3 +260,10 @@ if (PYTHON_VERSION_MAJOR GREATER 2 AND SSG_PRODUCT_RHEL7)
     ssg_refcheck_test("rhel7" "cis_server_l1" "cis")
     ssg_refcheck_test("rhel7" "cis" "cis")
 endif()
+
+if (PYTHON_VERSION_MAJOR GREATER 2)
+    add_test(
+        NAME "test-compare-disa-xml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/compare_disa_xml.py" "${CMAKE_SOURCE_DIR}/shared/references/disa-stig-rhel8-v1r8-xccdf-manual.xml" "${CMAKE_SOURCE_DIR}/tests/data/utils/disa-stig-rhel8-v1r6-xccdf-manual.xml"
+    )
+endif()


### PR DESCRIPTION
#### Description:

Add sanity tests for compare_disa_xml.py

#### Rationale:


Ensure that we don't break scripts during development.

