### PR TITLE
Fixes related to SLE 12/15 for the rules set_min/max_life_existing

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -11,13 +11,18 @@
   register: user_names
 
 - name: Change the maximum time period between password changes
-{{% if product not in ["rhel7", "ol7"] %}}
+{{% if product in ["rhel7", "ol7","sle12","sle15"] %}}
+{{% if product in ["rhel7", "ol7"] %}}
+  ansible.builtin.command:
+    cmd: chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
+{{% else %}}
+  ansible.builtin.command:
+    cmd:  passwd -q -x {{ var_accounts_maximum_age_login_defs }} {{ item }}
+{{% endif %}}        
+{{% else %}}
   ansible.builtin.user:
     user: '{{ item }}'
     password_expire_max: '{{ var_accounts_maximum_age_login_defs }}'
-{{% else %}}
-  ansible.builtin.command:
-    cmd: chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
 {{% endif %}}
   with_items: '{{ user_names.stdout_lines }}'
   when: user_names.stdout_lines | length > 0

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/ansible/shared.yml
@@ -11,15 +11,13 @@
   register: user_names
 
 - name: Change the maximum time period between password changes
-{{% if product in ["rhel7", "ol7","sle12","sle15"] %}}
 {{% if product in ["rhel7", "ol7"] %}}
   ansible.builtin.command:
     cmd: chage -M {{ var_accounts_maximum_age_login_defs }} {{ item }}
-{{% else %}}
+{{% elif product in ["sle12","sle15"] %}}    
   ansible.builtin.command:
     cmd:  passwd -q -x {{ var_accounts_maximum_age_login_defs }} {{ item }}
-{{% endif %}}        
-{{% else %}}
+{{% else %}}        
   ansible.builtin.user:
     user: '{{ item }}'
     password_expire_max: '{{ var_accounts_maximum_age_login_defs }}'

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -6,6 +6,14 @@
 
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
+{{% if product not in ["sle12", "sle15"] %}}
 {{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_maximum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($5 > var || $5 == \"\")) {print $1}' /etc/shadow") -%}}
 chage -M $var_accounts_maximum_age_login_defs $i
 {{%- endcall %}}
+{{% else %}}
+usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
+for i in ${usrs_max_pass_age[@]};
+do
+  passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
+done
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -6,14 +6,14 @@
 
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
-{{% if product not in ["sle12", "sle15"] %}}
-{{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_maximum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($5 > var || $5 == \"\")) {print $1}' /etc/shadow") -%}}
-chage -M $var_accounts_maximum_age_login_defs $i
-{{%- endcall %}}
-{{% else %}}
+{{% if product in ["sle12", "sle15"] %}}
 usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
 for i in ${usrs_max_pass_age[@]};
 do
   passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
 done
+{{% else %}}
+{{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_maximum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($5 > var || $5 == \"\")) {print $1}' /etc/shadow") -%}}
+chage -M $var_accounts_maximum_age_login_defs $i
+{{%- endcall %}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -7,8 +7,8 @@
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
 {{% if product in ["sle12", "sle15"] %}}
-usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
-for i in ${usrs_max_pass_age[@]}
+usrs_max_pass_age=( "$(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow)" )
+for i in "${usrs_max_pass_age[@]}"
 do
   passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
 done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -8,7 +8,7 @@
 
 {{% if product in ["sle12", "sle15"] %}}
 usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
-for i in ${usrs_max_pass_age[@]};
+for i in ${usrs_max_pass_age[@]}
 do
   passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
 done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -59,7 +59,7 @@ fixtext: |-
     passwd -q -x {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}} [user]
     {{% else %}}
     usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
-    for i in ${usrs_max_pass_age[@]};
+    for i in ${usrs_max_pass_age[@]}
     do
         passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
     done    

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -55,8 +55,15 @@ ocil: |-
 
 fixtext: |-
     Configure non-compliant accounts to enforce a 60-day maximum password lifetime restriction.
-
-    passwd -x {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}} [user]
+    {{% if product not in ["sle12", "sle15"] %}}
+    passwd -q -x {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}} [user]
+    {{% else %}}
+    usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
+    for i in ${usrs_max_pass_age[@]};
+    do
+        passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
+    done    
+    {{% endif %}}
 
 srg_requirement: |-
     {{{ full_name }}} user account passwords must have a 60-day maximum password lifetime restriction.

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/rule.yml
@@ -58,8 +58,8 @@ fixtext: |-
     {{% if product not in ["sle12", "sle15"] %}}
     passwd -q -x {{{ xccdf_value("var_accounts_maximum_age_login_defs") }}} [user]
     {{% else %}}
-    usrs_max_pass_age=( $(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow) )
-    for i in ${usrs_max_pass_age[@]}
+    usrs_max_pass_age=( "$(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow)" )
+    for i in "${usrs_max_pass_age[@]}"
     do
         passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
     done    

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
@@ -12,12 +12,12 @@
   register: user_names
 
 - name: Change the minimum time period between password changes
-{{% if product not in ["sle12", "sle15"] %}}
-  command: >
-    chage -m 1 {{ item }}
-{{% else %}}
+{{% if product in ["sle12", "sle15"] %}}
   command: >
     passwd -q -n {{ var_accounts_minimum_age_login_defs }} {{ item }}
