### PR TITLE
Change sshd_disable_compression applicability

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
@@ -53,6 +53,10 @@ ocil: |-
     <pre>$ sudo grep Compression /etc/ssh/sshd_config</pre>
     If configured properly, output should be <pre>no</pre> or <pre>delayed</pre>.
 
+{{% if product == "rhel7" %}}
+platform: rhel7_older_than_7_4
+{{% endif %}}
+
 fixtext: '{{{ fixtext_sshd_lineinfile("Compression", xccdf_value("var_sshd_disable_compression"), no) }}}'
 
 srg_requirement: 'The {{{ full_name }}} SSH daemon must not allow compression or must only allow compression after successful authentication.'

--- a/shared/applicability/rhel7_older_than_7_4.yml
+++ b/shared/applicability/rhel7_older_than_7_4.yml
@@ -1,0 +1,3 @@
+name: "cpe:/o:redhat:enterprise_linux:7:older_than_7_4"
+title: "RHEL 7 is older than 7.4"
+check_id: rhel7_older_than_7_4

--- a/shared/checks/oval/rhel7_older_than_7_4.xml
+++ b/shared/checks/oval/rhel7_older_than_7_4.xml
@@ -1,0 +1,96 @@
+<def-group>
+  <definition class="inventory"
+  id="rhel7_older_than_7_4" version="1">
+    <metadata>
+      <title>Red Hat Enterprise Linux 7</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <reference ref_id="cpe:/o:redhat:enterprise_linux:7:older_than_7_4"
+      source="CPE" />
+      <description>The operating system installed on the system is
+      Red Hat Enterprise Linux 7 older than 7.4</description>
+    </metadata>
+    <criteria>
+      <criterion comment="Installed operating system is part of the unix family"
+      test_ref="test_rhel7_unix_family_older_than_7_4" />
+      <criteria operator="OR">
+        <criterion comment="RHEL 7 Client is installed" test_ref="test_rhel7_client_older_than_7_4" />
+        <criterion comment="RHEL 7 Workstation is installed" test_ref="test_rhel7_workstation_older_than_7_4" />
+        <criterion comment="RHEL 7 Server is installed" test_ref="test_rhel7_server_older_than_7_4" />
+        <criterion comment="RHEL 7 Compute Node is installed" test_ref="test_rhel7_computenode_older_than_7_4" />
+        <criteria operator="AND" comment="Red Hat Enterprise Virtualization Host is installed">
+          <criterion comment="Red Hat Virtualization Host (RHVH)" test_ref="test_rhvh4_version" />
+          <criterion comment="Red Hat Enterprise Virtualization Host is based on RHEL 7" test_ref="test_rhevh_rhel7_version_older_than_7_4" />
+        </criteria>
+      </criteria>
+    </criteria>
+  </definition>
+
+  <ind:family_test check="all" check_existence="at_least_one_exists" comment="installed OS part of unix family" id="test_rhel7_unix_family_older_than_7_4" version="1">
+    <ind:object object_ref="obj_rhel7_unix_family_older_than_7_4" />
+    <ind:state state_ref="state_rhel7_unix_family_older_than_7_4" />
+  </ind:family_test>
+  <ind:family_state id="state_rhel7_unix_family_older_than_7_4" version="1">
+    <ind:family>unix</ind:family>
+  </ind:family_state>
+  <ind:family_object id="obj_rhel7_unix_family_older_than_7_4" version="1" />
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-client is version 7" id="test_rhel7_client_older_than_7_4" version="1">
+    <linux:object object_ref="obj_rhel7_client_older_than_7_4" />
+    <linux:state state_ref="state_rhel7_client_older_than_7_4" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_client_older_than_7_4" version="1">
+    <linux:version operation="less than" datatype="version">7.4</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_client_older_than_7_4" version="1">
+    <linux:name>redhat-release-client</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-workstation is version 7" id="test_rhel7_workstation_older_than_7_4" version="1">
+    <linux:object object_ref="obj_rhel7_workstation_older_than_7_4" />
+    <linux:state state_ref="state_rhel7_workstation_older_than_7_4" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_workstation_older_than_7_4" version="1">
+    <linux:version operation="less than" datatype="version">7.4</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_workstation_older_than_7_4" version="1">
+    <linux:name>redhat-release-workstation</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-server is version 7" id="test_rhel7_server_older_than_7_4" version="1">
+    <linux:object object_ref="obj_rhel7_server_older_than_7_4" />
+    <linux:state state_ref="state_rhel7_server_older_than_7_4" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_server_older_than_7_4" version="1">
+    <linux:version operation="less than" datatype="version">7.4</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_server_older_than_7_4" version="1">
+    <linux:name>redhat-release-server</linux:name>
+  </linux:rpminfo_object>
+
+  <linux:rpminfo_test check="all" check_existence="at_least_one_exists" comment="redhat-release-computenode is version 7" id="test_rhel7_computenode_older_than_7_4" version="1">
+    <linux:object object_ref="obj_rhel7_computenode_older_than_7_4" />
+    <linux:state state_ref="state_rhel7_computenode_older_than_7_4" />
+  </linux:rpminfo_test>
+  <linux:rpminfo_state id="state_rhel7_computenode_older_than_7_4" version="1">
+    <linux:version operation="less than" datatype="version">7.4</linux:version>
+  </linux:rpminfo_state>
+  <linux:rpminfo_object id="obj_rhel7_computenode_older_than_7_4" version="1">
+    <linux:name>redhat-release-computenode</linux:name>
+  </linux:rpminfo_object>
+
+  <ind:textfilecontent54_test check="all" comment="RHEVH base RHEL is version 7" id="test_rhevh_rhel7_version_older_than_7_4" version="1">
+    <ind:object object_ref="obj_rhevh_rhel7_version_older_than_7_4" />
+    <ind:state state_ref="state_rhevh_rhel7_version_older_than_7_4" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhevh_rhel7_version_older_than_7_4" version="1">
+    <ind:filepath>/etc/redhat-release</ind:filepath>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux \w* release (\d\.\d+).*$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhevh_rhel7_version_older_than_7_4" version="1">
+    <ind:subexpression operation="less than" datatype="version">7.4</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>


### PR DESCRIPTION
#### Description:
Makes the rule sshd_disable_compression not applicable for RHEL 7.4 and newer.


#### Rationale:
RHEL 7 STIG v3r10 says in STIG ID RHEL-07-040470 that "for RHEL 7.4 and above, this requirement is not applicable.".

