### PR TITLE
Platforms: prevent building content when version comparison is used and platform provides remediation conditional

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1236,7 +1236,7 @@ included in the dictionary.
 Allows the construction of logical expressions involving CPEs.
 
 CPEs can be combined to form an applicability statement.
-The `platfrom` property of a rule (or a group) can contain a [Boolean expression](https://booleanpy.readthedocs.io/en/latest/concepts.html),
+The `platform` property of a rule (or a group) can contain a [Boolean expression](https://booleanpy.readthedocs.io/en/latest/concepts.html),
 that describes the relationship of a set of individual CPEs (symbols), which would later be converted
 by the build system into the CPE AL definition in the XCCDF document.
 

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -163,9 +163,9 @@ A rule itself contains these attributes:
     means it will be evaluated only if the targeted scan environment is either
     bare-metal or virtual
     machine. Also, it can restrict applicability on higher software
-    layers. By setting to `shadow-utils`, the rule will have its
+    layers. By setting to `package[audit]`, the rule will have its
     applicability restricted to only environments which have
-    `shadow-utils` package installed.
+    `audit` package installed.
 
     The available options can be found
     in the file &lt;product&gt;/cpe/&lt;product&gt;-cpe-dictionary.xml

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -189,6 +189,12 @@ A rule itself contains these attributes:
     but only if there is no *shadow-utils* or *ssh* package installed.
 
     Some platforms can also define applicability based on the version of the entity they check.
+    Please note that this feature is not yet consistently implemented.
+    Read the following before using it.
+    If the version specification is used, it is correctly rendered into appropriate OVAL check which is later used when deciding on applicability of a rule.
+    However, conditionals used to limit applicability of Bash and Ansible remediations are currently not generated correctly in this case; the version specification is not taken into account.
+    Therefore, the build will be interrupted in case you try to use a platform with version specification which influences Bash or Ansible remediation.
+
     Version specifiers notation loosely follows [PEP440](https://peps.python.org/pep-0440/#version-specifiers),
     most notably not supporting *wildcard*, *epoch* and *non-numeric* suffixes.
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -169,9 +169,10 @@ class Remediation(object):
             platform = cpe_platforms[p]
             if self._check_if_platform_uses_version_comparison(platform, language):
                 raise ValueError(
-                    "Platforms using version comparison are currently not producing consistent "
-                    "results when used with {0} remediations. Therefore the platform defined as "
-                    "{1} can't be used.".format(language, platform.original_expression))
+                    "The platform definition you are trying to use uses version comparison. "
+                    "Remediation conditionals for such platforms are currently not implemented "
+                    "for {0} remediations. {1} can't be used.".format(
+                        language, platform.original_expression))
             conditional = platform.get_remediation_conditional(language)
             if conditional is not None:
                 stripped_conditional = conditional.strip()

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -145,11 +145,13 @@ class Remediation(object):
                 if p not in inherited_cpe_platform_names}
         return rule_specific_cpe_platform_names
 
-    def _check_if_platform_uses_version_comparison(self, platform):
+    def _check_if_platform_uses_version_comparison(self, platform, language):
         version_comparison_characters = ("<", ">", "=")
-        for char in version_comparison_characters:
-            if char in platform.original_expression:
-                return True
+        languages_with_not_working_version_comparison = ("ansible", "bash")
+        if language in languages_with_not_working_version_comparison:
+            for char in version_comparison_characters:
+                if char in platform.original_expression:
+                    return True
         return False
 
     def get_stripped_conditionals(self, language, cpe_platform_names, cpe_platforms):
@@ -158,7 +160,6 @@ class Remediation(object):
         and strip them of white spaces
         """
         stripped_conditionals = []
-        languages_with_not_working_version_comparison = ("ansible", "bash")
         for p in cpe_platform_names:
             # if a platform uses specification of versions as an applicability criteria
             # it is currently correctly used in OVAL checks
@@ -166,8 +167,7 @@ class Remediation(object):
             # we prevent building content which uses
             # such a platform with a remediation conditional specified
             platform = cpe_platforms[p]
-            if language in languages_with_not_working_version_comparison and (
-                    self._check_if_platform_uses_version_comparison(platform)):
+            if self._check_if_platform_uses_version_comparison(platform, language):
                 raise ValueError(
                     "Platforms using version comparison are currently not producing consistent "
                     "results when used with {0} remediations. Therefore the platform defined as "

--- a/tests/unit/ssg-module/data/package_ntp.yml
+++ b/tests/unit/ssg-module/data/package_ntp.yml
@@ -4,6 +4,5 @@ xml_content: <ns0:platform xmlns:ns0="http://cpe.mitre.org/language/2.0" id="pac
     operator="AND" negate="false"><ns0:fact-ref name="cpe:/a:ntp" /></ns0:logical-test></ns0:platform>
 bash_conditional: ( ( rpm --quiet -q ntp ) )
 ansible_conditional: ( ( "ntp" in ansible_facts.packages ) )
-definition_location: ''
 documentation_complete: true
 title: 'NTP Package'

--- a/tests/unit/ssg-module/data/package_ntp_eq_1_0.yml
+++ b/tests/unit/ssg-module/data/package_ntp_eq_1_0.yml
@@ -1,0 +1,9 @@
+name: package_ntp_eq_1_0
+original_expression: package[ntp]==1.0
+xml_content: <ns0:platform xmlns:ns0="http://cpe.mitre.org/language/2.0" id="package_ntp_eq_1_0"><ns0:logical-test
+    operator="AND" negate="false"><ns0:fact-ref name="cpe:/a:ntp:eq:1.0" /></ns0:logical-test></ns0:platform>
+bash_conditional: rpm --quiet -q ntp
+ansible_conditional: '"ntp" in ansible_facts.packages'
+title: ''
+definition_location: /home/vojta/repos/upstream/content/build/rhel7/platforms/package_ntp_eq_1_0.yml
+documentation_complete: true

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -25,6 +25,10 @@ def cpe_platforms(env_yaml):
     platforms[platform.name] = platform
     return platforms
 
+@pytest.fixture
+def cpe_platforms_with_version_comparison(env_yaml):
+    
+
 
 def test_is_supported_file_name():
     assert sbr.is_supported_filename('bash', 'something.sh')

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -27,7 +27,11 @@ def cpe_platforms(env_yaml):
 
 @pytest.fixture
 def cpe_platforms_with_version_comparison(env_yaml):
-    
+    platforms = dict()
+    platform_path = os.path.join(DATADIR, "package_ntp_eq_1_0.yml")
+    platform = ssg.build_yaml.Platform.from_yaml(platform_path, env_yaml)
+    platforms[platform.name] = platform
+    return platforms
 
 
 def test_is_supported_file_name():
@@ -122,3 +126,9 @@ def test_get_rule_dir_remediations():
     something_bash = sbr.get_rule_dir_remediations(rule_dir, 'bash', 'something')
     assert len(something_bash) == 1
     assert something_bash != rhel_bash
+
+def test_deny_to_parse_remediation_if_platform_has_version_comparison(cpe_platforms_with_version_comparison):
+    remediation_cls = sbr.REMEDIATION_TO_CLASS["bash"]
+    remediation_obj = remediation_cls(rhel_bash)
+    with pytest.raises(ValueError):
+        remediation_obj.get_stripped_conditionals("bash", ["package_ntp_eq_1_0"], cpe_platforms_with_version_comparison)


### PR DESCRIPTION
#### Description:

- when building remediations, check if a platform which should influence the remediation by providing conditional tries to check applicability by version comparison
- if yes, abort the build and explain the reason
- update documentation accordingly
- add relevant test

#### Rationale:

If the version comparison is used within platform definition, the resulting OVAL check will perform the check but remediation conditionals will not. This introduces inconsistency and there should be prevented.