### PR TITLE
Parametrize rule audit_rules_system_shutdown

### DIFF
--- a/controls/srg_gpos/SRG-OS-000046-GPOS-00022.yml
+++ b/controls/srg_gpos/SRG-OS-000046-GPOS-00022.yml
@@ -9,6 +9,7 @@ controls:
             - postfix_client_configure_mail_alias_postmaster
             - var_postfix_root_mail_alias=mil_sysadmin
             - audit_rules_system_shutdown
+            - var_audit_failure_mode=panic
             - auditd_data_retention_action_mail_acct
             - var_auditd_action_mail_acct=root
         status: automated

--- a/controls/srg_gpos/SRG-OS-000047-GPOS-00023.yml
+++ b/controls/srg_gpos/SRG-OS-000047-GPOS-00023.yml
@@ -6,6 +6,7 @@ controls:
             availability is an overriding concern).
         rules:
             - audit_rules_system_shutdown
+            - var_audit_failure_mode=panic
             - auditd_data_disk_error_action_stig
             - var_auditd_disk_error_action=halt
             - auditd_data_disk_full_action_stig

--- a/docs/workshop/data/ospp-rhel7.profile
+++ b/docs/workshop/data/ospp-rhel7.profile
@@ -174,6 +174,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/ansible/shared.yml
@@ -4,6 +4,8 @@
 # complexity = low
 # disruption = low
 
+{{{ ansible_instantiate_variables("var_audit_failure_mode") }}}
+
 - name: Collect all files from /etc/audit/rules.d with .rules extension
   find:
     paths: "/etc/audit/rules.d/"
@@ -21,7 +23,7 @@
   lineinfile:
     path: "{{ item }}"
     create: True
-    line: "-f 2"
+    line: "-f {{ var_audit_failure_mode }}"
   loop:
     - "/etc/audit/audit.rules"
     - "/etc/audit/rules.d/immutable.rules"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/bash/shared.sh
@@ -1,5 +1,7 @@
 # platform = multi_platform_all
 
+{{{ bash_instantiate_variables("var_audit_failure_mode") }}}
+
 # Traverse all of:
 #
 # /etc/audit/audit.rules,			(for auditctl case)
@@ -10,5 +12,5 @@ for AUDIT_FILE in "/etc/audit/audit.rules" "/etc/audit/rules.d/immutable.rules"
 do
 	echo '' >> $AUDIT_FILE
 	echo '# Set the audit.rules configuration to halt system upon audit failure per security requirements' >> $AUDIT_FILE
-	echo '-f 2' >> $AUDIT_FILE
+	echo "-f $var_audit_failure_mode" >> $AUDIT_FILE
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/oval/shared.xml
@@ -21,29 +21,26 @@
 
   <ind:textfilecontent54_test check="at least one" comment="audit augenrules configuration shutdown" id="test_ars_shutdown_augenrules" version="1">
     <ind:object object_ref="object_ars_shutdown_augenrules" />
-    <ind:state state_ref="state_ars_shutdown_augenrules" />
+    <ind:state state_ref="state_ars_shutdown" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_ars_shutdown_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     <ind:pattern operation="pattern match">^\-f\s+(\d)\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_ars_shutdown_augenrules" version="1">
+  <ind:textfilecontent54_state id="state_ars_shutdown" version="1">
     <ind:subexpression datatype="string" operation="equals" var_check="all" var_ref="var_audit_failure_mode" />
   </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test check="all" comment="audit auditctl configuration shutdown" id="test_ars_shutdown_auditctl" version="1">
     <ind:object object_ref="object_ars_shutdown_auditctl" />
-    <ind:state state_ref="state_ars_shutdown_auditctl" />
+    <ind:state state_ref="state_ars_shutdown" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_ars_shutdown_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match">^\-f\s+(\d)\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_ars_shutdown_auditctl" version="1">
-    <ind:subexpression datatype="string" operation="equals" var_check="all" var_ref="var_audit_failure_mode" />
-  </ind:textfilecontent54_state>
 
   <external_variable comment="external variable for audit failure mode"
     datatype="string" id="var_audit_failure_mode" version="1" />

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/oval/shared.xml
@@ -19,22 +19,32 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" comment="audit augenrules configuration shutdown" id="test_ars_shutdown_augenrules" version="1">
+  <ind:textfilecontent54_test check="at least one" comment="audit augenrules configuration shutdown" id="test_ars_shutdown_augenrules" version="1">
     <ind:object object_ref="object_ars_shutdown_augenrules" />
