### PR TITLE
Add account_emergency_expire_date to OL7 stig

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_emergency_expire_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,ol9,rhel7,rhel8,rhel9
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9
 
 title: 'Assign Expiration Date to Emergency Accounts'
 
@@ -42,6 +42,7 @@ references:
     nist: AC-2(2),AC-2(3),CM-6(a)
     nist-csf: DE.CM-1,DE.CM-3,PR.AC-1,PR.AC-4,PR.AC-6
     srg: SRG-OS-000123-GPOS-00064,SRG-OS-000002-GPOS-00002
+    stigid@ol7: OL07-00-010271
     stigid@ol8: OL08-00-020270
     stigid@rhel7: RHEL-07-010271
     stigid@rhel8: RHEL-08-020270

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -329,3 +329,4 @@ selections:
     - auditd_audispd_remote_daemon_direction
     - auditd_audispd_remote_daemon_path
     - auditd_audispd_remote_daemon_type
+    - account_emergency_expire_date


### PR DESCRIPTION
#### Description:

- Add `account_emergency_expire_date` rule to the OL7 stig profile

#### Rationale:

- OL7 DISA STIG efforts