### PR TITLE
RHCOS4: Temporarily disable selinux_confinement_of_daemons to work around kubelet bug

### DIFF
--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -484,7 +484,8 @@ controls:
   rules:
   - var_selinux_policy_name=targeted
   - selinux_policytype
-  - selinux_confinement_of_daemons
+  # (jhrozek): Disabled because of https://issues.redhat.com/browse/OCPBUGS-6969
+  #- selinux_confinement_of_daemons
   - var_selinux_state=enforcing
   - selinux_state
   - coreos_enable_selinux_kernel_argument
@@ -828,7 +829,8 @@ controls:
 
     https://issues.redhat.com/browse/CMP-115
   rules:
-  - selinux_confinement_of_daemons
+  # (jhrozek): Disabled because of https://issues.redhat.com/browse/OCPBUGS-6969
+  #- selinux_confinement_of_daemons
   - no_shelllogin_for_systemaccounts
   - sysctl_kernel_perf_event_paranoid
   - sysctl_kernel_unprivileged_bpf_disabled
@@ -4990,7 +4992,8 @@ controls:
   - audit_rules_privileged_commands_userhelper
   - audit_rules_networkconfig_modification
   - audit_rules_etc_shadow_openat
-  - selinux_confinement_of_daemons
+  # (jhrozek): Disabled because of https://issues.redhat.com/browse/OCPBUGS-6968
+  #- selinux_confinement_of_daemons
   - audit_rules_etc_gshadow_open_by_handle_at
   - audit_rules_etc_gshadow_open
   - var_auditd_space_left_action=syslog
@@ -5235,7 +5238,8 @@ controls:
   - service_bluetooth_disabled
   - kernel_module_tipc_disabled
   - sysctl_net_ipv6_conf_all_accept_redirects
-  - selinux_confinement_of_daemons
+  # (jhrozek): Disabled because of https://issues.redhat.com/browse/OCPBUGS-6969
+  #- selinux_confinement_of_daemons
   - sysctl_net_ipv4_tcp_syncookies
   - sysctl_net_ipv4_icmp_ignore_bogus_error_responses
   - coreos_vsyscall_kernel_argument


### PR DESCRIPTION
#### Description:

- Disables `selinux_confinement_of_daemons` for RHCos

#### Rationale:

kubelet changed its context to `unconfined_service_t` so this rule fails
and is impossible to remediate. We should push the kubelet developers to
provide a confined domain, but since there is no remediation, we need
to disable the rule in the meantime.

See https://issues.redhat.com/browse/OCPBUGS-6968 for more details.

#### Review Hints:

- Make sure that the rule is not enabled in any of RHCOS profiles
