### PR TITLE
add cap_system_chroot capability to Automatus podman container

### DIFF
--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -519,6 +519,7 @@ class PodmanTestEnv(ContainerTestEnv):
         podman_cmd = ["podman", "run", "--name", long_name,
                       "--cap-add=cap_audit_write",
                       "--cap-add=cap_sys_admin",
+                      "--cap-add=cap_sys_chroot",
                     #   "--privileged",
                       "--publish", "{}".format(self.internal_ssh_port), "--detach", image_name,
                       "/usr/sbin/sshd", "-p", "{}".format(self.internal_ssh_port), "-D"]


### PR DESCRIPTION
#### Description:

- extend command line parameters when running podman container byAutomatus in container rule mode

#### Rationale:

recent changes made it impossible to login to a podman container with sshd running without giving this capability to it

#### Review Hints:

- install RHEL 8.8 machine with the latest compose
- ./build_product rhel8
- cd tests
- ./build_test_container.sh --flavor rhel8
- python3.8 automatus.py rule --container ssg_test_suite configure_ssh_crypto_policy