### PR TITLE
Add UFW related rule for CIS on Ubuntu

### DIFF
--- a/linux_os/guide/system/network/network-ufw/set_ufw_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_default_rule/rule.yml
@@ -1,0 +1,39 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure ufw Default Deny Firewall Policy'
+
+description: |-
+    A default deny policy on connections ensures that any unconfigured
+    network usage will be rejected.
+
+    Note: Any port or protocol without a explicit allow before the default
+    deny will be blocked.
+
+rationale: |-
+    With a default accept policy the firewall will accept any packet that
+    is not configured to be denied. It is easier to allow acceptable
+    usage than to block unacceptable usage.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.7
+    cis@ubuntu2204: 3.5.1.7
+
+ocil_clause: |-
+    the default policy for the incoming, outgoing and routed is not set to deny,
+    reject or disabled
+
+ocil: |-
+    Run the following command and verify that the default policy for incoming,
+    outgoing, and routed directions is deny, reject, or disabled:
+    <pre># ufw status verbose | grep Default:</pre>
+    Example output:
+    <pre>Default: deny (incoming), deny (outgoing), disabled (routed)</pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-ufw/set_ufw_default_rule/sce/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_default_rule/sce/shared.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+default_status=$(ufw status verbose | grep "Default:")
+
+count=$(echo "$default_status" | grep -oP "(deny|reject|disabled) \((incoming|outgoing|routed)\)" | wc -l)
+
+if [ "$count" -ne 3 ]; then
+    exit "$XCCDF_RESULT_FAIL"
+fi
+
+exit "$XCCDF_RESULT_PASS"

--- a/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/bash/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/bash/shared.sh
@@ -1,0 +1,6 @@
+# platform = multi_platform_ubuntu
+
+ufw allow in on lo
+ufw allow out on lo
+ufw deny in from 127.0.0.0/8
+ufw deny in from ::1

--- a/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/rule.yml
@@ -1,5 +1,7 @@
 documentation_complete: true
 
+prodtype: ubuntu2004,ubuntu2204
+
 title: 'Set UFW Loopback Traffic'
 
 description: |-

