### PR TITLE
OCP4 Modify etcd encryption check rules for hypershift

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Encryption Provider Cipher'
 
+{{% set custom_jqfilter = '{{.var_apiserver_encryption_filter}}' %}}
+{{% set default_jqfilter = '[.spec.encryption.type]' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}{{else}}{{.var_apiserver_encryption_path}}{{end}}' %}}
+{{% set default_api_path = '/apis/config.openshift.io/v1/apiservers/cluster' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To ensure the correct cipher, set the encryption type <tt>aescbc</tt> in the
     <tt>apiserver</tt> object which configures the API server itself.
@@ -37,21 +43,19 @@ ocil_clause: '<tt>aescbc</tt> is not configured as the encryption provider'
 
 ocil: |-
     Run the following command:
-    <pre>$ oc get apiserver cluster -ojson | jq -r '.spec.encryption.type'</pre>
+    <pre>$ oc get --raw {{.var_apiserver_encryption_path}} | jq {{.var_apiserver_encryption_filter}} </pre>
     The output should return <tt>aescbc</tt> as the encryption type.
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/apiservers/cluster") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "at least one"
-    filepath: '/apis/config.openshift.io/v1/apiservers/cluster'
-    yamlpath: '.spec.encryption.type'
-    values:
-    - value: 'aescbc'
-      type: "string"
-      operation: "pattern match"
+    entity_check: "all"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: "[:]"
+    xccdf_variable: var_apiserver_encryption_type
+    regex_data: true

--- a/applications/openshift/api-server/api_server_encryption_provider_config/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_config/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the Encryption Provider'
 
+{{% set custom_jqfilter = '{{.var_apiserver_encryption_filter}}' %}}
+{{% set default_jqfilter = '[.spec.encryption.type]' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}{{else}}{{.var_apiserver_encryption_path}}{{end}}' %}}
+{{% set default_api_path = '/apis/config.openshift.io/v1/apiservers/cluster' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To encrypt the etcd key-value store, set the encryption type <tt>aescbc</tt> in the
     <tt>apiserver</tt> object which configures the API server itself.
@@ -41,21 +47,19 @@ ocil_clause: '<tt>aescbc</tt> is not set as the encryption type for etcd.'
 
 ocil: |-
     Run the following command:
-    <pre>$ oc get apiserver cluster -ojson | jq -r '.spec.encryption.type'</pre>
+    <pre>$ oc get --raw {{.var_apiserver_encryption_path}} | jq {{.var_apiserver_encryption_filter}} </pre>
     The output should return <tt>aescbc</tt> as the encryption type.
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/apis/config.openshift.io/v1/apiservers/cluster") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    entity_check: "at least one"
-    filepath: '/apis/config.openshift.io/v1/apiservers/cluster'
-    yamlpath: '.spec.encryption.type'
-    values:
-    - value: 'aescbc'
-      type: "string"
-      operation: "pattern match"
+    entity_check: "all"
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: "[:]"
+    xccdf_variable: var_apiserver_encryption_type
+    regex_data: true

--- a/applications/openshift/api-server/var_apiserver_encryption_filter.var
+++ b/applications/openshift/api-server/var_apiserver_encryption_filter.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift APIServer etcd encryption filter'
+
+description: 'OpenShift APIServer etcd encryption config check jq filter'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '[.spec.encryption.type]'

--- a/applications/openshift/api-server/var_apiserver_encryption_path.var
+++ b/applications/openshift/api-server/var_apiserver_encryption_path.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift APIServer etcd encryption path'
+
+description: 'OpenShift APIServer etcd encryption config check api path'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: '/apis/config.openshift.io/v1/apiservers/cluster'

--- a/applications/openshift/api-server/var_apiserver_encryption_type.var
+++ b/applications/openshift/api-server/var_apiserver_encryption_type.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift APIServer etcd encryption type'
+
+description: 'OpenShift APIServer etcd encryption config check encryption type'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: 'aescbc'

--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure Controller insecure port argument is unset'
 
 {{% set custom_jqfilter = '{{.var_kube_controller_manager_port_zero_filter}}' %}}
 {{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["port"]!=null then .extendedArguments["port"]==["0"] else true end]' %}}
-{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-controller-manager{{else}}{{.var_kube_controller_manager_config_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure that the RotateKubeletServerCertificate argument is set'
 
 {{% set custom_jqfilter = '{{.var_kube_controller_manager_rotate_kubelet_server_certs_filter}}' %}}
 {{% set default_jqfilter = '.data."config.yaml" | fromjson | .extendedArguments["feature-gates"]' %}}
-{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-controller-manager{{else}}{{.var_kube_controller_manager_config_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure Controller secure-port argument is set'
 
 {{% set custom_jqfilter = '{{.var_kube_controller_manager_secure_port_filter}}' %}}
 {{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["secure-port"][]=="10257" then true else false end]' %}}
-{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-controller-manager{{else}}{{.var_kube_controller_manager_config_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure the Service Account Certificate Authority Key for the Controll
 
 {{% set custom_jqfilter = '{{.var_kube_controller_manager_service_account_ca_filter}}' %}}
 {{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["root-ca-file"]!=null then true else false end]' %}}
-{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-controller-manager{{else}}{{.var_kube_controller_manager_config_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure the Service Account Private Key for the Controller Manager'
 
 {{% set custom_jqfilter = '{{.var_kube_controller_manager_service_account_private_key_filter}}' %}}
 {{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["service-account-private-key-file"]!=null then true else false end]' %}}
-{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-controller-manager{{else}}{{.var_kube_controller_manager_config_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure that use-service-account-credentials is enabled'
 
 {{% set custom_jqfilter = '{{.var_kube_controller_manager_use_service_account_filter}}' %}}
 {{% set default_jqfilter = '[.data."config.yaml" | fromjson | if .extendedArguments["use-service-account-credentials"][]=="true" then true else false end]' %}}
-{{% set custom_api_path = '{{.var_kube_controller_manager_config_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-controller-manager{{else}}{{.var_kube_controller_manager_config_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-controller-manager/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -6,7 +6,7 @@ title: 'Disable etcd Self-Signed Certificates'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure That The etcd Client Certificate Is Correctly Set'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -6,7 +6,7 @@ title: 'Enable The Client Certificate Authentication'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure That The etcd Key File Is Correctly Set'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
@@ -6,7 +6,7 @@ title: 'Disable etcd Peer Self-Signed Certificates'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure That The etcd Peer Client Certificate Is Correctly Set'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -6,7 +6,7 @@ title: 'Enable The Peer Client Certificate Authentication'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -6,7 +6,7 @@ title: 'Ensure That The etcd Peer Key File Is Correctly Set'
 
 {{% set custom_jqfilter = '{{.var_etcd_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_etcd_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Detcd{{else}}{{.var_etcd_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-etcd/configmaps/etcd-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
+++ b/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
@@ -6,7 +6,7 @@ title: Ensure that the bind-address parameter is not used
 
 {{% set custom_jqfilter = '{{.var_scheduler_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_scheduler_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-scheduler{{else}}{{.var_scheduler_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 

--- a/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
+++ b/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
@@ -6,7 +6,7 @@ title: Ensure that the port parameter is zero
 
 {{% set custom_jqfilter = '{{.var_scheduler_argument_filter}}' %}}
 {{% set default_jqfilter = '[.data."pod.yaml"]' %}}
-{{% set custom_api_path = '{{.var_scheduler_filepath}}' %}}
+{{% set custom_api_path = '{{if ne .hypershift_cluster "None"}}/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/pods?labelSelector=app%3Dkube-scheduler{{else}}{{.var_scheduler_filepath}}{{end}}' %}}
 {{% set default_api_path = '/api/v1/namespaces/openshift-kube-scheduler/configmaps/kube-scheduler-pod' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 


### PR DESCRIPTION
This PR modify rule `api_server_encryption_provider_cipher` and rule `api_server_encryption_provider_config` so that they will work on the HyperShift cluster

Updated all the HyperShift-related rules for a better user experience. In the past, we need to set full api-path for some rules, with these updates, it is not needed anymore.