### PR TITLE
Move two rules to higher level in cis_rhel8 control file

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -50,8 +50,8 @@ controls:
   - id: 1.1.1.2
     title: Ensure mounting of squashfs filesystems is disabled (Automated)
     levels:
-      - l1_server
-      - l1_workstation
+      - l2_server
+      - l2_workstation
     status: automated
     rules:
       - kernel_module_squashfs_disabled
@@ -2171,8 +2171,8 @@ controls:
   - id: 5.3.4
     title: Ensure users must provide password for escalation (Automated)
     levels:
-      - l1_server
-      - l1_workstation
+      - l2_server
+      - l2_workstation
     status: automated
     rules:
       - sudo_require_authentication


### PR DESCRIPTION
#### Description:

- move rule sudo_require_authentication and kernel_module_squashfs_disabled to level 2 for server and workstation in RHEL8 CIS

#### Rationale:

- this aligns the control file with the 2.0.0 version of CIS benchmark.
- fixes https://bugzilla.redhat.com/show_bug.cgi?id=2162803



#### Review Hints:

- build the content and check for example HTML guides for CIS server level 1 and CIS server level 2