### PR TITLE
SUSE: fix rule package_dhcp_removed

### DIFF
--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -9,7 +9,7 @@ description: |-
     the dhcp package can be uninstalled.
     {{% if 'ubuntu' in product %}}
     {{{ describe_package_remove(package="isc-dhcp-server") }}}
-    {{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+    {{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9', 'sle12', 'sle15'] %}}
     {{{ describe_package_remove(package="dhcp-server") }}}
     {{% else %}}
     {{{ describe_package_remove(package="dhcp") }}}

--- a/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
+++ b/linux_os/guide/services/dhcp/disabling_dhcp_server/package_dhcp_removed/rule.yml
@@ -48,7 +48,7 @@ references:
 
 {{% if 'ubuntu' in product %}}
 {{{ complete_ocil_entry_package(package="isc-dhcp-server") }}}
-{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9'] %}}
+{{% elif product in ['ol8', 'ol9', 'rhel8', 'rhel9', 'sle12', 'sle15'] %}}
 {{{ complete_ocil_entry_package(package="dhcp-server") }}}
 {{% else %}}
 {{{ complete_ocil_entry_package(package="dhcp") }}}
@@ -64,3 +64,5 @@ template:
         pkgname@ubuntu1804: isc-dhcp-server
         pkgname@ubuntu2004: isc-dhcp-server
         pkgname@ubuntu2204: isc-dhcp-server
+        pkgname@sle12: dhcp-server
+        pkgname@sle15: dhcp-server


### PR DESCRIPTION
For SUSE SLE12 and SLE15, the dhcp server package is dhcp-server not dhcp. In these OSes the dhcp package is:
dhcp  | Common Files Used by ISC DHCP Software

As result the current code incorrectly fails the package_dhcp_removed test and remediation incorrectly removes the packages: dhcp | Common Files Used by ISC DHCP Software
dhcp-client | ISC DHCP Client
yast2-dhcp-server | YaST2 - DHCP Server Configuration

The change is to specify dhcp-server as the dhcp server package for SL12 and SL15.

#### Description:

- for SUSE check for dhcp-server not dhcp 

#### Rationale:

- current test and remediation is incorrect for SLE12 and SLE15