+    <ind:state state_ref="state_ars_shutdown_augenrules" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_ars_shutdown_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^\-f\s+2\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-f\s+(\d)\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_ars_shutdown_augenrules" version="1">
+    <ind:subexpression datatype="string" operation="equals" var_check="all" var_ref="var_audit_failure_mode" />
+  </ind:textfilecontent54_state>
 
   <ind:textfilecontent54_test check="all" comment="audit auditctl configuration shutdown" id="test_ars_shutdown_auditctl" version="1">
     <ind:object object_ref="object_ars_shutdown_auditctl" />
+    <ind:state state_ref="state_ars_shutdown_auditctl" />
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_ars_shutdown_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^\-f\s+2\s*$</ind:pattern>
+    <ind:pattern operation="pattern match">^\-f\s+(\d)\s*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_ars_shutdown_auditctl" version="1">
+    <ind:subexpression datatype="string" operation="equals" var_check="all" var_ref="var_audit_failure_mode" />
+  </ind:textfilecontent54_state>
 
+  <external_variable comment="external variable for audit failure mode"
+    datatype="string" id="var_audit_failure_mode" version="1" />
 </def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_system_shutdown/rule.yml
@@ -9,11 +9,11 @@ description: |-
     <tt>augenrules</tt> program to read audit rules during daemon startup (the
     default), add the following line to to the bottom of a file with suffix
     <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt>:
-    <pre>-f 2</pre>
+    <pre>-f {{{ xccdf_value("var_audit_failure_mode") }}}</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
     utility to read audit rules during daemon startup, add the following line to the
     bottom of the <tt>/etc/audit/audit.rules</tt> file:
-    <pre>-f 2</pre>
+    <pre>-f {{{ xccdf_value("var_audit_failure_mode") }}}</pre>
 
 rationale: |-
     It is critical for the appropriate personnel to be aware if a system
@@ -54,9 +54,9 @@ ocil_clause: 'the system is not configured to shutdown on auditd failures'
 ocil: |-
     To verify that the system will shutdown when <tt>auditd</tt> fails,
     run the following command:
-    <pre>$ sudo grep "\-f 2" /etc/audit/audit.rules</pre>
+    <pre>$ sudo grep "\-f {{{ xccdf_value("var_audit_failure_mode") }}}" /etc/audit/audit.rules</pre>
     The output should contain:
-    <pre>-f 2</pre>
+    <pre>-f {{{ xccdf_value("var_audit_failure_mode") }}}</pre>
 
 fixtext: |-
     Configure {{{ full_name }}} to shutdown when auditing failures occur.
@@ -64,11 +64,11 @@ fixtext: |-
     If the auditd daemon is configured to use the augenrules program to read
     audit rules during daemon startup (the default), add the following line to
     the bottom of "/etc/audit/rules.d/immutable.rules":
-    -f 2
+    -f {{{ xccdf_value("var_audit_failure_mode") }}}
 
     If the auditd daemon is configured to use the auditctl utility to read
     audit rules during daemon startup, add the following line to the
     bottom of the /etc/audit/audit.rules file:
-    -f 2
+    -f {{{ xccdf_value("var_audit_failure_mode") }}}
 
 srg_requirement: The {{{ full_name }}} system must shut down when an audit processing failure occurs.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/var_audit_failure_mode.var
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/var_audit_failure_mode.var
@@ -1,0 +1,20 @@
+documentation_complete: true
+
+title: 'Audit failure mode'
+
+description: |-
+    This variable is the setting for the -f option in "/etc/audit/rules.d/audit.rules" which configures the failure mode of audit.
+    This option lets you determine how you want the kernel to handle critical errors.
+    Possible values are: 0=silent, 1=printk, 2=panic.
+    If the value is set to "2", the system is configured to panic (shut down) in the event of an auditing failure.
+    If the value is set to "1", the system is configured to only send information to the kernel log regarding the failure.
+
+type: string
+
+interactive: true
+
+options:
+    default: 2
+    silent: 0
+    printk: 1
+    panic: 2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/var_audit_failure_mode.var
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/var_audit_failure_mode.var
@@ -3,7 +3,7 @@ documentation_complete: true
 title: 'Audit failure mode'
 
 description: |-
