### PR TITLE
Add versions checks for the os_linux platform

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -1279,6 +1279,21 @@ Examine the actual contents and changelog of the rpm/deb pakcage in the specific
 Then, use the `os_linux` platform instead of `package` platform.
 For example, use `os_linux[rhel]>=8.6` instead of `package[foo]>=1.2.4`, if you know that an up-to-date RHEL 8.6 and later comes with `foo` that contains the feature that you are interested in.
 
+#### OS Linux CPEs
+
+OS Linux CPEs are used to define rule applicability based on the operating system and its version.
+The platform name is `os_linux`.
+To limit the applicability of a rule to a specific version of the operating system, use this platform in the `platform` key in the `rule.yml` file.
+The platform supports versioned expressions.
+
+For example, if you want to make the rule applicable only on RHEL 8.6 and newer, add the following line to the `rule.yml`:
+
+   platform: os_linux[rhel]>=8.6
+
+The `os_linux` platform is defined in `shared/applicability/os_linux.yml`.
+To add a new CPE based on the OS type, add a new entry there.
+The platform is implemented using the `platform_os_linux` template which is defined in `shared/templates/platform_os_linux`.
+
 ## Tests (ctest)
 
 ComplianceAsCode uses ctest to orchestrate testing upstream. To run the

--- a/shared/applicability/os_linux.yml
+++ b/shared/applicability/os_linux.yml
@@ -1,7 +1,6 @@
-name: "cpe:/o:{arg}"
+name: "cpe:/o:{arg}:{ver_specs_cpe}"
 title: "Operating System is {arg}"
-check_id: platform_os_linux_{arg}
-versioned: false
+versioned: true
 template:
     name: platform_os_linux
 args:

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2360,3 +2360,46 @@ fi
 {{%- endmacro %}}
 
 
