### PR TITLE
Enable SCE integrity checks for RHEL8

### DIFF
--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -522,7 +522,7 @@ macro(ssg_build_sds PRODUCT)
         set_tests_properties("missing-references-ssg-${PRODUCT}-ds.xml" PROPERTIES LABELS quick)
 
     endif()
-    if("${PRODUCT}" MATCHES "ubuntu2004" AND SSG_SCE_ENABLED)
+    if(("${PRODUCT}" MATCHES "ubuntu2004" OR "${PRODUCT}" MATCHES "rhel8") AND SSG_SCE_ENABLED)
         add_test(
             NAME "ds-sce-${PRODUCT}"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/test_ds_sce.py" "${CMAKE_BINARY_DIR}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"


### PR DESCRIPTION
#### Description:

Enable SCE integrity checks for RHEL8: as we build the datastream ourselves, we need to ensure we insert the proper SCE metadata inside that datastream.

#### Rationale:

Currently, the SCE check runs only for the ubuntu20.04 target, because that was the only platform that supplied an "upstream" SCE checks (there is corporate "downstream" projects that incorporate SCE checks on top of CAC).

This is a bit weak, as removing this platform would be enough to silence errors in the datastream regarding SCE checks.

This changed with the integration of the ssh_keys_passphrase_protected SCE check for RHEL8 targets in https://github.com/ComplianceAsCode/content/pull/10017.