### PR TITLE
Add aide_build_database to STIG in OL and RHEL

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -61,7 +61,10 @@ references:
     nist: CM-6(a)
     nist-csf: DE.CM-1,DE.CM-7,PR.DS-1,PR.DS-6,PR.DS-8,PR.IP-1,PR.IP-3
     pcidss: Req-11.5
+    stigid@ol7: OL07-00-020029
+    stigid@ol8: OL08-00-010359
     stigid@rhel7: RHEL-07-020029
+    stigid@rhel8: RHEL-08-010359
 
 ocil_clause: 'there is no database file'
 

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -101,6 +101,7 @@ selections:
     - package_ypserv_removed
     - selinux_user_login_roles
     - package_aide_installed
+    - aide_build_database
     - aide_periodic_cron_checking
     - aide_scan_notification
     - ensure_gpgcheck_globally_activated

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -240,6 +240,7 @@ selections:
 
     # OL08-00-010359
     - package_aide_installed
+    - aide_build_database
 
     # OL08-00-010360
     - aide_scan_notification

--- a/products/rhel7/profiles/stig.profile
+++ b/products/rhel7/profiles/stig.profile
@@ -127,6 +127,7 @@ selections:
     - package_ypserv_removed
     - selinux_user_login_roles
     - package_aide_installed
+    - aide_build_database
     - aide_periodic_cron_checking
     - aide_scan_notification
     - ensure_gpgcheck_globally_activated

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -248,6 +248,7 @@ selections:
 
     # RHEL-08-010359
     - package_aide_installed
+    - aide_build_database
 
     # RHEL-08-010360
     - aide_scan_notification

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -74,6 +74,7 @@ selections:
 - accounts_users_home_files_groupownership
 - accounts_users_home_files_permissions
 - agent_mfetpd_running
+- aide_build_database
 - aide_check_audit_tools
 - aide_scan_notification
 - aide_verify_acls

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -85,6 +85,7 @@ selections:
 - accounts_users_home_files_groupownership
 - accounts_users_home_files_permissions
 - agent_mfetpd_running
+- aide_build_database
 - aide_check_audit_tools
 - aide_scan_notification
 - aide_verify_acls


### PR DESCRIPTION
#### Description:

- Add rule `aide_build_database` to STIG profile in OL7, OL8 & RHEL8

#### Rationale:

- This is to comply with Jan 13th release of DISA STIG requirements

#### Review Hints:

- No changes on behavior, only added the rule to the STIG profiles