### PR TITLE
Typo corrections in the name of the rule

### DIFF
--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -642,7 +642,7 @@ controls:
     status: automated
     rules:
       - service_rpcbind_disabled
-      - package_rcpbind_removed
+      - package_rpcbind_removed
 
   - id: 2.2.9
     title: Ensure DNS Server is not installed (Automated)

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -623,7 +623,7 @@ controls:
     status: automated
     rules:
       - service_rpcbind_disabled
-      - package_rcpbind_removed
+      - package_rpcbind_removed
 
   - id: 2.2.9
     title: Ensure DNS Server is not installed (Automated)

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/package_rpcbind_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/package_rpcbind_removed/rule.yml
@@ -27,11 +27,11 @@ references:
     cis@sle12: 2.2.8
     cis@sle15: 2.2.8
 
-{{{ complete_ocil_entry_package(package="rcpbind") }}}
+{{{ complete_ocil_entry_package(package="rpcbind") }}}
 
-fixtext: '{{{ fixtext_package_removed("rcpbind") }}}'
+fixtext: '{{{ fixtext_package_removed("rpcbind") }}}'
 
 template:
     name: package_removed
     vars:
-        pkgname: rcpbind
+        pkgname: rpcbind


### PR DESCRIPTION
#### Description:

- _Correction of typo error in the name of rule  _

#### Rationale:

- Instead of rpcbind , rcpbind was used as a name of service 

