### PR TITLE
Create OVAL macro to consistently identify Interactive Users

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_forward_files/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_forward_files/oval/shared.xml
@@ -6,19 +6,13 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_users_home_forward_file_existance_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_accounts_users_home_forward_file_existance_interactive_gids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_users_home_forward_file_existance_interactive_gids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_users_home_forward_file_existance_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_accounts_users_home_forward_file_existance_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <unix:file_object id="object_accounts_users_home_forward_file_existance" version="1">

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_forward_files/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_forward_files/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = none
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+touch /home/$USER/.forward

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/ansible/shared.yml
@@ -7,4 +7,4 @@
 - name: Ensure interactive local users are the group-owners of their respective initialization files
   ansible.builtin.command:
     cmd: |
-      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chgrp -f " $3" "$6"/.[^\.]?*") }' /etc/passwd
+      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chgrp -f " $4" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chgrp -f " $3" "$6"/.[^\.]?*") }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chgrp -f " $4" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/oval/shared.xml
@@ -1,37 +1,25 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("User Initialization Files Must Be Group-Owned By The Primary User") }}}
+    {{{ oval_metadata("User Initialization Files Must Be Group-Owned By The Primary Group") }}}
     <criteria>
       <criterion test_ref="test_accounts_user_dot_group_ownership"
-                 comment="User Initialization Files Must Be Group-Owned By The Primary User"/>
+                 comment="User Initialization Files Must Be Group-Owned By The Primary Group"/>
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_user_dot_group_ownership_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter action="include">state_accounts_user_dot_group_ownership_interactive_gids</filter>
-    <filter action="exclude">state_accounts_user_dot_group_ownership_nobody</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_user_dot_group_ownership_interactive_gids" version="1">
-    <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
-  </unix:password_state>
-
-  <unix:password_state id="state_accounts_user_dot_group_ownership_nobody" version="1">
-    <unix:group_id datatype="int" operation="equals">{{{ nobody_gid }}}</unix:group_id>
-  </unix:password_state>
-
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_user_dot_group_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_accounts_user_dot_group_ownership_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_user_dot_group_ownership_gids" datatype="int" version="1"
                   comment="List of interactive users gids">
     <object_component item_field="group_id"
-                      object_ref="object_accounts_user_dot_group_ownership_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
 
-title: 'User Initialization Files Must Be Group-Owned By The Primary User'
+title: 'User Initialization Files Must Be Group-Owned By The Primary Group'
 
 description: |-
     Change the group owner of interactive users files to the group found

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+touch /home/$USER/.bashrc
+chgrp 10005 /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/oval/shared.xml
@@ -7,22 +7,13 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_user_dot_no_world_writable_programs_objects"
-    version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter
-        action="include">state_accounts_user_dot_no_world_writable_programs_interactive_uids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_user_dot_no_world_writable_programs_interactive_uids"
-    version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_user_dot_no_world_writable_programs_dirs" datatype="string"
       version="1" comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-      object_ref="object_accounts_user_dot_no_world_writable_programs_objects"/>
+      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <local_variable id="var_world_writable_programs" datatype="string" version="1"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/common.sh
@@ -2,13 +2,13 @@
 
 USER="cac_user"
 world_writable_file="/wwf.exec"
-dot_file="/home/$USER/.profile"
-not_dot_file="/home/$USER/.notinitfile"
+initialization_dot_file="/home/$USER/.profile"
+not_initialization_dot_file="/home/$USER/.notinitfile"
 
 useradd -m $USER
 
 touch $world_writable_file
-touch $dot_file
-touch $not_dot_file
+touch $initialization_dot_file
+touch $not_initialization_dot_file
 
 chmod o+w $world_writable_file

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source common.sh
+
+NO_SHELL_USER="cac_user_no_shell"
+useradd -m -s /sbin/nologin $NO_SHELL_USER
+user_init_dot_file="/home/$NO_SHELL_USER/.profile"
+echo "sudo bash $world_writable_file" >> $user_init_dot_file

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/no_world_writable_in_dot_file.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/no_world_writable_in_dot_file.pass.sh
@@ -2,5 +2,5 @@
 
 source common.sh
 
