### PR TITLE
Shorten rule title

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2204
 
-title: 'Require re-authentication when using the sudo command'
+title: 'Require Re-Authentication When Using the sudo Command'
 
 description: |-
     The sudo <tt>timestamp_timeout</tt> tag sets the amount of time sudo password prompt waits.

--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -2,8 +2,7 @@ documentation_complete: true
 
 prodtype: ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15,ubuntu2204
 
-title: 'The operating system must require Re-Authentication when using the sudo command.
- Ensure sudo timestamp_timeout is appropriate - sudo timestamp_timeout'
+title: 'Require re-authentication when using the sudo command'
 
 description: |-
     The sudo <tt>timestamp_timeout</tt> tag sets the amount of time sudo password prompt waits.


### PR DESCRIPTION
Rule titles should be brief. The very long rule title causes text overflows in HTML report and causes horizontal scrolling in SCAP Workbench.
