### PR TITLE
Modify platform check in USBGuard rules

### DIFF
--- a/linux_os/guide/services/usbguard/group.yml
+++ b/linux_os/guide/services/usbguard/group.yml
@@ -5,4 +5,4 @@ title: 'USBGuard daemon'
 description: |-
     The USBGuard daemon enforces the USB device authorization policy for all USB devices.
 
-platform: not_s390x_arch
+platform: not_s390x_arch and machine

--- a/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
+++ b/linux_os/guide/services/usbguard/service_usbguard_enabled/rule.yml
@@ -14,8 +14,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 identifiers:
     cce@rhcos4: CCE-82537-2
     cce@rhel8: CCE-82853-3

--- a/linux_os/guide/services/usbguard/usbguard_generate_policy/rule.yml
+++ b/linux_os/guide/services/usbguard/usbguard_generate_policy/rule.yml
@@ -16,8 +16,6 @@ rationale: |-
 
 severity: medium
 
-platform: machine
-
 identifiers:
     cce@rhel8: CCE-83774-0
     cce@rhel9: CCE-88882-6


### PR DESCRIPTION
#### Description:

This PR introduces additional conditions for USBGuard rules' checks and remediations to ignore containers.
This change will mean that USBGuard rules will result in `notapplicable` when on containers, therefore the installation and configuration of USBGuard will not be included in the remediation script and will prevent automatic builds from failing.

#### Rationale:

USBGuard rules should not be applicable to containers in any distribution.

Fixes #8248

#### Review Hints:
Some comments have been included in order to facilitate the PR review.