-echo "# sudo bash $world_writable_file" >> $dot_file
-echo "sudo bash $world_writable_file" >> $not_dot_file
+echo "# sudo bash $world_writable_file" >> $initialization_dot_file
+echo "sudo bash $world_writable_file" >> $not_initialization_dot_file

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/world_writable_in_dot_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/world_writable_in_dot_file.fail.sh
@@ -2,4 +2,4 @@
 
 source common.sh
 
-echo "sudo bash $world_writable_file" >> $dot_file
+echo "sudo bash $world_writable_file" >> $initialization_dot_file

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/oval/shared.xml
@@ -7,25 +7,19 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_user_dot_user_ownership_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter action="include">state_accounts_user_dot_user_ownership_interactive_uids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_user_dot_user_ownership_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_user_dot_user_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_accounts_user_dot_user_ownership_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_user_dot_user_ownership_uids" datatype="int" version="1"
                   comment="List of interactive users uids">
     <object_component item_field="user_id"
-                      object_ref="object_accounts_user_dot_user_ownership_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+touch /home/$USER/.bashrc
+chown 10005 /home/$USER/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/oval/shared.xml
@@ -7,19 +7,8 @@
     </criteria>
   </definition>
 
-  <!-- For detailed comments about logic used in this OVAL, check the
-       "file_ownership_home_directories" rule.
-       #### creation of object #### -->
-  <unix:password_object id="object_accounts_user_interactive_home_directory_defined_objects"
-                        version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter action="include">state_accounts_user_interactive_home_directory_defined_uids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_user_interactive_home_directory_defined_uids"
-                       version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <!-- #### creation of state #### -->
   <unix:password_state id="state_accounts_user_interactive_home_directory_defined" version="1">
@@ -30,7 +19,7 @@
   <unix:password_test id="test_accounts_user_interactive_home_directory_defined" check="all"
                       check_existence="any_exist" version="1"
                       comment="All Interactive Users Have A Home Directory Defined">
-    <unix:object object_ref="object_accounts_user_interactive_home_directory_defined_objects"/>
+    <unix:object object_ref="{{{ interactive_users_object }}}"/>
     <unix:state state_ref="state_accounts_user_interactive_home_directory_defined"/>
   </unix:password_test>
 </def-group>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+sed -i "s/\($USER:x:[0-9]*:[0-9]*:.*:\).*\(:.*\)$/\1\2/g" /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/oval/shared.xml
@@ -9,23 +9,15 @@
     </criteria>
   </definition>
 
-  <!-- #### prepare a password object for the two tests in this rule #### -->
-  <unix:password_object id="object_accounts_user_interactive_home_directory_exists_objects"
-                        version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter action="include">state_accounts_user_interactive_home_directory_exists_uids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_user_interactive_home_directory_exists_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <!-- #### create a local variable composed by the list of home dirs from /etc/passwd #### -->
   <local_variable id="var_accounts_user_interactive_home_directory_exists_dirs_list"
                   datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_accounts_user_interactive_home_directory_exists_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### create a local variable composed by the number of home dirs from /etc/passwd #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -M -s /sbin/nologin $USER

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/ansible/shared.yml
@@ -13,14 +13,14 @@
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
 
-- name: Test for existence home directories to avoid creating them, but only fixing ownership
+- name: Test for existence of home directories to avoid creating them, but only fixing ownership
   ansible.builtin.stat:
     path: '{{ item.value[4] }}'
   register: path_exists
   loop: '{{ local_users }}'
   when:
