### PR TITLE
OCP4 STIG: SRG-APP-000342-CTR-000775 is covered by two manual rules

### DIFF
--- a/applications/openshift/scc/scc_limit_privileged_containers/policy/stig/shared.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/policy/stig/shared.yml
@@ -1,43 +1,7 @@
-documentation_complete: true
-
-prodtype: ocp4
-
-title: 'Limit Container Running As Root User'
-
-description: |-
-    Containers should run as a random non-privileged user.
-    To prevent containers from running as root user,
-    the appropriate Security Context Constraints (SCCs) should set
-    <tt>.runAsUser.type</tt> to <tt>MustRunAsRange</tt>.
-
-rationale: |-
-    It is strongly recommended that containers running on OpenShift
-    should support running as any arbitrary UID. OpenShift will then assign
-    a random, non-privileged UID to the running container instance. This
-    avoids the risk from containers running with specific uids that could
-    map to host service accounts, or an even greater risk of running as root
-    level service.  OpenShift uses the default security context constraints
-    (SCC), restricted, to prevent containers from running as root or other
-    privileged user ids. Pods may be configured to use an scc policy
-    that allows the container to run as a specific uid, including root(0)
-    when approved. Only a cluster administrator may grant the change of
-    an scc policy.
-
-severity: medium
-
-references:
-    cis@ocp4: 5.2.6
-    nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
-    nist: CM-6,CM-6(1)
-    pcidss: Req-2.2
-    srg: SRG-APP-000342-CTR-000775
-
-ocil_clause: 'runAsUser.type usage in SCCs needs review'
-
-ocil: |-
+checktext: |-
     Inspect each SCC and the users and groups allowed to use it returned
     from running the following command:
-    <pre>oc get scc -ojson | jq '.items[]|select(.runAsUser.type != "MustRunAsRange" )|.metadata.name,{"Group:":.groups},{"User":.users}'</pre>
+    <pre>oc get scc -ojson | jq '.items[]|select(.allowPrivilegedContainer)|.metadata.name,{"Group:":.groups},{"User":.users}'</pre>
 
     The group "system:authenticated" is the default group for any
     authenticated user, this group should only be associated with the
@@ -78,3 +42,34 @@ ocil: |-
     </pre>
 
     Excluding any platform namespaces (kube-*,openshift-*), if there are any rolebindings to roles that are not permitted, this is a finding.
+
+fixtext: |-
+   For users and groups that are defined in the SCC policy, remove the users or groups by editing the corresponding SCC policy.
+
+   > oc edit scc <SCC>
+
+   The following instructions will remove the user or group from the cluster role binding for the SCC policy.
+
+   Remove user from the SCC Policy binding:
+
+   > oc adm policy remove-scc-from-user <SCC> <USER>
+
+   Remove a group from the SCC Policy binding:
+
+   > oc adm policy remove-scc-from-group <SCC> <GROUP>
+
+   Remove service account from the SCC Policy binding:
+
+   > oc project <SERVICE_ACC_PROJECT>
+   > oc adm policy remove-scc-from-user <SCC> -z <SERVICE_ACC>
+
+   Finally, remove any roles that allows use of non-permitted SCC policies (excluding platform defined roles)
+
+   > oc delete clusterrole.rbac <ROLE>
+
+   or
+
+   > oc delete role.rbac <ROLE> -n <NAMESPACE>  
+
+srg_requirement: |-
+   Container images instantiated by the container platform must execute using least privileges.

--- a/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
+++ b/applications/openshift/scc/scc_limit_privileged_containers/rule.yml
@@ -23,23 +23,54 @@ references:
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2
-    srg: SRG-APP-000516-CTR-001325,SRG-APP-000516-CTR-001330,SRG-APP-000516-CTR-001335
+    srg: SRG-APP-000342-CTR-000775
 
 ocil_clause: 'allowPrivilegedContainer usage in SCCs needs review'
 
 ocil: |-
