### PR TITLE
Fix prefer_64bit_os for SLE platforms

### DIFF
--- a/linux_os/guide/system/software/prefer_64bit_os/oval/shared.xml
+++ b/linux_os/guide/system/software/prefer_64bit_os/oval/shared.xml
@@ -1,9 +1,18 @@
 <def-group>
   <definition class="compliance" id="prefer_64bit_os" version="1">
     {{{ oval_metadata("Check if the system supports a 64-bit Operating System") }}}
-    <criteria comment="Either the OS is 64-bit, or the CPU doesn't support 64-bit (it is 32 or 16 bit)" operator="OR">
-      <criterion comment="Check kernel rpm is x86_64" test_ref="test_package_kernel_x64" />
-      <criterion comment="Check if CPU is not 64-bit" test_ref="test_proc_cpuinfo_64_bit" negate="true" />
+    <criteria
+        comment="Either the OS is 64-bit, or the CPU doesn't support 64-bit (it is 32 or 16 bit)"
+        operator="OR">
+      <criteria comment="Either check osrelease in procfs, or kernel package arch parameter"
+                operator="OR">
+        <criterion comment="Check if OS is 64-bit"
+                   test_ref="test_proc_sys_kernel_osrelease_64_bit"/>
+        <criterion comment="Check kernel rpm is x86_64"
+                   test_ref="test_package_kernel_x64" />
+      </criteria>
+      <criterion comment="Check if CPU is not 64-bit" test_ref="test_proc_cpuinfo_64_bit"
+                 negate="true" />
     </criteria>
   </definition>
 
@@ -39,6 +48,20 @@
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_proc_cpuinfo_64_bit" version="1">
     <ind:subexpression operation="pattern match">\blm\b</ind:subexpression>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+      comment="Check if kernel nvr arch is 64-bit" id="test_proc_sys_kernel_osrelease_64_bit" version="1">
+    <ind:object object_ref="object_proc_sys_kernel_osrelease_64_bit" />
+    <ind:state state_ref="state_proc_sys_kernel_osrelease_64_bit" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="object_proc_sys_kernel_osrelease_64_bit" version="1">
+    <ind:filepath>/proc/sys/kernel/osrelease</ind:filepath>
+    <ind:pattern operation="pattern match">^.*\.(.*)$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_state id="state_proc_sys_kernel_osrelease_64_bit" version="1">
+    <ind:subexpression datatype="string" operation="pattern match">^(x86_64|aarch64|ppc64le|s390x)$</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>

--- a/linux_os/guide/system/software/prefer_64bit_os/oval/shared.xml
+++ b/linux_os/guide/system/software/prefer_64bit_os/oval/shared.xml
@@ -2,10 +2,29 @@
   <definition class="compliance" id="prefer_64bit_os" version="1">
     {{{ oval_metadata("Check if the system supports a 64-bit Operating System") }}}
     <criteria comment="Either the OS is 64-bit, or the CPU doesn't support 64-bit (it is 32 or 16 bit)" operator="OR">
-      <criterion comment="Check if OS is 64-bit" test_ref="test_proc_sys_kernel_osrelease_64_bit" />
+      <criterion comment="Check kernel rpm is x86_64" test_ref="test_package_kernel_x64" />
       <criterion comment="Check if CPU is not 64-bit" test_ref="test_proc_cpuinfo_64_bit" negate="true" />
     </criteria>
   </definition>
+
+  <linux:rpminfo_test check="all" check_existence="all_exist"
+  id="test_package_kernel_x64" version="1"
+  comment="Package kernel arch is x64">
+    <linux:object object_ref="obj_package_kernel" />
+    <linux:state state_ref="state_installed_arch_of_kernel_package" />
+  </linux:rpminfo_test>
+
+  <linux:rpminfo_state id="state_installed_arch_of_kernel_package" version="1">
+    <linux:arch>x86_64</linux:arch>
+  </linux:rpminfo_state>
+
+  <linux:rpminfo_object id="obj_package_kernel" version="1">
+    {{% if 'sle' in product %}}
+    <linux:name>kernel-default</linux:name>
+    {{% else %}}
+    <linux:name>kernel</linux:name>
+    {{% endif %}}
+  </linux:rpminfo_object>
 
   <ind:textfilecontent54_test id="test_proc_cpuinfo_64_bit"
   comment="Check for CPU flag lm" check="all" version="1">
@@ -20,20 +39,6 @@
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_proc_cpuinfo_64_bit" version="1">
     <ind:subexpression operation="pattern match">\blm\b</ind:subexpression>
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
-      comment="Check if kernel nvr arch is 64-bit" id="test_proc_sys_kernel_osrelease_64_bit" version="1">
-    <ind:object object_ref="object_proc_sys_kernel_osrelease_64_bit" />
-    <ind:state state_ref="state_proc_sys_kernel_osrelease_64_bit" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_proc_sys_kernel_osrelease_64_bit" version="1">
-    <ind:filepath>/proc/sys/kernel/osrelease</ind:filepath>
-    <ind:pattern operation="pattern match">^.*\.(.*)$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
-  </ind:textfilecontent54_object>
-  <ind:textfilecontent54_state id="state_proc_sys_kernel_osrelease_64_bit" version="1">
-    <ind:subexpression datatype="string" operation="pattern match">^(x86_64|aarch64|ppc64le|s390x)$</ind:subexpression>
   </ind:textfilecontent54_state>
 
 </def-group>


### PR DESCRIPTION
#### Description:

- Check if kernel package arch is 64 instead of matching kernel release name

#### Rationale:

- Previous implementation was relying on the release-name parameter of the kernel to match if system is 64bit. Took a bit different approach, hopefully will make the code more extendable.

