### PR TITLE
Updated CIS RHEL requirements related to rpcbind and cups

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -773,7 +773,9 @@ controls:
     - l1_workstation
     status: automated
     rules:
-    - package_rpcbind_removed
+      - service_rpcbind_disabled
+    related_rules:
+      - package_rpcbind_removed
 
   - id: 2.2.19
     title: Ensure rsync is not installed or the rsyncd service is masked (Automated)

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -706,7 +706,6 @@ controls:
     title: Ensure CUPS is not installed (Automated)
     levels:
       - l1_server
-      - l2_workstation
     status: automated
     rules:
       - package_cups_removed

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -858,6 +858,8 @@ controls:
       - l1_workstation
     status: automated
     rules:
+      - service_rpcbind_disabled
+    related_rules:
       - package_rpcbind_removed
 
   - id: 2.2.20

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -850,6 +850,8 @@ controls:
       - l1_workstation
     status: automated
     rules:
+      - service_rpcbind_disabled
+    related_rules:
       - package_rpcbind_removed
 
   - id: 2.2.18

--- a/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/disabling_nfs/disabling_nfs_services/service_rpcbind_disabled/rule.yml
@@ -30,6 +30,8 @@ references:
     cis@alinux2: 2.1.7
     cis@alinux3: 2.2.13
     cis@rhel7: 2.2.18
+    cis@rhel8: 2.2.19
+    cis@rhel9: 2.2.17
     cis@sle12: 2.2.8
     cis@sle15: 2.2.8
 


### PR DESCRIPTION
#### Description:

Disable `rpcbind` instead of removing the package.
Remove `l1_workstation` from 2.2.4 requirement in RHEL8.

#### Rationale:

Fixes #10143 