-    - item.value[2]|int >= {{{ gid_min }}}
-    - item.value[2]|int != 65534
+    - item.value[1]|int >= {{{ uid_min }}}
+    - item.value[1]|int != {{{ nobody_uid }}}
 
 - name: Ensure interactive local users are the owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/ansible/shared.yml
@@ -12,6 +12,9 @@
 - name: Create local_users variable from the getent output
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
+    # Creates a dictionary where the key is the first field of the /etc/passwd file, the username.
+    # The list of values are the next 6 fields from /etc/passwd. Example for the root entry:
+    # The "root" key would have these values: ["x", "0", "0", "root", "/root", "/bin/bash"]
 
 - name: Test for existence of home directories to avoid creating them, but only fixing ownership
   ansible.builtin.stat:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != 65534) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1 }' /etc/passwd); do
     home_dir=$(getent passwd $user | cut -d: -f6)
     group=$(getent passwd $user | cut -d: -f4)
     # Only update the group-ownership when necessary. This will avoid changing the inode timestamp

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/oval/shared.xml
@@ -1,36 +1,25 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary User") }}}
+    {{{ oval_metadata("All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary Group") }}}
     <criteria>
       <criterion test_ref="test_accounts_users_home_files_groupownership"
-                 comment="All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary User"/>
+                 comment="All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary Group"/>
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_users_home_files_groupownership_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_accounts_users_home_files_groupownership_interactive_gids</filter>
-    <filter action="exclude">state_accounts_users_home_files_groupownership_user_list</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_users_home_files_groupownership_interactive_gids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:user_id>
-  </unix:password_state>
-
-  <unix:password_state id="state_accounts_users_home_files_groupownership_user_list" version="1">
-    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_users_home_files_groupownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_accounts_users_home_files_groupownership_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_users_home_files_groupownership_gids" datatype="int" version="1"
                   comment="List of interactive users gids">
     <object_component item_field="group_id"
-                      object_ref="object_accounts_users_home_files_groupownership_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: ol7,ol8,rhel7,rhel8,rhv4,sle12,sle15
 
-title: 'All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary User'
+title: 'All User Files and Directories In The Home Directory Must Be Group-Owned By The Primary Group'
 
 description: |-
     Change the group of a local interactive users files and directories to a

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+echo "$USER" > /home/$USER/$USER.txt
+chgrp 10005 /home/$USER/$USER.txt

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/ansible/shared.yml
@@ -12,6 +12,9 @@
 - name: Create local_users variable from the getent output
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
+    # Creates a dictionary where the key is the first field of the /etc/passwd file, the username.
+    # The list of values are the next 6 fields from /etc/passwd. Example for the root entry:
+    # The "root" key would have these values: ["x", "0", "0", "root", "/root", "/bin/bash"]
 
 - name: Test for existence of home directories to avoid creating them, but only fixing ownership
   ansible.builtin.stat:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/ansible/shared.yml
@@ -13,14 +13,14 @@
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
 
-- name: Test for existence home directories to avoid creating them, but only fixing ownership
+- name: Test for existence of home directories to avoid creating them, but only fixing ownership
   ansible.builtin.stat:
     path: '{{ item.value[4] }}'
   register: path_exists
   loop: '{{ local_users }}'
   when:
     - item.value[1]|int >= {{{ uid_min }}}
-    - item.value[1]|int != 65534
+    - item.value[1]|int != {{{ nobody_uid }}}
 
 - name: Ensure interactive local users are the owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/oval/shared.xml
@@ -7,30 +7,17 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_users_home_files_ownership_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_accounts_users_home_files_ownership_interactive_uids</filter>
-    <filter action="exclude">state_accounts_users_home_files_ownership_user_list</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_users_home_files_ownership_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
-
-  <unix:password_state id="state_accounts_users_home_files_ownership_user_list" version="1">
-    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_users_home_files_ownership_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir"
-                      object_ref="object_accounts_users_home_files_ownership_objects"/>
+    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <local_variable id="var_accounts_users_home_files_ownership_uids" datatype="int" version="1"
                   comment="List of interactive users uids">
