### PR TITLE
Minor update in baseline for STIG stability test

### DIFF
--- a/tests/data/profile_stability/rhel8/stig.profile
+++ b/tests/data/profile_stability/rhel8/stig.profile
@@ -363,6 +363,7 @@ selections:
 - set_password_hashing_algorithm_passwordauth
 - set_password_hashing_algorithm_systemauth
 - set_password_hashing_min_rounds_logindefs
+- ssh_keys_passphrase_protected
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth
 - sshd_disable_kerb_auth
@@ -418,7 +419,6 @@ selections:
 - sysctl_net_ipv6_conf_default_accept_redirects
 - sysctl_net_ipv6_conf_default_accept_source_route
 - sysctl_user_max_user_namespaces
-- ssh_keys_passphrase_protected
 - tftpd_uses_secure_mode
 - usbguard_generate_policy
 - wireless_disable_interfaces

--- a/tests/data/profile_stability/rhel8/stig_gui.profile
+++ b/tests/data/profile_stability/rhel8/stig_gui.profile
@@ -373,6 +373,7 @@ selections:
 - set_password_hashing_algorithm_passwordauth
 - set_password_hashing_algorithm_systemauth
 - set_password_hashing_min_rounds_logindefs
+- ssh_keys_passphrase_protected
 - sshd_disable_empty_passwords
 - sshd_disable_gssapi_auth
 - sshd_disable_kerb_auth
@@ -389,7 +390,6 @@ selections:
 - sshd_use_approved_kex_ordered_stig
 - sshd_use_strong_rng
 - sshd_x11_use_localhost
-- ssh_keys_passphrase_protected
 - sssd_certificate_verification
 - sssd_enable_certmap
 - sssd_enable_smartcards


### PR DESCRIPTION
#### Description:

For some reason, the ordering of the `ssh_keys_passphrase_protected` rule is changed in the `stig.profile` and `stig_gui.profile`. Therefore, the baselines for the stability checks should be consistent.

#### Rationale:

It is related to the #10017 and is causing issues with the #10175