### PR TITLE
Remove check of /var/log/dmesg from OVAL

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
+++ b/linux_os/guide/system/permissions/restrictions/enable_nx/bios_enable_execution_restrictions/oval/shared.xml
@@ -3,17 +3,12 @@
         {{{ oval_metadata("The NX (no-execution) bit flag should be set on the system.") }}}
         <criteria operator="AND">
             <criterion comment="NX bit is set" test_ref="test_NX_cpu_support" />
-            <criterion comment="No log messages about NX being disabled" test_ref="test_messages_nx_active" />
             <criterion comment="NX is not disabled in the kernel command line" test_ref="test_noexec_cmd_line" />
         </criteria>
     </definition>
 
     <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="CPUs support for NX bit" id="test_NX_cpu_support" version="1">
         <ind:object object_ref="obj_NX_cpu_support" />
-    </ind:textfilecontent54_test>
-
-    <ind:textfilecontent54_test check="all" check_existence="none_exist" id="test_messages_nx_active" version="1" comment="No log messages about NX being disabled">
-        <ind:object object_ref="obj_messages_nx_active" />
     </ind:textfilecontent54_test>
 
     <ind:textfilecontent54_test check="all" check_existence="none_exist" id="test_noexec_cmd_line" version="1" comment="NX is not disabled in the kernel command line">
@@ -23,16 +18,6 @@
     <ind:textfilecontent54_object id="obj_NX_cpu_support" version="1">
         <ind:filepath>/proc/cpuinfo</ind:filepath>
         <ind:pattern operation="pattern match">^flags[\s]+:.*[\s]+nx[\s]+.*$</ind:pattern>
-        <ind:instance datatype="int">1</ind:instance>
-    </ind:textfilecontent54_object>
-
-    <ind:textfilecontent54_object id="obj_messages_nx_active" version="1">
-        {{% if 'ubuntu' not in product %}}
-        <ind:filepath>/var/log/messages</ind:filepath>
-        {{% else %}}
-        <ind:filepath>/var/log/dmesg</ind:filepath>
-        {{% endif %}}
-        <ind:pattern operation="pattern match">^.+protection: disabled.+</ind:pattern>
         <ind:instance datatype="int">1</ind:instance>
     </ind:textfilecontent54_object>
 


### PR DESCRIPTION
#### Description:

Don't check `/var/log/dmesg` using OVAL, because it may legitimately fail.

However, the rule has a STIG ID, so I guess that modifying its check isn't so simple - whoever understands this, please clarify.

#### Rationale:

Unlike the output of the dmesg command, the corresponding file may be binary, and therefore unsuitable to be examined by the textfilecontent OVAL test, as that one assumes that the file is encoded in UTF-8.

Moreover, the removed checking regex was quite fragile, which was probably caused by the NX feature having different name on different platforms and the corresponding log entry not being designed as machine-readable.

- Fixes #9901 
