### PR TITLE
Misc CIS changes for Ubuntu

### DIFF
--- a/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/service_sshd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Enable the OpenSSH Service'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs_ordered_stig/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel7,sle15,ubuntu2004,ubuntu2204
+prodtype: ol7,rhel7,sle15,ubuntu2004
 
 title: 'Use Only FIPS 140-2 Validated MACs'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_x11_use_localhost/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_x11_use_localhost/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,ubuntu2004
 
 title: 'Prevent remote hosts from connecting to the proxy display'
 
@@ -22,7 +22,7 @@ rationale: |-
     on the wildcard address. By default, sshd binds the forwarding server to the
     loopback address and sets the hostname part of the <tt>DISPLAY</tt>
     environment variable to localhost. This prevents remote hosts from
-    connecting to the proxy display.  
+    connecting to the proxy display.
 
 severity: medium
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Limit Password Reuse'
 

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: sle12,sle15,ubuntu2004
 
 title: 'Enforce Delay After Failed Logon Attempts'
 

--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel7,rhel8,rhel9,ubuntu2004,ubuntu2204
+prodtype: rhel7,rhel8,rhel9,ubuntu2004
 
 title: 'Install pam_pwquality Package'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dictcheck/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol8,ol9,rhel8,rhel9,ubuntu2004,ubuntu2204
+prodtype: fedora,ol8,ol9,rhel8,rhel9,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Prevent the Use of Dictionary Words'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_difok/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Different Characters'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_enforcing/rule.yml
@@ -1,13 +1,13 @@
 documentation_complete: true
- 
-prodtype: ubuntu2004,ubuntu2204
- 
+
+prodtype: ubuntu2004
+
 title: 'Ensure PAM Enforces Password Requirements - Enforcing'
 
 description: |-
     Verify that the operating system uses "pwquality" to enforce the
     password complexity rules.
-    
+
     Verify the pwquality module is being enforced by operating system by
     running the following command:
     <pre>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol8,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: ol8,sle12,sle15,ubuntu2004
 
 title: 'Check that vlock is installed to allow session locking'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/install_smartcard_packages/rule.yml
@@ -12,7 +12,7 @@
 
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2004
 
 title: 'Install Smart Card Packages For Multifactor Authentication'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/package_opensc_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004
 
 title: 'Install the opensc Package For Multifactor Authentication'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_ca/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: sle12,sle15,ubuntu2004
 
 title: 'Configure Smart Card Certificate Authority Validation'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: ol7,ol8,rhel7,sle12,sle15,ubuntu2004
 
 title: 'Configure Smart Card Certificate Status Checking'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_crl/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ubuntu2004,ubuntu2204
+prodtype: ubuntu2004
 
 title: 'Configure Smart Card Local Cache of Revocation Data'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_pam_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: sle12,sle15,ubuntu2004
 
 title: 'Enable Smart Card Logins in PAM'
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/verify_use_mappers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ubuntu2004,ubuntu2204
+prodtype: ubuntu2004
 
 title: "Verify that 'use_mappers' is set to 'pwent' in PAM"
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_temp_expire_date/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
 
 title: 'Assign Expiration Date to Temporary Accounts'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/ensure_sudo_group_restricted/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/ensure_sudo_group_restricted/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ubuntu2004,ubuntu2204
+prodtype: ubuntu2004
 
 title: 'Ensure sudo group has only necessary members'
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/rule.yml
@@ -51,7 +51,7 @@ references:
     cis@rhel8: 4.1.3.2
     cis@rhel9: 4.1.3.2
     cis@ubuntu2004: 4.1.15
-    cis@ubuntu2204: 4.1.15
+    cis@ubuntu2204: 4.1.3.2
     disa: CCI-001814,CCI-001882,CCI-001889,CCI-001880,CCI-001881,CCI-001878,CCI-001879,CCI-001875,CCI-001877,CCI-001914,CCI-002233,CCI-002234
     nist: CM-5(1),AU-7(a),AU-7(b),AU-8(b),AU-12(3),AC-6(9)
     srg: SRG-OS-000326-GPOS-00126,SRG-OS-000327-GPOS-00127

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_sudo_log_events/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_sudo_log_events/rule.yml
@@ -44,6 +44,7 @@ identifiers:
 references:
     cis@rhel8: 4.1.3.3
     cis@rhel9: 4.1.3.3
+    cis@ubuntu2204: 4.1.3.3
     disa: CCI-000172,CCI-002884
     srg: SRG-OS-000392-GPOS-00172,SRG-OS-000471-GPOS-00215
     stigid@ubuntu2004: UBTU-20-010244

--- a/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_only_required_services/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ubuntu2004,ubuntu2204
+prodtype: ubuntu2004
 
 title: 'Only Allow Authorized Network Services in ufw'
 
