### PR TITLE
OCP4: Use variable for network policy rule

### DIFF
--- a/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
+++ b/applications/openshift/networking/configure_network_policies_namespaces/rule.yml
@@ -27,8 +27,8 @@ references:
 
 {{% set networkpolicies_api_path = '/apis/networking.k8s.io/v1/networkpolicies' %}}
 {{% set namespaces_api_path = '/api/v1/namespaces' %}}
-{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique' %}}
-{{% set non_ctlplane_namespaces_filter = '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]' %}}
+{{% set networkpolicies_for_non_ctlplane_namespaces_filter = '{{.var_noncontrol_network_policy_namespace_filter}}' %}}
+{{% set non_ctlplane_namespaces_filter = '{{.var_noncontrol_namespace_filter}}' %}}
 
 ocil_clause: 'Namespaced Network Policies needs review'
 

--- a/applications/openshift/networking/var_noncontrol_namespace_filter.var
+++ b/applications/openshift/networking/var_noncontrol_namespace_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift non-control plane namespace jq filter '
+
+description: 'OpenShift non-control plane namespace jq filter'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.items[] | select((.metadata.name | startswith("openshift") | not) and (.metadata.name | startswith("kube-") | not) and .metadata.name != "default")]'

--- a/applications/openshift/networking/var_noncontrol_network_policy_namespace_filter.var
+++ b/applications/openshift/networking/var_noncontrol_network_policy_namespace_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift network policy non-control plane namespace jq filter'
+
+description: 'OpenShift network policy non-control plane namespace jq filter'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.items[] | select((.metadata.namespace | startswith("openshift") | not) and (.metadata.namespace | startswith("kube-") | not) and .metadata.namespace != "default") | .metadata.namespace] | unique'


### PR DESCRIPTION
We added two variables for `configure_network_policies_namespaces` rule, this can be useful when we want to exclude a network namespace from the check.

