### PR TITLE
Update link to NTP docs

### DIFF
--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -64,7 +64,7 @@ description: |-
     {{% elif "alinux" in product %}}
         {{{ weblink(link="https://www.alibabacloud.com/help/en/elastic-compute-service/latest/alibaba-cloud-ntp-server") }}}
     {{% else %}}
-        {{{ weblink(link="https://docs.fedoraproject.org/en-US/fedora/rawhide/system-administrators-guide/servers/Configuring_NTP_Using_the_chrony_Suite/") }}}
+        {{{ weblink(link="https://docs.fedoraproject.org/en-US/fedora/latest/system-administrators-guide/servers/Configuring_NTP_Using_the_chrony_Suite/") }}}
     {{% endif %}}
     for more detailed comparison of features of <tt>chronyd</tt>
     and <tt>ntpd</tt> daemon features respectively, and for further guidance how to

--- a/linux_os/guide/services/ntp/group.yml
+++ b/linux_os/guide/services/ntp/group.yml
@@ -57,6 +57,10 @@ description: |-
         {{{ weblink(link="https://docs.oracle.com/en/operating-systems/oracle-linux/9/network/network-ConfiguringNetworkTime.html#ol-nettime") }}}
     {{% elif product == "rhel7" %}}
         {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system_administrators_guide/ch-configuring_ntp_using_the_chrony_suite") }}}
+    {{% elif product == "rhel8" %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings") }}}
+    {{% elif product == "rhel9" %}}
+        {{{ weblink(link="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_basic_system_settings/using-chrony-to-configure-ntp_configuring-basic-system-settings#doc-wrapper") }}}
     {{% elif "ubuntu" in product  %}}
         {{{ weblink(link="https://help.ubuntu.com/lts/serverguide/NTP.html") }}}
     {{% elif "debian" in product %}}


### PR DESCRIPTION

#### Description:

- Fixed docs link for Fedora NTP config with `chrony` 
- Added links to docs how to configure NTP using  `chrony`  for RHEL8 and RHEL9.
  - They were still using links to RHEL7.

#### Rationale:

- The link to rawhide doesn't work anymore.