### PR TITLE
support locked account with hash present

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -15,13 +15,13 @@
   <unix:shadow_object id="object_accounts_password_all_shadowed_sha512" version="1">
     <unix:username operation="pattern match">.*</unix:username>
     <filter action="exclude">state_accounts_password_all_shadowed_has_no_password</filter>
-    <filter action="exclude">state_accounts_password_all_shadowed_has_password</filter>
+    <filter action="exclude">state_accounts_password_all_shadowed_has_locked_password</filter>
     <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
   </unix:shadow_object>
   <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
       <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked)$</unix:password>
   </unix:shadow_state>
-  <unix:shadow_state id="state_accounts_password_all_shadowed_has_password" version="1">
+  <unix:shadow_state id="state_accounts_password_all_shadowed_has_locked_password" version="1">
       <unix:password operation="pattern match">^(!\$6\$|!!\$6\$).*$</unix:password>
   </unix:shadow_state>
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -18,7 +18,7 @@
     <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
   </unix:shadow_object>
   <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
-      <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked)$</unix:password>
+      <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked|!\$6\$.*|!!\$6\$.*)$</unix:password>
   </unix:shadow_state>
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
       <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/oval/shared.xml
@@ -15,10 +15,14 @@
   <unix:shadow_object id="object_accounts_password_all_shadowed_sha512" version="1">
     <unix:username operation="pattern match">.*</unix:username>
     <filter action="exclude">state_accounts_password_all_shadowed_has_no_password</filter>
+    <filter action="exclude">state_accounts_password_all_shadowed_has_password</filter>
     <filter action="exclude">state_accounts_password_all_shadowed_sha512</filter>
   </unix:shadow_object>
   <unix:shadow_state id="state_accounts_password_all_shadowed_has_no_password" version="1">
-      <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked|!\$6\$.*|!!\$6\$.*)$</unix:password>
+      <unix:password operation="pattern match">^(!|!!|!\*|\*|!locked)$</unix:password>
+  </unix:shadow_state>
+  <unix:shadow_state id="state_accounts_password_all_shadowed_has_password" version="1">
+      <unix:password operation="pattern match">^(!\$6\$|!!\$6\$).*$</unix:password>
   </unix:shadow_state>
   <unix:shadow_state id="state_accounts_password_all_shadowed_sha512" version="1">
       <unix:encrypt_method operation="equals">SHA-512</unix:encrypt_method>

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_all_shadowed_sha512/tests/sha512_password.pass.sh
@@ -7,4 +7,5 @@ echo 'locked2:!!:18793:0:99999:7:::'
 echo 'locked3:!*:18793:0:99999:7:::'
 echo 'locked4:*:18793:0:99999:7:::'
 echo 'locked5:!locked:18793:0:99999:7:::'
+echo 'locked6:!!$6$.2mKSYajcpiOnmC7$2/H9H9vGwhlqKuRH7Jbn8UdwvOtz8KBx.QRYlYIvFy0BGPozWSI6xAoA8p.QA7yIOA/goUrV2X7pjSE762gwh1::0:99999:7:::'
 } >> /etc/shadow


### PR DESCRIPTION
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>

#### Description:

When an account is locked but the password hash is present (`!$6$...`) Rule ID  `accounts_password_all_shadowed_sha512` fails.

![image](https://user-images.githubusercontent.com/7956715/216018494-330dd59a-34a9-43b5-acc9-dc70bfc21ad8.png)

#### Review Hints:

Tested on AlmaLinux 8, AlmaLinux 9 and Ubuntu Jammy (doesn't use SHA512, but the behaviour is the same).

```sh
$ sudo grep root /etc/shadow
root:$y$j9T$p9a/xbnBEe6yybGLtzjG20$k5tSo24KyjoQHfu.YiPSvdLnS/ge.Z1rnkuYcrZVl91:19389:0:99999:7:::
$ sudo passwd -l root
passwd: password expiry information changed.
$ sudo grep root /etc/shadow
root:!$y$j9T$p9a/xbnBEe6yybGLtzjG20$k5tSo24KyjoQHfu.YiPSvdLnS/ge.Z1rnkuYcrZVl91:19389:0:99999:7:::
```

```sh
$ cat /etc/redhat-release
AlmaLinux release 9.1 (Lime Lynx)
$ sudo grep root /etc/shadow
root:$6$.2mKSYajcpiOnmC7$2/H9H9vGwhlqKuRH7Jbn8UdwvOtz8KBx.QRYlYIvFy0BGPozWSI6xAoA8p.QA7yIOA/goUrV2X7pjSE762gwh1::0:99999:7:::
$ sudo passwd -l root
Locking password for user root.
passwd: Success
$ sudo grep root /etc/shadow
root:!!$6$.2mKSYajcpiOnmC7$2/H9H9vGwhlqKuRH7Jbn8UdwvOtz8KBx.QRYlYIvFy0BGPozWSI6xAoA8p.QA7yIOA/goUrV2X7pjSE762gwh1::0:99999:7:::
```