### PR TITLE
Add 'not osbuild' platform to polyinstantiated and selinux-boolean rules

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/rule.yml
@@ -18,6 +18,8 @@ rationale: |-
 
 severity: low
 
+platform: not osbuild
+
 identifiers:
   cce@rhel7: CCE-83743-5
   cce@rhel8: CCE-83744-3

--- a/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/enable_pam_namespace/rule.yml
@@ -18,8 +18,6 @@ rationale: |-
 
 severity: low
 
-platform: not osbuild
-
 identifiers:
   cce@rhel7: CCE-83743-5
   cce@rhel8: CCE-83744-3
@@ -38,4 +36,4 @@ ocil: |-
   The output should return the following uncommented:
   <pre>session    required     pam_namespace.so</pre>
 
-platform: package[pam]
+platform: package[pam] and not osbuild

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/rule.yml
@@ -16,6 +16,8 @@ rationale: |-
 
 severity: low
 
+platform: not osbuild
+
 identifiers:
   cce@rhel7: CCE-83731-0
   cce@rhel8: CCE-83732-8

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/rule.yml
@@ -16,6 +16,8 @@ rationale: |-
 
 severity: low
 
+platform: not osbuild
+
 identifiers:
   cce@rhel7: CCE-83777-3
   cce@rhel8: CCE-83778-1

--- a/linux_os/guide/system/selinux/selinux-booleans/group.yml
+++ b/linux_os/guide/system/selinux/selinux-booleans/group.yml
@@ -2,6 +2,8 @@ documentation_complete: true
 
 title: 'SELinux - Booleans'
 
+platform: not osbuild
+
 description: |-
     Enable or Disable runtime customization of SELinux system policies
     without having to reload or recompile the SELinux policy.

--- a/shared/applicability/osbuild.yml
+++ b/shared/applicability/osbuild.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:osbuild
 title: OSBuild
 check_id: installed_env_is_osbuild
-bash_conditional: '[ "$container" == "bwrap-osbuild" ]'
+bash_conditional: '[ "${container:-}" == "bwrap-osbuild" ]'
 ansible_conditional: 'lookup("env", "container") == "bwrap-osbuild"'


### PR DESCRIPTION
#### Description:

- The `not osbuild` platform would prevent there rules from being checked/remediated in OSBuild pipeline:
  - system/accounts/accounts-pam/enable_pam_namespace
  - system/accounts/accounts-session/accounts_polyinstantiated_tmp
  - system/accounts/accounts-session/accounts_polyinstantiated_var_tmp
  - system/selinux/selinux-booleans/*

#### Rationale:

- As the OSBuild pipeline can not set a SELinux Boolean value at this moment we can't execute remediations that require specific sebool configuration to function properly.
- Also, there is not much sense in trying to check or set these values.

- Fixes #9536 