### PR TITLE
Use integer comparison for api_server_audit_log_maxsize

### DIFF
--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -61,7 +61,7 @@ template:
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.apiServerArguments["audit-log-maxsize"][:]'
     values:
-    - value: '100'
-      operation: "pattern match"
-      type: "string"
+    - value: 100
+      operation: "greater than or equal"
+      type: "int"
       entity_check: "at least one"


### PR DESCRIPTION
Previously, the api_server_audit_log_maxsize rule compared the maxsize
configuration option using strings. This meant it would fail if
`audit-log-maxsize` were set to anything other than 100 Mb. However,
it is reasonable for users to have that configuration value set to
something larger than 100 Mb, meaning they retaining even more audit log
information.

This commit updates the rule so that it will succeed with values larger
than 100 Mb.

Related Jira: https://issues.redhat.com/browse/OCPBUGS-7520
