### PR TITLE
OCP4 STIG: Add status justification and artifact description to two rules covering IA-11

### DIFF
--- a/controls/srg_ctr/SRG-APP-000389-CTR-000925.yml
+++ b/controls/srg_ctr/SRG-APP-000389-CTR-000925.yml
@@ -5,3 +5,12 @@ controls:
   title: {{{ full_name }}} must require users to reauthenticate when organization-defined
     circumstances or situations require reauthentication.
   status: inherently met
+  artifact_description: |-
+    Supporting evidence is in the following documentation
+
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+  status_justification: |-
+    The OpenShift Container Platform does not required a user to re-authenticate when changes to the RBAC policy, or permissions to a service/object change in the system.  These changes are applied and effective immediately and do not require the user to first logout.
+
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+

--- a/controls/srg_ctr/SRG-APP-000390-CTR-000930.yml
+++ b/controls/srg_ctr/SRG-APP-000390-CTR-000930.yml
@@ -5,3 +5,12 @@ controls:
   title: {{{ full_name }}} must require devices to reauthenticate when organization-defined
     circumstances or situations requiring reauthentication.
   status: inherently met
+  artifact_description: |-
+    Supporting evidence is in the following documentation
+
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+  status_justification: |-
+    The OpenShift Container Platform does not required a user/device to re-authenticate when changes to the RBAC policy, or permissions to a service/object change in the system.  These changes are applied and effective immediately and do not require the user/device to first logout.
+
+    https://docs.openshift.com/container-platform/latest/authentication/using-rbac.html
+


### PR DESCRIPTION
#### Description:

- The IA family is mostly covered by setting up the IDP, this commit just adds
  artifact description and status justification to two rules in the IA-11 family.

#### Rationale:

- OCP4 stig

#### Review Hints:

- I will post the link to the SRG export later
