### PR TITLE
Add utils/controlrefcheck.py

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -635,7 +635,7 @@ controls:
       - dconf_gnome_disable_automount
       - dconf_gnome_disable_automount_open
 
-  - id: 1.9
+  - id: "1.9"
     title: Ensure updates, patches, and additional security software are installed (Manual)
     levels:
       - l1_server
@@ -644,7 +644,7 @@ controls:
     related_rules:
       - security_patches_up_to_date
 
-  - id: 1.10
+  - id: "1.10"
     title: Ensure system-wide crypto policy is not legacy (Automated)
     levels:
       - l1_server

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -661,7 +661,7 @@ controls:
     related_rules:
       - security_patches_up_to_date
 
-  - id: 1.10
+  - id: "1.10"
     title: Ensure system-wide crypto policy is not legacy (Automated)
     levels:
       - l1_server

--- a/docs/manual/developer/05_tools_and_utilities.md
+++ b/docs/manual/developer/05_tools_and_utilities.md
@@ -611,3 +611,16 @@ $ ./build_product rhel9
 $ utils/shorthand_to_oval.py build/rhel9/checks/oval/accounts_tmout.xml oval.xml
 $ oscap oval eval oval.xml
 ```
+
+### Ensure Control Files and Rules Are Consistent - `utils/controlrefcheck.py`
+
+This script helps ensure that control files and rules files are in sync.
+The script takes in what product, control, and reference you are looking for.
+The script loops over every rule in each control; the script then checks if the control's id is in the rule's reference that passed to the script.
+If a control's ID does not match or rule does not exist in the project the script will exit with a non-zero status.
+If the reference you are looking for is `cis` the script will not attempt to match anything that does not match a CIS section number.
+
+To execute:
+```bash
+$ ./utils/controlrefcheck.py rhel9 cis_rhel9 cis
+```

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/package_xinetd_removed/rule.yml
@@ -25,7 +25,7 @@ references:
     cis-csc: 11,12,14,15,3,8,9
     cis@alinux3: 2.1.1
     cis@rhel7: 2.1.1
-    cis@rhel8: 2.1.1
+    cis@rhel8: 2.2.1
     cis@sle12: 2.1.1
     cis@sle15: 2.1.1
     cis@ubuntu2004: 2.1.1

--- a/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_rsh_trust_files/rule.yml
@@ -29,7 +29,7 @@ references:
     cis-csc: 11,12,14,15,3,8,9
     cis@alinux2: 6.2.14
     cis@alinux3: 6.2.10
-    cis@rhel7: 6.2.14
+    cis@rhel7: 6.2.17
     cis@rhel8: 6.2.16
     cis@rhel9: 6.2.15
     cis@sle12: 6.2.12

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faillock_unlock_time/rule.yml
@@ -33,7 +33,7 @@ references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16
     cis@rhel7: 5.3.2
-    cis@rhel8: 5.4.2
+    cis@rhel8: 5.5.2
     cis@rhel9: 5.5.2
     cis@ubuntu2204: 5.4.2
     cjis: 5.5.3

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -37,7 +37,7 @@ references:
     cis-csc: 1,11,12,15,16,3,5,9
     cis@alinux3: 5.5.1
     cis@rhel7: 5.4.1
-    cis@rhel8: 5.4.1
+    cis@rhel8: 5.5.1
     cis@rhel9: 5.5.1
     cis@ubuntu2004: 5.3.1
     cis@ubuntu2204: 5.4.1

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/rule.yml
@@ -56,7 +56,7 @@ references:
     cis@alinux2: 5.3.4
     cis@alinux3: 5.5.4
     cis@rhel7: 5.4.3
-    cis@rhel8: 5.4.4
+    cis@rhel8: 5.5.4
     cis@rhel9: 5.5.4
     cjis: 5.6.2.2
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/group_unique_id/rule.yml
@@ -20,7 +20,7 @@ identifiers:
 references:
     cis@alinux2: 6.2.17
     cis@alinux3: 6.2.13
-    cis@rhel7: 6.2.7
+    cis@rhel7: 6.2.8
     cis@rhel8: 6.2.4
     cis@rhel9: 6.2.5
     cis@sle12: 6.2.15

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
@@ -32,7 +32,7 @@ references:
     anssi: BP28(R36)
     cis@alinux2: 4.2.1.3
     cis@rhel7: 4.2.1.3
-    cis@rhel8: 4.2.3
+    cis@rhel8: 4.2.1.4,4.2.3
     cis@rhel9: 4.2.3
     cis@sle12: 4.2.1.3
     cis@sle15: 4.2.1.3

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/rule.yml
@@ -47,7 +47,7 @@ references:
     cis-csc: 1,13,14,15,16,2,3,5,6
     cis@alinux2: 4.2.1.4
     cis@alinux3: 4.2.1.5
-    cis@rhel7: 4.2.1.4
+    cis@rhel7: 4.2.1.5
     cis@rhel8: 4.2.1.6
     cis@rhel9: 4.2.1.6
     cis@sle12: 4.2.1.5

--- a/linux_os/guide/system/selinux/selinux_state/rule.yml
+++ b/linux_os/guide/system/selinux/selinux_state/rule.yml
@@ -33,7 +33,7 @@ references:
     cis@alinux2: 1.6.1.2
     cis@alinux3: 1.7.1.4,1.7.1.5
     cis@rhel7: 1.6.1.4,1.6.1.5
-    cis@rhel8: 1.7.1.4
+    cis@rhel8: 1.6.1.5
     cis@rhel9: 1.6.1.5
     cobit5: APO01.06,APO11.04,APO13.01,BAI03.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.05,DSS05.07,DSS06.02,DSS06.03,DSS06.06,MEA02.01
     cui: 3.1.2,3.7.2

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -32,7 +32,7 @@ identifiers:
     cce@sle15: CCE-85764-9
 
 references:
-    cis@rhel8: 5.3.6
+    cis@rhel8: 5.3.5,5.3.6
     cis@rhel9: 5.3.5,5.3.6
     cis@ubuntu2204: 5.3.6
     disa: CCI-002038
@@ -62,6 +62,6 @@ fixtext: |-
 
     Defaults timestamp_timeout={{{ xccdf_value("var_sudo_timestamp_timeout") }}}
 
-    Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files. 
+    Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files.
 
 srg_requirement: '{{{ full_name }}} must require re-authentication when using the "sudo" command.'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -303,3 +303,19 @@ if (PYTHON_VERSION_MAJOR GREATER 2)
     )
     set_tests_properties("test-compare-disa-xml" PROPERTIES LABELS quick)
 endif()
+
+macro(ssg_controlrefcheck_test PRODUCT CONTROL KEY)
+    if (PYTHON_VERSION_MAJOR GREATER 2)
+        add_test(
+            NAME "controlrefchecker-${PRODUCT}-${CONTROL}"
+            COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/utils/controlrefcheck.py" --json "${CMAKE_SOURCE_DIR}/build/rule_dirs.json" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" "${PRODUCT}" "${CONTROL}" "${KEY}"
+        )
+        set_tests_properties("controlrefchecker-${PRODUCT}-${CONTROL}" PROPERTIES FIXTURES_REQUIRED "rule-dir-json")
+        set_tests_properties("controlrefchecker-${PRODUCT}-${CONTROL}" PROPERTIES DEPENDS "test-rule-dir-json")
+        set_tests_properties("controlrefchecker-${PRODUCT}-${CONTROL}" PROPERTIES LABELS quick)
+    endif()
+endmacro()
+
+ssg_controlrefcheck_test("rhel7" "cis_rhel7" "cis")
+ssg_controlrefcheck_test("rhel8" "cis_rhel8" "cis")
+ssg_controlrefcheck_test("rhel9" "cis_rhel9" "cis")

--- a/utils/controlrefcheck.py
+++ b/utils/controlrefcheck.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+
+import argparse
+import json
+import os
+import re
+import sys
+
+try:
+    from ssg.build_cpe import ProductCPEs
+    import ssg.build_profile
+    import ssg.controls
+    import ssg.environment
+    import ssg.products
+except (ModuleNotFoundError, ImportError):
+    sys.stderr.write("Unable to load ssg python modules.\n")
+    sys.stderr.write("Hint: run source ./.pyenv.sh\n")
+    exit(6)
+
+SSG_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+RULES_JSON = os.path.join(SSG_ROOT, "build", "rule_dirs.json")
+BUILD_CONFIG = os.path.join(SSG_ROOT, "build", "build_config.yml")
+CONTROLS_DIR = os.path.join(SSG_ROOT, "controls")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Ensures that Control and rule files are in sync")
+    parser.add_argument("-j", "--json", type=str, action="store",
+                        default=RULES_JSON, help="File to read "
+                        "json output of rule_dir_json from (defaults to "
+                        f"{RULES_JSON}")
+    parser.add_argument("-c", "--build-config-yaml", default=BUILD_CONFIG,
+                        help="YAML file with information about the build configuration. "
+                        f"Defaults to {BUILD_CONFIG}")
+    parser.add_argument("--controls", default=CONTROLS_DIR,
+                        help="Directory that contains control files with policy controls.")
+    parser.add_argument("product", type=str, help="Product to check has required references")
+    parser.add_argument("control", type=str, help="Control to iterate over")
+    parser.add_argument("reference", type=str, help="Required reference system to check for")
+    return parser.parse_args()
+
+
+def check_product(product: str) -> None:
+    linux_products, other_products = ssg.products.get_all(SSG_ROOT)
+    all_products = linux_products.union(other_products)
+    if product not in all_products:
+        sys.stderr.write(f"{product} is not a valid product\n")
+        exit(2)
+    return None
+
+
+def check_files(json_path: str, controls_dir: str) -> None:
+    if not os.path.exists(json_path):
+        sys.stderr.write(f"JSON at {json_path} was not found.\n")
+        sys.stderr.write("Run  ./utils/rule_dir_json.py to create.")
+        exit(3)
+    if not os.path.exists(controls_dir):
+        sys.stderr.write(f"Controls directory {controls_dir} was not found.\n")
+        exit(4)
+    if not os.path.isdir(controls_dir):
+        sys.stderr.write("Given controls directory {controls_dir} is not a directory.\n")
+        exit(5)
+
+
+def get_rule_object(all_rules, args, control_rule, env_yaml):
+    rule_dict = all_rules.get(control_rule)
+    rule_path = os.path.join(rule_dict['dir'], 'rule.yml')
+    rule_obj = ssg.build_yaml.Rule.from_yaml(rule_path, env_yaml=env_yaml)
+    rule_obj.normalize(args.product)
+    return rule_obj
+
+
+def main():
+    args = parse_args()
+
+    check_product(args.product)
+
+    rule_dir_json = open(args.json, 'r')
+    all_rules = json.load(rule_dir_json)
+
+    product_base = os.path.join(SSG_ROOT, "products", args.product)
+    product_yaml = os.path.join(product_base, "product.yml")
+    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
+
+    controls_manager = ssg.controls.ControlsManager(args.controls, env_yaml)
+    controls_manager.load()
+
+    ok = True
+    for control in controls_manager.get_all_controls(args.control):
+        for control_rule in control.selected:
+            rule_object = get_rule_object(all_rules, args, control_rule, env_yaml)
+            control_id = str(control.id)
+            if args.reference == 'cis' and not re.match(r"\d(\.\d+){0,3}", control_id):
+                # Skip control ids that in this control for technical reasons.
+                print(f"Skipping {control_id} as it does not match a CIS id.")
+                continue
+            if args.reference in rule_object.references and control_id \
+                    not in rule_object.references[args.reference].split(','):
+                ok = False
+                print(f"{rule_object.id_} {args.reference}@{args.product} "
+                      f"{rule_object.references[args.reference]} does not match the control id "
+                      f"{control.id}")
+            if not rule_object:
+                print(f"Unable to find rule: {control_rule} from {control.id}")
+
+    if not ok:
+        exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/controlrefcheck.py
+++ b/utils/controlrefcheck.py
@@ -62,7 +62,7 @@ def check_files(json_path: str, controls_dir: str) -> None:
         exit(5)
 
 
-def get_rule_object(all_rules, args, control_rule, env_yaml):
+def get_rule_object(all_rules, args, control_rule, env_yaml) -> ssg.build_yaml.Rule:
     rule_dict = all_rules.get(control_rule)
     rule_path = os.path.join(rule_dict['dir'], 'rule.yml')
     rule_obj = ssg.build_yaml.Rule.from_yaml(rule_path, env_yaml=env_yaml)
@@ -88,6 +88,10 @@ def main():
     ok = True
     for control in controls_manager.get_all_controls(args.control):
         for control_rule in control.selected:
+            if all_rules.get(control_rule) is None:
+                print(f'Rule {control_rule} was not found in the project.')
+                ok = False
+                continue
             rule_object = get_rule_object(all_rules, args, control_rule, env_yaml)
             control_id = str(control.id)
             if args.reference == 'cis' and not re.match(r"\d(\.\d+){0,3}", control_id):

--- a/utils/controlrefcheck.py
+++ b/utils/controlrefcheck.py
@@ -116,8 +116,6 @@ def main():
                 print(f"{rule_object.id_} {args.reference}@{args.product} "
                       f"{rule_object.references[args.reference]} does not match the control id "
                       f"{control.id}")
-            if not rule_object:
-                print(f"Unable to find rule: {control_rule} from {control.id}")
 
     if not ok:
         exit(1)


### PR DESCRIPTION
#### Description:

Add a script to test if the control id equals the reference of a rule. 

#### Rationale:
To ensure that the control file and the rules are in sync.

#### Review Hints:

`$ ./utils/controlrefcheck.py rhel8 cis_rhel8 cis`

Example output:

```
Skipping reload_dconf_db as it does not match a CIS id.
Skipping enable_authselect as it does not match a CIS id.
selinux_state cis@rhel8 1.7.1.4 does not match the control id 1.6.1.5
configure_crypto_policy cis@rhel8 1.10,1.11 does not match the control id 1.1
package_xinetd_removed cis@rhel8 2.1.1 does not match the control id 2.2.1
rsyslog_files_permissions cis@rhel8 4.2.3 does not match the control id 4.2.1.4
sudo_require_reauthentication cis@rhel8 5.3.6 does not match the control id 5.3.5
accounts_password_pam_retry cis@rhel8 5.4.1 does not match the control id 5.5.1
accounts_passwords_pam_faillock_unlock_time cis@rhel8 5.4.2 does not match the control id 5.5.2
set_password_hashing_algorithm_systemauth cis@rhel8 5.4.4 does not match the control id 5.5.4
set_password_hashing_algorithm_passwordauth cis@rhel8 5.4.4 does not match the control id 5.5.4
```
