### PR TITLE
OCP: Add OCP 4.13 support for applicable rules

### DIFF
--- a/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/rule.yml
@@ -27,7 +27,7 @@ identifiers:
   cce@ocp4: CCE-86390-2
 
 platforms:
-  - ocp4.11 or ocp4.12
+  - ocp4.11 or ocp4.12 or ocp4.13
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/tests/ocp4/4.13.yml
+++ b/applications/openshift/api-server/api_server_api_priority_v1beta2_flowschema_catch_all/tests/ocp4/4.13.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -33,7 +33,7 @@ identifiers:
   cce@ocp4: CCE-84080-1
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/tests/ocp4/4.13.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/tests/ocp4/4.13.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -33,7 +33,7 @@ identifiers:
   cce@ocp4: CCE-83591-8
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key/tests/ocp4/4.13.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/tests/ocp4/4.13.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -4,6 +4,12 @@ prodtype: ocp4
 
 title: 'Configure the OpenShift API Server Maximum Retained Audit Logs'
 
+{{% set custom_jqfilter = '.data."{{.var_openshift_apiserver_config_data_name}}" | fromjson' %}}
+{{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_apiserver_namespace}}/configmaps/{{.var_openshift_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-apiserver/configmaps/config' %}}
+{{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
+
 description: |-
     To configure how many rotations of audit logs are retained,
     edit the <tt>openshift-apiserver</tt> configmap
@@ -45,16 +51,17 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
     entity_check: "at least one"
-    filepath: /api/v1/namespaces/openshift-apiserver/configmaps/config
-    yamlpath: '.data["config.yaml"]'
+    filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
+    yamlpath: '.apiServerArguments["audit-log-maxbackup"][:]'
     values:
-    - value: '"apiServerArguments":{.*"audit-log-maxbackup":\["10"\]'
+    - value: '10'
       operation: "pattern match"
       type: "string"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -4,10 +4,10 @@ prodtype: ocp4
 
 title: 'Configure OpenShift API Server Maximum Audit Log Size'
 
-{{% set custom_jqfilter = '.data."{{.var_openshift_kube_apiserver_config_data_name}}" | fromjson' %}}
+{{% set custom_jqfilter = '.data."{{.var_openshift_apiserver_config_data_name}}" | fromjson' %}}
 {{% set default_jqfilter = '.data."config.yaml" | fromjson' %}}
-{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_kube_apiserver_namespace}}/configmaps/{{.var_openshift_kube_apiserver_config}}' %}}
-{{% set default_api_path = '/api/v1/namespaces/openshift-kube-apiserver/configmaps/config' %}}
+{{% set custom_api_path = '/api/v1/namespaces/{{.var_openshift_apiserver_namespace}}/configmaps/{{.var_openshift_apiserver_config}}' %}}
+{{% set default_api_path = '/api/v1/namespaces/openshift-apiserver/configmaps/config' %}}
 {{% set dump_path = default_api_path ~ ',' ~ default_jqfilter ~ ',' ~ custom_jqfilter %}}
 
 description: |-
@@ -51,17 +51,17 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_cluster_setting("/api/v1/namespaces/openshift-apiserver/configmaps/config") | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
+    entity_check: "at least one"
     filepath: {{{ openshift_filtered_path(default_api_path, default_jqfilter) }}}
     yamlpath: '.apiServerArguments["audit-log-maxsize"][:]'
-    xccdf_variable: var_apiserver_audit_log_maxsize
-    embedded_data: "true"
     values:
-    - value: '(.+)'
-      type: "string"
-      operation: "pattern match"
+    - value: 100
+      operation: "greater than or equal"
+      type: "int"
+      entity_check: "at least one"

--- a/applications/openshift/api-server/var_openshift_apiserver_config.var
+++ b/applications/openshift/api-server/var_openshift_apiserver_config.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift API Server config name'
+
+description: 'OpenShift API Server config name'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "config"

--- a/applications/openshift/api-server/var_openshift_apiserver_config_data_name.var
+++ b/applications/openshift/api-server/var_openshift_apiserver_config_data_name.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift API Server config data name'
+
+description: 'OpenShift API Server config data name'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "config.yaml"

--- a/applications/openshift/api-server/var_openshift_apiserver_namespace.var
+++ b/applications/openshift/api-server/var_openshift_apiserver_namespace.var
@@ -1,0 +1,14 @@
+documentation_complete: true
+
+title: 'OpenShift APIServer namespace'
+
+description: 'OpenShift APIServer namespace'
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: "openshift-apiserver"

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@ocp4: CCE-83396-2
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
 
 references:
     cis@ocp4: 4.2.10

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/tests/ocp4/4.13.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/tests/ocp4/4.13.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -26,7 +26,7 @@ identifiers:
     cce@ocp4: CCE-90614-9
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12
+  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
 
 references:
     cis@ocp4: 4.2.10

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/tests/ocp4/4.13.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/tests/ocp4/4.13.yml
@@ -1,0 +1,3 @@
+---
+default_result: PASS
+


### PR DESCRIPTION
We are adding ocp4.13 CPE to applicable rules so that they will be able to run on OCP 4.13.

Fix OpenShift API server check rules, they were checking the wrong path.
