### PR TITLE
OCP4 fix version detection for OCP

### DIFF
--- a/applications/openshift/general/version_detect_in_hypershift/rule.yml
+++ b/applications/openshift/general/version_detect_in_hypershift/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'This is a helper rule to fetch the required api resource for detecting HyperShift OCP version'
 
 {{% set custom_jqfilter = '[.status.version.history[].version]' %}}
-{{% set custom_api_path = '/apis/hypershift.openshift.io/v1alpha1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
+{{% set custom_api_path = '/apis/hypershift.openshift.io/v1beta1/namespaces/clusters/hostedclusters/{{.hypershift_cluster}}' %}}
 {{% set default_api_path = '/hypershift/version' %}}
 {{% set dump_path = default_api_path ~ ',' ~ custom_jqfilter %}}
 

--- a/shared/checks/oval/installed_app_is_ocp4.xml
+++ b/shared/checks/oval/installed_app_is_ocp4.xml
@@ -61,6 +61,24 @@
       </ind:value>
   </ind:yamlfilecontent_state>
 
+
+  <ind:yamlfilecontent_test id="test_hypershift_version" check="at least one" comment="Find one match" version="1">
+      <ind:object object_ref="object_hypershift_version"/>
+      <ind:state state_ref="state_hypershift_version"/>
+  </ind:yamlfilecontent_test>
+
+
+  <ind:yamlfilecontent_object id="object_hypershift_version" version="1">
+      <ind:filepath var_ref="ocp4_hypershift_dump_location"/>
+      <ind:yamlpath>[:]</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+  <ind:yamlfilecontent_state id="state_hypershift_version" version="1">
+      <ind:value datatype="record">
+          <field name="#" datatype="string" operation="pattern match">4\..*</field>
+      </ind:value>
+  </ind:yamlfilecontent_state>
+
 {{% for minorversion in range(6, 19) %}}
   <!-- Check for OpenShift Container Platform 4.{{{ minorversion }}} -->
   <definition class="inventory" id="installed_app_is_ocp4_{{{ minorversion }}}" version="1">
@@ -76,7 +94,7 @@
       <criteria operator="AND">
         <criterion comment="cluster is OpenShift 4.{{{ minorversion }}}" test_ref="test_ocp4_{{{ minorversion }}}" />
         <criterion comment="Make sure OCP4 clusteroperators file is present" test_ref="test_file_for_ocp4"/>
-        <criterion negate="true" comment="Make sure HyperShift OCP4 clusteroperators file is not present" test_ref="test_hypershift_file_for_ocp4"/>
+        <criterion negate="true" comment="HyperShift cluster should not have version" test_ref="test_hypershift_version" />
       </criteria>
       <criteria operator="AND">
         <criterion comment="cluster is OpenShift 4.{{{ minorversion }}}" test_ref="test_hypershift_ocp4_{{{ minorversion }}}" />


### PR DESCRIPTION
A recent CO release changed how we collect and save fetched API resources, there will be a dump file even in a non-existent API-path. Let's add an assertion with the HyperShift version dump file existing in the condition, we should make sure we don't get any version for the HyperShift cluster.

In a cluster, if var `hypershift_cluster` is not set and defaults to None, we will not get a version for the HyperShift cluster, so the correct OCP version will be detected. If we set `hypershift_cluster`, and the minor version for the HyperShift is correctly detected, we should use the version of the HyperShfit. 
