### PR TITLE
Include Ubuntu products in package_prelink_removed

### DIFF
--- a/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
+++ b/linux_os/guide/system/software/integrity/disable_prelink/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,ol7,rhcos4,rhel7,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,ol7,rhcos4,rhel7,sle12,sle15
 
 title: 'Disable Prelinking'
 
@@ -30,8 +30,6 @@ references:
     cis@rhel7: 1.5.4
     cis@sle12: 1.6.4
     cis@sle15: 1.6.4
-    cis@ubuntu2004: 1.6.3
-    cis@ubuntu2204: 1.5.2
     cjis: 5.10.1.3
     cobit5: APO01.06,BAI02.01,BAI03.05,BAI06.01,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS04.07,DSS05.03,DSS06.02,DSS06.06
     cui: 3.13.11

--- a/linux_os/guide/system/software/integrity/package_prelink_removed/rule.yml
+++ b/linux_os/guide/system/software/integrity/package_prelink_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7
+prodtype: rhel7,ubuntu2004,ubuntu2204
 
 title: 'Package "prelink" Must not be Installed'
 
@@ -19,6 +19,8 @@ identifiers:
 
 references:
     cis@rhel7: 1.5.4
+    cis@ubuntu2004: 1.6.3
+    cis@ubuntu2204: 1.5.2
 
 template:
     name: package_removed

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -148,7 +148,7 @@ selections:
     - sysctl_kernel_randomize_va_space
 
     ### 1.6.3 Ensure prelink is disabled (Automated)
-    - disable_prelink
+    - package_prelink_removed
 
     ### 1.6.4 Ensure core dumps are restricted (Automated)
     - disable_users_coredumps

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -139,7 +139,7 @@ selections:
     - sysctl_kernel_randomize_va_space
 
     ### 1.5.2 Ensure prelink is disabled (Automated)
-    - disable_prelink
+    - package_prelink_removed
 
     ### 1.5.3 Ensure Automatic Error Reporting is not enabled (Automated)
     - service_apport_disabled


### PR DESCRIPTION
#### Description:

- The `package_prelink_removed` rule is also applicable for Ubuntu

#### Rationale:

- This rule can cover benchmarks requirements, like CIS for Ubuntu 20.04 and Ubuntu 22.04.