### PR TITLE
Add existent rules to Ubuntu 22.04 CIS profile

### DIFF
--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -28,6 +28,8 @@ identifiers:
 references:
     cis@rhel7: 2.2.1.3
     cis@rhel8: 2.2.1.2
+    cis@ubuntu2004: 2.1.1.1
+    cis@ubuntu2204: 2.1.2.3
     ism: 0988,1405
     srg: SRG-OS-000355-GPOS-00143
 
@@ -43,5 +45,7 @@ srg_requirement: '{{{ srg_requirement_service_enabled(service="chronyd") }}}'
 template:
     name: service_enabled
     vars:
-        servicename: chronyd
         packagename: chrony
+        servicename: chronyd
+        servicename@ubuntu2004: chrony
+        servicename@ubuntu2204: chrony

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,fedora,ol7,ol8,rhcos4,rhel7,rhel8,rhv4,sle12,sle15
 
 title: 'Enable the NTP Daemon'
 
@@ -49,8 +49,6 @@ identifiers:
 references:
     cis-csc: 1,14,15,16,3,5,6
     cis@rhel8: 2.2.1.1
-    cis@ubuntu2004: 2.2.1.1
-    cis@ubuntu2204: 2.2.1.1
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01
     cui: 3.3.7
     disa: CCI-000160

--- a/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_accepting_remote_messages/rsyslog_nolisten/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux3,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux3,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2204
 
 title: 'Ensure rsyslog Does Not Accept Remote Messages Unless Acting As Log Server'
 
@@ -38,6 +38,7 @@ references:
     cis@rhel9: 4.2.1.7
     cis@sle12: 4.2.1.6
     cis@sle15: 4.2.1.6
+    cis@ubuntu2204: 4.2.2.7
     cobit5: APO01.06,APO11.04,APO13.01,BAI03.05,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.05,DSS03.01,DSS05.02,DSS05.04,DSS05.07,DSS06.02,MEA02.01
     disa: CCI-000318,CCI-000366,CCI-000368,CCI-001812,CCI-001813,CCI-001814
     isa-62443-2009: 4.2.3.4,4.3.3.3.9,4.3.3.4,4.3.3.5.8,4.3.4.3.2,4.3.4.3.3,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4,4.4.3.3

--- a/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_local_var_log/rule.yml
@@ -34,6 +34,7 @@ references:
     cis@sle12: 4.2.3
     cis@sle15: 4.2.3
     cis@ubuntu2004: 4.2.3
+    cis@ubuntu2204: 4.2.3
     disa: CCI-001312
     nist: SI-11(a),SI-11(b),SI-11.1(iii)
     nist-csf: PR.AC-4,PR.DS-5

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -220,7 +220,7 @@ selections:
     # Needs variable: var_time_synchronization_daemon=chrony
     - package_chrony_installed
     # Needs rule: package_ntp_removed
-    - service_chronyd_or_ntpd_enabled
+    - service_chronyd_enabled
 
     #### 2.2.1.2 Ensure systemd-timesyncd is configured (Manual)
     # Needs rule: package_chrony_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -677,7 +677,8 @@ selections:
     - rsyslog_remote_loghost
 
     #### 4.2.2.7 Ensure rsyslog is not configured to receive logs from a remote client (Automated)
-    # NEEDS RULE
+    # This rule should be extended to consider rainerscript syntax
+    - rsyslog_nolisten
 
     ### 4.2.3 Ensure all logfiles have appropriate permissions and ownership (Automated)
     - permissions_local_var_log

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -239,7 +239,7 @@ selections:
     - chronyd_run_as_chrony_user
 
     #### 2.1.2.3 Ensure chrony is enabled and running (Automated)
-    # NEEDS RULE
+    - service_chronyd_enabled
 
     ### 2.1.3 Configure systemd-timesyncd ###
     #### 2.1.3.1 Ensure systemd-timesyncd configured with autorized timeserver (Manual)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -680,7 +680,7 @@ selections:
     # NEEDS RULE
 
     ### 4.2.3 Ensure all logfiles have appropriate permissions and ownership (Automated)
-    # NEEDS RULE
+    - permissions_local_var_log
 
     # 5 Access, Authentication and Authorization #
     ## 5.1 Configure time-based job schedulers ##


### PR DESCRIPTION
#### Description:

- Add a few existent rules to Ubuntu 22.04 CIS profile

#### Rationale:

- Those rules are needed on CIS for Ubuntu