### PR TITLE
OCP4 STIG: Add status justification to SRG-APP-000033

### DIFF
--- a/controls/srg_ctr/SRG-APP-000033-CTR-000090.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000090.yml
@@ -5,3 +5,14 @@ controls:
   title: Least privilege access and need to know must be required to access the container
     platform registry.
   status: inherently met
+  status_justification: |-
+    The OpenShift Container Platform provides RBAC policies and
+    enforcement of those policies out of the box.  Verification of
+    SRG-APP-000340-CTR-000770 will ensure that binding of user and groups
+    to roles provides proper restriction of access to resources. For more
+    information on how RBAC policies work in OpenShift, refer to
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+
+    The internal OpenShift registry is protected by the platform's RBAC
+    policies. Users requiring access to the registry must be granted the
+    role registry-viewer or registry-editor to access the internal registry.

--- a/controls/srg_ctr/SRG-APP-000033-CTR-000095.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000095.yml
@@ -5,3 +5,13 @@ controls:
   title: Least privilege access and need to know must be required to access the container
     platform runtime.
   status: inherently met
+  status_justification: |-
+    The OpenShift Container Platform provides RBAC policies and
+    enforcement of those policies out of the box.  Verification of
+    SRG-APP-000340-CTR-000770 will ensure that binding of user and groups
+    to roles provides proper restriction of access to resources. For more
+    information on how RBAC policies work in OpenShift, refer to
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+
+    Access to the OpenShift Container Platform API service is enforced by
+    the platform's RBAC policy.

--- a/controls/srg_ctr/SRG-APP-000033-CTR-000100.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000100.yml
@@ -5,3 +5,14 @@ controls:
   title: Least privilege access and need to know must be required to access the container
     platform keystore.
   status: inherently met
+  status_justification: |-
+    The OpenShift Container Platform provides RBAC policies and
+    enforcement of those policies out of the box.  Verification of
+    SRG-APP-000340-CTR-000770 will ensure that binding of user and groups
+    to roles provides proper restriction of access to resources. For more
+    information on how RBAC policies work in OpenShift, refer to
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+
+    OpenShift Container Platform stores private keys and certs as Secret
+    objects within the platform. Access to those objects is enforced by
+    the platform's RBAC policies.


### PR DESCRIPTION
#### Description:

- Adds a status justification to three controls (SRG-APP-000033-* aka AC-3)

#### Rationale:

- Parity with the DISA STIG spreadsheet

#### Review Hints:

- `export PYTHONPATH=$(pwd); python3 utils/create_srg_export.py -c controls/srg_ctr.yml -p ocp4 -m shared/references/disa-ctr-srg-v1r3.xml --out-format html --output /tmp/srg-mapping-ocp4.html`
