### PR TITLE
OVAL: Do not treat empty HyperShift file as an indication that HyperShift is installed

### DIFF
--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -32,13 +32,10 @@
       <unix:object object_ref="object_file_for_ocp4"/>
   </unix:file_test>
 
-  <unix:file_test id="test_hypershift_file_for_ocp4" check="only one" comment="Find the actual file to be scanned for hypershift." version="1">
-      <unix:object object_ref="object_hypershift_file_for_ocp4"/>
-  </unix:file_test>
-
-  <unix:file_object id="object_hypershift_file_for_ocp4" version="1">
-      <unix:filepath var_ref="ocp4_hypershift_dump_location"/>
-  </unix:file_object>
+  <ind:yamlfilecontent_test id="test_hypershift_file_for_ocp4" check="at least one" comment="Find one match" version="1">
+      <ind:object object_ref="object_hypershift_ocp4"/>
+      <ind:state state_ref="state_ocp4"/>
+  </ind:yamlfilecontent_test>
 
   <ind:yamlfilecontent_object id="object_hypershift_ocp4" version="1">
       <ind:filepath var_ref="ocp4_hypershift_dump_location"/>


### PR DESCRIPTION
#### Description:

The `installed_app_is_ocp4_{{{ minorversion }}}` check tries to make
sure that hyperShift clusteroperator file is not present, but it does so
by checking the file presence. This does not work, because even for an
non-existent hypershift file, the api-resource-collector saves a file with contents:
```
kube-api-error=NotFound
```
Let's check that the file matches a regex starting with 4 instead.

#### Rationale:

- OCP4 rules that depend on the `installed_app_is_ocp4_{{{ minorversion }}}`
  are all not applicable
