### PR TITLE
Disable FIPS-related rule group for 'osbuild' platform

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/group.yml
+++ b/linux_os/guide/system/software/integrity/fips/group.yml
@@ -15,4 +15,4 @@ description: |-
     <br /><br />
     See <b>{{{ weblink(link="http://csrc.nist.gov/publications/PubsFIPS.html") }}}</b> for more information.
 
-platform: machine
+platform: machine and not osbuild


### PR DESCRIPTION
#### Description:

Do not execute FIPS-related rules in OSBuild environment. Due to the nature of the image creation process the way FIPS should be enabled is different. It is yet to be developed on the IB side but it will be similar to Anakonda's process.

#### Rationale:

- The rules are based on runtime sources of information and therefore can't be used in the OSBuild environment.
- Moreover, the script that is used in remediation also does not support chrooted environment.

- Fixes #9559