@@ -26,7 +26,7 @@ rationale: |-
     information, or unauthorized tunneling (i.e., embedding of data types
     within data types), organizations must disable or restrict unused or
     unnecessary physical and logical ports/protocols on information systems.
-    
+
     Operating systems are capable of providing a wide variety of functions
     and services. Some of the functions and services provided by default
     may not be necessary to support essential organizational operations.

--- a/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_rate_limit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ubuntu2004,ubuntu2204
+prodtype: ubuntu2004
 
 title: 'ufw Must rate-limit network interfaces'
 

--- a/products/ubuntu2004/profiles/cis_level2_server.profile
+++ b/products/ubuntu2004/profiles/cis_level2_server.profile
@@ -54,12 +54,17 @@ selections:
     - '!zipl_audit_backlog_limit_argument'
 
     #### 4.1.2.1 Ensure audit log storage size is configured (Automated)
+    - var_auditd_max_log_file=6
     - auditd_data_retention_max_log_file
 
     #### 4.1.2.2 Ensure audit logs are not automatically deleted (Automated)
+    - var_auditd_max_log_file_action=rotate
     - auditd_data_retention_max_log_file_action
 
     #### 4.1.2.3 Ensure system is disabled when audit logs are full (Automated)
+    - var_auditd_space_left_action=email
+    - var_auditd_action_mail_acct=root
+    - var_auditd_admin_space_left_action=halt
     - auditd_data_retention_space_left_action
     - auditd_data_retention_action_mail_acct
     - auditd_data_retention_admin_space_left_action

--- a/products/ubuntu2204/profiles/cis_level2_server.profile
+++ b/products/ubuntu2204/profiles/cis_level2_server.profile
@@ -81,7 +81,7 @@ selections:
     - audit_rules_sysadmin_actions
 
     #### 4.1.3.2 Ensure actions as another user are always logged (Automated)
-    # NEEDS RULE
+    - audit_rules_suid_privilege_function
 
     #### 4.1.3.3 Ensure events that modify the sudo log file are collected (Automated)
     # NEEDS RULE

--- a/products/ubuntu2204/profiles/cis_level2_server.profile
+++ b/products/ubuntu2204/profiles/cis_level2_server.profile
@@ -84,7 +84,7 @@ selections:
     - audit_rules_suid_privilege_function
 
     #### 4.1.3.3 Ensure events that modify the sudo log file are collected (Automated)
-    # NEEDS RULE
+    - audit_sudo_log_events
 
     #### 4.1.3.4 Ensure events that modify date and time information are collected (Automated)
     - audit_rules_time_clock_settime

--- a/products/ubuntu2204/profiles/cis_level2_server.profile
+++ b/products/ubuntu2204/profiles/cis_level2_server.profile
@@ -62,12 +62,17 @@ selections:
     - '!zipl_audit_backlog_limit_argument'
 
     #### 4.1.2.1 Ensure audit log storage size is configured (Automated)
+    - var_auditd_max_log_file=6
     - auditd_data_retention_max_log_file
 
     #### 4.1.2.2 Ensure audit logs are not automatically deleted (Automated)
+    - var_auditd_max_log_file_action=keep_logs
     - auditd_data_retention_max_log_file_action
 
     #### 4.1.2.3 Ensure system is disabled when audit logs are full (Automated)
+    - var_auditd_space_left_action=email
+    - var_auditd_action_mail_acct=root
+    - var_auditd_admin_space_left_action=halt
     - auditd_data_retention_space_left_action
     - auditd_data_retention_action_mail_acct
     - auditd_data_retention_admin_space_left_action

--- a/products/ubuntu2204/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2204/profiles/cis_level2_workstation.profile
@@ -93,7 +93,7 @@ selections:
     - audit_rules_sysadmin_actions
 
     #### 4.1.3.2 Ensure actions as another user are always logged (Automated)
-    # NEEDS RULE
+    - audit_rules_suid_privilege_function
 
     #### 4.1.3.3 Ensure events that modify the sudo log file are collected (Automated)
     # NEEDS RULE

--- a/products/ubuntu2204/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2204/profiles/cis_level2_workstation.profile
@@ -96,7 +96,7 @@ selections:
     - audit_rules_suid_privilege_function
 
     #### 4.1.3.3 Ensure events that modify the sudo log file are collected (Automated)
-    # NEEDS RULE
+    - audit_sudo_log_events
 
     #### 4.1.3.4 Ensure events that modify date and time information are collected (Automated)
     - audit_rules_time_clock_settime


### PR DESCRIPTION
#### Description:

- This PR fixes some minor things such as:
1.  Remove ubunt2204 prodtype from rules not being used
2. Add missing variables to ubuntu2004 and ubuntu2204 cis profiles
3. Add rules `audit_rules_suid_privilege_function` and `audit_sudo_log_events` to CIS profile

#### Rationale:

- Do some clean up and add missing variables and rules to CIS profile