### PR TITLE
Update contributors list for v0.1.66 release

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,5 +1,5 @@
 <!---This file is generated using the contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2022-11-18 11:05
+Last Modified: 2023-01-23 09:28 UTC
 --->
 
 The following people have contributed to the SCAP Security Guide project
@@ -49,11 +49,13 @@ The following people have contributed to the SCAP Security Guide project
 * Jayson Cofell <1051437+70k10@users.noreply.github.com>
 * Caleb Cooper <coopercd@ornl.gov>
 * Richard Maciel Costa <richard.maciel.costa@canonical.com>
+* Xavier Coulon <xavier.coulon@suse.com>
 * Deric Crago <deric.crago@gmail.com>
 * crleekwc <crleekwc@gmail.com>
 * cyarbrough76 <42849651+cyarbrough76@users.noreply.github.com>
 * Maura Dailey <maura@eclipse.ncsc.mil>
 * Klaas Demter <demter@atix.de>
+* denknorr <dennis.knorr@suse.com>
 * dhanushkar-wso2 <dhanushkar@wso2.com>
 * Andrew DiPrinzio <andrew.diprinzio@jhuapl.edu>
 * dom <dominique.blaze@devinci.fr>
@@ -74,10 +76,12 @@ The following people have contributed to the SCAP Security Guide project
 * Andrew Gilmore <agilmore2@gmail.com>
 * Joshua Glemza <jglemza@nasa.gov>
 * Nick Gompper <forestgomp@yahoo.com>
+* David Fernandez Gonzalez <david.fernandezgonzalez@canonical.com>
 * Loren Gordon <lorengordon@users.noreply.github.com>
 * Patrik Greco <sikevux@sikevux.se>
 * Steve Grubb <sgrubb@redhat.com>
 * guangyee <gyee@suse.com>
+* Christian Hagenest <christian.hagenest@suse.com>
 * Marek Haicman <mhaicman@redhat.com>
 * Vern Hart <vern.hart@canonical.com>
 * Alex Haydock <alex@alexhaydock.co.uk>
@@ -123,7 +127,7 @@ The following people have contributed to the SCAP Security Guide project
 * Jan Lieskovsky <jlieskov@redhat.com>
 * Markus Linnala <Markus.Linnala@knowit.fi>
 * Flos Lonicerae <lonicerae@gmail.com>
-* Šimon Lukašík <slukasik@redhat.com>
+* Simon Lukasik <slukasik@redhat.com>
 * Milan Lysonek <mlysonek@redhat.com>
 * Fredrik Lysén <fredrik@pipemore.se>
 * Caitlin Macleod <caitelatte@gmail.com>
@@ -176,7 +180,7 @@ The following people have contributed to the SCAP Security Guide project
 * Kenyon Ralph <kenyon@kenyonralph.com>
 * Mike Ralph <mralph@redhat.com>
 * Federico Ramirez <federico.r.ramirez@oracle.com>
-* Rumen Chikov <rumen.chikov@suse.com>
+* rchikov <rumen.chikov@suse.com>
 * Rick Renshaw <Richard_Renshaw@xtoenergy.com>
 * Chris Reynolds <c.reynolds82@gmail.com>
 * rhayes <rhayes@rivierautilities.com>
@@ -207,8 +211,10 @@ The following people have contributed to the SCAP Security Guide project
 * Mark Shoger <mshoger@redhat.com>
 * THOBY Simon <Simon.THOBY@viveris.fr>
 * Thomas Sjögren <konstruktoid@users.noreply.github.com>
+* Jindrich Skacel <102800748+jskacel@users.noreply.github.com>
 * Francisco Slavin <fslavin@tresys.com>
 * Dave Smith <dsmith@eclipse.ncsc.mil>
+* David Smith <dsmith@fornax.eclipse.ncsc.mil>
 * Kevin Spargur <kspargur@redhat.com>
 * Kenneth Stailey <kstailey.lists@gmail.com>
 * Leland Steinke <leland.j.steinke.ctr@mail.mil>
