### PR TITLE
resubmit: update the Ubuntu products

### DIFF
--- a/products/ubuntu1604/product.yml
+++ b/products/ubuntu1604/product.yml
@@ -8,6 +8,7 @@ benchmark_root: "../../linux_os/guide"
 profiles_root: "./profiles"
 
 pkg_manager: "apt_get"
+pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
 oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml"

--- a/products/ubuntu1804/product.yml
+++ b/products/ubuntu1804/product.yml
@@ -8,6 +8,7 @@ benchmark_root: "../../linux_os/guide"
 profiles_root: "./profiles"
 
 pkg_manager: "apt_get"
+pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
 

--- a/products/ubuntu2004/product.yml
+++ b/products/ubuntu2004/product.yml
@@ -8,6 +8,7 @@ benchmark_root: "../../linux_os/guide"
 profiles_root: "./profiles"
 
 pkg_manager: "apt_get"
+pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
 oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml"

--- a/products/ubuntu2204/product.yml
+++ b/products/ubuntu2204/product.yml
@@ -8,6 +8,7 @@ benchmark_root: "../../linux_os/guide"
 profiles_root: "./profiles"
 
 pkg_manager: "apt_get"
+pkg_manager_config_file: "/etc/apt/apt.conf"
 
 init_system: "systemd"
 oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml"
@@ -15,7 +16,7 @@ oval_feed_url: "https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.fo
 grub2_boot_path: "/boot/grub"
 grub2_uefi_boot_path: "/boot/grub"
 
-aide_bin_path: "/usr/bin/aide.wrapper"
+aide_bin_path: "/usr/bin/aide"
 aide_conf_path: "/etc/aide/aide.conf"
 chrony_conf_path: "/etc/chrony/chrony.conf"
 


### PR DESCRIPTION
Resubmit of https://github.com/ComplianceAsCode/content/pull/10192

This PR updates the Ubuntu products:

- adds pkg_manager_config_file: "/etc/apt/apt.conf"
- corrects aide_bin_path since /usr/bin/aide.wrapper isn't present in 22.04