### PR TITLE
Using the Ansible shell actions is needed in package_prelink_remove

### DIFF
--- a/linux_os/guide/system/software/integrity/package_prelink_removed/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/package_prelink_removed/ansible/shared.yml
@@ -11,7 +11,7 @@
   register: prelink
 
 - name: Restore Prelinked Binaries
-  ansible.builtin.shell:
+  ansible.builtin.command:
     cmd: prelink -ua
   when: prelink.stat.exists
 


### PR DESCRIPTION
#### Description:

Replace `ansible.builtin.shell` with `ansible.builtin.command` in `package_prelink_remove`.

#### Rationale:
Fix Ansible lint issues.