+{{% else %}}
+  command: >
+    chage -m 1 {{ item }}
 {{% endif %}}    
   with_items: "{{ user_names.stdout_lines }}"
   when: user_names.stdout_lines | length > 0

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
@@ -4,13 +4,20 @@
 # complexity = low
 # disruption = low
 
+{{{ ansible_instantiate_variables("var_accounts_minimum_age_login_defs") }}}
+
 - name: Collect users with not correct minimum time period between password changes
   command: >
-    awk -F: '(/^[^:]+:[^!*]/ && ($4 < 1 || $4 == "")) {print $1}' /etc/shadow
+    awk -F':' '(/^[^:]+:[^!*]/ && ($4 < {{ var_accounts_minimum_age_login_defs }} || $4 == "")) {print $1}' /etc/shadow
   register: user_names
 
 - name: Change the minimum time period between password changes
+{{% if product not in ["sle12", "sle15"] %}}
   command: >
     chage -m 1 {{ item }}
+{{% else %}}
+  command: >
+    passwd -q -n {{ var_accounts_minimum_age_login_defs }} {{ item }}
+{{% endif %}}    
   with_items: "{{ user_names.stdout_lines }}"
   when: user_names.stdout_lines | length > 0

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -6,6 +6,14 @@
 
 {{{ bash_instantiate_variables("var_accounts_minimum_age_login_defs") }}}
 
+{{% if product not in ["sle12", "sle15"] %}}
 {{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_minimum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($4 < var || $4 == \"\")) {print $1}' /etc/shadow") -%}}
 chage -m $var_accounts_minimum_age_login_defs $i
 {{%- endcall %}}
+{{% else %}}
+usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
+for i in ${usrs_min_pass_age[@]};
+do
+  passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
+done
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -7,8 +7,8 @@
 {{{ bash_instantiate_variables("var_accounts_minimum_age_login_defs") }}}
 
 {{% if product in ["sle12", "sle15"] %}}
-usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
-for i in ${usrs_min_pass_age[@]}
+usrs_min_pass_age=( "$(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow)" )
+for i in "${usrs_min_pass_age[@]}"
 do
   passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
 done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -6,14 +6,14 @@
 
 {{{ bash_instantiate_variables("var_accounts_minimum_age_login_defs") }}}
 
-{{% if product not in ["sle12", "sle15"] %}}
-{{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_minimum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($4 < var || $4 == \"\")) {print $1}' /etc/shadow") -%}}
-chage -m $var_accounts_minimum_age_login_defs $i
-{{%- endcall %}}
-{{% else %}}
+{{% if product in ["sle12", "sle15"] %}}
 usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
 for i in ${usrs_min_pass_age[@]};
 do
   passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
 done
+{{% else %}}
+{{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_minimum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($4 < var || $4 == \"\")) {print $1}' /etc/shadow") -%}}
+chage -m $var_accounts_minimum_age_login_defs $i
+{{%- endcall %}}
 {{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -8,7 +8,7 @@
 
 {{% if product in ["sle12", "sle15"] %}}
 usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
-for i in ${usrs_min_pass_age[@]};
+for i in ${usrs_min_pass_age[@]}
 do
   passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
 done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -57,8 +57,8 @@ fixtext: |-
     {{% if product not in ["sle12", "sle15"] %}}
     $ sudo chage -m {{{ xccdf_value("var_accounts_minimum_age_login_defs") }}} [user]
     {{% else %}}
-    usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
-    for i in ${usrs_min_pass_age[@]}
+    usrs_min_pass_age=( "$(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow)" )
+    for i in "${usrs_min_pass_age[@]}"
     do
       passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
     done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -58,7 +58,7 @@ fixtext: |-
     $ sudo chage -m {{{ xccdf_value("var_accounts_minimum_age_login_defs") }}} [user]
     {{% else %}}
     usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
-    for i in ${usrs_min_pass_age[@]};
+    for i in ${usrs_min_pass_age[@]}
     do
       passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
     done

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/rule.yml
@@ -54,8 +54,15 @@ ocil: |-
 
 fixtext: |-
     Configure non-compliant accounts to enforce a 24 hours/1 day minimum password lifetime:
-
+    {{% if product not in ["sle12", "sle15"] %}}
     $ sudo chage -m {{{ xccdf_value("var_accounts_minimum_age_login_defs") }}} [user]
+    {{% else %}}
+    usrs_min_pass_age=( $(awk -F: '$4 < $var_accounts_minimum_age_login_defs || $4 == "" {print $1}' /etc/shadow) )
+    for i in ${usrs_min_pass_age[@]};
+    do
+      passwd -q -n $((var_accounts_minimum_age_login_defs)) $i
+    done
+    {{% endif %}}
 
 srg_requirement: |-
     {{{ full_name }}} passwords must have a 24 hours/1 day minimum password lifetime restriction in /etc/shadow.


### PR DESCRIPTION
#### Description:

- _Fixes in bash/ansible and rule part of 2 SLE 12/15 rules _

#### Rationale:

- Fixes cover the following common issues in SLE 12/15  rules accounts_password_set_max_life_existing, and accounts_password_set_min_life_existing: 1)The rules as they exist do not update all rows (all accounts) in /etc/shadow 2)When PAM module is active on the OS - the session token expires during the execution of the rules 3)The rules.yml files do not present fact that the rule is applicable for all users  4)The realization of the rules had differences - for example in both cases we have variables, but for in the one the rules the variable was not used - in general in both cases the approach should be similar  
