### PR TITLE
Add some new iptables rules

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ubuntu2204
+
+title: 'Ensure ip6tables Firewall Rules Exist for All Open Ports'
+
+description: |-
+    Any ports that have been opened on non-loopback addresses
+    need firewall rules to govern traffic.
+
+rationale: |-
+    Without a firewall rule configured for open ports default
+    firewall policy will drop all packets to these ports.
+
+severity: medium
+
+references:
+    cis@ubuntu2204: 3.5.3.2.4
+
+ocil_clause: 'open ports are denied connection'
+
+ocil: |-
+    Run the following command to determine open ports:
+    <pre># ss -6tuln</pre>
+    Run the following command to determine firewall rules:
+    <pre># ip6tables -L INPUT -v -n</pre>
+    For each port identified in the audit which does not have a firewall
+    rule, add rule for accepting or denying inbound connections
+    <pre># ip6tables -A INPUT -p \<protocol\> --dport \<port\> -m state --state NEW -j ACCEPT</pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/sce/shared.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+result=$XCCDF_RESULT_PASS
+iptables_status="$(ip6tables -L INPUT -v -n)"
+
+while read -r lpn;
+do
+        if ! grep -Pq "dpt:$lpn" <<< "$iptables_status"; then
+                result=$XCCDF_RESULT_FAIL
+                break
+        fi
+done < <(ss -6tuln | awk '($5!~/%lo:/ && $5!~/127.0.0.1:/ && $5!~/::1/) {split($5, a, ":"); print a[2]}i' | sort | uniq)
+
+exit "$result"

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_rules_for_open_ports/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_rules_for_open_ports/rule.yml
@@ -1,0 +1,34 @@
+documentation_complete: true
+
+prodtype: ubuntu2204
+
+title: 'Ensure iptables Firewall Rules Exist for All Open Ports'
+
+description: |-
+    Any ports that have been opened on non-loopback addresses
+    need firewall rules to govern traffic.
+
+rationale: |-
+    Without a firewall rule configured for open ports default
+    firewall policy will drop all packets to these ports.
+
+severity: medium
+
+references:
+    cis@ubuntu2204: 3.5.3.2.4
+
+ocil_clause: 'open ports are denied connection'
+
+ocil: |-
+    Run the following command to determine open ports:
+    <pre># ss -4tuln</pre>
+    Run the following command to determine firewall rules:
+    <pre># iptables -L INPUT -v -n</pre>
+    For each port identified in the audit which does not have a firewall
+    rule, add rule for accepting or denying inbound connections
+    <pre># iptables -A INPUT -p <protocol> --dport <port> -m state --state NEW -j ACCEPT</pre>
+
+warnings:
+    - general: |-
+        Changing firewall settings while connected over network can
+        result in being locked out of the system.

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_rules_for_open_ports/sce/shared.sh
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_rules_for_open_ports/sce/shared.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+result=$XCCDF_RESULT_PASS
+iptables_status="$(iptables -L INPUT -v -n)"
+
+while read -r lpn;
+do
+        if ! grep -Pq "dpt:$lpn" <<< "$iptables_status"; then
+                result=$XCCDF_RESULT_FAIL
+                break
+        fi
+done < <(ss -4tuln | awk '($5!~/%lo:/ && $5!~/127.0.0.1:/ && $5!~/::1/) {split($5, a, ":"); print a[2]}i' | sort | uniq)
+
+exit "$result"

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -483,7 +483,7 @@ selections:
     # Skip due to being a manual test
 
     ##### 3.5.3.2.4 Ensure iptables firewall rules exist for all open ports (Automated)
-    # not manual anymore
+    - iptables_rules_for_open_ports
 
     #### 3.5.3.3 Configure IPv6 ip6tables ####
     ##### 3.5.3.3.1 Ensure ip6tables default deny firewall policy (Automated)
@@ -496,8 +496,7 @@ selections:
     # Skip due to being a manual test
 
     # 3.5.3.3.4 Ensure ip6tables firewall rules exist for all open ports (Automated)
-    # not manual anymore
-    # NEEDS RULE
+    - ip6tables_rules_for_open_ports
 
     # 4 Logging and Auditing #
     ## 4.1 Configure System Accounting (auditd) ##


### PR DESCRIPTION
#### Description:

- On CIS for Ubuntu 22.04 some previous iptables rules that were manual became automated. This is an attempt to provide some auditing through the SCE engine. There won't be remediation scripts or tests, as the remediation can cause disruption and there won't be an OVAL.

#### Rationale:

- The rules are needed on CIS for Ubuntu 22.04.