### PR TITLE
Include Ubuntu products in package_cups_removed

### DIFF
--- a/linux_os/guide/services/printing/package_cups_removed/rule.yml
+++ b/linux_os/guide/services/printing/package_cups_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle12,sle15
+prodtype: rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Uninstall CUPS Package'
 
@@ -26,6 +26,8 @@ references:
     cis@rhel8: 2.2.4
     cis@sle12: 2.2.4
     cis@sle15: 2.2.4
+    cis@ubuntu2004: 2.2.4
+    cis@ubuntu2204: 2.2.3
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS05.02,DSS05.05,DSS06.06
     isa-62443-2009: 4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.2,4.3.4.3.3
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR 7.6'

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -243,7 +243,7 @@ selections:
 
     ### 2.2.4 Ensure CUPS is not installed (Automated)
     - service_cups_disabled
-    # Needs rule: package_cups_removed
+    - package_cups_removed
 
     ### 2.2.5 Ensure DHCP Server is not installed (Automated)
     - package_dhcp_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -272,6 +272,7 @@ selections:
 
     ### 2.2.3 Ensure CUPS is not installed (Automated)
     - service_cups_disabled
+    - package_cups_removed
 
     ### 2.2.4 Ensure DHCP Server is not installed (Automated)
     - package_dhcp_removed


### PR DESCRIPTION
#### Description:

- The `package_cups_removed` rule is also applicable for Ubuntu

#### Rationale:

- This rule can cover benchmarks requirements, like CIS for Ubuntu 20.04 and Ubuntu 22.04.