### PR TITLE
OCPBUGS-7307: Add instructions for alert-receiver-configured rule

### DIFF
--- a/applications/openshift/general/alert_receiver_configured/rule.yml
+++ b/applications/openshift/general/alert_receiver_configured/rule.yml
@@ -30,8 +30,8 @@ references:
 ocil_clause: 'Alert receiver is not configured'
 
 ocil: |-
-    Run the following command to see if alert receiver has been configured to send alerts to a orgzinational defined external system:
-    <pre>$ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .data "alertmanager.yaml" }}' | base64 --decode</pre>
+    Run the following command to see if alert receiver has been configured to send alerts to a organizational defined external system:
+    <pre>$ oc -n openshift-monitoring get secret alertmanager-main -ojson | jq '.data."alertmanager.yaml"' -r | base64 --decode</pre>
     Make sure that alert receiver has configured to send alerts to at least one real time external notification system.
 
 severity: medium


### PR DESCRIPTION
The tail of the description for this rule actually works well as
instructions.

Let's move the links to an instructions section so that users relying on
`instructions` for Manual rules get pointed to documentation for setting
up receivers.
