### PR TITLE
Include Ubuntu products in package_nftables_installed

### DIFF
--- a/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9,sle15
+prodtype: rhel8,rhel9,sle15,ubuntu2004,ubuntu2204
 
 title: 'Install nftables Package'
 
@@ -9,12 +9,12 @@ description: |-
     network-specific Virtual Machine (VM) and a new nft userspace command line tool.
     nftables reuses the existing Netfilter subsystems such as the existing hook infrastructure,
     the connection tracking system, NAT, userspace queuing and logging subsystem.
-    {{{ describe_package_install(package="nftables") }}}   
+    {{{ describe_package_install(package="nftables") }}}
 
 rationale: |-
-    <tt>nftables</tt> is a subsystem of the Linux kernel that can protect against threats 
-    originating from within a corporate network to include malicious mobile code and poorly 
-    configured software on a host. 
+    <tt>nftables</tt> is a subsystem of the Linux kernel that can protect against threats
+    originating from within a corporate network to include malicious mobile code and poorly
+    configured software on a host.
 
 severity: medium
 
@@ -26,6 +26,8 @@ identifiers:
 references:
     cis@rhel8: 3.4.2.1
     cis@sle15: 3.5.2.1
+    cis@ubuntu2004: 3.5.2.1
+    cis@ubuntu2204: 3.5.2.1
 
 ocil_clause: 'the package is not installed'
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -399,7 +399,7 @@ selections:
 
     ### 3.5.2 Configure nftables
     #### 3.5.2.1 Ensure nftables is installed (Automated)
-    # Needs rule
+    - package_nftables_installed
 
     #### 3.5.2.2 Ensure Uncomplicated Firewall is not installed or disabled (Automated)
     # Needs rule

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -429,7 +429,7 @@ selections:
 
     ### 3.5.2 Configure nftables ###
     #### 3.5.2.1 Ensure nftables is installed (Automated)
-    # NEEDS RULE
+    - package_nftables_installed
 
     #### 3.5.2.2 Ensure ufw is uninstalled or disabled with nftables (Automated)
     # NEEDS RULE


### PR DESCRIPTION
#### Description:

- The `package_nftables_installed` rule is also applicable for Ubuntu

#### Rationale:

- This rule can cover benchmarks requirements, like CIS for Ubuntu 20.04 and Ubuntu 22.04.