### PR TITLE
Bump fedora version in Dockerfiles to 37

### DIFF
--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -1,4 +1,4 @@
-FROM fedora:35 as builder
+FROM fedora:37 as builder
 
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content

--- a/ocp-resources/ds-build-remote.yaml
+++ b/ocp-resources/ds-build-remote.yaml
@@ -17,7 +17,7 @@ spec:
       type: "ImageChange"
   source: 
     dockerfile: |
-      FROM registry.fedoraproject.org/fedora-minimal:35 as builder
+      FROM registry.fedoraproject.org/fedora-minimal:37 as builder
 
       WORKDIR /content
 


### PR DESCRIPTION
#### Description:

- Bump Fedora version from 35 to 37 in our Dockerfiles

#### Rationale:

- Fedora 35 is no longer maintained and the images will be removed at some point. I even saw weird failures locally (microdnf not found)
  which might indicate the images are broken.

#### Review Hints:

- `./utils/build_ds_container.py -c -p` should be enough to test the change in `ocp-resources/ds-build-remote.yaml`.
- The change in `Dockerfiles/quay_publish` will be tested when our quay.io images are regenerated. In the meantime, local testing can
  be done with `podman build -f Dockerfiles/quay_publish`
