### PR TITLE
Add missing SRG to aide_build_database rule (for master branch)

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/rule.yml
@@ -62,6 +62,7 @@ references:
     nist: CM-6(a)
     nist-csf: DE.CM-1,DE.CM-7,PR.DS-1,PR.DS-6,PR.DS-8,PR.IP-1,PR.IP-3
     pcidss: Req-11.5
+    srg: SRG-OS-000445-GPOS-00199
     stigid@ol7: OL07-00-020029
     stigid@ol8: OL08-00-010359
     stigid@rhel7: RHEL-07-020029

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/package_aide_installed/rule.yml
@@ -40,7 +40,7 @@ references:
     nist: CM-6(a)
     nist-csf: DE.CM-1,DE.CM-7,PR.DS-1,PR.DS-6,PR.DS-8,PR.IP-1,PR.IP-3
     pcidss: Req-11.5
-    srg: SRG-OS-000363-GPOS-00150,SRG-OS-000445-GPOS-00199
+    srg: SRG-OS-000445-GPOS-00199
     stigid@ol7: OL07-00-020029
     stigid@ol8: OL08-00-010359
     stigid@rhel7: RHEL-07-020029


### PR DESCRIPTION
This is backport of PR https://github.com/ComplianceAsCode/content/pull/10136 into the master branch. Original description and rationale follows:

#### Description:

- add correct SRG to rule aide_build_database
- remove wrongly assigned SRG from package_aide_installed

#### Rationale:

- rules in STIG profiles should have SRGs

- fixes #10135 

#### Review Hints:

- build RHEL7 or RHEL8 content
- check the STIG guide and check the SRG reference of the rule aide_build_database