### PR TITLE
Include Ubuntu products in package_rsync_removed

### DIFF
--- a/linux_os/guide/services/obsolete/package_rsync_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/package_rsync_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,sle12,sle15
+prodtype: rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Uninstall rsync Package'
 
@@ -26,6 +26,8 @@ references:
     cis@rhel8: 2.2.20
     cis@sle12: 2.2.17
     cis@sle15: 2.2.17
+    cis@ubuntu2004: 2.2.16
+    cis@ubuntu2204: 2.2.16
 
 {{{ complete_ocil_entry_package(package="rsync") }}}
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -279,7 +279,7 @@ selections:
     # Needs rule
 
     ### 2.2.16 Ensure rsync service is not installed (Automated)
-    # Needs rule: package_rsync_removed
+    - package_rsync_removed
 
     ### 2.2.17 Ensure NIS Server is not installed (Automated)
     - package_nis_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -311,7 +311,7 @@ selections:
     - postfix_network_listening_disabled
 
     ### 2.2.16 Ensure rsync service is not installed (Automated)
-    # NEEDS RULE
+    - package_rsync_removed
 
     ## 2.3 Service Clients ##
     ### 2.3.1 Ensure NIS Client is not installed (Automated)


### PR DESCRIPTION
#### Description:

- The `package_cups_removed` rule is also applicable for Ubuntu

#### Rationale:

- This rule can cover benchmarks requirements, like CIS for Ubuntu 20.04 and Ubuntu 22.04.