### PR TITLE
Introduce the release_helper.py script

### DIFF
--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -670,7 +670,7 @@ def release_prep(repo, args) -> None:
 
 
 def release(repo, args) -> None:
-    if not is_next_release_in_progress(repo):
+    if is_next_release_in_progress(repo):
         if args.tag:
             next_version = get_next_release_version(repo)
             tag_name = f'v{next_version}'

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -533,13 +533,13 @@ def update_milestone(repo, object_list) -> None:
 def update_milestone_in_issues(repo, issues_list) -> None:
     outdate_issues = filter_outdated_items(repo, issues_list, "Issue")
     if outdate_issues:
-        update_milestone(outdate_issues)
+        update_milestone(repo, outdate_issues)
 
 
 def update_milestone_in_prs(repo, prs_list) -> None:
     outdate_prs = filter_outdated_items(repo, prs_list, 'PR')
     if outdate_prs:
-        update_milestone(outdate_prs)
+        update_milestone(repo, outdate_prs)
 
 
 # Repo Stats

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -42,6 +42,7 @@ def create_ini_file_template(creds_file):
 
 
 def get_github_token(creds_file) -> str:
+    creds_file = os.path.expanduser(creds_file)
     if os.path.exists(creds_file):
         return get_parameter_from_ini(creds_file, "DEFAULT", "github_token")
     else:

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -583,7 +583,7 @@ def collect_release_info(repo) -> dict:
 def print_specific_stat(status, current, total) -> None:
     if current > 0:
         percent = round((current / total) * 100.00, 2)
-        print(f'{status:21} {current:6} / {total:3} = {percent:4}%')
+        print(f'{status:23.23} {current} / {total} = {percent}%')
 
 
 def print_last_release_stats(data):
@@ -595,11 +595,11 @@ def print_last_release_stats(data):
     total_issues = data["previous_milestone_total_issues"]
 
     print('Information based on the latest published release:')
-    print(f'Current Version:\t {version}\n'
-          f'Created at:\t\t {created_at}\n'
-          f'Published at:\t\t {published_at}\n'
-          f'Release Notes:\t\t {url_download}')
-    print_specific_stat("Closed Issues/PRs", closed_issues, total_issues)
+    print(f'Current Version:        {version}')
+    print(f'Created at:             {created_at}')
+    print(f'Published at:           {published_at}')
+    print(f'Release Notes:          {url_download}')
+    print_specific_stat("Closed Issues/PRs:", closed_issues, total_issues)
 
 
 def print_next_release_stats(data):
@@ -615,13 +615,13 @@ def print_next_release_stats(data):
     total_issues = data["active_milestone_total_issues"]
 
     print(f'\nNext release information in {now}:')
-    print(f'Next Version:\t\t {next_release_version}\n'
-          f'Current State:\t\t {next_release_state}\n'
-          f'Estimated Release Date:\t {next_release_date} ({next_release_days} remaining days)\n'
-          f'Stabilization Date:\t {next_stab_date} ({next_stab_days} remaining days)\n'
-          f'Working Milestone:\t {milestone}')
+    print(f'Next Version:           {next_release_version}')
+    print(f'Current State:          {next_release_state}')
+    print(f'Estimated Release Date: {next_release_date} ({next_release_days} remaining days)')
+    print(f'Stabilization Date:     {next_stab_date} ({next_stab_days} remaining days)')
+    print(f'Working Milestone:      {milestone}')
 
-    print_specific_stat("Closed Issues/PRs", closed_issues, total_issues)
+    print_specific_stat("Closed Issues/PRs:", closed_issues, total_issues)
 
 
 # Functions to specific phases of the process

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -768,7 +768,7 @@ def main():
     try:
         repo = get_repo_object(ghs, args.repository)
     except Exception as e:
-        print(f'Error: {e}')
+        print(f'Error when getting the repository {args.repository}: {e}')
         exit(1)
 
     if args.subcmd == "stats":

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -60,10 +60,7 @@ def create_github_session(creds_file) -> object:
 
 def get_confirmation(question) -> bool:
     answer = str(input(f'{question} (Y/N): ')).lower().strip()
-    if answer[:1] == 'y':
-        return True
-    else:
-        return False
+    return answer[:1] == 'y'
 
 
 def get_repo_object(session, repo_id) -> object:

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -236,7 +236,7 @@ def close_milestone(milestone) -> None:
 
 def create_repo_milestone(repo, name) -> None:
     if get_version_milestone(name):
-        print(f'Great. The "{name}" milestone is already created.')
+        print(f'Great! The "{name}" milestone is already created.')
         return
 
     latest_release = get_latest_release(repo)
@@ -309,6 +309,8 @@ def bump_master_version(repo):
         with open(os.path.join(repo_root, "CMakeLists.txt"), mode='w', encoding='utf-8') as file:
             file.writelines(content)
         show_git_diff()
+    else:
+        print('Great! The version in CMakeLists.txt file is already updated.')
 
 
 def get_friday(date) -> datetime:
@@ -498,7 +500,7 @@ def filter_outdated_items(repo, objects_list, type) -> list:
         else:
             print(f'Aborted! {type}(s) milestones not updated.')
     else:
-        print(f'Great. There is no {type} with an outdated milestone.')
+        print(f'Great! There is no {type} with an outdated milestone.')
         return []
 
 
@@ -638,7 +640,7 @@ def cleanup(repo, args) -> None:
         if branch_to_remove:
             remove_old_stabilization_branch(branch_to_remove)
         else:
-            print('Great. There is no branch to be removed.')
+            print('Great! There is no branch to be removed.')
 
 
 def release_prep(repo, args) -> None:
@@ -750,11 +752,11 @@ def parse_arguments():
     release_parser = subparsers.add_parser(
         'release', help="Tasks to be done during the stabilization phase.")
     release_parser.add_argument(
-        '-t', '--tag', action='store_true',
-        help="Show commands to properly tag the branch and start the release.")
-    release_parser.add_argument(
         '-m', '--message', action='store_true',
         help="Prepare a message to communicate the stabilization process has started.")
+    release_parser.add_argument(
+        '-t', '--tag', action='store_true',
+        help="Show commands to properly tag the branch and start the release.")
 
     finish_parser = subparsers.add_parser(
         'finish', help="Tasks to be done when the release is out.")

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -1,0 +1,778 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""
+Script created to help maintainers during the release process by automating Github tasks.
+"""
+
+# References:
+# - https://developer.github.com/v3/libraries/
+# - https://github.com/PyGithub/PyGithub
+# - https://pygithub.readthedocs.io/en/latest/github_objects.html
+# - https://docs.github.com/en/rest
+
+from datetime import datetime, timedelta
+from github import Github
+import argparse
+import configparser
+import os.path
+import re
+import subprocess
+
+def get_parameter_from_ini(config_file, section, parameter) -> str:
+    config = configparser.ConfigParser()
+    try:
+        config.read(config_file)
+        return config[section][parameter]
+    except Exception as e:
+        print(f'{e} entry was not found - Information cannot be retrieved!')
+        exit(1)
+
+
+def create_ini_file_template(creds_file):
+    try:
+        new_creds_file = os.path.expanduser(creds_file)
+        with open(new_creds_file, mode='w', encoding='utf-8') as file:
+            file.write(
+                '[DEFAULT]\n'
+                'github_token = <generate your token in https://github.com/settings/tokens>\n')
+        print(f'Great! {new_creds_file} was created! Edit it to include your personal token.')
+    except Exception as e:
+        print(f'Error: {e}')
+        exit(1)
+
+
+def get_github_token(creds_file) -> str:
+    if os.path.exists(creds_file):
+        return get_parameter_from_ini(creds_file, "DEFAULT", "github_token")
+    else:
+        print(f'{creds_file} file was not found!')
+        if get_confirmation(f'Would you like to create the "{creds_file}" file?'):
+            create_ini_file_template(creds_file)
+        exit(1)
+
+
+def create_github_session(args) -> object:
+    return Github(get_github_token(args.creds_file))
+
+
+def get_confirmation(question) -> bool:
+    answer = str(input(f'{question} (Y/N): ')).lower().strip()
+    if answer[:1] == 'y':
+        return True
+    else:
+        return False
+
+
+def get_repo_object(session, repo_id) -> object:
+    return session.get_repo(repo_id)
+
+
+# Repository Branches
+def filter_repo_branch_by_name(branches, name) -> object:
+    return [branch for branch in branches if branch.name == name]
+
+
+def get_repo_branch(repo, branch_name) -> object:
+    try:
+        return repo.get_branch(branch_name)
+    except Exception as e:
+        print(f'Error: {e}')
+        exit(1)
+
+
+def get_repo_branches(repo) -> list:
+    return repo.get_branches()
+
+
+def get_repo_stable_branch(repo) -> object:
+    branches = get_repo_branches(repo)
+    return filter_repo_branch_by_name(branches, "stable")
+
+
+def get_old_stabilization_branch(repo) -> object:
+    branches = get_repo_branches(repo)
+    latest_version = get_latest_version(repo)
+    branch_name = f'stabilization-v{latest_version}'
+    return filter_repo_branch_by_name(branches, branch_name)
+
+
+def remove_old_stabilization_branch(repo, branch) -> None:
+    if get_confirmation(f'Are you sure about removing the "{branch.name}" branch?'):
+        #https://github.com/PyGithub/PyGithub/issues/1570
+        try:
+            branch_ref = repo.get_git_ref(f'heads/{branch.name}')
+            branch_ref.delete()
+        except Exception as e:
+            print(f'Error: {e}')
+            exit(1)
+    else:
+        print(f'Aborted! {branch.name} branch not removed.')
+
+
+# Repository Contributors
+def get_contributors_commit_diff(commit) -> str:
+    commit_diff = subprocess.run(
+        ['git', 'show', '--word-diff', commit, 'Contributors.md'],
+        capture_output=True, text=True)
+    return commit_diff.stdout
+
+
+def get_contributors_last_commit() -> str:
+    last_commit = subprocess.run(
+        ['git', 'log', '--pretty=format:%h', '-1', '--', 'Contributors.md'],
+        capture_output=True, text=True)
+    return last_commit.stdout
+
+
+def get_contributors_last_update() -> str:
+    last_commit = get_contributors_last_commit()
+    last_commit_diff = get_contributors_commit_diff(last_commit)
+
+    for line in last_commit_diff.split('\n'):
+        # The "generate_contributors.py" creates a commend in the beginning of the file.
+        # This comment informs when the file was updated.
+        if 'Last Modified:' in line:
+            elements = line.split('{+')
+            datetime = elements[1].replace('+}', '')
+            return datetime
+
+
+def get_new_contributors(commit) -> str:
+    last_commit_diff = get_contributors_commit_diff(commit)
+    new_contributors = []
+
+    for line in last_commit_diff.split('\n'):
+        if line.startswith('{+'):
+            for chars in ['{+', '+}']:
+                line = line.replace(chars, '')
+            new_contributors.append(line)
+    return '\n'.join(new_contributors)
+
+
+def is_contributors_list_updated(date_string) -> bool:
+    date = datetime.strptime(date_string, '%Y-%m-%d %H:%M')
+    # As a rule of thumbs, this function consider contributors list
+    # updated if not older than 2 weeks.
+    two_weeks_back = datetime.now() - timedelta(days=15)
+    if date < two_weeks_back:
+        return False
+    return True
+
+
+def update_contributors():
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    contributors_script = os.path.join(root_dir, "utils/generate_contributors.py")
+    subprocess.run([f'PYTHONPATH=. {contributors_script}'], shell=True)
+    subprocess.run(['git', 'diff'])
+    print('Please, review the changes and propose a PR to "master" branch.')
+
+
+# Repository Milestones
+def has_milestone_version_format(milestone) -> bool:
+    regex = re.compile('\d\.\d\.\d')
+    return regex.match(milestone.title)
+
+
+def filter_version_milestones(milestones) -> list:
+    version_milestones = []
+    for milestone in milestones:
+        if has_milestone_version_format(milestone):
+            version_milestones.append(milestone)
+    return version_milestones
+
+
+def get_repo_milestones(repo) -> list:
+    return repo.get_milestones(state="all", direction="desc")
+
+
+def get_latest_version_milestone(repo) -> object:
+    milestones = get_repo_milestones(repo)
+    version_milestones = filter_version_milestones(milestones)
+    latest_version_milestone = version_milestones[0]
+    # It is not ensured the returned milestones list is ordered as expected.
+    # This function ensures the last milestone based on titles.
+    for milestone in version_milestones:
+        if milestone.title > latest_version_milestone.title:
+            latest_version_milestone = milestone
+    return latest_version_milestone
+
+
+def get_version_milestone(repo, version) -> object:
+    milestones = get_repo_milestones(repo)
+    version_milestones = filter_version_milestones(milestones)
+    for milestone in version_milestones:
+        if milestone.title == version:
+            return milestone
+
+
+def close_milestone(milestone) -> None:
+    try:
+        milestone.edit(state="closed")
+    except Exception as e:
+        print(f'Error: {e}')
+        exit(1)
+
+
+def create_repo_milestone(repo, name) -> None:
+    latest_release = get_latest_release(repo)
+    estimated_release_date = get_next_release_date(latest_release.published_at)
+    if get_confirmation(f'Are you sure about creating the "{name}" milestone?'):
+        try:
+            repo.create_milestone(
+                title=name, description=f'Milestone for the release {name}',
+                due_on=estimated_release_date)
+        except Exception as e:
+            print(f'Error: {e}')
+            exit(1)
+    else:
+        print(f'Aborted! {name} milestone not created.')
+
+
+# Repository Releases
+def get_repo_releases(repo) -> list:
+    return repo.get_releases()
+
+
+def get_latest_release(repo) -> object:
+    releases = get_repo_releases(repo)
+    # The API returns the list already ordered by published date.
+    return releases[0]
+
+
+# Repository Versions
+def extract_version_from_tag_name(version) -> str:
+    return version.split("v")[1]
+
+
+def get_latest_version(repo) -> str:
+    release = get_latest_release(repo)
+    return extract_version_from_tag_name(release.tag_name)
+
+
+# Repository Next Release
+def bump_version(current_version, bump_position) -> str:
+    # version format example: 0.1.64
+    if bump_position == 'minor':
+        position = 2
+    elif bump_position == 'major':
+        position = 1
+    else:
+        position = 0
+
+    split_version = current_version.split('.')
+    bumped = int(split_version[position]) + 1
+    split_version[position] = str(bumped)
+    return ".".join(split_version)
+
+
+def bump_master_version(old_version, new_version):
+    old_minor_version = old_version.split('.')[2]
+    new_minor_version = new_version.split('.')[2]
+    root_dir = os.path.dirname(os.path.dirname(__file__))
+    with open(os.path.join(root_dir, "CMakeLists.txt"), mode='r', encoding='utf-8') as file:
+        content = file.readlines()
+
+    for ln, line in enumerate(content):
+        if f'set(SSG_PATCH_VERSION {old_minor_version}' in line:
+            content[ln] = content[ln].replace(old_minor_version, new_minor_version)
+
+    with open(os.path.join(root_dir, "CMakeLists.txt"), mode='w', encoding='utf-8') as file:
+        file.writelines(content)
+
+
+def get_friday(date) -> datetime:
+    return date + timedelta((4-date.weekday()) % 7)
+
+
+def get_monday(date) -> datetime:
+    return date + timedelta((0-date.weekday()) % 7)
+
+
+def get_next_stabilization_date(release_date) -> datetime:
+    two_weeks_before = release_date - timedelta(weeks=2)
+    stabilization_monday = get_monday(two_weeks_before)
+    return stabilization_monday.date()
+
+
+def get_next_release_date(latest_release_date) -> datetime:
+    two_months_ahead = latest_release_date + timedelta(days=60)
+    return get_friday(two_months_ahead)
+
+
+def is_next_release_in_progress(repo) -> bool:
+    stabilization_branch = get_next_stabilization_branch(repo)
+    branches_names = [branch.name for branch in get_repo_branches(repo)]
+    if stabilization_branch in branches_names:
+        return True
+    else:
+        return False
+
+
+def get_next_release_state(repo) -> str:
+    if is_next_release_in_progress(repo):
+        return 'In Stabilization Phase'
+    else:
+        return 'Scheduled'
+
+
+def get_next_release_version(repo) -> str:
+    current_version = get_latest_version(repo)
+    next_version = bump_version(current_version, 'minor')
+    return next_version
+
+
+def get_next_stabilization_branch(repo) -> str:
+    next_release = get_next_release_version(repo)
+    return f'stabilization-v{next_release}'
+
+
+# Communication
+def get_date_for_message(date) -> datetime:
+    return date.strftime("%B %d, %Y")
+
+
+def get_release_highlights(release) -> str:
+    highlights = []
+    for line in release.body.split('\r\n'):
+        if '### Important Highlights' in line:
+            continue
+        if '###' in line:
+            break
+        if line:
+            highlights.append(line)
+    return '\n'.join(highlights)
+
+
+def get_release_start_message(repo) -> str:
+    latest_release = get_latest_release(repo)
+    next_release_version = get_next_release_version(repo)
+    next_release_date = get_next_release_date(latest_release.published_at)
+    date = get_date_for_message(next_release_date)
+    branch = get_next_stabilization_branch(repo)
+
+    future_version = bump_version(next_release_version, 'minor')
+    future_release_date = get_next_release_date(next_release_date)
+    future_date = get_date_for_message(future_release_date)
+    future_stabilization_date = get_next_stabilization_date(future_release_date)
+    future_date_stabilization = get_date_for_message(future_stabilization_date)
+
+    template = f'''
+        Subject: stabilization of v{next_release_version}
+
+        Hello all,
+
+        The release of Content version {next_release_version} is scheduled for {date}.
+        As part of the release process, a stabilization branch was created.
+        Issues and PRs that were not solved were moved to the {future_version} milestone.
+
+        Any bug fixes you would like to include in release {next_release_version} should be proposed
+        for the *{branch}* and *master* branches as a measure to avoid
+        potential conflicts between these branches.
+
+        The next version, {future_version}, is scheduled to be released on {future_date},
+        with the stabilization phase starting on {future_date_stabilization}.
+
+        Regards,'''
+    return template
+
+
+def get_release_end_message(repo) -> str:
+    latest_release = get_latest_release(repo)
+    latest_release_url = latest_release.html_url
+    highlights = get_release_highlights(latest_release)
+    new_contributors = get_new_contributors(get_contributors_last_commit())
+    released_version = get_latest_version(repo)
+
+    for asset in latest_release.get_assets():
+        if asset.content_type == 'application/x-bzip2':
+            source_tarball = asset.browser_download_url
+        elif asset.content_type == 'application/zip':
+            prebuild_zip = asset.browser_download_url
+        else:
+            if '.tar.bz2.sha512' in asset.name:
+                source_tarball_hash = asset.browser_download_url
+            else:
+                prebuild_zip_hash = asset.browser_download_url
+
+    # It would be more readable if this multiline string would be indented. However, this makes
+    # the final text weird, after the "format" substitutions, when highlights and new_contributors
+    # have multilines too. So, the readability was compromised in favor of simplicity and user
+    # experience. This way, the user only needs to copy and paste, without removing leading spaces.
+    template = f'''
+Subject: ComplianceAsCode/content v{released_version}
+
+Hello all,
+
+ComplianceAsCode/Content v{released_version} is out.
+
+Some of the highlights of this release are:
+{highlights}
+
+Welcome to the new contributors:
+{new_contributors}
+
+For full release notes, please have a look at:
+{latest_release_url}
+
+Pre-built content: {prebuild_zip}
+SHA-512 hash: {source_tarball_hash}
+
+Source tarball: {source_tarball}
+SHA-512 hash: {prebuild_zip_hash}
+
+Thank you to everyone who contributed!
+
+Regards,'''
+    return template
+
+
+# Issues and PRs
+def filter_items_outdated_milestone(objects_list, milestone) -> list:
+    items_old_milestone = []
+    for item in objects_list:
+        if has_milestone_version_format(item.milestone):
+            if item.milestone.title != milestone.title:
+                items_old_milestone.append(item)
+    return items_old_milestone
+
+
+def filter_outdated_items(repo, objects_list, type) -> list:
+    latest_milestone = get_latest_version_milestone(repo)
+    items_to_update = filter_items_outdated_milestone(objects_list, latest_milestone)
+    if items_to_update:
+        count = len(items_to_update)
+        print(f'The following {count} {type}(s) have an outdated milestone:')
+        for item in items_to_update:
+            print(f'{item.number:5} - {item.url:65} - {item.milestone.title} - {item.title}')
+        if get_confirmation(f'Are you sure about updating the milestone in {count} Open {type}s?'):
+            return items_to_update
+        else:
+            print(f'Aborted! {type}(s) milestones not updated.')
+    else:
+        print(f'Great. There is no {type} with an outdated milestone.')
+        return []
+
+
+def get_items_with_milestone(object_list) -> list:
+    with_milestone = []
+    for item in object_list:
+        if item.milestone:
+            with_milestone.append(item)
+    return with_milestone
+
+
+def get_open_issues_with_milestone(repo) -> list:
+    open_issues = repo.get_issues(state='open', direction='asc')
+    return get_items_with_milestone(open_issues)
+
+
+def get_open_prs_with_milestone(repo) -> list:
+    open_prs = repo.get_pulls(state='open', direction='asc')
+    return get_items_with_milestone(open_prs)
+
+
+def update_milestone(repo, object_list) -> None:
+    milestone = get_latest_version_milestone(repo)
+    for item in object_list:
+        try:
+            item.edit(milestone=milestone)
+        except Exception as e:
+            print(f'Error: {e}')
+            exit(1)
+
+
+def update_milestone_in_issues(repo, issues_list) -> None:
+    outdate_issues = filter_outdated_items(repo, issues_list, "Issue")
+    if outdate_issues:
+        update_milestone(outdate_issues)
+
+
+def update_milestone_in_prs(repo, prs_list) -> None:
+    outdate_prs = filter_outdated_items(repo, prs_list, 'PR')
+    if outdate_prs:
+        update_milestone(outdate_prs)
+
+
+# Repo Stats
+def collect_release_info(repo) -> dict:
+    data = dict()
+    latest_release = get_latest_release(repo)
+    data["latest_release_created"] = latest_release.created_at
+    data["latest_release_published"] = latest_release.published_at
+    data["latest_release_url"] = latest_release.html_url
+    data["latest_version"] = get_latest_version(repo)
+
+    next_release_date = get_next_release_date(latest_release.published_at)
+    next_release_remaining_days = next_release_date - datetime.today()
+    data["next_release_date"] = next_release_date
+    data["next_release_remaining_days"] = next_release_remaining_days.days
+    data["next_release_state"] = get_next_release_state(repo)
+    data["next_release_version"] = get_next_release_version(repo)
+    next_stabilization_date = get_next_stabilization_date(next_release_date)
+    next_stabilization_remaining_days = next_stabilization_date - datetime.today().date()
+    data["next_stabilization_date"] = next_stabilization_date
+    data["next_stabilization_remaining_days"] = next_stabilization_remaining_days.days
+
+    previous_milestone = get_version_milestone(repo, data["latest_version"])
+    data["previous_milestone"] = previous_milestone.title
+    data["previous_milestone_closed_issues"] = previous_milestone.closed_issues
+    data["previous_milestone_open_issues"] = previous_milestone.open_issues
+    data["previous_milestone_total_issues"] = data["previous_milestone_closed_issues"]\
+        + data["previous_milestone_open_issues"]
+
+    active_milestone = get_latest_version_milestone(repo)
+    data["active_milestone"] = active_milestone.title
+    data["active_milestone_closed_issues"] = active_milestone.closed_issues
+    data["active_milestone_open_issues"] = active_milestone.open_issues
+    data["active_milestone_total_issues"] = data["active_milestone_closed_issues"]\
+        + data["active_milestone_open_issues"]
+    return data
+
+
+def print_specific_stat(status, current, total) -> None:
+    if current > 0:
+        percent = round((current / total) * 100.00, 2)
+        print(f'{status:21} {current:6} / {total:3} = {percent:4}%')
+
+
+def print_last_release_stats(data):
+    version = data['latest_version']
+    created_at = data['latest_release_created']
+    published_at = data['latest_release_published']
+    url_download = data['latest_release_url']
+    closed_issues = data["previous_milestone_closed_issues"]
+    total_issues = data["previous_milestone_total_issues"]
+
+    print('Information based on the latest published release:')
+    print(f'Current Version:\t {version}\n'
+          f'Created at:\t\t {created_at}\n'
+          f'Published at:\t\t {published_at}\n'
+          f'Release Notes:\t\t {url_download}')
+    print_specific_stat("Closed Issues/PRs", closed_issues, total_issues)
+
+
+def print_next_release_stats(data):
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    milestone = data['active_milestone']
+    next_release_version = data['next_release_version']
+    next_release_date = data['next_release_date']
+    next_release_days = data['next_release_remaining_days']
+    next_release_state = data['next_release_state']
+    next_stabilization_date = data['next_stabilization_date']
+    next_stabilization_days = data['next_stabilization_remaining_days']
+    closed_issues = data["active_milestone_closed_issues"]
+    total_issues = data["active_milestone_total_issues"]
+
+    print(f'\nNext release information in {now}:')
+    print(f'Next Version:\t\t {next_release_version}\n'
+          f'Current State:\t\t {next_release_state}\n'
+          f'Estimated Release Date:\t {next_release_date} ({next_release_days} remaining days)\n'
+          f'Stabilization Date:\t {next_stabilization_date} ({next_stabilization_days} remaining days)\n'
+          f'Working Milestone:\t {milestone}')
+
+    print_specific_stat("Closed Issues/PRs", closed_issues, total_issues)
+
+
+# Functions to specific phases of the process
+def stats(repo):
+    rel_data = collect_release_info(repo)
+    print_last_release_stats(rel_data)
+    print_next_release_stats(rel_data)
+
+
+def cleanup(repo, args) -> None:
+    if args.branch:
+        branch_to_remove = get_old_stabilization_branch(repo)
+        if branch_to_remove:
+            remove_old_stabilization_branch(branch_to_remove)
+        else:
+            print('Great. There is no branch to be removed.')
+
+
+def release_prep(repo, args) -> None:
+    if get_old_stabilization_branch(repo):
+        print('Ops. There is an old branch to be removed. Please, check branch cleanup.')
+        exit(1)
+
+    if args.contributors:
+        last_update = get_contributors_last_update()
+        if is_contributors_list_updated(last_update):
+            print(f'It is all fine, the contributors list was updated in {last_update}')
+        else:
+            print(f'Contributors list last update was in {last_update}. I can update it for you.')
+            update_contributors()
+
+    stab_branch_name = get_next_stabilization_branch(repo)
+    if args.branch:
+        print('git checkout master\n'
+              'git pull upstream master\n'
+              f'git checkout -b {stab_branch_name}\n'
+              f'git push -u upstream {stab_branch_name}')
+
+    if args.milestone:
+        if is_next_release_in_progress(repo):
+            stab_milestone = get_latest_version_milestone(repo)
+            if stab_milestone.state == "open":
+                if get_confirmation(f'The "{stab_milestone}" milestone should be closed. Ok?'):
+                    close_milestone(stab_milestone)
+                else:
+                    print(f'Aborted! {stab_milestone} milestone not closed.')
+            else:
+                print(f'Nice. The "{stab_milestone}" milestone is already closed.')
+
+            next_release_version = get_next_release_version(repo)
+            new_milestone = bump_version(next_release_version, 'minor')
+            if not get_version_milestone(new_milestone):
+                if get_confirmation(f'The "{new_milestone}" milestone should be created. Ok?'):
+                    create_repo_milestone(repo, new_milestone)
+                else:
+                    print(f'Aborted! {new_milestone} milestone not created!')
+            else:
+                print(f'Great. The "{new_milestone}" milestone is already created.')
+        else:
+            print(f'Before managing milestones, ensure the "{stab_branch_name}" branch is created.')
+        exit()
+
+    if args.issues:
+        issues_list = get_open_issues_with_milestone(repo)
+        update_milestone_in_issues(repo, issues_list)
+
+    if args.prs:
+        prs_list = get_open_prs_with_milestone(repo)
+        update_milestone_in_prs(repo, prs_list)
+
+
+def release(repo, args) -> None:
+    if not is_next_release_in_progress(repo):
+        if args.tag:
+            next_version = get_next_release_version(repo)
+            tag_name = f'v{next_version}'
+            stab_branch = get_next_stabilization_branch(repo)
+            print('Release process starts when a version tag is added to the stabilization branch.\n'
+                  'It is better to do it manually. But here are the commands you need:\n')
+            print(f'git tag {tag_name} {stab_branch}\n'
+                  'git push --tags')
+
+        if args.message:
+            message = get_release_start_message(repo)
+            print('Please, share the following message in:\n'
+                  '* Gitter (https://gitter.im/Compliance-As-Code-The/content)\n'
+                  '* SCAP Security Guide Mail List (scap-security-guide@lists.fedorahosted.org)\n'
+                  '* Github Discussion (https://github.com/ComplianceAsCode/content/discussions/new?category=announcements)')
+            print(message)
+
+        if args.bump_version:
+            current_version = get_next_release_version(repo)
+            new_version = bump_version(current_version, 'minor')
+            bump_master_version(current_version, new_version)
+            subprocess.run(['git', 'diff'])
+            print('\nPlease, review the changes and propose a PR to "master" branch.')
+    else:
+        print('Please, ensure the all steps in the Release Preparation are concluded.')
+
+
+def finish(repo, args) -> None:
+    if not is_next_release_in_progress(repo):
+        if args.message:
+            message = get_release_end_message(repo)
+            print('Please, share the following message in:\n'
+                  '* Gitter (https://gitter.im/Compliance-As-Code-The/content)\n'
+                  '* SCAP Security Guide Mail List (scap-security-guide@lists.fedorahosted.org)\n'
+                  '* OpenSCAP Mail List (open-scap-list@redhat.com)\n'
+                  '* Github Discussion (https://github.com/ComplianceAsCode/content/discussions/new?category=announcements)\n'
+                  '* Twitter (https://twitter.com/openscap)')
+            print(message)
+    else:
+        print('Please, ensure the all steps in the Release process are concluded.')
+
+
+def parse_arguments():
+    '''Call argparse to process input parameters and return parsed args'''
+    parser = argparse.ArgumentParser(
+        description="Automate Github tasks included in the Release Process.",
+        epilog="Example: release_helper.py -c ~/secrets.ini -r ComplianceAsCode/content stats",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '-c', '--creds-file', default='~/secret.ini',
+        help="INI file containing Github token.")
+    parser.add_argument(
+        '-r', '--repository', action='store', default='ComplianceAsCode/content',
+        help="Project repository name.")
+
+    subparsers = parser.add_subparsers(dest='subcmd', required=True)
+    subparsers.add_parser(
+        'stats', help="Return information about the repository current state.")
+
+    cleanup_parser = subparsers.add_parser(
+        'cleanup', help="Cleanup after completing a release.")
+    cleanup_parser.add_argument(
+        '-b', '--branch', action='store_true',
+        help="Remove temporary branch used during stabilization phase.")
+
+    release_prep_parser = subparsers.add_parser(
+        'release_prep', help="Prepare the repository for the next release.")
+    release_prep_parser.add_argument(
+        '-c', '--contributors', action='store_true',
+        help="Update the contributors lists. Do it before creating the stabilization branch.")
+    release_prep_parser.add_argument(
+        '-b', '--branch', action='store_true',
+        help="Create the stabilization branch for the next release.")
+    release_prep_parser.add_argument(
+        '-m', '--milestone', action='store_true',
+        help="Create the next milestone and close the current milestone.")
+    release_prep_parser.add_argument(
+        '-i', '--issues', action='store_true',
+        help="Move Open Issues with a milestone to the next milestone.")
+    release_prep_parser.add_argument(
+        '-p', '--prs', action='store_true',
+        help="Move Open PRs with a milestone to the new milestone.")
+
+    release_parser = subparsers.add_parser(
+        'release', help="Tasks to be done during the stabilization phase.")
+    release_parser.add_argument(
+        '-t', '--tag', action='store_true',
+        help="Show commands to properly tag the branch and start the release.")
+    release_parser.add_argument(
+        '-m', '--message', action='store_true',
+        help="Prepare a message to communicate the stabilization process has started.")
+    release_parser.add_argument(
+        '-b', '--bump-version', action='store_true',
+        help="Bump the project version in *master* branch.")
+
+    finish_parser = subparsers.add_parser(
+        'finish', help="Tasks to be done when the release is out.")
+    finish_parser.add_argument(
+        '-m', '--message', action='store_true',
+        help="Prepare a message to communicate the release is out.")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_arguments()
+    ghs = create_github_session(args)
+
+    try:
+        repo = get_repo_object(ghs, args.repository)
+    except Exception as e:
+        print(f'Error: {e}')
+        exit(1)
+
+    if args.subcmd == "stats":
+        stats(repo)
+
+    if args.subcmd == "cleanup":
+        cleanup(repo, args)
+
+    if args.subcmd == "release_prep":
+        release_prep(repo, args)
+
+    if args.subcmd == "release":
+        release(repo, args)
+
+    if args.subcmd == "finish":
+        finish(repo, args)
+
+
+if __name__ == "__main__":
+    main()

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -622,7 +622,7 @@ def print_next_release_stats(data):
 
 
 # Functions to specific phases of the process
-def stats(repo):
+def stats(repo, args):
     try:
         rel_data = collect_release_info(repo)
         print_last_release_stats(rel_data)
@@ -764,6 +764,13 @@ def parse_arguments():
 
 
 def main():
+    subcmds = dict(
+        stats=stats,
+        cleanup=cleanup,
+        release_prep=release_prep,
+        release=release,
+        finish=finish)
+
     args = parse_arguments()
 
     try:
@@ -773,23 +780,7 @@ def main():
         print(f'Error when getting the repository {args.repository}: {e}')
         exit(1)
 
-    if args.subcmd == "stats":
-        stats(repo)
-
-    if args.subcmd == "cleanup":
-        cleanup(repo, args)
-
-    if args.subcmd == "release_prep":
-        if get_old_stabilization_branch(repo):
-            print('Ops. There is an old branch to be removed. Please, check branch cleanup.')
-            exit(1)
-        release_prep(repo, args)
-
-    if args.subcmd == "release":
-        release(repo, args)
-
-    if args.subcmd == "finish":
-        finish(repo, args)
+    subcmds[args.subcmd](repo, args)
 
 
 if __name__ == "__main__":

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -158,7 +158,7 @@ def get_new_contributors(commit) -> str:
 
 
 def is_contributors_list_updated(date_string) -> bool:
-    date = datetime.strptime(date_string, '%Y-%m-%d %H:%M')
+    date = datetime.strptime(date_string[:16], '%Y-%m-%d %H:%M')
     # As a rule of thumbs, this function consider contributors list
     # updated if not older than 2 weeks.
     two_weeks_back = datetime.now() - timedelta(days=15)

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -227,7 +227,7 @@ def close_milestone(milestone) -> None:
 
     if get_confirmation(f'The "{milestone}" milestone should be closed. Ok?'):
         try:
-            milestone.edit(state="closed")
+            milestone.edit(milestone.title, state="closed")
         except Exception as e:
             print(f'Error: {e}')
             exit(1)

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -88,14 +88,6 @@ def filter_repo_branch_by_name(branches, name) -> object:
     return [branch for branch in branches if branch.name == name]
 
 
-def get_repo_branch(repo, branch_name) -> object:
-    try:
-        return repo.get_branch(branch_name)
-    except Exception as e:
-        print(f'Error: {e}')
-        exit(1)
-
-
 def get_repo_branches(repo) -> list:
     return repo.get_branches()
 

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -163,6 +163,8 @@ def is_contributors_list_updated(date_string) -> bool:
 
 def update_contributors():
     last_update = get_contributors_last_update()
+    # Currently, this script considers contributors lists is already updated if not
+    # older than 2 weeks.
     if is_contributors_list_updated(last_update):
         print(f'It is all fine, the contributors list was updated in {last_update}')
     else:
@@ -345,23 +347,6 @@ def get_next_stabilization_branch(repo) -> str:
 
 
 # Communication
-def get_communication_channels(phase='release') -> None:
-    gitter_lnk = 'https://gitter.im/Compliance-As-Code-The/content'
-    ghd_lnk = 'https://github.com/ComplianceAsCode/content/discussions/new?category=announcements'
-    twitter_lnk = 'https://twitter.com/openscap'
-    ssg_mail = 'scap-security-guide@lists.fedorahosted.org'
-    openscap_mail = 'open-scap-list@redhat.com'
-
-    print('Please, share the following message in:\n'
-          f'* Gitter ({gitter_lnk})\n'
-          f'* Github Discussion ({ghd_lnk})\n'
-          f'* SCAP Security Guide Mail List ({ssg_mail})')
-
-    if phase == "finish":
-        print(f'* OpenSCAP Mail List ({openscap_mail})\n'
-              f'* Twitter ({twitter_lnk})')
-
-
 def get_date_for_message(date) -> datetime:
     return date.strftime("%B %d, %Y")
 
@@ -451,15 +436,32 @@ For full release notes, please have a look at:
 {latest_release_url}
 
 Pre-built content: {prebuild_zip}
-SHA-512 hash: {source_tarball_hash}
+SHA-512 hash: {prebuild_zip_hash}
 
 Source tarball: {source_tarball}
-SHA-512 hash: {prebuild_zip_hash}
+SHA-512 hash: {source_tarball_hash}
 
 Thank you to everyone who contributed!
 
 Regards,'''
     return template
+
+
+def print_communication_channels(phase='release') -> None:
+    gitter_lnk = 'https://gitter.im/Compliance-As-Code-The/content'
+    ghd_lnk = 'https://github.com/ComplianceAsCode/content/discussions/new?category=announcements'
+    twitter_lnk = 'https://twitter.com/openscap'
+    ssg_mail = 'scap-security-guide@lists.fedorahosted.org'
+    openscap_mail = 'open-scap-list@redhat.com'
+
+    print('Please, share the following message in:\n'
+          f'* Gitter ({gitter_lnk})\n'
+          f'* Github Discussion ({ghd_lnk})\n'
+          f'* SCAP Security Guide Mail List ({ssg_mail})')
+
+    if phase == "finish":
+        print(f'* OpenSCAP Mail List ({openscap_mail})\n'
+              f'* Twitter ({twitter_lnk})')
 
 
 # Issues and PRs
@@ -669,7 +671,7 @@ def release(repo, args) -> None:
 
         if args.message:
             message = get_release_start_message(repo)
-            get_communication_channels('release')
+            print_communication_channels('release')
             print(message)
 
         if args.bump_version:
@@ -679,17 +681,17 @@ def release(repo, args) -> None:
             subprocess.run(['git', 'diff'])
             print('\nPlease, review the changes and propose a PR to "master" branch.')
     else:
-        print('Please, ensure the all steps in the Release Preparation are concluded.')
+        print('Please, ensure that all steps in the Release Preparation are concluded.')
 
 
 def finish(repo, args) -> None:
     if not is_next_release_in_progress(repo):
         if args.message:
             message = get_release_end_message(repo)
-            get_communication_channels('finish')
+            print_communication_channels('finish')
             print(message)
     else:
-        print('Please, ensure the all steps in the Release process are concluded.')
+        print('Please, ensure that all steps in the Release process are concluded.')
 
 
 def parse_arguments():

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -420,11 +420,10 @@ def get_release_end_message(repo) -> str:
             source_tarball = asset.browser_download_url
         elif asset.content_type == 'application/zip':
             prebuild_zip = asset.browser_download_url
+        elif '.tar.bz2.sha512' in asset.name:
+            source_tarball_hash = asset.browser_download_url
         else:
-            if '.tar.bz2.sha512' in asset.name:
-                source_tarball_hash = asset.browser_download_url
-            else:
-                prebuild_zip_hash = asset.browser_download_url
+            prebuild_zip_hash = asset.browser_download_url
 
     # It would be more readable if this multiline string would be indented. However, this makes
     # the final text weird, after the "format" substitutions, when highlights and new_contributors

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -313,23 +313,30 @@ def bump_master_version(repo):
         print('Great! The version in CMakeLists.txt file is already updated.')
 
 
-def get_friday(date) -> datetime:
-    return date + timedelta((4-date.weekday()) % 7)
+def describe_next_release_state(repo) -> str:
+    if is_next_release_in_progress(repo):
+        return 'In Stabilization Phase'
+    else:
+        return 'Scheduled'
 
 
-def get_monday(date) -> datetime:
-    return date + timedelta((0-date.weekday()) % 7)
+def get_friday_that_follows(date) -> datetime:
+    return date + timedelta((4 - date.weekday()) % 7)
+
+
+def get_monday_that_follows(date) -> datetime:
+    return date + timedelta((0 - date.weekday()) % 7)
 
 
 def get_next_stabilization_date(release_date) -> datetime:
     two_weeks_before = release_date - timedelta(weeks=2)
-    stabilization_monday = get_monday(two_weeks_before)
+    stabilization_monday = get_monday_that_follows(two_weeks_before)
     return stabilization_monday.date()
 
 
 def get_next_release_date(latest_release_date) -> datetime:
     two_months_ahead = latest_release_date + timedelta(days=60)
-    return get_friday(two_months_ahead)
+    return get_friday_that_follows(two_months_ahead)
 
 
 def is_next_release_in_progress(repo) -> bool:
@@ -339,13 +346,6 @@ def is_next_release_in_progress(repo) -> bool:
         return True
     else:
         return False
-
-
-def get_next_release_state(repo) -> str:
-    if is_next_release_in_progress(repo):
-        return 'In Stabilization Phase'
-    else:
-        return 'Scheduled'
 
 
 def get_next_release_version(repo) -> str:
@@ -557,7 +557,7 @@ def collect_release_info(repo) -> dict:
     next_release_remaining_days = next_release_date - datetime.today()
     data["next_release_date"] = next_release_date
     data["next_release_remaining_days"] = next_release_remaining_days.days
-    data["next_release_state"] = get_next_release_state(repo)
+    data["next_release_state"] = describe_next_release_state(repo)
     data["next_release_version"] = get_next_release_version(repo)
     next_stabilization_date = get_next_stabilization_date(next_release_date)
     next_stabilization_remaining_days = next_stabilization_date - datetime.today().date()

--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -233,7 +233,7 @@ def close_milestone(milestone) -> None:
 
 
 def create_repo_milestone(repo, name) -> None:
-    if get_version_milestone(name):
+    if get_version_milestone(repo, name):
         print(f'Great! The "{name}" milestone is already created.')
         return
 


### PR DESCRIPTION
#### Description:

During the preparation for the release `0.1.65`, the release process was reviewed and updated in order to make the process more efficient and easier to be automated.
During the release, all steps in the process were validated.
In parallel, I started this script to help in each Github task related to the process.
The script was now polished and should be ready to be shared with the community.

The script contains 5 sub-commands:
```
    stats               Return information about the repository current state.
    cleanup             Cleanup after completing a release.
    release_prep        Prepare the repository for the next release.
    release             Tasks to be done during the stabilization phase.
    finish              Tasks to be done when the release is out.
```

Each sub-command has its own options, which are well explained with `--help`.

#### Rationale:

The intention is to make repetitive tasks more efficient and remove unnecessary human efforts, like calculating dates, manually collecting data, etc.

#### Review Hints:

First check the help to get familiar with the options:
`utils/release_helper.py --help`

The scripts interacts with Github API, therefore, a personal token is necessary. The token should be stored in a `ini` formatted file. The file can be informed with the global option `-c`. You don't need to worry about the file format. The script will help you to create a brand new one, if necessary. I suggest to create a read-only token while exploring the options. In any case, any sensitive action demands an explicit confirmation.

I suggest to start testing it with the stats. This will show some nice information:
`utils/release_helper.py stats`

Then you can explore the options for `release_prep`, `release`, `finish` and finally `cleanup`.