@@ -219,6 +225,7 @@ The following people have contributed to the SCAP Security Guide project
 * teacup-on-rockingchair <315160+teacup-on-rockingchair@users.noreply.github.com>
 * Ian Tewksbury <itewk@redhat.com>
 * Philippe Thierry <phil@reseau-libre.net>
+* Simon THOBY <git@nightmared.fr>
 * Derek Thurston <thegrit@gmail.com>
 * tianzhenjia <jiatianzhen@cmss.chinamobile.com>
 * Greg Tinsley <gtinsley@redhat.com>

--- a/Contributors.xml
+++ b/Contributors.xml
@@ -1,5 +1,5 @@
 <!--This file is generated using the contributors.py script. DO NOT MANUALLY EDIT!!!!
-Last Modified: 2022-11-18 11:05
+Last Modified: 2023-01-23 09:28 UTC
 -->
 
 <text>
@@ -47,11 +47,13 @@ Last Modified: 2022-11-18 11:05
 <contributor>Jayson Cofell &lt;1051437+70k10@users.noreply.github.com&gt;</contributor>
 <contributor>Caleb Cooper &lt;coopercd@ornl.gov&gt;</contributor>
 <contributor>Richard Maciel Costa &lt;richard.maciel.costa@canonical.com&gt;</contributor>
+<contributor>Xavier Coulon &lt;xavier.coulon@suse.com&gt;</contributor>
 <contributor>Deric Crago &lt;deric.crago@gmail.com&gt;</contributor>
 <contributor>crleekwc &lt;crleekwc@gmail.com&gt;</contributor>
 <contributor>cyarbrough76 &lt;42849651+cyarbrough76@users.noreply.github.com&gt;</contributor>
 <contributor>Maura Dailey &lt;maura@eclipse.ncsc.mil&gt;</contributor>
 <contributor>Klaas Demter &lt;demter@atix.de&gt;</contributor>
+<contributor>denknorr &lt;dennis.knorr@suse.com&gt;</contributor>
 <contributor>dhanushkar-wso2 &lt;dhanushkar@wso2.com&gt;</contributor>
 <contributor>Andrew DiPrinzio &lt;andrew.diprinzio@jhuapl.edu&gt;</contributor>
 <contributor>dom &lt;dominique.blaze@devinci.fr&gt;</contributor>
@@ -72,10 +74,12 @@ Last Modified: 2022-11-18 11:05
 <contributor>Andrew Gilmore &lt;agilmore2@gmail.com&gt;</contributor>
 <contributor>Joshua Glemza &lt;jglemza@nasa.gov&gt;</contributor>
 <contributor>Nick Gompper &lt;forestgomp@yahoo.com&gt;</contributor>
+<contributor>David Fernandez Gonzalez &lt;david.fernandezgonzalez@canonical.com&gt;</contributor>
 <contributor>Loren Gordon &lt;lorengordon@users.noreply.github.com&gt;</contributor>
 <contributor>Patrik Greco &lt;sikevux@sikevux.se&gt;</contributor>
 <contributor>Steve Grubb &lt;sgrubb@redhat.com&gt;</contributor>
 <contributor>guangyee &lt;gyee@suse.com&gt;</contributor>
+<contributor>Christian Hagenest &lt;christian.hagenest@suse.com&gt;</contributor>
 <contributor>Marek Haicman &lt;mhaicman@redhat.com&gt;</contributor>
 <contributor>Vern Hart &lt;vern.hart@canonical.com&gt;</contributor>
 <contributor>Alex Haydock &lt;alex@alexhaydock.co.uk&gt;</contributor>
@@ -121,7 +125,7 @@ Last Modified: 2022-11-18 11:05
 <contributor>Jan Lieskovsky &lt;jlieskov@redhat.com&gt;</contributor>
 <contributor>Markus Linnala &lt;Markus.Linnala@knowit.fi&gt;</contributor>
 <contributor>Flos Lonicerae &lt;lonicerae@gmail.com&gt;</contributor>
