### PR TITLE
Update test scenarios for accounts_password_last_change_is_in_past

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/tests/all_password_change_time_in_past.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/tests/all_password_change_time_in_past.pass.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-# create valid testuser
-echo 'testuservalid:$6$rounds=65536$exIFis0tobKRcGBk$b.UR.Z8h96FdxJ1bgA/vhdnp0Lsm488swdILNguQX/5qH5hdmClyYb5xk3TpELXWzr4JOiTlHfRkPsXSjMPjv0:19396:1:60:7:35::' >> /etc/shadow
+# create valid testuser entry in /etc/shadow
+echo 'testuservalid:$6$exIFis0tobKRcGBk$b.UR.Z8h96FdxJ1bgA/vhdnp0Lsm488swdILNguQX/5qH5hdmClyYb5xk3TpELXWzr4JOiTlHfRkPsXSjMPjv0:19396:1:60:7:35::' >> /etc/shadow
 
 TODAY="$(($(date +%s)/86400))"
 DAY_AGO="$(( TODAY - 1 ))"
 
+# Ensure the sp_lstchg field holds a value which represents a date in the past
 awk -v newdate="$DAY_AGO" 'BEGIN { FS=":"; OFS = ":"}
     {$3=newdate; print}' /etc/shadow > /etc/shadow_new
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/tests/user_password_change_time_in_future.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/tests/user_password_change_time_in_future.fail.sh
@@ -1,17 +1,14 @@
 #!/bin/bash
 # remediation = none
 
-# create valid testuser
-echo 'testuservalid:$6$rounds=65536$exIFis0tobKRcGBk$b.UR.Z8h96FdxJ1bgA/vhdnp0Lsm488swdILNguQX/5qH5hdmClyYb5xk3TpELXWzr4JOiTlHfRkPsXSjMPjv0:19396:1:60:7:35::' >> /etc/shadow
-
-TEST_USER="testUserChage1"
-
-useradd $TEST_USER
-echo -e "testpass\ntestpass" | passwd $TEST_USER
+# create testuser entry in /etc/shadow
+TEST_USER="testuser"
+echo "$TEST_USER:\$6\$exIFis0tobKRcGBk\$b.UR.Z8h96FdxJ1bgA/vhdnp0Lsm488swdILNguQX/5qH5hdmClyYb5xk3TpELXWzr4JOiTlHfRkPsXSjMPjv0:19396:1:60:7:35::" >> /etc/shadow
 
 TODAY="$(($(date +%s)/86400))"
 TOMORROW="$(( TODAY + 1 ))"
 
+# Ensure the sp_lstchg field holds a value which represents a date in the future
 awk -v newdate="$TOMORROW" -v test_user="$TEST_USER" 'BEGIN { FS=":"; OFS = ":"} \
     {  if($1 ==test_user) ($3=newdate); print}' /etc/shadow > /etc/shadow_new
 mv /etc/shadow_new /etc/shadow


### PR DESCRIPTION
#### Description:

Some CI tests use containers, and those container might not have commands like `passwd`.
One approach would be to install the package in the test scenarios, but the name of the package that brings up the `passwd` command differs among distros.
In favor of simplicity, entries were manually created in the /etc/shadow file.
This is sufficient for the context of this rule.

#### Rationale:

- Fixes #10212

#### Review Hints:

Automatus Tests should pass in CI tests.