### PR TITLE
improve applicability of rule package_rear_installed

### DIFF
--- a/linux_os/guide/system/software/system-tools/package_rear_installed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_rear_installed/rule.yml
@@ -22,12 +22,9 @@ ocil_clause: 'the package is not installed'
 
 ocil: '{{{ ocil_package(package="rear") }}}'
 
-# The package is not available for s309x on RHEL<8.5
-# platform: not_s390x_arch
 
-{{%- if product in ["ol9", "rhel9"] %}}
-platform: not_aarch64_arch
-{{%- endif %}}
+platforms:
+    - not ((s390x_arch and rhel_less_equal_8_4) or (rhel_greater_equal_9_0 and aarch64_arch) or (ol_greater_equal_9_0 and aarch64_arch))
 
 template:
     name: package_installed

--- a/shared/applicability/ol_greater_equal_9_0.yml
+++ b/shared/applicability/ol_greater_equal_9_0.yml
@@ -1,0 +1,4 @@
+name: "cpe:/o:ol:ge:9:0"
+title: "Operating System is OL and version is greater than or equal to 9.0"
+check_id: ol9_greater_equal_9_0
+ansible_conditional: ansible_distribution == "OracleLinux" and ansible_distribution_version is version("9.0", ">=")

--- a/shared/applicability/rhel_greater_equal_9_0.yml
+++ b/shared/applicability/rhel_greater_equal_9_0.yml
@@ -1,0 +1,4 @@
+name: "cpe:/o:rhel:ge:9:0"
+title: "Operating System is RHEL and version is greater than or equal to 9.0"
+check_id: rhel9_greater_equal_9_0
+ansible_conditional: ansible_distribution == "RedHat" and ansible_distribution_version is version("9.0", ">=")

--- a/shared/applicability/rhel_less_equal_8_4.yml
+++ b/shared/applicability/rhel_less_equal_8_4.yml
@@ -1,0 +1,4 @@
+name: "cpe:/o:rhel:le:8:4"
+title: "Operating System is RHEL and version is less than or equal to 8.4"
+check_id: rhel8_less_equal_8_4
+ansible_conditional: ansible_distribution == "RedHat" and ansible_distribution_version is version("8.4", "<=")

--- a/shared/checks/oval/installed_OS_is_ol.xml
+++ b/shared/checks/oval/installed_OS_is_ol.xml
@@ -1,9 +1,9 @@
 <def-group>
 
   <definition class="inventory" id="installed_os_is_ol" version="1">