-    This variable is the setting for the -f option in "/etc/audit/rules.d/audit.rules" which configures the failure mode of audit.
+    This variable is the setting for the -f option in Audit configuration which sets the failure mode of audit.
     This option lets you determine how you want the kernel to handle critical errors.
     Possible values are: 0=silent, 1=printk, 2=panic.
     If the value is set to "2", the system is configured to panic (shut down) in the event of an auditing failure.

--- a/products/ol7/profiles/hipaa.profile
+++ b/products/ol7/profiles/hipaa.profile
@@ -146,6 +146,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/ol7/profiles/ncp.profile
+++ b/products/ol7/profiles/ncp.profile
@@ -124,6 +124,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -158,6 +158,7 @@ selections:
     - file_permissions_var_log_audit
     - file_ownership_var_log_audit
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - auditd_audispd_configure_remote_server
     - auditd_audispd_encrypt_sent_records
     - auditd_audispd_disk_full_action

--- a/products/ol8/profiles/hipaa.profile
+++ b/products/ol8/profiles/hipaa.profile
@@ -145,6 +145,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/ol9/profiles/hipaa.profile
+++ b/products/ol9/profiles/hipaa.profile
@@ -141,6 +141,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhel7/profiles/hipaa.profile
+++ b/products/rhel7/profiles/hipaa.profile
@@ -150,6 +150,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhel7/profiles/ncp.profile
+++ b/products/rhel7/profiles/ncp.profile
@@ -129,6 +129,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhel7/profiles/rhelh-stig.profile
+++ b/products/rhel7/profiles/rhelh-stig.profile
@@ -148,6 +148,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhel7/profiles/rhelh-vpp.profile
+++ b/products/rhel7/profiles/rhelh-vpp.profile
@@ -83,6 +83,7 @@ selections:
 
     # AU -5(b)
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
 
     # AU-9
     - file_permissions_var_log_audit

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -182,6 +182,7 @@ selections:
     - package_telnet-server_removed
     - service_auditd_enabled
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - auditd_audispd_configure_remote_server
     - auditd_audispd_encrypt_sent_records
     - auditd_audispd_disk_full_action

--- a/products/rhel8/profiles/hipaa.profile
+++ b/products/rhel8/profiles/hipaa.profile
@@ -147,6 +147,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhel9/profiles/hipaa.profile
+++ b/products/rhel9/profiles/hipaa.profile
@@ -147,6 +147,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhv4/profiles/rhvh-stig.profile
+++ b/products/rhv4/profiles/rhvh-stig.profile
@@ -155,6 +155,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday

--- a/products/rhv4/profiles/rhvh-vpp.profile
+++ b/products/rhv4/profiles/rhvh-vpp.profile
@@ -91,6 +91,7 @@ selections:
 
     # AU -5(b)
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
 
     # AU-9
     - file_permissions_var_log_audit

--- a/products/sle15/profiles/hipaa.profile
+++ b/products/sle15/profiles/hipaa.profile
@@ -121,6 +121,7 @@ selections:
     - audit_rules_session_events
     - audit_rules_sysadmin_actions
     - audit_rules_system_shutdown
+    - var_audit_failure_mode=panic
     - audit_rules_time_adjtimex
     - audit_rules_time_clock_settime
     - audit_rules_time_settimeofday


### PR DESCRIPTION
#### Description:
Parametrize rule "audit_rules_system_shutdown" by XCCDF Value "var_audit_failure_mode". 


#### Rationale:
This allows users to customize their settings using a tailoring. The reason for allowing it is that the STIG ID RHEL-07-030010 allows audit to be configured with either `auditctl -f 2` or `auditctl -f 1`.


#### Review Hints:
- build RHEL 7 product and check if the OVAL, Bash and Ansible for rule `audit_rules_system_shutdown` are parametrized by an XCCDF value