### PR TITLE
Update RHEL8 STIG selections (V1R9)

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
@@ -40,7 +40,6 @@ references:
     stigid@ol7: OL07-00-040470
     stigid@ol8: OL08-00-010510
     stigid@rhel7: RHEL-07-040470
-    stigid@rhel8: RHEL-08-010510
     stigid@sle12: SLES-12-030250
     stigid@sle15: SLES-15-040280
     vmmsrg: SRG-OS-000480-VMM-002000

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -31,7 +31,6 @@ selections:
     - var_accounts_user_umask=077
     - var_password_pam_difok=8
     - var_password_pam_maxrepeat=3
-    - var_sshd_disable_compression=no
     - var_password_hashing_algorithm=SHA512
     - var_password_pam_maxclassrepeat=4
     - var_password_pam_minclass=4
@@ -348,9 +347,6 @@ selections:
 
     # RHEL-08-010500
     - sshd_enable_strictmodes
-
-    # RHEL-08-010510
-    - sshd_disable_compression
 
     # RHEL-08-010520
     - sshd_disable_user_known_hosts

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -360,7 +360,6 @@ selections:
 - set_password_hashing_algorithm_passwordauth
 - set_password_hashing_algorithm_systemauth
 - set_password_hashing_min_rounds_logindefs
-- sshd_disable_compression
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth
 - sshd_disable_kerb_auth
@@ -425,7 +424,6 @@ selections:
 - var_accounts_user_umask=077
 - var_password_pam_difok=8
 - var_password_pam_maxrepeat=3
-- var_sshd_disable_compression=no
 - var_password_hashing_algorithm=SHA512
 - var_password_pam_maxclassrepeat=4
 - var_password_pam_minclass=4

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -370,7 +370,6 @@ selections:
 - set_password_hashing_algorithm_passwordauth
 - set_password_hashing_algorithm_systemauth
 - set_password_hashing_min_rounds_logindefs
-- sshd_disable_compression
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth
 - sshd_disable_kerb_auth
@@ -433,7 +432,6 @@ selections:
 - var_accounts_user_umask=077
 - var_password_pam_difok=8
 - var_password_pam_maxrepeat=3
-- var_sshd_disable_compression=no
 - var_password_hashing_algorithm=SHA512
 - var_password_pam_maxclassrepeat=4
 - var_password_pam_minclass=4


### PR DESCRIPTION
#### Description:

- Remove rule for SSHD Compresion from RHEL8 STIG

#### Rationale:

- Follows changes in the  DISA STIG for RHEL8.