-    {{{ oval_metadata("Installed OS is ol", affected_platforms=["multi_platform_all"]) }}}
+    {{{ oval_metadata("Installed OS is OL", affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="AND">
-      <criterion comment="The operating system installed on the system is ol"
+      <criterion comment="The operating system installed on the system is OL"
       test_ref="test_os_id_is_ol" />
     </criteria>
   </definition>

--- a/shared/checks/oval/installed_os_is_ol.xml
+++ b/shared/checks/oval/installed_os_is_ol.xml
@@ -1,0 +1,24 @@
+<def-group>
+
+  <definition class="inventory" id="installed_os_is_ol" version="1">
+    {{{ oval_metadata("Installed OS is ol", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <criterion comment="The operating system installed on the system is ol"
+      test_ref="test_os_id_is_ol" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="ID in os-release is ol" id="test_os_id_is_ol" version="1">
+    <ind:object object_ref="obj_os_id_is_ol" />
+    <ind:state state_ref="state_os_id_is_ol" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_os_id_is_ol" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^ID=[&quot;&apos;]?(\w+)[&quot;&apos;]?$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_os_id_is_ol" version="1">
+    <ind:subexpression operation="pattern match">ol</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/shared/checks/oval/ol9_greater_equal_9_0.xml
+++ b/shared/checks/oval/ol9_greater_equal_9_0.xml
@@ -1,0 +1,26 @@
+<def-group>
+
+  <definition class="inventory" id="ol9_greater_equal_9_0" version="1">
+    {{{ oval_metadata("ol version greater or equal to 9.0", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <extend_definition comment="The operating system installed on the system is ol"
+      definition_ref="installed_os_is_ol" />
+      <criterion comment="The version of operating system ol is greater than or equal 9.0"
+      test_ref="test_ol_version_id_is_gt_9_0" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is greater than or equal to 9.0" id="test_ol_version_id_is_gt_9_0" version="1">
+    <ind:object object_ref="obj_ol_version_id_is_gt_9_0" />
+    <ind:state state_ref="state_ol_version_id_is_gt_9_0" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_ol_version_id_is_gt_9_0" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?([\d\.]+)[&quot;&apos;]?$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_ol_version_id_is_gt_9_0" version="1">
+    <ind:subexpression datatype="evr_string" operation="greater than or equal">9.0</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/shared/checks/oval/rhel8_less_equal_8_4.xml
+++ b/shared/checks/oval/rhel8_less_equal_8_4.xml
@@ -1,0 +1,26 @@
+<def-group>
+
+  <definition class="inventory" id="rhel8_less_equal_8_4" version="1">
+    {{{ oval_metadata("RHEL version less or equal to 8.4", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <extend_definition comment="The operating system installed on the system is RHEL"
+      definition_ref="installed_os_is_rhel" />
+      <criterion comment="The version of operating system RHEL is less than or equal 8.4"
+      test_ref="test_rhel_version_id_is_lt_8_4" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is less than or equal to 8.4" id="test_rhel_version_id_is_lt_8_4" version="1">
+    <ind:object object_ref="obj_rhel_version_id_is_lt_8_4" />
+    <ind:state state_ref="state_rhel_version_id_is_lt_8_4" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhel_version_id_is_lt_8_4" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?([\d\.]+)[&quot;&apos;]?$</ind:pattern>
+    <ind:instance operation="less than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhel_version_id_is_lt_8_4" version="1">
+    <ind:subexpression datatype="evr_string" operation="less than or equal">8.4</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>

--- a/shared/checks/oval/rhel9_greater_equal_9_0.xml
+++ b/shared/checks/oval/rhel9_greater_equal_9_0.xml
@@ -1,0 +1,26 @@
+<def-group>
+
+  <definition class="inventory" id="rhel9_greater_equal_9_0" version="1">
+    {{{ oval_metadata("RHEL version greater or equal to 9.0", affected_platforms=["multi_platform_all"]) }}}
+    <criteria operator="AND">
+      <extend_definition comment="The operating system installed on the system is RHEL"
+      definition_ref="installed_os_is_rhel" />
+      <criterion comment="The version of operating system RHEL is greater than or equal 9.0"
+      test_ref="test_rhel_version_id_is_gt_9_0" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is greater than or equal to 9.0" id="test_rhel_version_id_is_gt_9_0" version="1">
+    <ind:object object_ref="obj_rhel_version_id_is_gt_9_0" />
+    <ind:state state_ref="state_rhel_version_id_is_gt_9_0" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_rhel_version_id_is_gt_9_0" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?([\d\.]+)[&quot;&apos;]?$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_rhel_version_id_is_gt_9_0" version="1">
+    <ind:subexpression datatype="evr_string" operation="greater than or equal">9.0</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+</def-group>


### PR DESCRIPTION
#### Description:

Create appropriate platforms to fullfill the following:
Make the rule not applicable in following cases:
- arch is s390x and RHEL <= 8.4
- arch is aarch64 and RHEL or OL >= 9.0


#### Rationale:

- the rear package is not available on some arches and RHEL / OL versions



#### Review Hints:

- build the content
- instantiate some RHEL (OL) machine on s390x / aarch64 machine
- test that OVALs are applicable / not applicable in correct cases
- do the same with Ansible - you can use the e8 Ansible playbook with --tag=package_rear_installed
- tip: modify the /etc/os-release version_id line to simulate various distro versions