-    <object_component item_field="user_id"
-                      object_ref="object_accounts_users_home_files_ownership_objects"/>
+    <object_component item_field="user_id" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+echo "$USER" > /home/$USER/$USER.txt
+chown 10005 /home/$USER/$USER.txt

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/oval/shared.xml
@@ -8,23 +8,14 @@
                  comment="All direcories under home directories must have proper permissions"/>
     </criteria>
   </definition>
-  <!-- For detailed comments about logic used in this OVAL, check the
-       "file_ownership_home_directories" rule. -->
-  <unix:password_object id="object_accounts_users_home_files_permissions_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_accounts_users_home_files_permissions_interactive_uids</filter>
-    <filter action="exclude">state_accounts_users_home_files_permissions_user_list</filter>
-  </unix:password_object>
-  <unix:password_state id="state_accounts_users_home_files_permissions_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
-  <unix:password_state id="state_accounts_users_home_files_permissions_user_list" version="1">
-    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
-  </unix:password_state>
+
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
+
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_accounts_users_home_files_permissions_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="object_accounts_users_home_files_permissions_objects"/>
+    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
   <!-- #### creation of object #### -->
   <unix:file_object id="object_accounts_users_home_files_permissions_dirs" version="1">

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/acceptable_permission.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/acceptable_permission.pass.sh
@@ -3,4 +3,4 @@
 USER="cac_user"
 useradd -m $USER
 echo "$USER" > /home/$USER/$USER.txt
-chmod -Rf 750 /home/$USER/.*
+find "/home/$USER/" -perm /7027 -exec chmod u-s,g-w-s,o=- {} \;

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 USER="cac_user"
-useradd -m $USER
+useradd -m -s /sbin/nologin $USER
 echo "$USER" > /home/$USER/$USER.txt
 chmod -Rf 700 /home/$USER/.*
-find "/home/$USER/" -exec chmod u-s,g=-,o=- {} \;
+chmod -f o+r /home/$USER/$USER.txt

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/ansible/shared.yml
@@ -19,8 +19,8 @@
   register: path_exists
   loop: '{{ local_users }}'
   when:
-    - item.value[2]|int >= {{{ gid_min }}}
-    - item.value[2]|int != {{{ nobody_gid }}}
+    - item.value[1]|int >= {{{ uid_min }}}
+    - item.value[1]|int != {{{ nobody_uid }}}
 
 - name: Ensure interactive local users are the group-owners of their respective home directories
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/ansible/shared.yml
@@ -12,6 +12,9 @@
 - name: Create local_users variable from the getent output
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
+    # Creates a dictionary where the key is the first field of the /etc/passwd file, the username.
+    # The list of values are the next 6 fields from /etc/passwd. Example for the root entry:
+    # The "root" key would have these values: ["x", "0", "0", "root", "/root", "/bin/bash"]
 
 - name: Test for existence of home directories to avoid creating them, but only fixing group ownership
   ansible.builtin.stat:

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) system("chgrp -f " $4" "$6) }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chgrp -f " $4" "$6) }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/oval/shared.xml
@@ -7,31 +7,18 @@
     </criteria>
   </definition>
 
-  <!-- For detailed comments about logic used in this OVAL, check the
-       "file_ownership_home_directories" rule. -->
-  <unix:password_object id="object_file_groupownership_home_directories_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_file_groupownership_home_directories_interactive_uids</filter>
-    <filter action="exclude">state_file_permissions_groupownership_user_list</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_file_groupownership_home_directories_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
-
-  <unix:password_state id="state_file_permissions_groupownership_user_list" version="1">
-    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <!-- #### prepare for test_file_groupownership_home_directories #### -->
   <local_variable id="var_file_groupownership_home_directories_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from primary interactive groups">
