### PR TITLE
create_srg_export.py: Map NOT_APPLICABLE

### DIFF
--- a/utils/create_srg_export.py
+++ b/utils/create_srg_export.py
@@ -272,6 +272,8 @@ class DisaStatus:
             return DisaStatus.INHERENTLY_MET
         elif source == ssg.controls.Status.DOES_NOT_MEET:
             return DisaStatus.DOES_NOT_MEET
+        elif source == ssg.controls.Status.NOT_APPLICABLE:
+            return DisaStatus.NOT_APPLICABLE
         elif source == ssg.controls.Status.AUTOMATED or ssg.controls.Status.MANUAL:
             return DisaStatus.AUTOMATED
         return source


### PR DESCRIPTION
#### Description:

Enables rendering the "not applicable" status in the resulting
spreadsheet.

#### Rationale:

- This status was not handled previously

#### Review Hints:

- Not sure why this hadn't been an issue before, but a quick grep shows
  that SRG-OS-000379-GPOS-00164 and SRG-OS-000374-GPOS-00159 are not applicable
  in the RHEL-9 STIG