-<contributor>Šimon Lukašík &lt;slukasik@redhat.com&gt;</contributor>
+<contributor>Simon Lukasik &lt;slukasik@redhat.com&gt;</contributor>
 <contributor>Milan Lysonek &lt;mlysonek@redhat.com&gt;</contributor>
 <contributor>Fredrik Lysén &lt;fredrik@pipemore.se&gt;</contributor>
 <contributor>Caitlin Macleod &lt;caitelatte@gmail.com&gt;</contributor>
@@ -174,7 +178,7 @@ Last Modified: 2022-11-18 11:05
 <contributor>Kenyon Ralph &lt;kenyon@kenyonralph.com&gt;</contributor>
 <contributor>Mike Ralph &lt;mralph@redhat.com&gt;</contributor>
 <contributor>Federico Ramirez &lt;federico.r.ramirez@oracle.com&gt;</contributor>
-<contributor>Rumen Chikov &lt;rumen.chikov@suse.com&gt;</contributor>
+<contributor>rchikov &lt;rumen.chikov@suse.com&gt;</contributor>
 <contributor>Rick Renshaw &lt;Richard_Renshaw@xtoenergy.com&gt;</contributor>
 <contributor>Chris Reynolds &lt;c.reynolds82@gmail.com&gt;</contributor>
 <contributor>rhayes &lt;rhayes@rivierautilities.com&gt;</contributor>
@@ -205,8 +209,10 @@ Last Modified: 2022-11-18 11:05
 <contributor>Mark Shoger &lt;mshoger@redhat.com&gt;</contributor>
 <contributor>THOBY Simon &lt;Simon.THOBY@viveris.fr&gt;</contributor>
 <contributor>Thomas Sjögren &lt;konstruktoid@users.noreply.github.com&gt;</contributor>
+<contributor>Jindrich Skacel &lt;102800748+jskacel@users.noreply.github.com&gt;</contributor>
 <contributor>Francisco Slavin &lt;fslavin@tresys.com&gt;</contributor>
 <contributor>Dave Smith &lt;dsmith@eclipse.ncsc.mil&gt;</contributor>
+<contributor>David Smith &lt;dsmith@fornax.eclipse.ncsc.mil&gt;</contributor>
 <contributor>Kevin Spargur &lt;kspargur@redhat.com&gt;</contributor>
 <contributor>Kenneth Stailey &lt;kstailey.lists@gmail.com&gt;</contributor>
 <contributor>Leland Steinke &lt;leland.j.steinke.ctr@mail.mil&gt;</contributor>
@@ -217,6 +223,7 @@ Last Modified: 2022-11-18 11:05
 <contributor>teacup-on-rockingchair &lt;315160+teacup-on-rockingchair@users.noreply.github.com&gt;</contributor>
 <contributor>Ian Tewksbury &lt;itewk@redhat.com&gt;</contributor>
 <contributor>Philippe Thierry &lt;phil@reseau-libre.net&gt;</contributor>
+<contributor>Simon THOBY &lt;git@nightmared.fr&gt;</contributor>
 <contributor>Derek Thurston &lt;thegrit@gmail.com&gt;</contributor>
 <contributor>tianzhenjia &lt;jiatianzhen@cmss.chinamobile.com&gt;</contributor>
 <contributor>Greg Tinsley &lt;gtinsley@redhat.com&gt;</contributor>


### PR DESCRIPTION
#### Description:

Thank you all for the contributions.

Welcome to the new contributors:
* Xavier Coulon <xavier.coulon@suse.com>
* denknorr <dennis.knorr@suse.com>
* David Fernandez Gonzalez <david.fernandezgonzalez@canonical.com>
* Christian Hagenest <christian.hagenest@suse.com>
* Jindrich Skacel <102800748+jskacel@users.noreply.github.com>
* David Smith <dsmith@fornax.eclipse.ncsc.mil>
* Simon THOBY <git@nightmared.fr>
