### PR TITLE
Fix accounts_password template for OL

### DIFF
--- a/shared/templates/accounts_password/ansible.template
+++ b/shared/templates/accounts_password/ansible.template
@@ -7,7 +7,7 @@
 
 {{% if product == "ol8" %}}
 - name: {{{ rule_title }}} - Find pwquality.conf.d files
-  ansible.builtin.find::
+  ansible.builtin.find:
     paths: /etc/security/pwquality.conf.d/
     patterns: "*.conf"
   register: pwquality_conf_d_files


### PR DESCRIPTION


#### Description:

Fix a minor syntax issue.

#### Rationale:
This was causing invalid syntax errors for OL8 Ansible and nightly build failures.

#### Review Hints:

Running `ctest --output-on-failure -R ansible-playbook-syntax-check-ol8` on master should show the error.