### PR TITLE
Accept required and requisite control flag for pam_pwhistory

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -2267,7 +2267,7 @@ controls:
     rules:
       - accounts_password_pam_pwhistory_remember_password_auth
       - accounts_password_pam_pwhistory_remember_system_auth
-      - var_password_pam_remember_control_flag=requisite
+      - var_password_pam_remember_control_flag=requisite_or_required
       - var_password_pam_remember=5
 
   - id: 5.5.4

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -2112,7 +2112,7 @@ controls:
     rules:
       - accounts_password_pam_pwhistory_remember_password_auth
       - accounts_password_pam_pwhistory_remember_system_auth
-      - var_password_pam_remember_control_flag=requisite
+      - var_password_pam_remember_control_flag=requisite_or_required
       - var_password_pam_remember=5
 
   - id: 5.5.4

--- a/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
+++ b/controls/srg_gpos/SRG-OS-000077-GPOS-00045.yml
@@ -5,7 +5,7 @@ controls:
         title: {{{ full_name }}} must prohibit password reuse for a minimum of five generations.
         rules:
             - var_password_pam_remember=5
-            - var_password_pam_remember_control_flag=requisite
+            - var_password_pam_remember_control_flag=requisite_or_required
             - accounts_password_pam_pwhistory_remember_password_auth
             - accounts_password_pam_pwhistory_remember_system_auth
         status: automated

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember_password_auth/rule.yml
@@ -129,3 +129,7 @@ warnings:
        Newer versions of <tt>authselect</tt> contain an authselect feature to easily and properly
        enable <tt>pam_pwhistory.so</tt> module. If this feature is not yet available in your
        system, an authselect custom profile must be used to avoid integrity issues in PAM files.
+       If a custom profile was created and used in the system before this authselect feature was
+       available, the new feature can't be used with this custom profile and the
+       remediation will fail. In this case, the custom profile should be recreated or manually
+       updated.

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember_control_flag.var
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/var_password_pam_remember_control_flag.var
@@ -20,4 +20,5 @@ options:
     "sufficient": "sufficient"
     "binding": "binding"
     "ol8": "required,requisite"
+    "requisite_or_required": "requisite,required"
     default: "requisite"

--- a/products/rhel8/profiles/stig.profile
+++ b/products/rhel8/profiles/stig.profile
@@ -37,7 +37,7 @@ selections:
     - var_accounts_minimum_age_login_defs=1
     - var_accounts_max_concurrent_login_sessions=10
     - var_password_pam_remember=5
-    - var_password_pam_remember_control_flag=requisite
+    - var_password_pam_remember_control_flag=requisite_or_required
     - var_selinux_state=enforcing
     - var_selinux_policy_name=targeted
     - var_password_pam_unix_rounds=5000

--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -435,7 +435,7 @@ selections:
 - var_accounts_minimum_age_login_defs=1
 - var_accounts_max_concurrent_login_sessions=10
 - var_password_pam_remember=5
-- var_password_pam_remember_control_flag=requisite
+- var_password_pam_remember_control_flag=requisite_or_required
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_password_pam_unix_rounds=5000

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -443,7 +443,7 @@ selections:
 - var_accounts_minimum_age_login_defs=1
 - var_accounts_max_concurrent_login_sessions=10
 - var_password_pam_remember=5
-- var_password_pam_remember_control_flag=requisite
+- var_password_pam_remember_control_flag=requisite_or_required
 - var_selinux_state=enforcing
 - var_selinux_policy_name=targeted
 - var_password_pam_unix_rounds=5000


### PR DESCRIPTION
#### Description:

In RHEL8.8 and RHEL9.2 it was introduced a new `authselect` feature to  enable `pam_pwhistory` module.
Before the feature, the module was enabled by creating a custom `authselect` profile.
Historically, the control flag used to enable `pam_pwhistory.so` was `required`.
However, the `authselect` feature uses `requisite` instead.
These two control flags are correct and the differences are only about the module reporting, without affecting its effect.
Therefore, the assessment should pass if either `required` or `requisite` is used.

#### Rationale:

Thanks to @vojtapolasek researches, it was noticed a possible scenario where the feature is introduced in a system with a custom profile based in older `authselect` versions. In these cases, the system would be compliant by using the `required` control flag. However, since the rule is expecting only `requisite`, it will fail and the remediation would be executed.
However, in these cases, the remediation can't be safely ensured because the remediation will try to use the feature but the custom profile is not aware of the feature. The custom profile should be updated or recreated by the administrator.

#### Review Hints:

This is a corner case difficult to be tested.
Basically, it would be necessary to scan and remediate a system with the `authselect` package in a old version, like in the current RHEL8.7.
Then, the system should be updated to use the new `authselect` package version, which includes the `with-pwhistory` feature.

Before this patch, the scan with the new `authselect` package should fail because the control flag is set to `required`. Consequently, the remediation will fail due to the above mentioned issue.

After this patch, the scan with the new `authselect` package will pass because both `required` and `requisite` are accepted. No remediation will be necessary.