--- a/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/rule.yml
@@ -1,0 +1,43 @@
+documentation_complete: true
+
+title: 'Set UFW Loopback Traffic'
+
+description: |-
+    Configure the loopback interface to accept traffic.
+    Configure all other interfaces to deny traffic to the loopback
+    network.
+
+rationale: |-
+    Loopback traffic is generated between processes on machine and is
+    typically critical to operation of the system. The loopback interface
+    is the only place that loopback network traffic should be seen, all
+    other interfaces should ignore traffic on this network as an
+    anti-spoofing measure.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 3.5.1.4
+    cis@ubuntu2204: 3.5.1.4
+
+ocil_clause: 'loopback traffic is not configured'
+
+ocil: |-
+    Run the following commands to implement the loopback rules:
+    <pre>
+    # ufw allow in on lo
+    </pre>
+    <pre>
+    # ufw allow out on lo
+    </pre>
+    <pre>
+    # ufw deny in from 127.0.0.0/8
+    </pre>
+    <pre>
+    # ufw deny in from ::1
+    </pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/sce/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/sce/shared.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+ufw_status=$(ufw status verbose)
+
+# check in lo
+if echo "$ufw_status" | grep -q -P "^Anywhere on lo\s+ALLOW IN\s+Anywhere\b"; then
+    exit "${XCCDF_RESULT_FAIL}"
+fi
+
+if [ -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" -eq 0 ]; then
+    if echo "$ufw_status" | grep -q -P "^Anywhere \(v6\) on lo\s+ALLOW IN\s+Anywhere \(v6\)\b"; then
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+fi
+
+# check out lo
+if echo "$ufw_status" | grep -q -P "^Anywhere\s+ALLOW OUT\s+Anywhere on lo\b"; then
+    exit "${XCCDF_RESULT_FAIL}"
+fi
+
+if [ -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" -eq 0 ]; then
+    if echo "$ufw_status" | grep -P "^Anywhere \(v6\)\s+ALLOW OUT\s+Anywhere \(v6\) on lo\b"; then
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+fi
+
+# deny in localhost
+if echo "$ufw_status" | grep -P "^Anywhere\s+DENY IN\s+127.0.0.0/8\b"; then
+    exit "${XCCDF_RESULT_FAIL}"
+fi
+
+if [ -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" -eq 0 ]; then
+    if echo "$ufw_status" | grep -P "Anywhere \(v6\)\s+DENY IN\s+::1\b"; then
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+fi
+
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/network/network-ufw/ufw_rules_for_open_ports/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_rules_for_open_ports/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure ufw Firewall Rules Exist for All Open Ports'
+
+description: |-
+    Any ports that have been opened on non-loopback addresses
+    need firewall rules to govern traffic.
+
+rationale: |-
+    Without a firewall rule configured for open ports default
+    firewall policy will drop all packets to these ports.
+
+severity: medium
+
+references:
+    cis@ubuntu2204: 3.5.1.6
+
+ocil_clause: 'open ports are denied connection'
+
+ocil: |-
+    Run the following command to determine open ports:
+    <pre># ss -tuln</pre>
+    Run the following command to determine firewall rules:
+    <pre># ufw status verbose</pre>
+    For each port identified in the audit which does not have a firewall
+    rule, add rule for accepting or denying inbound connections
+    <pre># ufw allow in <port>/<tcp or udp protocol></pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-ufw/ufw_rules_for_open_ports/sce/shared.sh
+++ b/linux_os/guide/system/network/network-ufw/ufw_rules_for_open_ports/sce/shared.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+result=$XCCDF_RESULT_PASS
+ufw_status="$(ufw status verbose)"
+
+while read -r lpn;
+do
+    if ! grep -Pq "^\h*$lpn\b" <<< "$ufw_status"; then
+        result=$XCCDF_RESULT_FAIL
+        break
+    fi;
+done < <(ss -tuln | awk '($5!~/%lo:/ && $5!~/127.0.0.1:/ && $5!~/::1/) {split($5, a, ":"); print a[2]}i' | sort | uniq)
+
+exit "$result"

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -390,7 +390,7 @@ selections:
     - service_ufw_enabled
 
     #### 3.5.1.4 Ensure loopback traffic is configured (Automated)
-    # Needs rule
+    - set_ufw_loopback_traffic
 
     #### 3.5.1.5 Ensure outbound connections are configured (Manual)
     # Skip due to being a manual test

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -399,7 +399,7 @@ selections:
     # Skip due to being a manual test
 
     #### 3.5.1.7 Ensure default deny firewall policy (Automated)
-    # Needs rule
+    - set_ufw_default_rule
 
     ### 3.5.2 Configure nftables
     #### 3.5.2.1 Ensure nftables is installed (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -426,7 +426,7 @@ selections:
     - ufw_rules_for_open_ports
 
     #### 3.5.1.7 Ensure ufw default deny firewall policy (Automated)
-    # NEEDS RULE
+    - set_ufw_default_rule
 
     ### 3.5.2 Configure nftables ###
     #### 3.5.2.1 Ensure nftables is installed (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -423,7 +423,7 @@ selections:
     # Skip due to being a manual test
 
     #### 3.5.1.6 Ensure ufw firewall rules exist for all open ports (Automated)
-    # NEEDS RULE
+    - ufw_rules_for_open_ports
 
     #### 3.5.1.7 Ensure ufw default deny firewall policy (Automated)
     # NEEDS RULE

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -417,7 +417,7 @@ selections:
     - service_ufw_enabled
 
     #### 3.5.1.4 Ensure ufw loopback traffic is configured (Automated)
-    # NEEDS RULE
+    - set_ufw_loopback_traffic
 
     #### 3.5.1.5 Ensure ufw outbound connections are configured (Manual)
     # Skip due to being a manual test


### PR DESCRIPTION
#### Description:

- This PR adds a few rules related to UFW (Uncomplicated Firewall) for CIS on Ubuntu:
  - ufw_rules_for_open_ports
  - set_ufw_loopback_traffic
  - set_ufw_default_rule

#### Rationale:

- Those rules are needed for CIS on Ubuntu 22.04 and/or 20.04.