-    <object_component item_field="home_dir" object_ref="object_file_groupownership_home_directories_objects"/>
+    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <local_variable id="var_file_groupownership_home_directories_gids" datatype="int" version="1"
                   comment="Variable including all gids from primary interactive group">
-    <object_component item_field="group_id" object_ref="object_file_groupownership_home_directories_objects"/>
+    <object_component item_field="group_id" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
@@ -2,7 +2,7 @@ documentation_complete: true
 
 prodtype: alinux3,anolis8,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
 
-title: 'All Interactive User Home Directories Must Be Group-Owned By The Primary User'
+title: 'All Interactive User Home Directories Must Be Group-Owned By The Primary Group'
 
 description: |-
     Change the group owner of interactive users home directory to the

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+chgrp 10005 /home/$USER

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/ansible/shared.yml
@@ -12,6 +12,9 @@
 - name: Create local_users variable from the getent output
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
+    # Creates a dictionary where the key is the first field of the /etc/passwd file, the username.
+    # The list of values are the next 6 fields from /etc/passwd. Example for the root entry:
+    # The "root" key would have these values: ["x", "0", "0", "root", "/root", "/bin/bash"]
 
 - name: Test for existence of home directories to avoid creating them, but only fixing ownership
   ansible.builtin.stat:

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/ansible/shared.yml
@@ -13,7 +13,7 @@
   ansible.builtin.set_fact:
     local_users: '{{ ansible_facts.getent_passwd|dict2items }}'
 
-- name: Test for existence home directories to avoid creating them, but only fixing ownership
+- name: Test for existence of home directories to avoid creating them, but only fixing ownership
   ansible.builtin.stat:
     path: '{{ item.value[4] }}'
   register: path_exists

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/oval/shared.xml
@@ -13,31 +13,8 @@
     </criteria>
   </definition>
 
-  <!-- 
-    Extract a list composed of password objects filtered by UIDs starting in {{{ uid_min }}} and
-    not equal to "nobody". Most of (if not all) distros have the special user "nobody" with uid
-    65354. Despite it be technically classified as an interactive user, it is a special case with
-    very limited access. So, we ignore it. The resulted password object will be further used to
-    create local variables composed by UIDs e Home Dirs.
-  -->
-  <unix:password_object id="object_file_ownership_home_directories_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_file_ownership_home_directories_interactive_uids</filter>
-    <filter action="exclude">state_file_ownership_home_directories_user_list</filter>
-  </unix:password_object>
-
-  <!--
-    In distros which uses PAM (almost all), by default, the uid of interactive users and groups
-    starts at 1000. We use this information to make sure this password_state object will be
-    composed only with objects related to interactive users.
-  -->
-  <unix:password_state id="state_file_ownership_home_directories_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
-
-  <unix:password_state id="state_file_ownership_home_directories_user_list" version="1">
-    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <!-- 
     #### prepare for test_file_groupownership_home_directories ####
@@ -45,7 +22,7 @@
   -->
   <local_variable id="var_file_ownership_home_directories_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="object_file_ownership_home_directories_objects"/>
+    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- 
@@ -53,7 +30,7 @@
   -->
   <local_variable id="var_file_ownership_home_directories_uids" datatype="int" version="1"
                   comment="List of interactive users uids">
-    <object_component item_field="user_id" object_ref="object_file_ownership_home_directories_objects"/>
+    <object_component item_field="user_id" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- 

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+chown 10005 /home/$USER

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/oval/shared.xml
@@ -7,26 +7,13 @@
     </criteria>
   </definition>
 
