### PR TITLE
Ol8 v1r5 small updates - update policy text & remove rule for OL08-00-010510

### DIFF
--- a/linux_os/guide/services/ssh/file_permissions_sshd_private_key/policy/stig/shared.yml
+++ b/linux_os/guide/services/ssh/file_permissions_sshd_private_key/policy/stig/shared.yml
@@ -6,21 +6,20 @@ vuldiscussion: |-
     impersonated.
 
 checktext: |-
-    Verify the SSH private host key files have a mode of "0600" or less permissive with the following command:
+    Verify the SSH private host key files have mode "0640" or less permissive with the following command:
 
-    $ ls -l /etc/ssh/*_key
+    $ sudo ls -alL /etc/ssh/ssh_host*key
 
-    600 /etc/ssh/ssh_host_dsa_key
-    600 /etc/ssh/ssh_host_ecdsa_key
-    600 /etc/ssh/ssh_host_ed25519_key
-    600 /etc/ssh/ssh_host_rsa_key
+    -rw-r----- 1 root {{{ dedicated_ssh_groupname }}} 668 Nov 28 06:43 ssh_host_dsa_key
+    -rw-r----- 1 root {{{ dedicated_ssh_groupname }}} 582 Nov 28 06:43 ssh_host_key
+    -rw-r----- 1 root {{{ dedicated_ssh_groupname }}} 887 Nov 28 06:43 ssh_host_rsa_key
 
-    If any private host key file has a mode more permissive than "0600", this is a finding.
+    If any private host key file has a mode more permissive than "0640", this is a finding.
 
 fixtext: |-
-    Configure the mode of SSH private host key files under "/etc/ssh" to "0600" with the following command:
+    Configure the mode of SSH private host key files under "/etc/ssh" to "0640" with the following command:
 
-    $ sudo chmod 0600 /etc/ssh/ssh_host*key
+    $ sudo chmod 0640 /etc/ssh/ssh_host*key
 
     Restart the SSH daemon for the changes to take effect:
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
@@ -38,9 +38,7 @@ references:
     nist-csf: PR.IP-1
     srg: SRG-OS-000480-GPOS-00227
     stigid@ol7: OL07-00-040470
-    stigid@ol8: OL08-00-010510
     stigid@rhel7: RHEL-07-040470
-    stigid@rhel8: RHEL-08-010510
     stigid@sle12: SLES-12-030250
     stigid@sle15: SLES-15-040280
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -18,7 +18,6 @@ selections:
     - var_accounts_user_umask=077
     - var_password_pam_difok=8
     - var_password_pam_maxrepeat=3
-    - var_sshd_disable_compression=no
     - var_password_hashing_algorithm=SHA512
     - var_password_pam_maxclassrepeat=4
     - var_password_pam_minclass=4
@@ -342,9 +341,6 @@ selections:
 
     # OL08-00-010500
     - sshd_enable_strictmodes
-
-    # OL08-00-010510
-    - sshd_disable_compression
 
     # OL08-00-010520
     - sshd_disable_user_known_hosts

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -31,7 +31,6 @@ selections:
     - var_accounts_user_umask=077
     - var_password_pam_difok=8
     - var_password_pam_maxrepeat=3
-    - var_sshd_disable_compression=no
     - var_password_hashing_algorithm=SHA512
     - var_password_pam_maxclassrepeat=4
     - var_password_pam_minclass=4
@@ -347,9 +346,6 @@ selections:
 
     # RHEL-08-010500
     - sshd_enable_strictmodes
-
-    # RHEL-08-010510
-    - sshd_disable_compression
 
     # RHEL-08-010520
     - sshd_disable_user_known_hosts

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -359,7 +359,6 @@ selections:
 - set_password_hashing_algorithm_passwordauth
 - set_password_hashing_algorithm_systemauth
 - set_password_hashing_min_rounds_logindefs
-- sshd_disable_compression
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth
 - sshd_disable_kerb_auth
@@ -424,7 +423,6 @@ selections:
 - var_accounts_user_umask=077
 - var_password_pam_difok=8
 - var_password_pam_maxrepeat=3
-- var_sshd_disable_compression=no
 - var_password_hashing_algorithm=SHA512
 - var_password_pam_maxclassrepeat=4
 - var_password_pam_minclass=4

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -369,7 +369,6 @@ selections:
 - set_password_hashing_algorithm_passwordauth
 - set_password_hashing_algorithm_systemauth
 - set_password_hashing_min_rounds_logindefs
-- sshd_disable_compression
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth
 - sshd_disable_kerb_auth
@@ -432,7 +431,6 @@ selections:
 - var_accounts_user_umask=077
 - var_password_pam_difok=8
 - var_password_pam_maxrepeat=3
-- var_sshd_disable_compression=no
 - var_password_hashing_algorithm=SHA512
 - var_password_pam_maxclassrepeat=4
 - var_password_pam_minclass=4


### PR DESCRIPTION
#### Description:

- Update policy in rule `ssh_host_key_permissions`
- Remove rule `sshd_disable_compression` from OL8 & RHEL8

#### Rationale:

- This is to align with latest DISA STIG requirements. v1r5 for OL8 and v1r9 for RHEL8