+{{#
+This macro creates a Bash conditional which is used to determine if a
+remediation is applicable. The condition compares the actual version of the
+operating system with the expected version using the given operator. The macro
+takes the operating system name ID as an argument. If the operating system
+conforms and satisfies the optional version restricion, the Bash remediation
+will be applied.
+
+:param os_id: OS name, value of the ID variable in /etc/os-release
+:param expected_ver: expected OS version, value of the VERSION_ID variable in /etc/os-release
+            (optional argument, use together with "op")
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param os_release_path: path to the os-release file, default: "/etc/os-release"
+#}}
+{{%- macro bash_os_linux_conditional(os_id, expected_ver=None, op=None, os_release_path="/etc/os-release") -%}}
+{{%- if expected_ver -%}}
+grep -qP "^ID=[\"']?{{{ os_id }}}[\"']?$" "{{{ os_release_path }}}" && {{{ bash_compare_version_os_linux(expected_ver, op, os_release_path) }}}
+{{%- else -%}}
+grep -qP "^ID=[\"']?{{{ os_id }}}[\"']?$" "{{{ os_release_path }}}"
+{{%- endif -%}}
+{{%- endmacro %}}
+
+{{#
+This macro generates bash condition that compares the actual version of the
+operating system with the expected version using the given operator.
+
+:param expected: expected OS version, value of the VERSION_ID variable in /etc/os-release
+:param op: version comparison operator ("<", "<=", "==", "!=", ">", ">=")
+:param os_release_path: path to the os-release file, default: "/etc/os-release"
+#}}
+{{%- macro bash_compare_version_os_linux(expected, op, os_release_path="/etc/os-release") -%}}
+{ real="$({{{ bash_get_version_os_linux(os_release_path) }}})"; expected="{{{ expected }}}"; {{{ bash_compare_version("$real", op, "$expected") }}}; }
+{{%- endmacro -%}}
+
+{{#
+This macro generates code that retrieves the operating system version
+from /etc/os-release from VERSION_ID variable.
+
+:param os_release_path: path to the os-release file, default: "/etc/os-release"
+#}}
+{{%- macro bash_get_version_os_linux(os_release_path="/etc/os-release") -%}}
+grep -P "^VERSION_ID=[\"']?[\w.]+[\"']?$" {{{ os_release_path }}} | sed "s/^VERSION_ID=[\"']\?\([^\"']\+\)[\"']\?$/\1/"
+{{%- endmacro -%}}

--- a/shared/templates/platform_os_linux/ansible.template
+++ b/shared/templates/platform_os_linux/ansible.template
@@ -1,2 +1,6 @@
-{{%- set ansible_os_release_name_cond = 'ansible_distribution == "' + OS_ID_ANSIBLE + '"' -%}}
-  {{{ ansible_os_release_name_cond.strip() }}}
+{{%- for spec in VER_SPECS -%}}
+  ansible_distribution == '{{{ OS_ID_ANSIBLE }}}' and ansible_distribution_version is version('{{{ spec.ver }}}', '{{{ spec.op }}}')
+{{%- if not loop.last %}} and {{% endif -%}}
+{{%- else -%}}
+  ansible_distribution == '{{{ OS_ID_ANSIBLE }}}'
+{{%- endfor -%}}

--- a/shared/templates/platform_os_linux/bash.template
+++ b/shared/templates/platform_os_linux/bash.template
@@ -1,0 +1,6 @@
+{{%- for spec in VER_SPECS -%}}
+{{{ bash_os_linux_conditional(OS_ID, expected_ver=spec.ver, op=spec.op) | trim }}}
+{{%- if not loop.last %}} && {{% endif -%}}
+{{%- else -%}}
+{{{ bash_os_linux_conditional(OS_ID) }}}
+{{%- endfor -%}}

--- a/shared/templates/platform_os_linux/cpe-oval.template
+++ b/shared/templates/platform_os_linux/cpe-oval.template
@@ -11,7 +11,7 @@
       test_ref="test_os_id_is_{{{ ID }}}" />
       {{% for spec in VER_SPECS %}}
         <criterion comment="The operating system {{{ OS_NAME }}} of version {{{ spec.evr_op }}} {{{ spec.ver }}} is installed"
-        test_ref="test_{{{ _RULE_ID }}}" />
+        test_ref="test_{{{ _RULE_ID }}}_{{{ spec.id }}}" />
       {{% endfor %}}
     </criteria>
   </definition>
@@ -32,18 +32,18 @@
   </ind:textfilecontent54_state>
 
 {{% for spec in VER_SPECS %}}
-  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is {{{ spec.ver }}}" id="test_{{{ _RULE_ID }}}" version="1">
-    <ind:object object_ref="obj_{{{ _RULE_ID }}}" />
-    <ind:state state_ref="state_{{{ _RULE_ID }}}" />
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is {{{ spec.evr_op }}} {{{ spec.ver }}}" id="test_{{{ _RULE_ID }}}_{{{ spec.id }}}" version="1">
+    <ind:object object_ref="obj_{{{ _RULE_ID }}}_{{{ spec.id }}}" />
+    <ind:state state_ref="state_{{{ _RULE_ID }}}_{{{ spec.id }}}" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_{{{ _RULE_ID }}}" version="1">
+  <ind:textfilecontent54_object id="obj_{{{ _RULE_ID }}}_{{{ spec.id }}}" version="1">
     <ind:filepath>/etc/os-release</ind:filepath>
     <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?(\w+)[&quot;&apos;]?$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <ind:textfilecontent54_state id="state_{{{ _RULE_ID }}}" version="1">
+  <ind:textfilecontent54_state id="state_{{{ _RULE_ID }}}_{{{ spec.id }}}" version="1">
     <ind:subexpression operation="{{{ spec.evr_op }}}" datatype="version">{{{ spec.ver }}}</ind:subexpression>
   </ind:textfilecontent54_state>
 {{% endfor %}}

--- a/shared/templates/platform_os_linux/cpe-oval.template
+++ b/shared/templates/platform_os_linux/cpe-oval.template
@@ -1,9 +1,18 @@
 <def-group>
-  <definition class="inventory" id="platform_{{{ _RULE_ID }}}" version="1">
-    {{{ oval_metadata("The installed operating system is " + OS_NAME, affected_platforms=["multi_platform_all"]) }}}
+  <definition class="inventory" id="{{{ _RULE_ID }}}" version="1">
+    {{%- if VER_SPECS_TITLE -%}}
+      {{%- set description = "The installed operating system is " + OS_NAME -%}}
+    {{%- else -%}}
+      {{%- set description = "The installed operating system is " + OS_NAME + " version " + VER_SPECS_TITLE -%}}
+    {{%- endif -%}}
+    {{{ oval_metadata(description, affected_platforms=["multi_platform_all"]) }}}
     <criteria operator="AND">
       <criterion comment="The operating system installed on the system is {{{ OS_NAME }}}"
       test_ref="test_os_id_is_{{{ ID }}}" />
+      {{% for spec in VER_SPECS %}}
+        <criterion comment="The operating system {{{ OS_NAME }}} of version {{{ spec.evr_op }}} {{{ spec.ver }}} is installed"
+        test_ref="test_{{{ _RULE_ID }}}" />
+      {{% endfor %}}
     </criteria>
   </definition>
 
@@ -21,5 +30,22 @@
   <ind:textfilecontent54_state id="state_os_id_is_{{{ ID }}}" version="1">
     <ind:subexpression operation="pattern match">{{{ OS_ID }}}</ind:subexpression>
   </ind:textfilecontent54_state>
+
+{{% for spec in VER_SPECS %}}
+  <ind:textfilecontent54_test check="all" comment="VERSION_ID in os-release is {{{ spec.ver }}}" id="test_{{{ _RULE_ID }}}" version="1">
+    <ind:object object_ref="obj_{{{ _RULE_ID }}}" />
+    <ind:state state_ref="state_{{{ _RULE_ID }}}" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ _RULE_ID }}}" version="1">
+    <ind:filepath>/etc/os-release</ind:filepath>
+    <ind:pattern operation="pattern match">^VERSION_ID=[&quot;&apos;]?(\w+)[&quot;&apos;]?$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="state_{{{ _RULE_ID }}}" version="1">
+    <ind:subexpression operation="{{{ spec.evr_op }}}" datatype="version">{{{ spec.ver }}}</ind:subexpression>
+  </ind:textfilecontent54_state>
+{{% endfor %}}
 
 </def-group>

--- a/shared/templates/platform_os_linux/template.yml
+++ b/shared/templates/platform_os_linux/template.yml
@@ -1,3 +1,4 @@
 supported_languages:
   - ansible
+  - bash
   - cpe-oval

--- a/tests/unit/bash/bash_os_linux_conditional.bats.jinja
+++ b/tests/unit/bash/bash_os_linux_conditional.bats.jinja
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+@test "bash_os_linux_conditional - test OS release - RHEL" {
+    os_release_path="$(mktemp)"
+
+    cat << EOF > "$os_release_path"
+NAME="Red Hat Enterprise Linux"
+VERSION="9.2 (Plow)"
+ID="rhel"
+ID_LIKE="fedora"
+VERSION_ID="9.2"
+PLATFORM_ID="platform:el9"
+PRETTY_NAME="Red Hat Enterprise Linux 9.2 Beta (Plow)"
+ANSI_COLOR="0;31"
+LOGO="fedora-logo-icon"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
+HOME_URL="https://www.redhat.com/"
+DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
+REDHAT_BUGZILLA_PRODUCT_VERSION=9.2
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="9.2 Beta"
+EOF
+
+    {{{ bash_os_linux_conditional("rhel", os_release_path="$os_release_path") }}}
+    ! ( {{{ bash_os_linux_conditional("ubuntu", os_release_path="$os_release_path") }}} )
+
+    {{{ bash_os_linux_conditional("rhel", "9", ">", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.1", ">", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.1.4", ">", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.2", ">=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.2", "==", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.2", "<=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.4", "!=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.4", "<", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "9.2.7", "<", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "10", "<", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("rhel", "10.2", "<", "$os_release_path") }}}
+
+    ! ( {{{ bash_os_linux_conditional("fedora", "36", "==", "$os_release_path") }}} )
+    ! ( {{{ bash_os_linux_conditional("fedora", "9.2", "==", "$os_release_path") }}} )
+    ! ( {{{ bash_os_linux_conditional("fedora", "9.4", "<", "$os_release_path") }}} )
+
+    rm -rf "$os_release_path"
+}
+
+@test "bash_os_linux_conditional - test OS release - Ubuntu" {
+    os_release_path="$(mktemp)"
+
+    cat << EOF > "$os_release_path"
+PRETTY_NAME="Ubuntu 22.04.1 LTS"
+NAME="Ubuntu"
+VERSION_ID="22.04"
+VERSION="22.04.1 LTS (Jammy Jellyfish)"
+VERSION_CODENAME=jammy
+ID=ubuntu
+ID_LIKE=debian
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+UBUNTU_CODENAME=jammy
+EOF
+
+
+    {{{ bash_os_linux_conditional("ubuntu", os_release_path="$os_release_path") }}}
+    ! ( {{{ bash_os_linux_conditional("rhel", os_release_path="$os_release_path") }}} )
+
+    {{{ bash_os_linux_conditional("ubuntu", "20.10", ">", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.03", ">", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.04", ">=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.04", "==", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.04", "<=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.10", "!=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.10", "<=", "$os_release_path") }}}
+    {{{ bash_os_linux_conditional("ubuntu", "22.10", "<", "$os_release_path") }}}
+
+    ! ( {{{ bash_os_linux_conditional("ubuntu", "20.10", "<", "$os_release_path") }}} )
+    ! ( {{{ bash_os_linux_conditional("ubuntu", "22.10", ">", "$os_release_path") }}} )
+
+    ! ( {{{ bash_os_linux_conditional("fedora", "36", "==", "$os_release_path") }}} )
+    ! ( {{{ bash_os_linux_conditional("fedora", "22.10", "<", "$os_release_path") }}} )
+
+    rm -rf "$os_release_path"
+}


### PR DESCRIPTION
#### Description:

This PR introduces Bash and Ansible checks for the `os_linux` platform. This will allow content authors to create versioned applicability checks based on the version of the given the Linux distribution in their `rule.yml`, for example:

```
platform: os_linux[rhel]>=8.6
```

The rule will contain an CPE OVAL check that checks for the specific version and also the Ansible and Bash check for the remediation.

#### Rationale:
Enables to define rule applicablity in a more flexible way. There are use cases in which some compliance rules depend on a feature that isn't available in all versions of the product but only in some minor versions ie. the feature has been introduced by an update or the feature has been removed by an update.

Fixes: https://github.com/ComplianceAsCode/content/issues/9983

#### Review Hints:
Add a platform expression that uses the os_linux platform to your favorite rule, eg. `platform: os_linux[rhel]>8.7` and then  build the content and then review the Rule element, its platform element and Bash and Ansible remediations there.