### PR TITLE
Use distributed configuration in tests

### DIFF
--- a/shared/templates/sshd_lineinfile/tests/correct_value.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value.pass.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-{{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=false) -}}}
+{{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=sshd_distributed_config) -}}}

--- a/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
@@ -9,4 +9,4 @@ touch /etc/ssh/sshd_config.d/nothing
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
 {{% endif %}}
 
-{{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=true) -}}}
+{{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=sshd_distributed_config) -}}}


### PR DESCRIPTION
#### Description:
Use distributed configuration in templated test scenarios for the `sshd_lineinfile` template.


#### Rationale:
Some products (fedora and rhel9 at this moment) account for distributed configuration of sshd options. That means that the test scenarios also should work with distributed configuration, the test scenarios should make sure that there is no offending setting within `/etc/ssh/sshd_config.d` if they expect a `pass` result.

Fixes: https://github.com/ComplianceAsCode/content/issues/10169


#### Review Hints:
python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 sshd_disable_gssapi_auth 

python3 tests/automatus.py rule --libvirt qemu:///system ssgts_rhel9 --remediate-using ansible sshd_disable_gssapi_auth
