### PR TITLE
Fix OCP rule routes_protected_by_tls

### DIFF
--- a/applications/openshift/networking/routes_protected_by_tls/rule.yml
+++ b/applications/openshift/networking/routes_protected_by_tls/rule.yml
@@ -20,6 +20,8 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-84225-2
 
+{{% set jqfilter = '[.items[] | select(.spec.tls.insecureEdgeTerminationPolicy != null) | select(.spec.tls.insecureEdgeTerminationPolicy | test("^(^$|None|Redirect)$"; "") | not) | .metadata.name]' %}}
+
 references:
   nerc-cip: CIP-003-8 R4,CIP-003-8 R4.2,CIP-003-8 R5,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R7.1
   nist: AC-4,AC-4(21),AC-17(3),SC-8,SC-8(1),SC-8(2),SI-4
@@ -38,17 +40,16 @@ severity: medium
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/route.openshift.io/v1/routes?limit=500") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/apis/route.openshift.io/v1/routes': jqfilter}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
-    ocp_data: "true"
-    filepath: /apis/route.openshift.io/v1/routes?limit=500
-    yamlpath: ".items[:].spec.tls.insecureEdgeTerminationPolicy"
-    check_existence_yamlpath: ".items[:].spec.host"
-    entity_check: "all"
-    check_existence: "all_exist"
-    values:
-      - value: "^(None|Redirect)$"
-        operation: "pattern match"
+      ocp_data: "true"
+      filepath: "{{{ openshift_filtered_path('/apis/route.openshift.io/v1/routes', jqfilter) }}}"
+      yamlpath: "[:]"
+      check_existence: "none_exist"
+      entity_check: "all"
+      values:
+        - value: "(.*?)"
+          operation: "pattern match"

--- a/applications/openshift/networking/routes_protected_by_tls/tests/all_route.pass.sh
+++ b/applications/openshift/networking/routes_protected_by_tls/tests/all_route.pass.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
+
 # remediation = none
 
-mkdir -p /kubernetes-api-resources/apis/route.openshift.io/v1/
+yum install -y jq
 
-cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=500
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/route.openshift.io/v1"
+
+routes_apipath="/apis/route.openshift.io/v1/routes"
+
+cat <<EOF > "$kube_apipath$routes_apipath"
 {
     "apiVersion": "v1",
     "items": [
@@ -11,14 +18,14 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
             "apiVersion": "route.openshift.io/v1",
             "kind": "Route",
             "metadata": {
-                "creationTimestamp": "2022-02-07T15:44:41Z",
+                "creationTimestamp": "2021-11-10T16:47:27Z",
                 "labels": {
                     "app": "oauth-openshift"
                 },
                 "name": "oauth-openshift",
                 "namespace": "openshift-authentication",
-                "resourceVersion": "20112",
-                "uid": "f90675f0-6090-4222-8b41-bf32d522d9ac"
+                "resourceVersion": "21582",
+                "uid": "265f462c-eb31-43e5-abab-aaad3e34b448"
             },
             "spec": {
                 "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
@@ -41,7 +48,7 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                     {
                         "conditions": [
                             {
-                                "lastTransitionTime": "2022-02-07T15:47:15Z",
+                                "lastTransitionTime": "2021-11-10T16:49:45Z",
                                 "status": "True",
                                 "type": "Admitted"
                             }
@@ -61,30 +68,29 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                 "annotations": {
                     "openshift.io/host.generated": "true"
                 },
-                "creationTimestamp": "2022-02-07T15:48:36Z",
+                "creationTimestamp": "2021-11-11T00:26:39Z",
                 "labels": {
-                    "app.kubernetes.io/component": "query-layer",
-                    "app.kubernetes.io/instance": "thanos-querier",
-                    "app.kubernetes.io/name": "thanos-query",
-                    "app.kubernetes.io/version": "0.22.0"
+                    "app": "wordpress",
+                    "app.kubernetes.io/component": "wordpress",
+                    "app.kubernetes.io/instance": "wordpress"
                 },
-                "name": "thanos-querier",
-                "namespace": "openshift-monitoring",
-                "resourceVersion": "22723",
-                "uid": "a9aee465-0939-466a-a187-5d1c3e97d8e9"
+                "name": "wordpress",
+                "namespace": "test-no-rate-limit",
+                "resourceVersion": "213342",
+                "uid": "26f97c95-7351-49b8-a0dd-f6cdd88283ae"
             },
             "spec": {
-                "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                "host": "wordpress-test-no-rate-limit.apps.wenshen-51.devcluster.openshift.com",
                 "port": {
-                    "targetPort": "web"
+                    "targetPort": "8080-tcp"
                 },
                 "tls": {
                     "insecureEdgeTerminationPolicy": "Redirect",
-                    "termination": "reencrypt"
+                    "termination": "passthrough"
                 },
                 "to": {
                     "kind": "Service",
-                    "name": "thanos-querier",
+                    "name": "wordpress",
                     "weight": 100
                 },
                 "wildcardPolicy": "None"
@@ -94,12 +100,12 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                     {
                         "conditions": [
                             {
-                                "lastTransitionTime": "2022-02-07T15:48:36Z",
+                                "lastTransitionTime": "2021-11-11T00:26:39Z",
                                 "status": "True",
                                 "type": "Admitted"
                             }
                         ],
-                        "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                        "host": "wordpress-test-no-rate-limit.apps.wenshen-51.devcluster.openshift.com",
                         "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
                         "routerName": "default",
                         "wildcardPolicy": "None"
@@ -114,3 +120,12 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
         "selfLink": ""
     }
 }
+EOF
+
+jq_filter='[.items[] | select(.spec.tls.insecureEdgeTerminationPolicy != null) | select(.spec.tls.insecureEdgeTerminationPolicy | test("^(^$|None|Redirect)$"; "") | not) | .metadata.name]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$routes_apipath#$(echo -n "$routes_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$routes_apipath" > "$filteredpath"

--- a/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_none.pass.sh
+++ b/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_none.pass.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
+
 # remediation = none
 
-mkdir -p /kubernetes-api-resources/apis/route.openshift.io/v1/
+yum install -y jq
 
-cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=500
+kube_apipath="/kubernetes-api-resources"
+
+mkdir -p "$kube_apipath/apis/route.openshift.io/v1"
+
+routes_apipath="/apis/route.openshift.io/v1/routes"
+
+cat <<EOF > "$kube_apipath$routes_apipath"
 {
     "apiVersion": "v1",
     "items": [
@@ -11,14 +18,14 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
             "apiVersion": "route.openshift.io/v1",
             "kind": "Route",
             "metadata": {
-                "creationTimestamp": "2022-02-07T15:44:41Z",
+                "creationTimestamp": "2021-11-10T16:47:27Z",
                 "labels": {
                     "app": "oauth-openshift"
                 },
                 "name": "oauth-openshift",
                 "namespace": "openshift-authentication",
-                "resourceVersion": "20112",
-                "uid": "f90675f0-6090-4222-8b41-bf32d522d9ac"
+                "resourceVersion": "21582",
+                "uid": "265f462c-eb31-43e5-abab-aaad3e34b448"
             },
             "spec": {
                 "host": "oauth-openshift.apps.wenshen-51.devcluster.openshift.com",
@@ -26,7 +33,7 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                     "targetPort": 6443
                 },
                 "tls": {
-                    "insecureEdgeTerminationPolicy": "None",
+                    "insecureEdgeTerminationPolicy": "Redirect",
                     "termination": "passthrough"
                 },
                 "to": {
@@ -41,7 +48,7 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                     {
                         "conditions": [
                             {
-                                "lastTransitionTime": "2022-02-07T15:47:15Z",
+                                "lastTransitionTime": "2021-11-10T16:49:45Z",
                                 "status": "True",
                                 "type": "Admitted"
                             }
@@ -61,30 +68,29 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                 "annotations": {
                     "openshift.io/host.generated": "true"
                 },
-                "creationTimestamp": "2022-02-07T15:48:36Z",
+                "creationTimestamp": "2021-11-11T00:26:39Z",
                 "labels": {
-                    "app.kubernetes.io/component": "query-layer",
-                    "app.kubernetes.io/instance": "thanos-querier",
-                    "app.kubernetes.io/name": "thanos-query",
-                    "app.kubernetes.io/version": "0.22.0"
+                    "app": "wordpress",
+                    "app.kubernetes.io/component": "wordpress",
+                    "app.kubernetes.io/instance": "wordpress"
                 },
-                "name": "thanos-querier",
-                "namespace": "openshift-monitoring",
-                "resourceVersion": "22723",
-                "uid": "a9aee465-0939-466a-a187-5d1c3e97d8e9"
+                "name": "wordpress",
+                "namespace": "test-no-rate-limit",
+                "resourceVersion": "213342",
+                "uid": "26f97c95-7351-49b8-a0dd-f6cdd88283ae"
             },
             "spec": {
-                "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                "host": "wordpress-test-no-rate-limit.apps.wenshen-51.devcluster.openshift.com",
                 "port": {
-                    "targetPort": "web"
+                    "targetPort": "8080-tcp"
                 },
                 "tls": {
-                    "insecureEdgeTerminationPolicy": "Redirect",
-                    "termination": "reencrypt"
+                    "insecureEdgeTerminationPolicy": "None",
+                    "termination": "passthrough"
                 },
                 "to": {
                     "kind": "Service",
-                    "name": "thanos-querier",
+                    "name": "wordpress",
                     "weight": 100
                 },
                 "wildcardPolicy": "None"
@@ -94,12 +100,12 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
                     {
                         "conditions": [
                             {
-                                "lastTransitionTime": "2022-02-07T15:48:36Z",
+                                "lastTransitionTime": "2021-11-11T00:26:39Z",
                                 "status": "True",
                                 "type": "Admitted"
                             }
                         ],
-                        "host": "thanos-querier-openshift-monitoring.apps.wenshen-51.devcluster.openshift.com",
+                        "host": "wordpress-test-no-rate-limit.apps.wenshen-51.devcluster.openshift.com",
                         "routerCanonicalHostname": "router-default.apps.wenshen-51.devcluster.openshift.com",
                         "routerName": "default",
                         "wildcardPolicy": "None"
@@ -114,3 +120,12 @@ cat <<EOF > /kubernetes-api-resources/apis/route.openshift.io/v1/routes?limit=50
         "selfLink": ""
     }
 }
+EOF
+
+jq_filter='[.items[] | select(.spec.tls.insecureEdgeTerminationPolicy != null) | select(.spec.tls.insecureEdgeTerminationPolicy | test("^(^$|None|Redirect)$"; "") | not) | .metadata.name]'
+
+# Get file path. This will actually be read by the scan
+filteredpath="$kube_apipath$routes_apipath#$(echo -n "$routes_apipath$jq_filter" | sha256sum | awk '{print $1}')"
+
+# populate filtered path with jq-filtered result
+jq "$jq_filter" "$kube_apipath$routes_apipath" > "$filteredpath"

--- a/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_one_null.pass.sh
+++ b/applications/openshift/networking/routes_protected_by_tls/tests/all_route_with_one_null.pass.sh
@@ -85,7 +85,6 @@ cat <<EOF > "$kube_apipath$routes_apipath"
                     "targetPort": "8080-tcp"
                 },
                 "tls": {
-                    "insecureEdgeTerminationPolicy": "Allow",
                     "termination": "passthrough"
                 },
                 "to": {


### PR DESCRIPTION
The rules give false negative result on a route that does not have insecureEdgeTerminationPolicy, this PR uses a jq filter to filter out the null in insecureEdgeTerminationPolicy, so it gives the correct result.
