### PR TITLE
Add 1 more CIS SLE reference to remove nftables rule

### DIFF
--- a/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/package_nftables_removed/rule.yml
@@ -18,7 +18,7 @@ identifiers:
     cce@sle15: CCE-92518-0
 
 references:
-    cis@sle15: 3.5.1.2
+    cis@sle15: 3.5.1.2,3.5.3.1.2
     cis@ubuntu2004: 3.5.3.1.2
     cis@ubuntu2204: 3.5.3.1.2
 


### PR DESCRIPTION
#### Description:

-  Add one more CIS SLE 15 reference to package nftables rule

#### Rationale:

- Both CIS requirements are targeting same behaviour, just one is part of the group for iptables, where nftables package conflict with it, the other is with firewalld package, which also conflicts with nftables -package based configuration