### PR TITLE
Include Ubuntu products in two nftables rules

### DIFF
--- a/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Uninstall nftables package'
 
@@ -19,6 +19,8 @@ identifiers:
 
 references:
     cis@sle15: 3.5.1.2
+    cis@ubuntu2004: 3.5.3.1.2
+    cis@ubuntu2204: 3.5.3.1.2
 
 
 {{{ complete_ocil_entry_package(package="nftables") }}}

--- a/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_disabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Verify nftables service disabled'
 
@@ -19,6 +19,8 @@ identifiers:
 
 references:
     cis@sle15: 3.5.1.2
+    cis@ubuntu2004: 3.5.3.1.2
+    cis@ubuntu2204: 3.5.3.1.2
 
 
 ocil_clause: |-

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -435,6 +435,7 @@ selections:
     - service_iptables_enabled
 
     ###### 3.5.3.1.2 Ensure nftables is not installed (Automated)
+    - service_nftables_disabled
     - package_nftables_removed
 
     ###### 3.5.3.1.3 Ensure Uncomplicated Firewall is not installed or disabled (Automated)

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -435,7 +435,7 @@ selections:
     - service_iptables_enabled
 
     ###### 3.5.3.1.2 Ensure nftables is not installed (Automated)
-    # Needs rule: package_nftables_removed
+    - package_nftables_removed
 
     ###### 3.5.3.1.3 Ensure Uncomplicated Firewall is not installed or disabled (Automated)
     # - package_ufw_removed # (Duplicate of above)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -465,6 +465,7 @@ selections:
     - package_iptables_installed
 
     ###### 3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)
+    - service_nftables_disabled
     - packages_nftables_removed
 
     ###### 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -465,7 +465,7 @@ selections:
     - package_iptables_installed
 
     ###### 3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)
-    # NEEDS RULE
+    - packages_nftables_removed
 
     ###### 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables (Automated)
     # NEEDS RULE


### PR DESCRIPTION
#### Description:

- The `package_nftables_removed` and `service_nftables_disabled` rules are also applicable for Ubuntu

#### Rationale:

- These rules can cover benchmarks requirements, like CIS for Ubuntu 20.04 and Ubuntu 22.04.