-    Inspect each SCC returned from running the following command:
-    <pre>$ oc get scc</pre>
-    Review each SCC for those that have <tt>allowPrivilegedContainer</tt> set to <tt>true</tt>.
-    Next, examine the outputs of the following commands:
-    <pre>$ oc describe roles --all-namespaces</pre>
-    <pre>$ oc describe clusterroles</pre>
-    For any role/clusterrole that reference the
-    <tt>securitycontextconstraints</tt> resource with the <tt>resourceNames</tt>
-    of the SCCs that have <tt>allowPrivilegedContainer</tt>, examine the associated
-    rolebindings to account for the users that are bound to the role. Review the
-    account to determine if <tt>allowPrivilegedContainer</tt> is truly required.
+    Inspect each SCC and the users and groups allowed to use it returned
+    from running the following command:
+    <pre>oc get scc -ojson | jq '.items[]|select(.allowPrivilegedContainer)|.metadata.name,{"Group:":.groups},{"User":.users}'</pre>
 
+    The group "system:authenticated" is the default group for any
+    authenticated user, this group should only be associated with the
+    restricted profile. If this group is listed under any other SCC Policy,
+    or the restricted SCC policy has been altered to allow any of the
+    non-permitted actions, this is a finding.
+
+    Next, determine if there are any cluster roles or local roles that allow
+    the use of use of non-permitted SCC policies.  The following commands will
+    print the Role's name and namespace, followed by a list of resource names
+    and if that resource is an SCC.
+
+    > oc get clusterrole.rbac -ojson | jq -r '.items[]|select(.rules[]?|select( (.apiGroups[]? == ("security.openshift.io")) and (.resources[]? == ("securitycontextconstraints")) and (.verbs[]? == ("use"))))|.metadata.name,{"scc":(.rules[]?|select((.resources[]? == ("securitycontextconstraints"))).resourceNames[]?)}'
+
+    > oc get role.rbac --all-namespaces -ojson | jq -r '.items[]|select(.rules[]?|select( (.apiGroups[]? == ("security.openshift.io")) and (.resources[]? == ("securitycontextconstraints")) and (.verbs[]? == ("use"))))|.metadata.name,{"scc":(.rules[]?|select((.resources[]? == ("securitycontextconstraints"))).resourceNames[]?)}'
+
+    Excluding platform specific roles, identify any roles that allow use of non-permitted SCC policies for example the follow output shows that the role 'examplePrivilegedRole' allows use of the 'privileged' SCC.
+
+    <pre>
+    examplePrivilegedRole
+    {
+      "scc": "privileged"
+    }
+    </pre>
+
+    Finally, determine if there are any role bindings to cluster or local
+    roles that allow use of non-permitted SCCs.
+
+    > oc get clusterrolebinding.rbac -ojson | jq -r '.items[]|select(.roleRef.kind == ("ClusterRole","Role") and .roleRef.name == (<CLUSTER_ROLE_LIST>))|{ "crb": .metadata.name, "roleRef": .roleRef, "subjects": .subjects}'
+    > oc get rolebinding.rbac --all-namespaces -ojson | jq -r '.items[]|select(.roleRef.kind == ("ClusterRole","Role") and .roleRef.name == (<LOCAL_ROLE_LIST>))|{ "crb": .metadata.name, "roleRef": .roleRef, "subjects": .subjects}'
+
+    Where <tt>CLUSTER_ROLE_LIST</tt> and <tt>LOCAL_ROLE_LIST</tt> are
+    comma-separated lists of the roles allowing use of non-permitted SCC
+    policies as identified above. For example:
+
+    <pre>
+    ... .roleRef.name == ("system:openshift:scc:privileged","system:openshift:scc:hostnetwork","system:openshift:scc:hostaccess") ...
+    </pre>
+
+    Excluding any platform namespaces (kube-*,openshift-*), if there are any rolebindings to roles that are not permitted, this is a finding.
 
 #template:
 #    name: yamlfile_value

