### PR TITLE
stabilization: Update levels of some rules in RHEL8 CIS

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -59,8 +59,8 @@ controls:
   - id: 1.1.1.3
     title: Ensure mounting of udf filesystems is disabled (Automated)
     levels:
-      - l1_server
-      - l1_workstation
+      - l2_server
+      - l2_workstation
     status: automated
     rules:
       - kernel_module_udf_disabled
@@ -456,8 +456,8 @@ controls:
   - id: 1.6.1.1
     title: Ensure SELinux is installed (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: automated
     rules:
       - package_libselinux_installed
@@ -465,8 +465,8 @@ controls:
   - id: 1.6.1.2
     title: Ensure SELinux is not disabled in bootloader configuration (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: automated
     rules:
       - grub2_enable_selinux
@@ -474,8 +474,8 @@ controls:
   - id: 1.6.1.3
     title: Ensure SELinux policy is configured (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: automated
     rules:
       - var_selinux_policy_name=targeted
@@ -485,8 +485,8 @@ controls:
   - id: 1.6.1.4
     title: Ensure the SELinux mode is not disabled (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: planned
 
   - id: 1.6.1.5
@@ -502,8 +502,8 @@ controls:
   - id: 1.6.1.6
     title: Ensure no unconfined services exist (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: automated
     rules:
       - selinux_confinement_of_daemons
@@ -511,7 +511,7 @@ controls:
   - id: 1.6.1.7
     title: Ensure SETroubleshoot is not installed (Automated)
     levels:
-      - l2_server
+      - l1_server
     status: automated
     rules:
       - package_setroubleshoot_removed
@@ -519,8 +519,8 @@ controls:
   - id: 1.6.1.8
     title: Ensure the MCS Translation Service (mcstrans) is not installed (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: automated
     rules:
       - package_mcstrans_removed
@@ -1736,8 +1736,8 @@ controls:
   - id: 4.2.1.7
     title: Ensure rsyslog is not configured to recieve logs from a remote client (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: partial
     rules:
       - rsyslog_nolisten
@@ -1746,37 +1746,37 @@ controls:
   - id: 4.2.2.1.1
     title:  Ensure systemd-journal-remote is installed (Manual)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: manual
 
   - id: 4.2.2.1.2
     title:  Ensure systemd-journal-remote is configured (Manual)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: manual
 
   - id: 4.2.2.1.3
     title:  Ensure systemd-journal-remote is enabled (Manual)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: manual
 
   # NEEDS RULE
   - id: 4.2.2.1.4
     title: Ensure journald is not configured to recieve logs from a remote client (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: planned
 
   - id: 4.2.2.2
     title: Ensure journald service is enabled (Automated)
     levels:
-      - l2_server
-      - l2_workstation
+      - l1_server
+      - l1_workstation
     status: automated
     rules:
       - service_systemd-journald_enabled
@@ -2383,8 +2383,8 @@ controls:
   - id: 6.1.1
     title: Audit system file permissions (Manual)
     levels:
-      - l1_server
-      - l1_workstation
+      - l2_server
+      - l2_workstation
     status: manual
     related_rules:
       - rpm_verify_permissions


### PR DESCRIPTION
#### Description:

- update levels of selected rules in RHEL8 CIS

#### Rationale:

These levels were not aligned with CIS benchmark 2.0.0.