### PR TITLE
OCP4 STIG: Add status justification to SRG-APP-000178-CTR-000470, covering IA-6

### DIFF
--- a/controls/srg_ctr/SRG-APP-000178-CTR-000470.yml
+++ b/controls/srg_ctr/SRG-APP-000178-CTR-000470.yml
@@ -6,3 +6,15 @@ controls:
     during the authentication process to protect the information from possible exploitation/use
     by unauthorized individuals.
   status: inherently met
+  artifact_description: |-
+    Supporting evidence is in the following documentation
+
+    https://docs.openshift.com/container-platform/latest/authentication/index.html
+  status_justification: |-
+    The OpenShift Container Platform's web console hides the user's
+    password as it is typed in. The CLI interface also hides the password as it is typed
+    via standard input on the console.  To access the API server a user must first authenticate
+    and obtain an OAuth token (or a x.509 certificate) in order send requests to the
+    API server. In this way, the user's authentication credentials (username/password)
+    are protected from discovery.
+


### PR DESCRIPTION
#### Description:

- The IA family is mostly covered by setting up the IDP, this commit just adds
  artifact description and status justification to two rules in the IA-11 family

#### Rationale:

- OCP4 STIG

#### Review Hints:

- I will post a link to the SRG export later