--- a/applications/openshift/scc/scc_limit_root_containers/policy/stig/shared.yml
+++ b/applications/openshift/scc/scc_limit_root_containers/policy/stig/shared.yml
@@ -1,40 +1,4 @@
-documentation_complete: true
-
-prodtype: ocp4
-
-title: 'Limit Container Running As Root User'
-
-description: |-
-    Containers should run as a random non-privileged user.
-    To prevent containers from running as root user,
-    the appropriate Security Context Constraints (SCCs) should set
-    <tt>.runAsUser.type</tt> to <tt>MustRunAsRange</tt>.
-
-rationale: |-
-    It is strongly recommended that containers running on OpenShift
-    should support running as any arbitrary UID. OpenShift will then assign
-    a random, non-privileged UID to the running container instance. This
-    avoids the risk from containers running with specific uids that could
-    map to host service accounts, or an even greater risk of running as root
-    level service.  OpenShift uses the default security context constraints
-    (SCC), restricted, to prevent containers from running as root or other
-    privileged user ids. Pods may be configured to use an scc policy
-    that allows the container to run as a specific uid, including root(0)
-    when approved. Only a cluster administrator may grant the change of
-    an scc policy.
-
-severity: medium
-
-references:
-    cis@ocp4: 5.2.6
-    nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
-    nist: CM-6,CM-6(1)
-    pcidss: Req-2.2
-    srg: SRG-APP-000342-CTR-000775
-
-ocil_clause: 'runAsUser.type usage in SCCs needs review'
-
-ocil: |-
+checktext: |-
     Inspect each SCC and the users and groups allowed to use it returned
     from running the following command:
     <pre>oc get scc -ojson | jq '.items[]|select(.runAsUser.type != "MustRunAsRange" )|.metadata.name,{"Group:":.groups},{"User":.users}'</pre>
@@ -78,3 +42,34 @@ ocil: |-
     </pre>
 
     Excluding any platform namespaces (kube-*,openshift-*), if there are any rolebindings to roles that are not permitted, this is a finding.
+
+fixtext: |-
+   For users and groups that are defined in the SCC policy, remove the users or groups by editing the corresponding SCC policy.
+
+   > oc edit scc <SCC>
+
+   The following instructions will remove the user or group from the cluster role binding for the SCC policy.
+
+   Remove user from the SCC Policy binding:
+
+   > oc adm policy remove-scc-from-user <SCC> <USER>
+
+   Remove a group from the SCC Policy binding:
+
+   > oc adm policy remove-scc-from-group <SCC> <GROUP>
+
+   Remove service account from the SCC Policy binding:
+
+   > oc project <SERVICE_ACC_PROJECT>
+   > oc adm policy remove-scc-from-user <SCC> -z <SERVICE_ACC>
+
+   Finally, remove any roles that allows use of non-permitted SCC policies (excluding platform defined roles)
+
+   > oc delete clusterrole.rbac <ROLE>
+
+   or
+
+   > oc delete role.rbac <ROLE> -n <NAMESPACE>  
+
+srg_requirement: |-
+   Container images instantiated by the container platform must execute using least privileges.

--- a/controls/srg_ctr/SRG-APP-000342-CTR-000775.yml
+++ b/controls/srg_ctr/SRG-APP-000342-CTR-000775.yml
@@ -4,4 +4,7 @@ controls:
   - medium
   title: Container images instantiated by the container platform must execute using
     least privileges.
-  status: pending
+  status: manual
+  rules:
+  - scc_limit_privileged_containers
+  - scc_limit_root_containers


### PR DESCRIPTION
#### Description:

- SRG-APP-000342-CTR-000775 is a manual control, but it turns out that we already
  had the corresponding manual rules. Clean them up (the one about root SCCs was
  just plainly wrong and was checking the wrong attribute) and populate the policy
  files

#### Rationale:

- OCP4 STIG

#### Review Hints:

- Review the SRG export for SRG-APP-000342-CTR-000775