-  <!-- For detailed comments about logic used in this OVAL, check the
-       "file_ownership_home_directories" rule. -->
-  <unix:password_object id="object_file_permissions_home_directories_objects" version="1">
-    <unix:username datatype="string" operation="pattern match">.*</unix:username>
-    <filter action="include">state_file_permissions_home_directories_interactive_uids</filter>
-    <filter action="exclude">state_file_permissions_home_files_permissions_user_list</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_file_permissions_home_directories_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
-
-  <unix:password_state id="state_file_permissions_home_files_permissions_user_list" version="1">
-    <unix:username datatype="string" operation="pattern match">^{{{ user_list }}}$</unix:username>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <!-- #### prepare for test_file_permissions_home_directories #### -->
   <local_variable id="var_file_permissions_home_directories_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
-    <object_component item_field="home_dir" object_ref="object_file_permissions_home_directories_objects"/>
+    <object_component item_field="home_dir" object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+chmod 755 /home/$USER

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/oval/shared.xml
@@ -6,20 +6,14 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_file_permissions_home_dirs_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter action="include">state_file_permissions_home_dirs_interactive_uids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_file_permissions_home_dirs_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <!-- #### prepare for test_file_permissions_home_dirs #### -->
   <local_variable id="var_file_permissions_home_dirs_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_file_permissions_home_dirs_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+chmod 753 /home/$USER

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/oval/shared.xml
@@ -7,19 +7,13 @@
     </criteria>
   </definition>
 
-  <unix:password_object id="object_accounts_umask_interactive_users_objects" version="1">
-    <unix:username datatype="string" operation="not equal">nobody</unix:username>
-    <filter action="include">state_accounts_umask_interactive_users_interactive_uids</filter>
-  </unix:password_object>
-
-  <unix:password_state id="state_accounts_umask_interactive_users_interactive_uids" version="1">
-    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
-  </unix:password_state>
+  {{%- set interactive_users_object = "object_" ~ rule_id ~ "_objects" -%}}
+  {{{ create_interactive_users_list_object(interactive_users_object) }}}
 
   <local_variable id="var_accounts_umask_interactive_users_dirs" datatype="string" version="1"
                   comment="Variable including all home dirs from interactive users">
     <object_component item_field="home_dir"
-                      object_ref="object_accounts_umask_interactive_users_objects"/>
+                      object_ref="{{{ interactive_users_object }}}"/>
   </local_variable>
 
   <!-- #### creation of object #### -->

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_user_nologin_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_user_nologin_ignored.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+USER="cac_user"
+useradd -m -s /sbin/nologin $USER
+echo "umask 022" >> /home/$USER/.bashrc

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -967,14 +967,38 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
 </def-group>
 {{%- endmacro %}}
 
