### PR TITLE
OCP: Automated apiserver tls checks

### DIFF
--- a/applications/openshift/api-server/api_server_oauth_https_serving_cert/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_oauth_https_serving_cert/oval/shared.xml
@@ -1,0 +1,11 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="api_server_oauth_https_serving_cert" version="1">
+    {{{ oval_metadata("TLS security profile configured must use secure protocols in OpenShift OAuth API Server") }}}
+
+    <criteria operator="AND">
+      <extend_definition comment="APIServer tlsSecurityProfile=Old is not configured" definition_ref="api_server_tls_security_profile_not_old" />
+      <extend_definition comment="APIServer tlsSecurityProfile=Custom(TLS1.2) is configured" definition_ref="api_server_tls_security_profile_custom_min_tls_version" />
+    </criteria>
+
+  </definition>
+</def-group>

--- a/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_oauth_https_serving_cert/rule.yml
@@ -7,9 +7,8 @@ title: 'Ensure the openshift-oauth-apiserver service uses TLS'
 description: |-
     By default, the OpenShift OAuth API Server uses TLS. HTTPS should be
     used for connections between openshift-oauth-apiserver and kube-apiserver.
-    OpenShift OAuth API server enables TLS automatically if a TLS key and a
-    certificate are provided via the <tt>serving-cert</tt> secret
-    in the <tt>openshift-oauth-apiserver</tt> namespace.
+    By default, the OpenShift OAuth API Server uses Intermediate profile which
+    requires a minimum TLS version of 1.2.
 
 rationale: |-
     Connections between the kube-apiserver and the extension
@@ -28,27 +27,15 @@ references:
     srg: SRG-APP-000516-CTR-001325,SRG-APP-000516-CTR-001330,SRG-APP-000516-CTR-001335
 
 ocil_clause: |-
-    The openshift-apiserver serving-cert is not set to type
-    <tt>kubernetes.io/tls</tt> and that returned Data does not include <tt>tls.crt</tt>
-    and <tt>tls.key</tt>
+    The openshift-apiserver TLS security profile is set to old.
 
 ocil: |-
     Run the following command:
-    <pre>$ oc -n openshift-oauth-apiserver describe secret serving-cert</pre>
-    Verify that the <tt>serving-cert</tt> for the openshift-apiserver is type
-    <tt>kubernetes.io/tls</tt> and that returned Data includes <tt>tls.crt</tt>
-    and <tt>tls.key</tt>.
+    <pre>$ oc get APIServer cluster -o yaml</pre>
+    Verify that the <tt>tlsSecurityProfile</tt> is not type <tt>Old</tt>.
 
-# (jhrozek): Disabled because the compliance operator does not have the permissions
-#            to read secrets from openshift-oauth-apiserver namespace
-#            - checking for the type should be enough as the type enforces the required
-#              keys
-# template:
-#     name: yamlfile_value
-#     vars:
-#         ocp_data: "true"
-#         filepath: '/api/v1/namespaces/openshift-oauth-apiserver/secrets/serving-cert'
-#         yamlpath: '.type'
-#         values:
-#             - value: 'kubernetes.io/tls'
-#               type: "string"
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/apiservers/cluster") | indent(8) }}}
+
+

--- a/applications/openshift/api-server/api_server_oauth_https_serving_cert/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_oauth_https_serving_cert/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: MANUAL
+default_result: PASS
 

--- a/applications/openshift/api-server/api_server_openshift_https_serving_cert/oval/shared.xml
+++ b/applications/openshift/api-server/api_server_openshift_https_serving_cert/oval/shared.xml
@@ -1,0 +1,11 @@
+<def-group oval_version="5.11">
+  <definition class="compliance" id="api_server_openshift_https_serving_cert" version="1">
+    {{{ oval_metadata("TLS security profile configured must use secure protocols in OpenShift API Server") }}}
+
+    <criteria operator="AND">
+      <extend_definition comment="APIServer tlsSecurityProfile=Old is not configured" definition_ref="api_server_tls_security_profile_not_old" />
+      <extend_definition comment="APIServer tlsSecurityProfile=Custom(TLS1.2) is configured" definition_ref="api_server_tls_security_profile_custom_min_tls_version" />
+    </criteria>
+
+  </definition>
+</def-group>

--- a/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_openshift_https_serving_cert/rule.yml
@@ -7,9 +7,8 @@ title: 'Ensure the openshift-oauth-apiserver service uses TLS'
 description: |-
     By default, the OpenShift API Server uses TLS. HTTPS should be
     used for connections between openshift-apiserver and kube-apiserver.
-    OpenShift API server enables TLS automatically if a TLS key and a
-    certificate are provided via the <tt>serving-cert</tt> secret
-    in the <tt>openshift-apiserver</tt> namespace.
+    By default, the OpenShift OAuth API Server uses Intermediate profile which
+    requires a minimum TLS version of 1.2.
 
 rationale: |-
     Connections between the kube-apiserver and the extension
@@ -28,27 +27,15 @@ references:
     srg: SRG-APP-000516-CTR-001325,SRG-APP-000516-CTR-001330,SRG-APP-000516-CTR-001335
 
 ocil_clause: |-
-    The openshift-apiserver serving-cert is not set to type
-    <tt>kubernetes.io/tls</tt> and that returned Data does not include <tt>tls.crt</tt>
-    and <tt>tls.key</tt>
+    The openshift-apiserver TLS security profile is set to old.
 
 ocil: |-
     Run the following command:
-    <pre>$ oc -n openshift-apiserver describe secret serving-cert</pre>
-    Verify that the <tt>serving-cert</tt> for the openshift-apiserver is type
-    <tt>kubernetes.io/tls</tt> and that returned Data includes <tt>tls.crt</tt>
-    and <tt>tls.key</tt>.
+    <pre>$ oc get APIServer cluster -o yaml</pre>
+    Verify that the <tt>tlsSecurityProfile</tt> is not type <tt>Old</tt>.
 
-# (jhrozek): Disabled because the compliance operator does not have the permissions
-#            to read secrets from openshift-apiserver
-#            - checking for the type should be enough as the type enforces the required
-#              keys
-# template:
-#     name: yamlfile_value
-#     vars:
-#         ocp_data: "true"
-#         filepath: '/api/v1/namespaces/openshift-apiserver/secrets/serving-cert'
-#         yamlpath: '.type'
-#         values:
-#             - value: 'kubernetes.io/tls'
-#               type: "string"
+warnings:
+    - general: |-
+        {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/apiservers/cluster") | indent(8) }}}
+
+

--- a/applications/openshift/api-server/api_server_openshift_https_serving_cert/tests/ocp4/e2e.yml
+++ b/applications/openshift/api-server/api_server_openshift_https_serving_cert/tests/ocp4/e2e.yml
@@ -1,3 +1,3 @@
 ---
-default_result: MANUAL
+default_result: PASS
 


### PR DESCRIPTION
Automate `api_server_oauth_https_serving_cert` and `api_server_openshift_https_serving_cert` checks. It is possible to check if tls is being used under `/apis/config.openshift.io/v1/apiservers/cluster`.

By default API-Server uses `intermediate` TLS security profile, we want to check that `old` is not being used as a [TLS security profile](https://docs.openshift.com/container-platform/4.8/security/tls-security-profiles.html).


