### PR TITLE
Add Bash and Ansible checks for versions

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1250,9 +1250,9 @@ The platform is using the `platform_package` template which is defined in `share
 
 The package platform supports version checking.
 That allows you to define a platform for specific version.
-For example, to make a rule applicable only on systems with `systemd` newer than version 250, add the following to the `rule.yml`:
+For example, to make a rule applicable only on systems with `systemd` version 250 and newer, add the following to the `rule.yml`:
 
-    platform: package[systemd]>250
+    platform: package[systemd]>=250
 
 Only numeric versions are allowed, versions containing letters can't be used in the expressions.
 Versions with epochs are supported.

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1258,6 +1258,12 @@ Only numeric versions are allowed, versions containing letters can't be used in 
 Epoch isn't supported.
 We recommend to use sharp inequality (`>` and `<` instead of `>=` and `<=`) in the expressions.
 
+The package CPEs might seem a go-to approach for most of the applicability problems.
+But, in general, we recommend to derive rule applicability from operating system release version instead of basing that on a version of a specific package.
+The packages in Linux distributions might be patched, bug fixes sometimes get backported to older stable versions, so the behavior of the software might differ from upstream release behavior.
+If the check would be based on operating system version, you can track what packages are distributed there and what patches they contain.
+For example, you can use something like `os_linux[rhel]>8.6` instead of `package[foo]>1.2.3`, if you know that an up-to-date RHEL 8.6 and later comes with `foo` that contains the feature that you are interested in.
+
 ## Tests (ctest)
 
 ComplianceAsCode uses ctest to orchestrate testing upstream. To run the

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1255,7 +1255,8 @@ For example, to make a rule applicable only on systems with `systemd` newer than
     platform: package[systemd]>250
 
 Only numeric versions are allowed, versions containing letters can't be used in the expressions.
-Epoch isn't supported.
+Versions with epochs are supported.
+It isn't mandatory to put a 0 epoch if the package doesn't have epoch.
 We recommend to use sharp inequality (`>` and `<` instead of `>=` and `<=`) in the expressions.
 
 The package CPEs might seem a go-to approach for most of the applicability problems.

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1254,12 +1254,9 @@ For example, to make a rule applicable only on systems with `systemd` newer than
 
     platform: package[systemd]>250
 
-We recommend to use sharp inequality (`>` and `<` instead of `>=` and `<=`), otherwise you would have to use distribution specific versions in rules eg. `251.10-588.el9`.
-
-In general, we can use standard RPM or DEB package versions in these expressions.
-There are some exceptions where the behavior of OVAL check isn't consistent with Ansible and Bash behavior.
-- Epoch isn't supported.
-- Release part overrides the distribution part in the Bash conditionals therefore we don't recommend using distribution-specific versions.
+Only numeric versions are allowed, versions containing letters can't be used in the expressions.
+Epoch isn't supported.
+We recommend to use sharp inequality (`>` and `<` instead of `>=` and `<=`) in the expressions.
 
 ## Tests (ctest)
 

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1257,6 +1257,8 @@ For example, to make a rule applicable only on systems with `systemd` version 25
 Only numeric versions are allowed, versions containing letters can't be used in the expressions.
 Versions with epochs are supported.
 It isn't mandatory to put a 0 epoch if the package doesn't have epoch.
+The 0 epoch will be prepended automatically by the build system in order to normalize the comparison.
+The generated OVAL, Bash and Ansible code will always contain epoch string.
 We don't support using the release component (eg. `-1` or `-1.el8`) in the version expressions.
 
 > **NOTE**: It's tricky to create a correct version expression due to existence of epoch and release components of the version in the rpm or deb package versions.

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1240,6 +1240,27 @@ The `platform` property of a rule (or a group) can contain a [Boolean expression
 that describes the relationship of a set of individual CPEs (symbols), which would later be converted
 by the build system into the CPE AL definition in the XCCDF document.
 
+#### Package CPEs
+
+Package CPEs are used to define rule applicability based on presence of a package or of a specific version of the package.
+
+The `package` platform is defined in `shared/applicability/package.yml`.
+To add a new package-based CPE, simply create a new entry in this file.
+The platform is using the `platform_package` template which is defined in `shared/templates/platform_package`.
+
+The package platform supports version checking.
+That allows you to define a platform for specific version.
+For example, to make a rule applicable only on systems with `systemd` newer than version 250, add the following to the `rule.yml`:
+
+    platform: package[systemd]>250
+
+We recommend to use sharp inequality (`>` and `<` instead of `>=` and `<=`), otherwise you would have to use distribution specific versions in rules eg. `251.10-588.el9`.
+
+In general, we can use standard RPM or DEB package versions in these expressions.
+There are some exceptions where the behavior of OVAL check isn't consistent with Ansible and Bash behavior.
+- Epoch isn't supported.
+- Release part overrides the distribution part in the Bash conditionals therefore we don't recommend using distribution-specific versions.
+
 ## Tests (ctest)
 
 ComplianceAsCode uses ctest to orchestrate testing upstream. To run the

--- a/shared/applicability/grub2.yml
+++ b/shared/applicability/grub2.yml
@@ -2,4 +2,4 @@ name: "cpe:/a:grub2"
 title: "Package grub2 is installed"
 check_id: installed_env_has_grub2_package
 bash_conditional: {{{ bash_pkg_conditional("grub2") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("grub2") }}}
+ansible_conditional: '{{{ ansible_pkg_conditional("grub2") }}}'

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -1,6 +1,5 @@
 name: "cpe:/a:{arg}:{ver_specs_cpe}"
 title: "Package {pkgname} is installed"
-ansible_conditional: {{{ ansible_pkg_conditional("{pkgname}") }}}
 versioned: true
 template:
   name: platform_package

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -1,6 +1,5 @@
 name: "cpe:/a:{arg}:{ver_specs_cpe}"
 title: "Package {pkgname} is installed"
-bash_conditional: {{{ bash_pkg_conditional("{pkgname}", escape=True) }}}
 ansible_conditional: {{{ ansible_pkg_conditional("{pkgname}") }}}
 versioned: true
 template:

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -727,8 +727,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- if ver -%}}
 {{# For RPM packages, Ansible splits the package version into "epoch", "version" and "release" keys. For DEB packages, Ansible provides only "version" key. We don't take the "release" part into account. #}}
 {{%- if pkg_system == "rpm" -%}}
-{{# We don't support RPM epoch at this moment. #}}
-"{{{ package }}}" in ansible_facts.packages and (ansible_facts.packages["{{{ package }}}"] | last)["version"] is version("{{{ ver }}}", "{{{ op }}}")
+"{{{ package }}}" in ansible_facts.packages and (((((ansible_facts.packages["{{{ package }}}"] | last)["epoch"]) != None) | ternary((ansible_facts.packages["{{{ package }}}"] | last)["epoch"] ~ ":", "0:")) + ((ansible_facts.packages["{{{ package }}}"] | last)["version"] | split("-") | first)) is version("{{{ ver }}}", "{{{ op }}}")
 {{%- else -%}}
 "{{{ package }}}" in ansible_facts.packages and ((ansible_facts.packages["{{{ package }}}"] | last)["version"] | split("-") | first) is version("{{{ ver }}}", "{{{ op }}}")
 {{%- endif -%}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -717,10 +717,10 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   The macro respects `platform_package_overrides` variable.
 
 :param package: package name
-:param ver: package version (optional argument, use together with "op")
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param ver: package version (optional argument, use together with "op")
 #}}
-{{%- macro ansible_pkg_conditional(package, ver=None, op=None) -%}}
+{{%- macro ansible_pkg_conditional(package, op=None, ver=None) -%}}
 {{%- if package in platform_package_overrides -%}}
   {{%- set package = platform_package_overrides[package] -%}}
 {{%- endif -%}}

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -725,12 +725,12 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   {{%- set package = platform_package_overrides[package] -%}}
 {{%- endif -%}}
 {{%- if ver -%}}
-{{# For RPM packages, Ansible splits the package version into "epoch", "version" and "release" keys. For DEB packages, Ansible provides only "version" key. #}}
+{{# For RPM packages, Ansible splits the package version into "epoch", "version" and "release" keys. For DEB packages, Ansible provides only "version" key. We don't take the "release" part into account. #}}
 {{%- if pkg_system == "rpm" -%}}
 {{# We don't support RPM epoch at this moment. #}}
-"{{{ package }}}" in ansible_facts.packages and ((ansible_facts.packages["{{{ package }}}"] | last)["version"] + "-" + (ansible_facts.packages["{{{ package }}}"] | last)["release"]) is version("{{{ ver }}}", "{{{ op }}}")
-{{%- else -%}}
 "{{{ package }}}" in ansible_facts.packages and (ansible_facts.packages["{{{ package }}}"] | last)["version"] is version("{{{ ver }}}", "{{{ op }}}")
+{{%- else -%}}
+"{{{ package }}}" in ansible_facts.packages and ((ansible_facts.packages["{{{ package }}}"] | last)["version"] | split("-") | first) is version("{{{ ver }}}", "{{{ op }}}")
 {{%- endif -%}}
 {{%- else -%}}
 "{{{ package }}}" in ansible_facts.packages

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -727,7 +727,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 {{%- if ver -%}}
 "{{{ package }}}" in ansible_facts.packages and (ansible_facts.packages["{{{ package }}}"] | last)["version"] is version("{{{ ver }}}", "{{{ op }}}")
 {{%- else -%}}
-'"{{{ package }}}" in ansible_facts.packages'
+"{{{ package }}}" in ansible_facts.packages
 {{%- endif -%}}
 {{%- endmacro -%}}
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -715,12 +715,20 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   This macro creates an Ansible snipped which is used in `when` clause to determine applicability of a task.
   If the package passed as a parameter is installed, the task is applicable.
   The macro respects `platform_package_overrides` variable.
+
+:param package: package name
+:param ver: package version (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
-{{%- macro ansible_pkg_conditional(package) -%}}
+{{%- macro ansible_pkg_conditional(package, ver=None, op=None) -%}}
 {{%- if package in platform_package_overrides -%}}
   {{%- set package = platform_package_overrides[package] -%}}
 {{%- endif -%}}
+{{%- if ver -%}}
+"{{{ package }}}" in ansible_facts.packages and (ansible_facts.packages["{{{ package }}}"] | last)["version"] is version("{{{ ver }}}", "{{{ op }}}")
+{{%- else -%}}
 '"{{{ package }}}" in ansible_facts.packages'
+{{%- endif -%}}
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -725,7 +725,13 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
   {{%- set package = platform_package_overrides[package] -%}}
 {{%- endif -%}}
 {{%- if ver -%}}
+{{# For RPM packages, Ansible splits the package version into "epoch", "version" and "release" keys. For DEB packages, Ansible provides only "version" key. #}}
+{{%- if pkg_system == "rpm" -%}}
+{{# We don't support RPM epoch at this moment. #}}
+"{{{ package }}}" in ansible_facts.packages and ((ansible_facts.packages["{{{ package }}}"] | last)["version"] + "-" + (ansible_facts.packages["{{{ package }}}"] | last)["release"]) is version("{{{ ver }}}", "{{{ op }}}")
+{{%- else -%}}
 "{{{ package }}}" in ansible_facts.packages and (ansible_facts.packages["{{{ package }}}"] | last)["version"] is version("{{{ ver }}}", "{{{ op }}}")
+{{%- endif -%}}
 {{%- else -%}}
 "{{{ package }}}" in ansible_facts.packages
 {{%- endif -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1939,27 +1939,29 @@ https://www.gnu.org/software/coreutils/manual/coreutils.html#Version-sort-orderi
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
 {{%- macro bash_pkg_conditional_compare(real, expected, op) -%}}
-{ real="{{{ real }}}"; ver="{{{ expected }}}"; {{{ bash_compare_version(op) }}}; }
+{ real="{{{ real }}}"; expected="{{{ expected }}}"; {{{ bash_compare_version("$real", "$expected", op) }}}; }
 {{%- endmacro -%}}
 
 {{#
 This macro generates comparison code based on the operator.
 
+:param real: real package version
+:param expected: expected package version
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
-{{%- macro bash_compare_version(op) -%}}
+{{%- macro bash_compare_version(real, expected, op) -%}}
 {{%- if op == "<" -%}}
-[[ "$real" != "$ver" ]] && printf "%s\n%s" "$real" "$ver" | sort -VC
+[[ "{{{ real }}}" != "{{{ expected }}}" ]] && printf "%s\n%s" "{{{ real }}}" "{{{ expected }}}" | sort -VC
 {{%- elif op == "<=" -%}}
-printf "%s\n%s" "$real" "$ver" | sort -VC
+printf "%s\n%s" "{{{ real }}}" "{{{ expected }}}" | sort -VC
 {{%- elif op == "==" -%}}
-[[ "$real" == "$ver" ]]
+[[ "{{{ real }}}" == "{{{ expected }}}" ]]
 {{%- elif op == "!=" -%}}
-[[ "$real" != "$ver" ]]
+[[ "{{{ real }}}" != "{{{ expected }}}" ]]
 {{%- elif op == ">" -%}}
-[[ "$real" != "$ver" ]] && printf "%s\n%s" "$ver" "$real" | sort -VC
+[[ "{{{ real }}}" != "{{{ expected }}}" ]] && printf "%s\n%s" "{{{ expected }}}" "{{{ real }}}" | sort -VC
 {{%- elif op == ">=" -%}}
-printf "%s\n%s" "$ver" "$real" | sort -VC
+printf "%s\n%s" "{{{ expected }}}" "{{{ real }}}" | sort -VC
 {{%- endif -%}}
 {{%- endmacro -%}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1877,40 +1877,113 @@ Part of the grub2_bootloader_argument_absent template.
 {{% endmacro %}}
 
 {{#
-  This macro creates a bash conditional which is used to determine if a remediation is applicable.
-  The macro takes package as an argument and chooses appropriate package manager.
-  If the package is installed, the Bash remediation will be applied.
-  The macro respects `platform_package_overrides` variable.
+This macro creates a bash conditional which is used to determine if a
+remediation is applicable. The macro takes package as an argument and chooses
+appropriate package manager. If the package is installed and satisfies the
+optional version restricion, the Bash remediation will be applied. The macro
+respects `platform_package_overrides` variable.
+
+:param package: package name
+:param ver: package version (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
-{{%- macro bash_pkg_conditional(package, escape=False) -%}}
+{{%- macro bash_pkg_conditional(package, ver=None, op=None) -%}}
 {{%- if package in platform_package_overrides -%}}
   {{%- set package = platform_package_overrides[package] -%}}
 {{%- endif -%}}
   {{% if pkg_system is defined %}}
     {{%- if pkg_system == "rpm" -%}}
-        {{{ bash_pkg_conditional_rpm(package) }}}
+        {{{ bash_pkg_conditional_rpm(package, ver, op) }}}
     {{%- elif pkg_system == "dpkg" -%}}
-        {{{ bash_pkg_conditional_dpkg(package, escape) }}}
+        {{{ bash_pkg_conditional_dpkg(package, ver, op) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
 {{% endif %}}
 {{%- endmacro -%}}
 
+{{#
+This macro generates code that gets version of an installed RPM package.
+
+:param package: package name
+#}}
+{{%- macro bash_get_rpm_package_version(package) -%}}
+rpm -q --queryformat '%{VERSION}-%{RELEASE}' {{{ package }}}
+{{%- endmacro -%}}
 
 {{#
-  This macro creates a Bash conditional which uses rpm to check if a package passed as a parameter is installed.
+This macro creates a Bash conditional that compares version of the RPM package
+with a given version.
+
+:param package: package name
+:param ver: package version (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
-{{%- macro bash_pkg_conditional_rpm(package) -%}}
+{{%- macro bash_compare_version_rpm(package, ver, op) -%}}
+{ real=$({{{ bash_get_rpm_package_version(package) }}}); ver={{{ ver }}};
+{{%- if op == "<" -%}}
+[[ "$real" != "$ver" ]] && printf "%s\n%s" "$real" "$ver" | sort -VC
+{{%- elif op == "<=" -%}}
+printf "%s\n%s" "$real" "$ver" | sort -VC
+{{%- elif op == "==" -%}}
+[[ "$real" == "$ver" ]]
+{{%- elif op == "!=" -%}}
+[[ "$real" != "$ver" ]]
+{{%- elif op == ">" -%}}
+[[ "$real" != "$ver" ]] && printf "%s\n%s" "$ver" "$real" | sort -VC
+{{%- elif op == ">=" -%}}
+printf "%s\n%s" "$ver" "$real" | sort -VC
+{{%- endif -%}}
+; }
+{{%- endmacro -%}}
+
+{{#
+This macro creates a Bash conditional which uses rpm to check if a package passed as a parameter is installed.
+
+:param package: package name
+:param ver: package version (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+#}}
+{{%- macro bash_pkg_conditional_rpm(package, ver=None, op=None) -%}}
+{{%- if ver -%}}
+rpm --quiet -q {{{ package }}} && {{{ bash_compare_version_rpm(package, ver, op) }}}
+{{%- else -%}}
 rpm --quiet -q {{{ package }}}
+{{%- endif -%}}
 {{%- endmacro %}}
 
 {{#
-  This macro creates a Bash conditional which uses dpkg to check if a package passed as a parameter is installed.
+This macro generates code that gets version of an installed DEB package.
+
+:param package: package name
 #}}
-{{%- macro bash_pkg_conditional_dpkg (package, escape=False) -%}}
-{{%- if escape -%}}
-dpkg-query --show --showformat='${{db:Status-Status}}\n' '{{{ package }}}' 2>/dev/null | grep -q installed
+{{%- macro bash_get_dpkg_package_version(package) -%}}
+dpkg-query -f='${Version}\n' --show {{{ package }}}
+{{%- endmacro -%}}
+
+{{#
+This macro creates a Bash conditional that compares version of the DEB package
+with a given version.
+
+:param package: package name
+:param ver: package version (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+#}}
+{{%- macro bash_compare_version_dpkg(package, ver, op) -%}}
+{{%- set op_codes = ({"<":"lt", "<=":"le", "==":"eq", "!=":"ne", ">":"gt", ">=":"ge"}) -%}}
+{ real="$({{{ bash_get_dpkg_package_version(package) }}})"; ver="{{{ ver }}}"; dpkg --compare-versions "$real" "{{{ op_codes[op] }}}" "$ver"; }
+{{%- endmacro -%}}
+
+{{#
+This macro creates a Bash conditional which uses dpkg to check if a package passed as a parameter is installed.
+
+:param package: package name
+:param ver: package version (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+#}}
+{{%- macro bash_pkg_conditional_dpkg(package, ver=None, op=None) -%}}
+{{%- if ver -%}}
+dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q installed && {{{ bash_compare_version_dpkg(package, ver, op) }}}
 {{%- else -%}}
 dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q installed
 {{%- endif -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1970,6 +1970,7 @@ This macro creates a Bash conditional which uses rpm to check if a package passe
 
 :param package: package name
 :param ver: package version (optional argument, use together with "op")
+    The version always needs to contain epoch. If the package has no epoch, please prepend "0:".
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
 {{%- macro bash_pkg_conditional_rpm(package, ver=None, op=None) -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1908,7 +1908,7 @@ This macro generates code that gets version of an installed RPM package.
 :param package: package name
 #}}
 {{%- macro bash_get_rpm_package_version(package) -%}}
-$(rpm -q --queryformat '%{VERSION}' {{{ package }}})
+$(epoch=$(rpm -q --queryformat '%{EPOCH}' {{{ package }}}); version=$(rpm -q --queryformat '%{VERSION}' {{{ package }}}); [ "$epoch" = "(none)" ] && echo "0:$version" || echo "$epoch:$version")
 {{%- endmacro -%}}
 
 {{#
@@ -1939,7 +1939,7 @@ https://www.gnu.org/software/coreutils/manual/coreutils.html#Version-sort-orderi
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
 {{%- macro bash_pkg_conditional_compare(real, expected, op) -%}}
-{ real={{{ real }}}; ver={{{ expected }}}; {{{ bash_compare_version(op) }}}; }
+{ real="{{{ real }}}"; ver="{{{ expected }}}"; {{{ bash_compare_version(op) }}}; }
 {{%- endmacro -%}}
 
 {{#

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1908,7 +1908,7 @@ This macro generates code that gets version of an installed RPM package.
 :param package: package name
 #}}
 {{%- macro bash_get_rpm_package_version(package) -%}}
-rpm -q --queryformat '%{VERSION}-%{RELEASE}' {{{ package }}}
+rpm -q --queryformat '%{VERSION}' {{{ package }}}
 {{%- endmacro -%}}
 
 {{#
@@ -1985,7 +1985,8 @@ This macro generates code that gets version of an installed DEB package.
 :param package: package name
 #}}
 {{%- macro bash_get_dpkg_package_version(package) -%}}
-dpkg-query -f='${Version}\n' --show {{{ package }}}
+{{# We don't take the "release" part into account. #}}
+dpkg-query -f='${Version}\n' --show {{{ package }}} | cut -f1 -d-
 {{%- endmacro -%}}
 
 {{#

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1940,7 +1940,15 @@ https://www.gnu.org/software/coreutils/manual/coreutils.html#Version-sort-orderi
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
 {{%- macro bash_compare_version_rpm(package, ver, op) -%}}
-{ real=$({{{ bash_get_rpm_package_version(package) }}}); ver={{{ ver }}};
+{ real=$({{{ bash_get_rpm_package_version(package) }}}); ver={{{ ver }}}; {{{ bash_compare_version(op) }}}; }
+{{%- endmacro -%}}
+
+{{#
+This macro generates comparison code based on the operator.
+
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+#}}
+{{%- macro bash_compare_version(op) -%}}
 {{%- if op == "<" -%}}
 [[ "$real" != "$ver" ]] && printf "%s\n%s" "$real" "$ver" | sort -VC
 {{%- elif op == "<=" -%}}
@@ -1954,7 +1962,6 @@ printf "%s\n%s" "$real" "$ver" | sort -VC
 {{%- elif op == ">=" -%}}
 printf "%s\n%s" "$ver" "$real" | sort -VC
 {{%- endif -%}}
-; }
 {{%- endmacro -%}}
 
 {{#

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1915,8 +1915,28 @@ rpm -q --queryformat '%{VERSION}-%{RELEASE}' {{{ package }}}
 This macro creates a Bash conditional that compares version of the RPM package
 with a given version.
 
+Description of the algorithm:
+1. Get the actual version of the given package using the `rpm` command
+   and store it in `real`.
+2. Store the expected version in `ver`.
+3. Perform the comparison and return the result.
+   Comparison method is different based on the comparison operator. The method
+   code is chosen at the build time during Jinja expansion. Therefore, the
+   algorithm doesn't use the operator at all.
+   Based on the operator, these operations are performed:
+   a. "<": real != ver && is_sorted([real, ver])
+   b. "<=": is_sorted([real, ver])
+   c. "==": real == ver
+   d. "!=": real != ver
+   e. ">=" real != ver && is_sorted([ver, real])
+   f. ">" is_sorted([ver, real])
+   where is_sorted returns true if the given list parameter is a sorted list of version numbers.
+
+The implementation uses the GNU `sort` version ordering, which is described at:
+https://www.gnu.org/software/coreutils/manual/coreutils.html#Version-sort-ordering
+
 :param package: package name
-:param ver: package version (optional argument, use together with "op")
+:param ver: package version
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
 {{%- macro bash_compare_version_rpm(package, ver, op) -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1908,16 +1908,15 @@ This macro generates code that gets version of an installed RPM package.
 :param package: package name
 #}}
 {{%- macro bash_get_rpm_package_version(package) -%}}
-rpm -q --queryformat '%{VERSION}' {{{ package }}}
+$(rpm -q --queryformat '%{VERSION}' {{{ package }}})
 {{%- endmacro -%}}
 
 {{#
-This macro creates a Bash conditional that compares version of the RPM package
+This macro creates a Bash conditional that compares version of the package
 with a given version.
 
 Description of the algorithm:
-1. Get the actual version of the given package using the `rpm` command
-   and store it in `real`.
+1. Get the actual version of the given package and store it in `real`.
 2. Store the expected version in `ver`.
 3. Perform the comparison and return the result.
    Comparison method is different based on the comparison operator. The method
@@ -1935,12 +1934,12 @@ Description of the algorithm:
 The implementation uses the GNU `sort` version ordering, which is described at:
 https://www.gnu.org/software/coreutils/manual/coreutils.html#Version-sort-ordering
 
-:param package: package name
-:param ver: package version
+:param real: real package version
+:param expected: expected package version
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
-{{%- macro bash_compare_version_rpm(package, ver, op) -%}}
-{ real=$({{{ bash_get_rpm_package_version(package) }}}); ver={{{ ver }}}; {{{ bash_compare_version(op) }}}; }
+{{%- macro bash_pkg_conditional_compare(real, expected, op) -%}}
+{ real={{{ real }}}; ver={{{ expected }}}; {{{ bash_compare_version(op) }}}; }
 {{%- endmacro -%}}
 
 {{#
@@ -1973,7 +1972,7 @@ This macro creates a Bash conditional which uses rpm to check if a package passe
 #}}
 {{%- macro bash_pkg_conditional_rpm(package, ver=None, op=None) -%}}
 {{%- if ver -%}}
-rpm --quiet -q {{{ package }}} && {{{ bash_compare_version_rpm(package, ver, op) }}}
+rpm --quiet -q {{{ package }}} && {{{ bash_pkg_conditional_compare(bash_get_rpm_package_version(package), ver, op) }}}
 {{%- else -%}}
 rpm --quiet -q {{{ package }}}
 {{%- endif -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1884,18 +1884,18 @@ optional version restricion, the Bash remediation will be applied. The macro
 respects `platform_package_overrides` variable.
 
 :param package: package name
-:param ver: package version (optional argument, use together with "op")
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param ver: package version (optional argument, use together with "op")
 #}}
-{{%- macro bash_pkg_conditional(package, ver=None, op=None) -%}}
+{{%- macro bash_pkg_conditional(package, op=None, ver=None) -%}}
 {{%- if package in platform_package_overrides -%}}
   {{%- set package = platform_package_overrides[package] -%}}
 {{%- endif -%}}
   {{% if pkg_system is defined %}}
     {{%- if pkg_system == "rpm" -%}}
-        {{{ bash_pkg_conditional_rpm(package, ver, op) }}}
+        {{{ bash_pkg_conditional_rpm(package, op, ver) }}}
     {{%- elif pkg_system == "dpkg" -%}}
-        {{{ bash_pkg_conditional_dpkg(package, ver, op) }}}
+        {{{ bash_pkg_conditional_dpkg(package, op, ver) }}}
     {{%- else -%}}
 JINJA MACRO ERROR - Unknown package system '{{{ pkg_system }}}'.
     {{%- endif -%}}
@@ -1935,21 +1935,27 @@ The implementation uses the GNU `sort` version ordering, which is described at:
 https://www.gnu.org/software/coreutils/manual/coreutils.html#Version-sort-ordering
 
 :param real: real package version
-:param expected: expected package version
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param expected: expected package version
 #}}
-{{%- macro bash_pkg_conditional_compare(real, expected, op) -%}}
-{ real="{{{ real }}}"; expected="{{{ expected }}}"; {{{ bash_compare_version("$real", "$expected", op) }}}; }
+{{%- macro bash_pkg_conditional_compare(real, op, expected) -%}}
+{ real="{{{ real }}}"; expected="{{{ expected }}}"; {{{ bash_compare_version("$real", op, "$expected") }}}; }
 {{%- endmacro -%}}
 
 {{#
 This macro generates comparison code based on the operator.
 
+Assumptions:
+- Version arguments are either literal, or they expand to versions (e.g. the argument is a deferenced variable)
+- Either all versions have epoch, or none of them has.
+  - Violation of this results in undefined behavior.
+  - If one has epoch e.g. 0, and the other one has no epoch, they will not be treated as equal.
+
 :param real: real package version
-:param expected: expected package version
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param expected: expected package version
 #}}
-{{%- macro bash_compare_version(real, expected, op) -%}}
+{{%- macro bash_compare_version(real, op, expected) -%}}
 {{%- if op == "<" -%}}
 [[ "{{{ real }}}" != "{{{ expected }}}" ]] && printf "%s\n%s" "{{{ real }}}" "{{{ expected }}}" | sort -VC
 {{%- elif op == "<=" -%}}
@@ -1969,13 +1975,13 @@ printf "%s\n%s" "{{{ expected }}}" "{{{ real }}}" | sort -VC
 This macro creates a Bash conditional which uses rpm to check if a package passed as a parameter is installed.
 
 :param package: package name
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 :param ver: package version (optional argument, use together with "op")
     The version always needs to contain epoch. If the package has no epoch, please prepend "0:".
-:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
 #}}
-{{%- macro bash_pkg_conditional_rpm(package, ver=None, op=None) -%}}
+{{%- macro bash_pkg_conditional_rpm(package, op=None, ver=None) -%}}
 {{%- if ver -%}}
-rpm --quiet -q {{{ package }}} && {{{ bash_pkg_conditional_compare(bash_get_rpm_package_version(package), ver, op) }}}
+rpm --quiet -q {{{ package }}} && {{{ bash_pkg_conditional_compare(bash_get_rpm_package_version(package), op, ver) }}}
 {{%- else -%}}
 rpm --quiet -q {{{ package }}}
 {{%- endif -%}}
@@ -1996,10 +2002,10 @@ This macro creates a Bash conditional that compares version of the DEB package
 with a given version.
 
 :param package: package name
-:param ver: package version (optional argument, use together with "op")
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param ver: package version (optional argument, use together with "op")
 #}}
-{{%- macro bash_compare_version_dpkg(package, ver, op) -%}}
+{{%- macro bash_compare_version_dpkg(package, op, ver) -%}}
 {{%- set op_codes = ({"<":"lt", "<=":"le", "==":"eq", "!=":"ne", ">":"gt", ">=":"ge"}) -%}}
 { real="$({{{ bash_get_dpkg_package_version(package) }}})"; ver="{{{ ver }}}"; dpkg --compare-versions "$real" "{{{ op_codes[op] }}}" "$ver"; }
 {{%- endmacro -%}}
@@ -2008,12 +2014,12 @@ with a given version.
 This macro creates a Bash conditional which uses dpkg to check if a package passed as a parameter is installed.
 
 :param package: package name
-:param ver: package version (optional argument, use together with "op")
 :param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param ver: package version (optional argument, use together with "op")
 #}}
-{{%- macro bash_pkg_conditional_dpkg(package, ver=None, op=None) -%}}
+{{%- macro bash_pkg_conditional_dpkg(package, op=None, ver=None) -%}}
 {{%- if ver -%}}
-dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q installed && {{{ bash_compare_version_dpkg(package, ver, op) }}}
+dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q installed && {{{ bash_compare_version_dpkg(package, op, ver) }}}
 {{%- else -%}}
 dpkg-query --show --showformat='${db:Status-Status}\n' '{{{ package }}}' 2>/dev/null | grep -q installed
 {{%- endif -%}}

--- a/shared/templates/platform_package/ansible.template
+++ b/shared/templates/platform_package/ansible.template
@@ -1,6 +1,6 @@
 
 {{%- for spec in VER_SPECS -%}}
-{{{ ansible_pkg_conditional(PKGNAME, ver=spec.ev_ver, op=spec.op) | trim }}}
+{{{ ansible_pkg_conditional(PKGNAME, op=spec.op, ver=spec.ev_ver) | trim }}}
 {{%- if not loop.last %}} and {{% endif -%}}
 {{%- else -%}}
 {{{ ansible_pkg_conditional(PKGNAME) }}}

--- a/shared/templates/platform_package/ansible.template
+++ b/shared/templates/platform_package/ansible.template
@@ -1,0 +1,7 @@
+
+{{%- for spec in VER_SPECS -%}}
+{{{ ansible_pkg_conditional(PKGNAME, ver=spec.ver, op=spec.op) | trim }}}
+{{%- if not loop.last %}} and {{% endif -%}}
+{{%- else -%}}
+{{{ ansible_pkg_conditional(PKGNAME) }}}
+{{%- endfor -%}}

--- a/shared/templates/platform_package/ansible.template
+++ b/shared/templates/platform_package/ansible.template
@@ -1,6 +1,6 @@
 
 {{%- for spec in VER_SPECS -%}}
-{{{ ansible_pkg_conditional(PKGNAME, ver=spec.ver, op=spec.op) | trim }}}
+{{{ ansible_pkg_conditional(PKGNAME, ver=spec.ev_ver, op=spec.op) | trim }}}
 {{%- if not loop.last %}} and {{% endif -%}}
 {{%- else -%}}
 {{{ ansible_pkg_conditional(PKGNAME) }}}

--- a/shared/templates/platform_package/bash.template
+++ b/shared/templates/platform_package/bash.template
@@ -1,5 +1,5 @@
 {{%- for spec in VER_SPECS -%}}
-{{{ bash_pkg_conditional(PKGNAME, ver=spec.ver, op=spec.op) | trim }}}
+{{{ bash_pkg_conditional(PKGNAME, ver=spec.ev_ver, op=spec.op) | trim }}}
 {{%- if not loop.last %}} && {{% endif -%}}
 {{%- else -%}}
 {{{ bash_pkg_conditional(PKGNAME) }}}

--- a/shared/templates/platform_package/bash.template
+++ b/shared/templates/platform_package/bash.template
@@ -1,0 +1,6 @@
+{{%- for spec in VER_SPECS -%}}
+{{{ bash_pkg_conditional(PKGNAME, ver=spec.ver, op=spec.op) | trim }}}
+{{%- if not loop.last %}} && {{% endif -%}}
+{{%- else -%}}
+{{{ bash_pkg_conditional(PKGNAME) }}}
+{{%- endfor -%}}

--- a/shared/templates/platform_package/bash.template
+++ b/shared/templates/platform_package/bash.template
@@ -1,5 +1,5 @@
 {{%- for spec in VER_SPECS -%}}
-{{{ bash_pkg_conditional(PKGNAME, ver=spec.ev_ver, op=spec.op) | trim }}}
+{{{ bash_pkg_conditional(PKGNAME, op=spec.op, ver=spec.ev_ver) | trim }}}
 {{%- if not loop.last %}} && {{% endif -%}}
 {{%- else -%}}
 {{{ bash_pkg_conditional(PKGNAME) }}}

--- a/shared/templates/platform_package/template.py
+++ b/shared/templates/platform_package/template.py
@@ -2,7 +2,7 @@ import re
 
 
 def preprocess(data, lang):
-    pattern = r"^\d+(?:\.\d+(?:\.\d+)?)?$"
+    pattern = r"^(?:\d+:)?\d+(?:\.\d+(?:\.\d+)?)?$"
     for ver_spec in data["ver_specs"]:
         version = ver_spec["ver"]
         if not re.match(pattern, version):

--- a/shared/templates/platform_package/template.py
+++ b/shared/templates/platform_package/template.py
@@ -2,9 +2,9 @@ import re
 
 
 def preprocess(data, lang):
-    pattern = r"^(?:\d+:)?\d+(?:\.\d+(?:\.\d+)?)?$"
+    pattern = r"^\d+:\d+(?:\.\d+(?:\.\d+)?)?$"
     for ver_spec in data["ver_specs"]:
-        version = ver_spec["ver"]
+        version = ver_spec["ev_ver"]
         if not re.match(pattern, version):
             msg = (
                 "Error in platform package[%s]: version '%s' doesn't match "

--- a/shared/templates/platform_package/template.py
+++ b/shared/templates/platform_package/template.py
@@ -1,0 +1,13 @@
+import re
+
+
+def preprocess(data, lang):
+    pattern = r"^\d+(?:\.\d+(?:\.\d+)?)?$"
+    for ver_spec in data["ver_specs"]:
+        version = ver_spec["ver"]
+        if not re.match(pattern, version):
+            msg = (
+                "Error in platform package[%s]: version '%s' doesn't match "
+                "pattern '%s'" % (data["pkgname"], version, pattern))
+            raise ValueError(msg)
+    return data

--- a/shared/templates/platform_package/template.yml
+++ b/shared/templates/platform_package/template.yml
@@ -1,2 +1,3 @@
 supported_languages:
   - cpe-oval
+  - bash

--- a/shared/templates/platform_package/template.yml
+++ b/shared/templates/platform_package/template.yml
@@ -1,3 +1,4 @@
 supported_languages:
-  - cpe-oval
+  - ansible
   - bash
+  - cpe-oval

--- a/ssg/boolean_expression.py
+++ b/ssg/boolean_expression.py
@@ -3,7 +3,7 @@ from ssg import requirement_specs
 
 # We don't support ~= to avoid confusion with boolean operator NOT (~)
 SPEC_SYMBOLS = ['<', '>', '=', '!', ',', '[', ']']
-VERSION_SYMBOLS = ['.', '-', '_']
+VERSION_SYMBOLS = ['.', '-', '_', ":"]
 
 
 class Function(boolean.Function):
@@ -102,7 +102,8 @@ class Symbol(boolean.Symbol):
                     'op': ver_spec.op,
                     'ver': ver_spec.ver,
                     'evr_op': ver_spec.evr_op,
-                    'evr_ver': ver_spec.evr_ver
+                    'evr_ver': ver_spec.evr_ver,
+                    'ev_ver': ver_spec.ev_ver
                 })
             res['ver_specs_id'] = self.requirement.ver_specs.oval_id
             res['ver_specs_cpe'] = self.requirement.ver_specs.cpe_id

--- a/ssg/build_cpe.py
+++ b/ssg/build_cpe.py
@@ -33,6 +33,7 @@ class ProductCPEs(object):
         self.cpes_by_name = {}
         self.product_cpes = {}
         self.platforms = {}
+        self.cpe_oval_href = ""
         self.algebra = Algebra(
             symbol_cls=CPEALCheckFactRef, function_cls=CPEALLogicalTest)
 

--- a/ssg/build_remediations.py
+++ b/ssg/build_remediations.py
@@ -145,27 +145,7 @@ class Remediation(object):
                 if p not in inherited_cpe_platform_names}
         return rule_specific_cpe_platform_names
 
-    def _check_if_platform_uses_version_comparison(self, platform, language):
-        version_comparison_characters = ("<", ">", "=")
-        languages_with_not_working_version_comparison = ("ansible", "bash")
-        if language in languages_with_not_working_version_comparison:
-            for char in version_comparison_characters:
-                if char in platform.original_expression:
-                    return True
-        return False
-
     def _get_stripped_conditional(self, language, platform):
-        # if a platform uses specification of versions as an applicability criteria
-        # it is currently correctly used in OVAL checks
-        # but it is not implemented in conditionals, therefore creating inconsitency
-        # we prevent building content which uses
-        # such a platform with a remediation conditional specified
-        if self._check_if_platform_uses_version_comparison(platform, language):
-            raise ValueError(
-                "The platform definition you are trying to use uses version comparison. "
-                "Remediation conditionals for such platforms are currently not implemented "
-                "for {0} remediations. {1} can't be used.".format(
-                    language, platform.original_expression))
         conditional = platform.get_remediation_conditional(language)
         if conditional is not None:
             stripped_conditional = conditional.strip()

--- a/ssg/requirement_specs.py
+++ b/ssg/requirement_specs.py
@@ -13,11 +13,12 @@ pkg_resources.safe_extra = lambda extra: re.sub('[^A-Za-z0-9.-]+', '_', extra).l
 
 def _parse_version_into_evr(version):
     evr = {"epoch": None, "version": None, "release": None}
-    match_version = re.match(r'^(\d[\d\.]*)(?:-(\d*))?$', version)
+    match_version = re.match(r'^(?:(\d+):)?(\d[\d\.]*)(?:-(\d*))?$', version)
     if not match_version:
         raise ValueError("Invalid version specifier {0}".format(version))
-    evr["version"] = match_version.groups()[0]
-    evr["release"] = match_version.groups()[1]
+    evr["epoch"] = match_version.groups()[0]
+    evr["version"] = match_version.groups()[1]
+    evr["release"] = match_version.groups()[2]
     return evr
 
 

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -75,6 +75,10 @@ class VersionSpecifier:
         return VersionSpecifier.evr_dict_to_str(self._evr_ver_dict, True)
 
     @property
+    def ev_ver(self):
+        return VersionSpecifier.evr_dict_to_str(self._evr_ver_dict, True).split("-")[0]
+
+    @property
     def title(self):
         return '{0} {1}'.format(comparison_to_oval(self.op), self.ver)
 

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Mock the "rpm" command
-# mocked package: coconut-4.5.17-8.fc31
+# mocked package: coconut-4.5.17-8
 # The mock is used to avoid the need to have a specific RPM package in a
 # specific version installed on the system where this test is run.
 function rpm()
@@ -9,7 +9,7 @@ function rpm()
     if [[ "$*" == "--quiet -q coconut" ]] ; then
         return 0
     elif [[ "$*" ==  "-q --queryformat %{VERSION}-%{RELEASE} coconut" ]] ; then
-        echo "4.5.17-8.fc31"
+        echo "4.5.17-8"
         return 0
     else
         echo "BATS mock for rpm doesn't support this command"
@@ -26,51 +26,51 @@ export -f rpm
     {{{ bash_pkg_conditional_rpm("coconut", "5", "<") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1.fc31", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<") | indent(4) }}}
 
     {{{ bash_pkg_conditional_rpm("coconut", "5", "<=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1.fc31", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9.fc31", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10.fc31", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1.fc31", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12.fc31", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12", "<") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9.fc31", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10.fc31", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1.fc31", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12.fc31", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7.fc31", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1.fc31", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9.fc31", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1.fc31", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1", ">") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7.fc31", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1.fc31", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9.fc31", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1.fc31", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1", ">=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", "==") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", ">=") | indent(4) }}}
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", "!=") | indent(4) }}} )
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", ">=") | indent(4) }}}
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "!=") | indent(4) }}} )
 
     ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}} )
     ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "==") | indent(4) }}} )
 
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc44", "!=") | indent(4) }}} )
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc44", "==") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "!=") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}} )
 
     {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1.fc31", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">") | indent(4) }}}
 
     {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1.fc31", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">=") | indent(4) }}}
 }

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -72,5 +72,4 @@ export -f rpm
     {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">=") | indent(4) }}}
 }

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -26,53 +26,61 @@ export -f rpm
 }
 
 @test "bash_pkg_conditional_rpm - test package version" {
-    {{{ bash_pkg_conditional_rpm("coconut", "0:5", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:5.0", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<", "0:5") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<", "0:5.0") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:5", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:5.0", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<=", "0:5") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<=", "0:5.0") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.18", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<", "0:4.5.18") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.17", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.18", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<=", "0:4.5.17") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<=", "0:4.5.18") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.16", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.1.1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">", "0:4.5.16") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">", "0:4.1.1") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.16", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:4.1.1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">=", "0:4.5.16") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">=", "0:4.1.1") | indent(4) }}}
 
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.17", "!=") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "!=", "0:4.5.17") | indent(4) }}} )
 
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.18", "==") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "==", "0:4.5.18") | indent(4) }}} )
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:3", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0.0", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">", "0:3") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">", "0:3.0") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">", "0:3.0.0") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "0:3", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0.0", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">", "0:3") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">=", "0:3.0") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", ">=", "0:3.0.0") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "1:1.0", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "1:5.0.4", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "1:4.5.17", "!=") | indent(4) }}}
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:4.5.17", "==") | indent(4) }}} )
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:4.5", ">") | indent(4) }}} )
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:6.7", ">") | indent(4) }}} )
+    {{{ bash_pkg_conditional_rpm("coconut", "<", "1:1.0") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "<", "1:5.0.4") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "!=", "1:4.5.17") | indent(4) }}}
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "==", "1:4.5.17") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", ">", "1:4.5") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", ">", "1:6.7") | indent(4) }}} )
 }
 
 @test "bash_compare_version - test basic version comparison algorithm" {
-    {{{ bash_compare_version("0:0.1.2", "0:1.2", "<") }}}
-    {{{ bash_compare_version("0:2.3", "0:0.2.3", ">") }}}
-    {{{ bash_compare_version("1:2.3", "0:3.2", ">") }}}
-    {{{ bash_compare_version("0:2.3", "1:1.0", "<") }}}
-    {{{ bash_compare_version("0:1.0", "0:1.0", "==") }}}
-    {{{ bash_compare_version("0:1.0", "1:1.0", "!=") }}}
-    ! ({{{ bash_compare_version("0:1.0", "1:1.0", "==") }}} )
-    {{{ bash_compare_version("2:17.15.4.5", "2:17.15.4.6", "<") }}}
-    {{{ bash_compare_version("2:17.15.4.5", "2:17.15.4.6", "<=") }}}
-    {{{ bash_compare_version("2:17.15.4.9", "2:17.15.4.7", ">") }}}
-    {{{ bash_compare_version("2:17.15.4.9", "2:17.15.4.7", ">=") }}}
+    {{{ bash_compare_version("0:0.1.2", "<", "0:1.2") }}}
+    {{{ bash_compare_version("0:2.3", ">", "0:0.2.3") }}}
+    {{{ bash_compare_version("1:2.3", ">", "0:3.2") }}}
+
+    # Undefined behavior - only one epoch specified doesn't produce reasonable results
+    # Kept here for reference, if the behavior is fixed, remove the negation.
+    ! {{{ bash_compare_version("1:2.3", ">", "3.2") }}}
+    ! {{{ bash_compare_version("0:3.2", "==", "3.2") }}}
+
+    {{{ bash_compare_version("1:22.3", ">", "1:3.2") }}}
+    {{{ bash_compare_version("1:2.3", "<", "1:3.2") }}}
+    {{{ bash_compare_version("0:2.3", "<", "1:1.0") }}}
+    {{{ bash_compare_version("1.0", "==", "1.0") }}}
+    {{{ bash_compare_version("0:1.0", "!=", "1:1.0") }}}
+    ! ({{{ bash_compare_version("0:1.0", "==", "1:1.0") }}} )
+    {{{ bash_compare_version("2:17.15.4.5", "<", "2:17.15.4.6") }}}
+    {{{ bash_compare_version("2:17.15.4.5", "<=", "2:17.15.4.6") }}}
+    {{{ bash_compare_version("2:17.15.4.9", ">", "2:17.15.4.7") }}}
+    {{{ bash_compare_version("2:17.15.4.9", ">=", "2:17.15.4.7") }}}
 }

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+@test "test package presence" {
+    if ! rpm -q bash ; then
+        skip "RPM package 'bash' isn't installed"
+    fi
+
+    {{{ bash_pkg_conditional_rpm("bash") | indent(4) }}}
+}
+
+@test "test package version" {
+    if ! rpm -q bash ; then
+        skip "RPM package 'bash' isn't installed"
+    fi
+
+    {{{ bash_pkg_conditional_rpm("bash", "999.9", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("bash", "999.9", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("bash", "999.9", ">") | indent(4) }}} || true
+    {{{ bash_pkg_conditional_rpm("bash", "999.9", ">=") | indent(4) }}} || true
+    {{{ bash_pkg_conditional_rpm("bash", "999.9-8", "<") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("bash", "999.9", "!=") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("bash", "0.1", "<") | indent(4) }}} || true
+    {{{ bash_pkg_conditional_rpm("bash", "0.1", "<=") | indent(4) }}} || true
+    {{{ bash_pkg_conditional_rpm("bash", "0.1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("bash", "0.1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("bash", "0.1-2", ">") | indent(4) }}}
+}

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -48,6 +48,8 @@ export -f rpm
     {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1", ">") | indent(4) }}}
 
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.4.99", ">=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7", ">=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1", ">=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9", ">=") | indent(4) }}}

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -1,29 +1,76 @@
 #!/bin/bash
 
-@test "bash_pkg_conditional_rpm - test package presence" {
-    if ! rpm -q bash ; then
-        skip "RPM package 'bash' isn't installed"
+# Mock the "rpm" command
+# mocked package: coconut-4.5.17-8.fc31
+# The mock is used to avoid the need to have a specific RPM package in a
+# specific version installed on the system where this test is run.
+function rpm()
+{
+    if [[ "$*" == "--quiet -q coconut" ]] ; then
+        return 0
+    elif [[ "$*" ==  "-q --queryformat %{VERSION}-%{RELEASE} coconut" ]] ; then
+        echo "4.5.17-8.fc31"
+        return 0
+    else
+        echo "BATS mock for rpm doesn't support this command"
+        return 1
     fi
+}
+export -f rpm
 
-    {{{ bash_pkg_conditional_rpm("bash") | indent(4) }}}
+@test "bash_pkg_conditional_rpm - test package presence" {
+    {{{ bash_pkg_conditional_rpm("coconut") | indent(4) }}}
 }
 
 @test "bash_pkg_conditional_rpm - test package version" {
-    if ! rpm -q bash ; then
-        skip "RPM package 'bash' isn't installed"
-    fi
+    {{{ bash_pkg_conditional_rpm("coconut", "5", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1.fc31", "<") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("bash", "999.9", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("bash", "999.9", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("bash", "999.9", ">") | indent(4) }}} || true
-    {{{ bash_pkg_conditional_rpm("bash", "999.9", ">=") | indent(4) }}} || true
-    {{{ bash_pkg_conditional_rpm("bash", "999.9-8", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1.fc31", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("bash", "999.9", "!=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9.fc31", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10.fc31", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1.fc31", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12.fc31", "<") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("bash", "0.1", "<") | indent(4) }}} || true
-    {{{ bash_pkg_conditional_rpm("bash", "0.1", "<=") | indent(4) }}} || true
-    {{{ bash_pkg_conditional_rpm("bash", "0.1", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("bash", "0.1", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("bash", "0.1-2", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9.fc31", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10.fc31", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1.fc31", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12.fc31", "<=") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7.fc31", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1.fc31", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9.fc31", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1.fc31", ">") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7.fc31", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1.fc31", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9.fc31", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1.fc31", ">=") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", "==") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", ">=") | indent(4) }}}
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc31", "!=") | indent(4) }}} )
+
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "==") | indent(4) }}} )
+
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc44", "!=") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8.fc44", "==") | indent(4) }}} )
+
+    {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1.fc31", ">") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1.fc31", ">=") | indent(4) }}}
 }

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-@test "test package presence" {
+@test "bash_pkg_conditional_rpm - test package presence" {
     if ! rpm -q bash ; then
         skip "RPM package 'bash' isn't installed"
     fi
@@ -8,7 +8,7 @@
     {{{ bash_pkg_conditional_rpm("bash") | indent(4) }}}
 }
 
-@test "test package version" {
+@test "bash_pkg_conditional_rpm - test package version" {
     if ! rpm -q bash ; then
         skip "RPM package 'bash' isn't installed"
     fi

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Mock the "rpm" command
-# mocked package: coconut-4.5.17-8
+# mocked package: coconut-4.5.17
 # The mock is used to avoid the need to have a specific RPM package in a
 # specific version installed on the system where this test is run.
 function rpm()
@@ -61,4 +61,18 @@ export -f rpm
     ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:4.5.17", "==") | indent(4) }}} )
     ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:4.5", ">") | indent(4) }}} )
     ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:6.7", ">") | indent(4) }}} )
+}
+
+@test "bash_compare_version - test basic version comparison algorithm" {
+    {{{ bash_compare_version("0:0.1.2", "0:1.2", "<") }}}
+    {{{ bash_compare_version("0:2.3", "0:0.2.3", ">") }}}
+    {{{ bash_compare_version("1:2.3", "0:3.2", ">") }}}
+    {{{ bash_compare_version("0:2.3", "1:1.0", "<") }}}
+    {{{ bash_compare_version("0:1.0", "0:1.0", "==") }}}
+    {{{ bash_compare_version("0:1.0", "1:1.0", "!=") }}}
+    ! ({{{ bash_compare_version("0:1.0", "1:1.0", "==") }}} )
+    {{{ bash_compare_version("2:17.15.4.5", "2:17.15.4.6", "<") }}}
+    {{{ bash_compare_version("2:17.15.4.5", "2:17.15.4.6", "<=") }}}
+    {{{ bash_compare_version("2:17.15.4.9", "2:17.15.4.7", ">") }}}
+    {{{ bash_compare_version("2:17.15.4.9", "2:17.15.4.7", ">=") }}}
 }

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -8,8 +8,8 @@ function rpm()
 {
     if [[ "$*" == "--quiet -q coconut" ]] ; then
         return 0
-    elif [[ "$*" ==  "-q --queryformat %{VERSION}-%{RELEASE} coconut" ]] ; then
-        echo "4.5.17-8"
+    elif [[ "$*" ==  "-q --queryformat %{VERSION} coconut" ]] ; then
+        echo "4.5.17"
         return 0
     else
         echo "BATS mock for rpm doesn't support this command"
@@ -25,53 +25,30 @@ export -f rpm
 @test "bash_pkg_conditional_rpm - test package version" {
     {{{ bash_pkg_conditional_rpm("coconut", "5", "<") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<") | indent(4) }}}
 
     {{{ bash_pkg_conditional_rpm("coconut", "5", "<=") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0.0-1", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18", "<") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-9", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-10", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-1", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18-12", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1", ">") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.4.99", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-7", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16-1", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-9", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1-1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1", ">=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", ">=") | indent(4) }}}
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "!=") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "!=") | indent(4) }}} )
 
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}} )
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "==") | indent(4) }}} )
-
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "!=") | indent(4) }}} )
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17-8", "==") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.18", "==") | indent(4) }}} )
 
     {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0", ">") | indent(4) }}}
 
     {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
     {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0-1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0", ">=") | indent(4) }}}
 }

--- a/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
+++ b/tests/unit/bash/bash_pkg_conditional_rpm.bats.jinja
@@ -11,6 +11,9 @@ function rpm()
     elif [[ "$*" ==  "-q --queryformat %{VERSION} coconut" ]] ; then
         echo "4.5.17"
         return 0
+    elif [[ "$*" ==  "-q --queryformat %{EPOCH} coconut" ]] ; then
+        echo "(none)"
+        return 0
     else
         echo "BATS mock for rpm doesn't support this command"
         return 1
@@ -23,32 +26,39 @@ export -f rpm
 }
 
 @test "bash_pkg_conditional_rpm - test package version" {
-    {{{ bash_pkg_conditional_rpm("coconut", "5", "<") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:5", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:5.0", "<") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "5", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "5.0", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:5", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:5.0", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.18", "<") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "<=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.18", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.17", "<=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.18", "<=") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.16", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.1.1", ">") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "4.5.16", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "4.1.1", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.16", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:4.1.1", ">=") | indent(4) }}}
 
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.17", "!=") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.17", "!=") | indent(4) }}} )
 
-    ! ( {{{ bash_pkg_conditional_rpm("coconut", "4.5.18", "==") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "0:4.5.18", "==") | indent(4) }}} )
 
-    {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:3", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0.0", ">") | indent(4) }}}
 
-    {{{ bash_pkg_conditional_rpm("coconut", "3", ">") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0", ">=") | indent(4) }}}
-    {{{ bash_pkg_conditional_rpm("coconut", "3.0.0", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:3", ">") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0", ">=") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "0:3.0.0", ">=") | indent(4) }}}
+
+    {{{ bash_pkg_conditional_rpm("coconut", "1:1.0", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "1:5.0.4", "<") | indent(4) }}}
+    {{{ bash_pkg_conditional_rpm("coconut", "1:4.5.17", "!=") | indent(4) }}}
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:4.5.17", "==") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:4.5", ">") | indent(4) }}} )
+    ! ( {{{ bash_pkg_conditional_rpm("coconut", "1:6.7", ">") | indent(4) }}} )
 }

--- a/tests/unit/ssg-module/data/applicability/chrony.yml
+++ b/tests/unit/ssg-module/data/applicability/chrony.yml
@@ -2,4 +2,4 @@ name: "cpe:/a:chrony"
 title: "Package chrony is installed"
 check_id: installed_env_has_chrony_package
 bash_conditional: {{{ bash_pkg_conditional("chrony") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("chrony") }}}
+ansible_conditional: '{{{ ansible_pkg_conditional("chrony") }}}'

--- a/tests/unit/ssg-module/data/applicability/ntp.yml
+++ b/tests/unit/ssg-module/data/applicability/ntp.yml
@@ -2,4 +2,4 @@ name: "cpe:/a:ntp"
 title: "Package ntp is installed"
 check_id: installed_env_has_ntp_package
 bash_conditional: {{{ bash_pkg_conditional("ntp") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("ntp") }}}
+ansible_conditional: '{{{ ansible_pkg_conditional("ntp") }}}'

--- a/tests/unit/ssg-module/data/applicability/systemd.yml
+++ b/tests/unit/ssg-module/data/applicability/systemd.yml
@@ -2,4 +2,4 @@ name: "cpe:/a:systemd"
 title: "Package systemd is installed"
 check_id: installed_env_has_systemd_package
 bash_conditional: {{{ bash_pkg_conditional("systemd") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("systemd") }}}
+ansible_conditional: '{{{ ansible_pkg_conditional("systemd") }}}'

--- a/tests/unit/ssg-module/data/applicability/yum.yml
+++ b/tests/unit/ssg-module/data/applicability/yum.yml
@@ -2,4 +2,4 @@ name: "cpe:/a:yum"
 title: "Package yum is installed"
 check_id: installed_env_has_yum_package
 bash_conditional: {{{ bash_pkg_conditional("yum") }}}
-ansible_conditional: {{{ ansible_pkg_conditional("yum") }}}
+ansible_conditional: '{{{ ansible_pkg_conditional("yum") }}}'

--- a/tests/unit/ssg-module/data/package_ntp_eq_1_0.yml
+++ b/tests/unit/ssg-module/data/package_ntp_eq_1_0.yml
@@ -2,8 +2,10 @@ name: package_ntp_eq_1_0
 original_expression: package[ntp]==1.0
 xml_content: <ns0:platform xmlns:ns0="http://cpe.mitre.org/language/2.0" id="package_ntp_eq_1_0"><ns0:logical-test
     operator="AND" negate="false"><ns0:fact-ref name="cpe:/a:ntp:eq:1.0" /></ns0:logical-test></ns0:platform>
-bash_conditional: rpm --quiet -q ntp
-ansible_conditional: '"ntp" in ansible_facts.packages'
+bash_conditional: rpm --quiet -q ntp && { real=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}'
+    ntp); ver=1.0;[[ "$real" == "$ver" ]]; }
+ansible_conditional: '"ntp" in ansible_facts.packages and (ansible_facts.packages["ntp"]
+    | last)["version"] is version("1.0", "==")'
 title: ''
 definition_location: /home/vojta/repos/upstream/content/build/rhel7/platforms/package_ntp_eq_1_0.yml
 documentation_complete: true

--- a/tests/unit/ssg-module/data/package_ntp_eq_1_0.yml
+++ b/tests/unit/ssg-module/data/package_ntp_eq_1_0.yml
@@ -7,5 +7,4 @@ bash_conditional: rpm --quiet -q ntp && { real=$(rpm -q --queryformat '%{VERSION
 ansible_conditional: '"ntp" in ansible_facts.packages and (ansible_facts.packages["ntp"]
     | last)["version"] is version("1.0", "==")'
 title: ''
-definition_location: /home/vojta/repos/upstream/content/build/rhel7/platforms/package_ntp_eq_1_0.yml
 documentation_complete: true

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -127,8 +127,8 @@ def test_get_rule_dir_remediations():
     assert len(something_bash) == 1
     assert something_bash != rhel_bash
 
-def test_deny_to_parse_remediation_if_platform_has_version_comparison(cpe_platforms_with_version_comparison):
+def test_parse_remediation_if_platform_has_version_comparison(cpe_platforms_with_version_comparison):
     remediation_cls = sbr.REMEDIATION_TO_CLASS["bash"]
     remediation_obj = remediation_cls(rhel_bash)
-    with pytest.raises(ValueError):
-        remediation_obj.get_stripped_conditionals("bash", ["package_ntp_eq_1_0"], cpe_platforms_with_version_comparison)
+    conditionals = remediation_obj.get_stripped_conditionals("bash", ["package_ntp_eq_1_0"], cpe_platforms_with_version_comparison)
+    assert conditionals == ["rpm --quiet -q ntp && { real=$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' ntp); ver=1.0;[[ \"$real\" == \"$ver\" ]]; }"]

--- a/tests/unit/ssg-module/test_platform_expressions.py
+++ b/tests/unit/ssg-module/test_platform_expressions.py
@@ -106,6 +106,7 @@ def test_as_dict(algebra):
         "name": "package",
         'ver_specs': [{'evr_op': 'greater than',
                        'evr_ver': '0:1.0-0',
+                       'ev_ver': '0:1.0',
                        'id': 'gt_1_0',
                        'op': '>',
                        'ver': '1.0'}],

--- a/tests/unit/ssg-module/test_requirement_specs.py
+++ b/tests/unit/ssg-module/test_requirement_specs.py
@@ -17,10 +17,6 @@ def test_parse_version_into_evr():
     with pytest.raises(ValueError):
         v = requirement_specs._parse_version_into_evr('')
 
-    # We do not support epoch at this moment, this version string is invalid.
-    with pytest.raises(ValueError):
-        v = requirement_specs._parse_version_into_evr('1:1.0.0')
-
     # we do not support letters anywhere for now
 
     with pytest.raises(ValueError):


### PR DESCRIPTION
#### Description:
- add Ansible and Bash version checks to package CPE platform
- remove exception that prevents adding Bash and Ansible version checks
- add unit test for Bash macro used in the aforementioned check


#### Rationale:
Enable usage of versioned platform expressions in rules.

Fixes: #9983

#### Review Hints:
Add platform package expressions to your favorite rule, eg.: `platform: package[sudo]<=8.4`, then build the data stream and check the generated Bash and Ansible expressions in the built data streams.