### PR TITLE
OCP4: configure_network_policies: fix typo

### DIFF
--- a/applications/openshift/networking/configure_network_policies/rule.yml
+++ b/applications/openshift/networking/configure_network_policies/rule.yml
@@ -21,7 +21,7 @@ ocil_clause: 'Support for Network Policies needs review'
 
 ocil: |-
     Verify that your CNI plugin supports NetworkPolicies:
-    <pre>$ oc get network cluster -oyaml -ojsonpath='{.spec.networkType}'</pre>
+    <pre>$ oc get network cluster -ojsonpath='{.spec.networkType}'</pre>
     The result should list a CNI plugin that supports NetworkPolicies,
     currently the plugins in the rule's pass list are OpenShiftSDN, OVN
     and Calico.


### PR DESCRIPTION

#### Description:

Let's not use -oyaml and -ojsonpath at the same time.

#### Rationale:

Customers use the instructions for manually evaluating rules, they better be correct.

#### Review Hints:

- Manually review the OCIL
