### PR TITLE
Remove api_server_audit_log_maxsize remediation

### DIFF
--- a/applications/openshift/api-server/api_server_audit_log_maxsize/kubernetes/shared.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/kubernetes/shared.yml
@@ -1,8 +1,0 @@
----
-# platform = multi_platform_ocp
-apiVersion: config.openshift.io/v1
-kind: APIServer
-metadata:
-  name: cluster
-spec:
-  maximumFileSizeMegabytes: 100


### PR DESCRIPTION
This remediation doesn't work since OpenShift doesn't allow users to set
audit-log-maxsize.

  https://access.redhat.com/solutions/5993251

By having a remedation for it, we're creating confusion for users when
the remediation doesn't work. Additionally, we can't update the
configuration option without preventing future upgrades, which isn't a
good option.

Let's remove the remediation.
