### PR TITLE
Update Rawhide Before Use

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -178,6 +178,8 @@ jobs:
     container:
       image: fedora:rawhide
     steps:
+      -   name: Run Updates
+          run: dnf update -y
       -   name: Install Deps
           run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck python-mypy git
       -   name: Install deps python


### PR DESCRIPTION
#### Description:
On the Rawhide build update before installing anything.

#### Rationale:
Rawhide users are expected to keep their machines up to date