+
 {{#
-  User list in form of regex that are excluded when checking user home directory permissions and ownerships.
+  Extract from /etc/passwd a list composed of password objects related to non-system UIDs.
+  This list is then filtered to exclude some special usernames and users with /sbin/nologin shell.
+
+  The macro receives a string as parameter, which is used as the password_object id in the rule.
+
+  :param object_id: Object id to be created.
+  :type object_id: str
 #}}
-{{%- if product in ["rhel7", "ol7"] %}}
-  {{%- set user_list="(nobody|nfsnobody)" %}}
-{{%- else %}}
-  {{%- set user_list="nobody" %}}
-{{%- endif %}}
+{{%- macro create_interactive_users_list_object(object_id) -%}}
+  {{%- set ignored_users_list="(nobody|nfsnobody)" %}}
+
+  <unix:password_object id="{{{ object_id }}}" version="1">
+    <unix:username datatype="string" operation="pattern match">.*</unix:username>
+    <filter action="include">state_{{{ rule_id }}}_users_uids</filter>
+    <filter action="exclude">state_{{{ rule_id }}}_users_ignored</filter>
+    <filter action="exclude">state_{{{ rule_id }}}_users_nologin_shell</filter>
+  </unix:password_object>
+
+  <unix:password_state id="state_{{{ rule_id }}}_users_uids" version="1">
+    <unix:user_id datatype="int" operation="greater than or equal">{{{ uid_min }}}</unix:user_id>
+  </unix:password_state>
+
+  <unix:password_state id="state_{{{ rule_id }}}_users_ignored" version="1">
+    <unix:username datatype="string" operation="pattern match">^{{{ ignored_users_list }}}$</unix:username>
+  </unix:password_state>
+
+  <unix:password_state id="state_{{{ rule_id }}}_users_nologin_shell" version="1">
+    <unix:login_shell datatype="string" operation="pattern match">^/sbin/nologin$</unix:login_shell>
+  </unix:password_state>
+{{%- endmacro %}}
 
 
 {{%- macro partition_exists_criterion(path) %}}


### PR DESCRIPTION
#### Description:

Currently, there are 14 rules checking for requirements related to "interactive users":
1. accounts_umask_interactive_users
2. accounts_user_dot_user_ownership
3. accounts_user_dot_group_ownership
4. accounts_user_dot_no_world_writable_programs
5. accounts_user_interactive_home_directory_defined
6. accounts_user_interactive_home_directory_exists
7. accounts_users_home_files_groupownership
8. accounts_users_home_files_ownership
9. accounts_users_home_files_permissions
10. file_groupownership_home_directories
11. file_ownership_home_directories
12. file_permissions_home_directories
13. file_permissions_home_dirs
14. no_forward_files

For all these rules, the approach to identify interactive users is exactly the same.
However, each rule had its own OVAL check.

Besides the code duplication, during the review of these rules it was also noticed other minor issues:
- Some rules consider the `nobody` user while others not.
- Some rules ignore users based on a user list while other not.
- Some rules were filtering interactive users by their gids while the uids should be used instead.
- Some rules were using hard-coded uids or gids instead of products variables.

These issues prove how difficult is to keep consistency among these rules.
The maintenance is also expensive considering 14 rules.

Recently, after some [discussions in CIS Community](https://workbench.cisecurity.org/tickets/17249), after checking related requirements in existing benchmarks, like STIG and CIS, and also after offline conversations with experts, it was decided that users configured with `/sbin/nologin` shell should also be ignored in the "Interactive Users" list.

This change  inevitably would demand OVAL update in the 14 mentioned rules.
It was a great opportunity to improve the consistency of these rules, reduce maintenance cost and make it easier to introduce new similar rules.

So, in this PR I have created a OVAL macro to properly and consistently identify "Interactive Users" and provide a OVAL object to be used in the rules. Once the macro was created, the OVAL for these all 14 rules was updated to use the new macro and a new test scenario was included to cover the case of non-system accounts that has `/sbin/nologin` shell.

The minor issues mentioned before were also fixed.

#### Rationale:

- Maintenance cost reduced
- Stronger consistency
- Simplification

#### Review Hints:

Although I identified improvement opportunities also in remediation, I decided to limit the scope of this PR to OVAL updates and minor fixes in remediation. It makes the PR easier to review and test since the changes are more controlled. 

For review, check commit by commit in the order they are presented.
For test, I would recommend to use a loop for testing these 14 rules using `automatus`. Here is a simple example that can be used as reference:
```
for rule in accounts_umask_interactive_users accounts_user_dot_group_ownership accounts_user_dot_user_ownership accounts_user_dot_no_world_writable_programs accounts_user_interactive_home_directory_defined accounts_user_interactive_home_directory_exists accounts_users_home_files_groupownership accounts_users_home_files_ownership accounts_users_home_files_permissions file_groupownership_home_directories file_ownership_home_directories file_permissions_home_directories file_permissions_home_dirs no_forward_files; do
  for os in rhel9 rhel8 rhel7; do
    for flavor in bash ansible; do
      echo "`date` - $os - $rule - $flavor VM"
      ./tests/automatus.py rule --libvirt qemu:///session $os --datastream build/ssg-$os-ds.xml --dontclean --remediate-using $flavor $rule
    done
  done
done
```

As a follow-up, something similar should be done with the remediation.