### PR TITLE
Introduce script shorthand to OVAL

### DIFF
--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -596,3 +596,18 @@ Example:
     $ ./utils/srg_diff.py --target submission.xlsx --base build/cac_stig_output.xlsx --output build/diff.html -p rhel9
     Wrote output to build/diff.html.
 ```
+
+### Convert shorthand OVAL to a full OVAL - `utils/shorthand_to_oval.py`
+
+This script converts (resolved) shorthand OVAL files to a valid OVAL file.
+
+It can be useful for example when creating minimal bug reproducers.
+If you know that a problem is located in OVAL for a specific rule, you can use it to convert a resolved shorthand OVAL files from the `build/product/checks/oval` directory to a standalone valid OVAL file that you can then pass to `oscap`.
+
+Example:
+
+```bash
+$ ./build_product rhel9
+$ utils/shorthand_to_oval.py build/rhel9/checks/oval/accounts_tmout.xml oval.xml
+$ oscap oval eval oval.xml
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,12 @@ add_test(
 set_tests_properties("stable-profile-ids" PROPERTIES LABELS quick)
 
 add_test(
+    NAME "shorthand-to-oval"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/shorthand_to_oval.py" "${CMAKE_CURRENT_SOURCE_DIR}/data/utils/shorthand_oval.xml" "${CMAKE_CURRENT_BINARY_DIR}/oval.xml"
+)
+set_tests_properties("shorthand-to-oval" PROPERTIES LABELS quick)
+
+add_test(
     NAME "stable-profiles"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_profile_stability.py" "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/data/profile_stability"
 )

--- a/tests/data/utils/shorthand_oval.xml
+++ b/tests/data/utils/shorthand_oval.xml
@@ -1,0 +1,22 @@
+<def-group>
+  <definition class="compliance" id="no_empty_passwords" version="1">
+    <metadata>
+      <title>Prevent Login to Accounts With Empty Password</title>
+      <affected family="unix">
+        <platform>multi_platform_all</platform>
+      </affected>
+      <description>The file /etc/pam.d/system-auth should not contain the nullok option</description>
+    </metadata>
+    <criteria>
+      <criterion comment="make sure the nullok option is not used in /etc/pam.d/system-auth" test_ref="test_no_empty_passwords"/>
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="none_exist" version="1" id="test_no_empty_passwords" comment="make sure nullok is not used in /etc/pam.d/system-auth">
+    <ind:object object_ref="object_no_empty_passwords"/>
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_no_empty_passwords" version="1">
+    <ind:filepath operation="pattern match">^/etc/pam.d/(system|password)-auth$</ind:filepath>
+    <ind:pattern operation="pattern match">^[^#]*\bnullok\b.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/utils/shorthand_to_oval.py
+++ b/utils/shorthand_to_oval.py
@@ -1,0 +1,20 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+
+import ssg.build_ovals
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert shorthand OVAL file to a valid full OVAL.")
+    parser.add_argument("input", help="Input shorthand OVAL file")
+    parser.add_argument("output", help="Output OVAL file")
+    args = parser.parse_args()
+    env_yaml = {"rule_id": os.path.basename(args.input)}
+    ssg.build_ovals.expand_shorthand(args.input, args.output, env_yaml)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
#### Description:
Introduce a small script `shorthand_to_oval.py` that converts (resolved) shorthand OVAL files to a valid OVAL file.

It's based on already existing code from the CTest test "macros-oval".

#### Rationale:

The script can be useful for example when creating minimal bug reproducers. If you know that a problem is located in OVAL for a specific rule, you can use it to convert a resolved shorthand OVAL files from the `build/product/checks/oval` directory to a standalone valid OVAL file that you can then pass to `oscap`.

#### Review Hints:


```
$ ./build_product rhel9
$ utils/shorthand_to_oval.py build/rhel9/checks/oval/accounts_tmout.xml oval.xml
$ oscap oval eval oval.xml
```

For more details, please read the commit messages of every commit.