### PR TITLE
Update tmux rules and add them to OL8 STIG profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_exec_tmux/rule.yml
@@ -27,7 +27,6 @@ references:
     disa: CCI-000056,CCI-000058
     ospp: FMT_SMF_EXT.1,FMT_MOF_EXT.1,FTA_SSL.1
     srg: SRG-OS-000031-GPOS-00012,SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
-    stigid@ol8: OL08-00-020041
 
 platform: package[tmux]
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_bashrc_tmux/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8
+prodtype: ol8,rhel8
 
 title: 'Support session locking with tmux (not enforcing)'
 
@@ -26,6 +26,7 @@ identifiers:
 references:
     disa: CCI-000056,CCI-000058
     srg: SRG-OS-000031-GPOS-00012,SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
+    stigid@ol8: OL08-00-020041
     stigid@rhel8: RHEL-08-020041
 
 platform: package[tmux]

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/bash/shared.sh
@@ -2,9 +2,7 @@
 
 tmux_conf="/etc/tmux.conf"
 
-if grep -qP '^\s*bind\s+\w\s+lock-session' "$tmux_conf" ; then
-    sed -i 's/\s*bind\s\+\w\s\+lock-session.*$/bind X lock-session/' "$tmux_conf"
-else
+if ! grep -qP '^\s*bind\s+\w\s+lock-session' "$tmux_conf" ; then
     echo "bind X lock-session" >> "$tmux_conf"
 fi
 chmod 0644 "$tmux_conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/oval/shared.xml
@@ -14,7 +14,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_{{{ rule_id }}}" version="1">
     <ind:filepath>/etc/tmux.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*bind\s+X\s+lock-session(?:#.*)?$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*bind\s+[a-zA-Z]\s+lock-session(?:#.*)?$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8
+prodtype: fedora,ol8,rhel8
 
 title: 'Configure the tmux lock session key binding'
 
@@ -25,14 +25,15 @@ identifiers:
 references:
     disa: CCI-000056
     srg: SRG-OS-000028-GPOS-00009,SRG-OS-000030-GPOS-00011
+    stigid@ol8: OL08-00-020040
     stigid@rhel8: RHEL-08-020040
 
-ocil_clause: 'the "lock-session" is not bound to the X key'
+ocil_clause: 'the "lock-session" is not bound to a specific key'
 
 ocil: |-
     Verify {{{ full_name }}} enables the user to initiate a session lock trhough key bindings with the following commands:
 
-    <pre>$ grep "bind X lock-session" /etc/tmux.conf</pre>
+    <pre>$ grep "lock-session" /etc/tmux.conf</pre>
 
     <pre>bind X lock-session</pre>
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/alternative_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/alternative_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo 'bind W lock-session' >> '/etc/tmux.conf'
 chmod 0644 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo 'bind X lock-session' >> '/etc/tmux.conf'
 chmod 0644 "/etc/tmux.conf"

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/file_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/file_empty.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo > '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/line_commented.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo '# bind X lock-session' >> '/etc/tmux.conf'

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/wrong_permissions.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/tests/wrong_permissions.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 8,multi_platform_fedora
+# platform = Oracle Linux 8,Red Hat Enterprise Linux 8,multi_platform_fedora
 
 echo 'bind X lock-session' >> '/etc/tmux.conf'
 chmod 0600 "/etc/tmux.conf"

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -529,7 +529,7 @@ selections:
     - configure_tmux_lock_command
 
     # OL08-00-020041
-    - configure_bashrc_exec_tmux
+    - configure_bashrc_tmux
 
     # OL08-00-020042
     - no_tmux_in_shells

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -527,6 +527,7 @@ selections:
 
     # OL08-00-020040
     - configure_tmux_lock_command
+    - configure_tmux_lock_keybinding
 
     # OL08-00-020041
     - configure_bashrc_tmux


### PR DESCRIPTION
#### Description:

- Update `configure_tmux_lock_keybinding` to allow any key, add to it the OL8 STIG id reference
- Add the OL8 stig id reference to `configure_bashrc_tmux`
- Add the 2 mentioned rules to OL8 STIG profiles

#### Rationale:

- This is to make OL8 STIG profile comply with DISA's STIG requirements

#### Review Hints:

- The only change in behavior is in `configure_tmux_lock_keybinding`. This was covered in tests