### PR TITLE
Update CIS RHEL requirements for log files permissions

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1573,6 +1573,8 @@ controls:
     - l1_server
     - l1_workstation
     status: manual
+    rules:
+      - rsyslog_files_permissions
 
   - id: 4.2.4
     title: Ensure logrotate is configured (Manual)

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1713,9 +1713,7 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: partial
-    rules:
-      - rsyslog_files_permissions
+    status: planned
 
   - id: 4.2.1.5
     title: Ensure logging is configured (Manual)
@@ -1820,14 +1818,12 @@ controls:
       - l1_workstation
     status: manual
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5523
   - id: 4.2.3
     title: Ensure permissions on all logfiles are configured (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: partial
+    status: automated
     rules:
       - rsyslog_files_permissions
 

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1665,15 +1665,15 @@ controls:
       - l1_workstation
     status: manual
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5523
   - id: 4.2.3
     title: Ensure all logfiles have appropriate permissions and ownership (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: partial
+    status: automated
     rules:
+      - rsyslog_files_groupownership
+      - rsyslog_files_ownership
       - rsyslog_files_permissions
 
   - id: 4.3

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_groupownership/rule.yml
@@ -46,6 +46,7 @@ identifiers:
 references:
     anssi: BP28(R46),BP28(R5)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@rhel9: 4.2.3
     cis@sle12: 4.2.1.3
     cis@sle15: 4.2.1.3
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_ownership/rule.yml
@@ -52,6 +52,7 @@ identifiers:
 references:
     anssi: BP28(R46),BP28(R5)
     cis-csc: 12,13,14,15,16,18,3,5
+    cis@rhel9: 4.2.3
     cis@sle12: 4.2.1.3
     cis@sle15: 4.2.1.3
     cobit5: APO01.06,DSS05.04,DSS05.07,DSS06.02    

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
@@ -37,8 +37,8 @@ identifiers:
 references:
     anssi: BP28(R36)
     cis@alinux2: 4.2.1.3
-    cis@rhel7: 4.2.1.3
-    cis@rhel8: 4.2.1.4,4.2.3
+    cis@rhel7: 4.2.3
+    cis@rhel8: 4.2.3
     cis@rhel9: 4.2.3
     cis@sle12: 4.2.1.3
     cis@sle15: 4.2.1.3


### PR DESCRIPTION
#### Description:

CIS requirements to set on log files properties checks permissions in RHEL7 and RHEL8 while in RHEL9 also checks owner and group-owner.
Also, the `rsyslog_files_permissions` rule was also listed in 4.2.1.3 requirement for RHEL7 and 4.2.1.4 requirement for RHEL8. This is not correct and is fixed by this PR.

#### Rationale:

Better CIS coverage for RHEL products.