### PR TITLE
OCP4 STIG: Add artifact description to SRG-APP-000033

### DIFF
--- a/controls/srg_ctr/SRG-APP-000033-CTR-000090.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000090.yml
@@ -16,3 +16,7 @@ controls:
     The internal OpenShift registry is protected by the platform's RBAC
     policies. Users requiring access to the registry must be granted the
     role registry-viewer or registry-editor to access the internal registry.
+  artifact_description: |-
+    Supporting evidence is in the following documentation
+    https://docs.openshift.com/container-platform/latest/registry/accessing-the-registry.html
+    https://docs.openshift.com/container-platform/latest/post_installation_configuration/preparing-for-users.html#post-install-using-rbac-to-define-and-apply-permissions

--- a/controls/srg_ctr/SRG-APP-000033-CTR-000095.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000095.yml
@@ -15,3 +15,6 @@ controls:
 
     Access to the OpenShift Container Platform API service is enforced by
     the platform's RBAC policy.
+  artifact_description: |-
+    Supporting evidence is in the following documentation
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html

--- a/controls/srg_ctr/SRG-APP-000033-CTR-000100.yml
+++ b/controls/srg_ctr/SRG-APP-000033-CTR-000100.yml
@@ -16,3 +16,6 @@ controls:
     OpenShift Container Platform stores private keys and certs as Secret
     objects within the platform. Access to those objects is enforced by
     the platform's RBAC policies.
+  artifact_description: |-
+    Supporting evidence is in the following documentation
+    https://docs.openshift.com/container-platform/latest/authentication/index.html


### PR DESCRIPTION
#### Description:

- Sorry for the PR spam, but in my previous PR I forgot to add
  `artifact_description` to these two controls, my sync script
  was only recently enhanced with that.

#### Rationale:

- Render the controls correctly

#### Review Hints:

- `./build_product --debug ocp4`
- `export PYTHONPATH=$(pwd); python3 ./utils/rule_dir_json.py`
- `export PYTHONPATH=$(pwd); python3 utils/create_srg_export.py -c controls/srg_ctr.yml -p ocp4 -m shared/references/disa-ctr-srg-v1r3.xml --out-format html --output /tmp/srg-mapping-ocp4.html`
- compare with the current DISA STIG spreadsheet
