### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -133,7 +133,7 @@ jobs:
       - name: Install Deps
         run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck git python3-mypy python3-lxml
       - name: Install deps python
-        run: pip install ruamel.yaml yamlpath types-openpyxl types-PyYAML xmldiff openpyxl pandas
+        run: pip install ruamel.yaml yamlpath types-openpyxl types-PyYAML xmldiff openpyxl openpyxl-stubs pandas
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
@@ -183,7 +183,7 @@ jobs:
       -   name: Install Deps
           run: dnf install -y cmake make openscap-utils python3-pyyaml python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck python-mypy git
       -   name: Install deps python
-          run: pip install ruamel.yaml yamlpath types-openpyxl types-PyYAML openpyxl pandas
+          run: pip install ruamel.yaml yamlpath types-openpyxl types-PyYAML openpyxl openpyxl-stubs pandas
       -   name: Checkout
           uses: actions/checkout@v2
       -   name: Build

--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -214,7 +214,7 @@ apt-get install python3-mypy
 #### Type stubs
 
 ```bash
-pip install types-openpyxl types-PyYAML
+pip install types-openpyxl types-PyYAML openpyxl-stubs
 ```
 ## Downloading the source code
 

--- a/utils/import_srg_spreadsheet.py
+++ b/utils/import_srg_spreadsheet.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import re
 from pathlib import Path
+from typing import cast
 
 from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl import load_workbook
@@ -176,8 +177,8 @@ def main() -> None:
     full_name = get_full_name(args.root, args.product)
     changed_wb = load_workbook(args.changed)
     current_wb = load_workbook(args.current)
-    current_sheet = current_wb['Sheet']
-    changed_sheet = changed_wb['Sheet']
+    current_sheet = cast(Worksheet, current_wb['Sheet'])
+    changed_sheet = cast(Worksheet, changed_wb['Sheet'])
     common_set = get_common_set(changed_sheet, current_sheet, args.end_row)
 
     cac_cce_dict = get_cce_dict_to_row_dict(current_sheet, full_name, args.changed_name,


### PR DESCRIPTION
Fix broken CI on Fedora Latest and Fedora Rawhide GitHub Actions job caused by upgrade of the `types-openpyxl` PIP package to 3.0.4.7.

Addressing:

80/288 Test  #77: test-mypy .............................................................***Failed    5.60 sec
/__w/content/content/utils/srg_utils.py:37: error: Item "Tuple[Cell, ...]" of "Union[Cell, Tuple[Cell, ...]]" has no attribute "value"
/__w/content/content/utils/srg_utils.py:37: error: Incompatible types in assignment (expression has type "Union[str, float, datetime, None, Any]", variable has type "str")
