### PR TITLE
Link sshd_use_strong_kex rule to PCI_DSSv4 2.2.7 requirement

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_kex/rule.yml
@@ -25,6 +25,7 @@ identifiers:
 references:
     cis@sle12: 5.2.15
     cis@sle15: 5.2.15
+    pcidss: Req-2.2.7
 
 ocil_clause: 'KexAlgorithms option is commented out or not using strong hash algorithms'
 

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -112,6 +112,7 @@ selections:
     -  sshd_set_maxstartups
     -  sshd_use_approved_ciphers
     -  sshd_use_approved_macs
+    -  sshd_use_strong_kex
     -  sudo_add_use_pty
     -  sudo_custom_logfile
     -  sysctl_fs_suid_dumpable


### PR DESCRIPTION
#### Description:

- Add reference to PCI-DSS v4 2.2.7 requirement in  sshd_use_strong_kex rule

#### Rationale:

- Initially implementation in context of PCI-DSS started by @anivan-suse  in context of #9814 , but was dropped and after impmlementation done in #10032 we needed to add only the reference to the spec.