### PR TITLE
Add sub folders of utils to code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -41,6 +41,7 @@ exclude_patterns:
   - "!ssg/*.py"
   - "!ssg/**/*.py"
   - "!utils/*.py"
+  - "!utils/**/*.py"
 
   - "!shared/**/*.py"
 


### PR DESCRIPTION
#### Description:
Add python files that are in subfolders of `utils` to Code Climate checks.

#### Rationale:

To ensure that code quality standards are adhered to across the project. 

#### Review Hints:

The Code Climate issues introduced are expected.
