### PR TITLE
Include Ubuntu products in package_rpcbind_removed

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/package_rpcbind_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/package_rpcbind_removed/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: sle12,sle15
 
-title: 'Uninstall rcpbind Package'
+title: 'Uninstall rpcbind Package'
 
 description: |-
     The rpcbind utility maps RPC services to the ports on which they listen.
@@ -11,7 +11,7 @@ description: |-
     rpcbind service redirects the client to the proper port number so it can
     communicate with the requested service. If the system does not require RPC
     (such as for NFS servers) then this service should be disabled.
-    {{{ describe_package_remove(package="rcpbind") }}}
+    {{{ describe_package_remove(package="rpcbind") }}}
 
 rationale: |-
     If the system does not require rpc based services, it is recommended that

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/package_rpcbind_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/package_rpcbind_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Uninstall rpcbind Package'
 
@@ -26,6 +26,8 @@ identifiers:
 references:
     cis@sle12: 2.2.8
     cis@sle15: 2.2.8
+    cis@ubuntu2004: 2.3.6
+    cis@ubuntu2204: 2.3.6
 
 {{{ complete_ocil_entry_package(package="rpcbind") }}}
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -301,7 +301,7 @@ selections:
     - package_openldap-clients_removed
 
     ### 2.3.6 Ensure RPC is not installed (Automated)
-    # Needs rule: package_rpcbind_removed
+    - package_rpcbind_removed
 
     ## 2.4 Ensure nonessential services are removed or masked (Manual)
     # Skip due to being a manual test

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -332,7 +332,7 @@ selections:
     - package_openldap-clients_removed
 
     ### 2.3.6 Ensure RPC is not installed (Automated)
-    # NEEDS RULE
+    - package_rpcbind_removed
 
     ## 2.4 Ensure nonessential services are removed or masked (Manual)
     # Skip due to being a manual test


### PR DESCRIPTION
#### Description:

- The `package_rpcbind_removed` rule is also applicable for Ubuntu
- Fix some typos leftover

#### Rationale:

- This rule can cover benchmarks requirements, like CIS for Ubuntu 20.04 and Ubuntu 22.04.