### PR TITLE
Add new rule rsyslog_filecreatemode

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_files_permissions/rule.yml
@@ -42,7 +42,6 @@ references:
     cis@rhel9: 4.2.3
     cis@sle12: 4.2.1.3
     cis@sle15: 4.2.1.3
-    cis@ubuntu2004: 4.2.1.4
     disa: CCI-001314
     ism: 0988,1405
     nerc-cip: CIP-003-8 R5.1.1,CIP-003-8 R5.3,CIP-004-6 R2.3,CIP-007-3 R2.1,CIP-007-3 R2.2,CIP-007-3 R2.3,CIP-007-3 R5.1,CIP-007-3 R5.1.1,CIP-007-3 R5.1.2

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
@@ -1,0 +1,7 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_package_install("rsyslog") }}}
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
@@ -1,5 +1,27 @@
+#!/bin/bash
 # platform = multi_platform_all
 
-sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
-echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+readarray -t targets < <(grep -H '^\s*$FileCreateMode' /etc/rsyslog.conf /etc/rsyslog.d/*)
+
+# if $FileCreateMode set in multiple places
+if [ ${#targets[@]} -gt 1 ]; then
+    # delete all and create new entry with expected value
+    sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+    echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+# if $FileCreateMode set in only one place
+elif [ "${#targets[@]}" -eq 1 ]; then
+    filename=$(echo "${targets[0]}" | cut -d':' -f1)
+    value=$(echo "${targets[0]}" | cut -d' ' -f2)
+    #convert to decimal and bitwise or operation
+    result=$((8#"$value" | 416))
+    # if more permissive than expected, then set it to 0640
+    if [ $result -ne 416 ]; then
+        # if value is wrong remove it
+        sed -i '/^\s*$FileCreateMode/d' $filename
+        echo '$FileCreateMode 0640' > $filename
+    fi
+else
+    echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+fi
+
 systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/bash/shared.sh
@@ -1,6 +1,4 @@
-# platform = multi_platform_ubuntu
-
-{{{ bash_package_install("rsyslog") }}}
+# platform = multi_platform_all
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
 echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
@@ -1,107 +1,57 @@
 <def-group>
   <definition class="compliance" id="{{{ rule_id }}}" version="1">
-    {{{ oval_metadata("rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files.") }}}
-    <criteria operator="ONE">
-      <criteria operator="AND">
-        <criterion test_ref="tst_filecreatemode_for_rsyslog_conf" comment="rsyslog filecreatemode configured in /etc/rsyslog.conf" />
-        <criterion test_ref="tst_filecreatemode_valid_rsyslog_conf" comment="rsyslog filecreatemode from /etc/rsyslog.conf is valid" />
-      </criteria>
-      <criteria operator="AND">
-        <criterion test_ref="tst_filecreatemode_for_rsyslog_d" comment="rsyslog filecreatemode configured in /etc/rsyslog.d/*" />
-        <criterion test_ref="tst_filecreatemode_valid_rsyslog_d" comment="rsyslog filecreatemode from /etc/rsyslog.d/* is valid" />
-      </criteria>
+    {{{ oval_metadata("FileCreateMode setting controls permissions applied to newly created files.") }}}
+    <criteria operator="AND">
+      <criterion test_ref="tst_filecreatemode_declared"
+          comment="filecreatemode declared in either /etc/rsyslog.conf or /etc/rsyslog.d/*"/>
+      <criterion test_ref="tst_filecreatemode_valid"
+          comment="filecreatemode value is valid" />
     </criteria>
   </definition>
 
-  <!-- Test /etc/rsyslog.d/* -->
-  <ind:textfilecontent54_test check="all" id="tst_filecreatemode_for_rsyslog_conf" version="1"
-      comment="rsyslog filecreatemode configured in /etc/rsyslog.conf">
-    <ind:object object_ref="obj_filecreatemode_for_rsyslog_conf" />
+  <ind:textfilecontent54_test id="tst_filecreatemode_declared"
+      version="1" comment="rsyslog filecreatemode configured"
+      check="all" check_existence="only_one_exists">
+    <ind:object object_ref="obj_filecreatemode" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_filecreatemode_for_rsyslog_conf" version="1">
-    <ind:filepath datatype="string">/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match" datatype="string">^\$FileCreateMode\s+(\d+)</ind:pattern>
+  <ind:textfilecontent54_object id="obj_filecreatemode" version="1">
+    <ind:filepath operation="pattern match">\/etc\/rsyslog(\.conf|\.d\/.*\.conf)</ind:filepath>
+    <ind:pattern operation="pattern match">^\$FileCreateMode\s+(\d+)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <local_variable id="var_filecreatemode_int_rsyslog_conf"
+  <local_variable id="var_filecreatemode_dec"
       comment="decimal conversion of octal filecreatemode"
       version="1" datatype="int">
     <arithmetic arithmetic_operation="add">
       <arithmetic arithmetic_operation="multiply">
         <literal_component datatype="int">64</literal_component>
         <regex_capture pattern="\d(\d)\d\d">
-          <object_component object_ref="obj_filecreatemode_for_rsyslog_conf" item_field="subexpression" />
+          <object_component object_ref="obj_filecreatemode" item_field="subexpression" />
         </regex_capture>
       </arithmetic>
       <arithmetic arithmetic_operation="multiply">
         <literal_component datatype="int">8</literal_component>
         <regex_capture pattern="\d\d(\d)\d">
-          <object_component object_ref="obj_filecreatemode_for_rsyslog_conf" item_field="subexpression" />
+          <object_component object_ref="obj_filecreatemode" item_field="subexpression" />
         </regex_capture>
       </arithmetic>
       <regex_capture pattern="\d\d\d(\d)">
-        <object_component object_ref="obj_filecreatemode_for_rsyslog_conf" item_field="subexpression" />
+        <object_component object_ref="obj_filecreatemode" item_field="subexpression" />
       </regex_capture>
     </arithmetic>
   </local_variable>
 
-  <ind:variable_test id="tst_filecreatemode_valid_rsyslog_conf" version="1"
-      comment="Test if filecreatemode from /etc/rsyslog.conf is valid" check="all">
-    <ind:object object_ref="obj_filecreatemode_int_rsyslog_conf" />
+  <ind:variable_test id="tst_filecreatemode_valid" version="1"
+      comment="Test if filecreatemode value is valid" check="all">
+    <ind:object object_ref="obj_filecreatemode_dec" />
     <ind:state state_ref="ste_correct_permissions" />
   </ind:variable_test>
 
-  <ind:variable_object id="obj_filecreatemode_int_rsyslog_conf" version="1">
-    <ind:var_ref>var_filecreatemode_int_rsyslog_conf</ind:var_ref>
+  <ind:variable_object id="obj_filecreatemode_dec" version="1">
+    <ind:var_ref>var_filecreatemode_dec</ind:var_ref>
   </ind:variable_object>
-
-  <!-- Test /etc/rsyslog.d/* -->
-  <ind:textfilecontent54_test check="all" id="tst_filecreatemode_for_rsyslog_d" version="1"
-      comment="rsyslog filecreatemode configured in /etc/rsyslog.d/*">
-    <ind:object object_ref="obj_filecreatemode_for_rsyslog_d" />
-  </ind:textfilecontent54_test>
-
-  <ind:textfilecontent54_object id="obj_filecreatemode_for_rsyslog_d" version="1">
-    <ind:path datatype="string">/etc/rsyslog.d/</ind:path>
-    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match" datatype="string">^\$FileCreateMode\s+(\d+)</ind:pattern>
-    <ind:instance datatype="int">1</ind:instance>
-  </ind:textfilecontent54_object>
-
-  <local_variable id="var_filecreatemode_int_rsyslog_d"
-      comment="decimal conversion of octal filecreatemode"
-      version="1" datatype="int">
-    <arithmetic arithmetic_operation="add">
-      <arithmetic arithmetic_operation="multiply">
-        <literal_component datatype="int">64</literal_component>
-        <regex_capture pattern="\d(\d)\d\d">
-          <object_component object_ref="obj_filecreatemode_for_rsyslog_d" item_field="subexpression" />
-        </regex_capture>
-      </arithmetic>
-      <arithmetic arithmetic_operation="multiply">
-        <literal_component datatype="int">8</literal_component>
-        <regex_capture pattern="\d\d(\d)\d">
-          <object_component object_ref="obj_filecreatemode_for_rsyslog_d" item_field="subexpression" />
-        </regex_capture>
-      </arithmetic>
-      <regex_capture pattern="\d\d\d(\d)">
-        <object_component object_ref="obj_filecreatemode_for_rsyslog_d" item_field="subexpression" />
-      </regex_capture>
-    </arithmetic>
-  </local_variable>
-
-  <ind:variable_test id="tst_filecreatemode_valid_rsyslog_d" version="1"
-      comment="Test if filecreatemode from /etc/rsyslog.d/* is valid" check="all">
-    <ind:object object_ref="obj_filecreatemode_int_rsyslog_d" />
-    <ind:state state_ref="ste_correct_permissions" />
-  </ind:variable_test>
-
-  <ind:variable_object id="obj_filecreatemode_int_rsyslog_d" version="1">
-    <ind:var_ref>var_filecreatemode_int_rsyslog_d</ind:var_ref>
-  </ind:variable_object>
-
 
   <!-- state to compare to -->
   <ind:variable_state id="ste_correct_permissions" version="1">

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
@@ -3,26 +3,26 @@
     {{{ oval_metadata("FileCreateMode setting controls permissions applied to newly created files.") }}}
     <criteria operator="AND">
       <criterion test_ref="tst_filecreatemode_declared"
-          comment="filecreatemode declared in either /etc/rsyslog.conf or /etc/rsyslog.d/*"/>
+          comment="FileCreateMode declared once in either /etc/rsyslog.conf or /etc/rsyslog.d/*"/>
       <criterion test_ref="tst_filecreatemode_valid"
-          comment="filecreatemode value is valid" />
+          comment="FileCreateMode value is valid"/>
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test id="tst_filecreatemode_declared"
-      version="1" comment="rsyslog filecreatemode configured"
+      version="1" comment="rsyslog FileCreateMode is configured in only one place"
       check="all" check_existence="only_one_exists">
     <ind:object object_ref="obj_filecreatemode" />
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_filecreatemode" version="1">
-    <ind:filepath operation="pattern match">\/etc\/rsyslog(\.conf|\.d\/.*\.conf)</ind:filepath>
+    <ind:filepath operation="pattern match">^\/etc\/rsyslog(\.conf|\.d\/.*\.conf)$</ind:filepath>
     <ind:pattern operation="pattern match">^\$FileCreateMode\s+(\d+)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <local_variable id="var_filecreatemode_dec"
-      comment="decimal conversion of octal filecreatemode"
+      comment="decimal conversion of octal value from FileCreateMode parameter"
       version="1" datatype="int">
     <arithmetic arithmetic_operation="add">
       <arithmetic arithmetic_operation="multiply">
@@ -44,9 +44,9 @@
   </local_variable>
 
   <ind:variable_test id="tst_filecreatemode_valid" version="1"
-      comment="Test if filecreatemode value is valid" check="all">
+      comment="Test if FileCreateMode value is valid" check="all">
     <ind:object object_ref="obj_filecreatemode_dec" />
-    <ind:state state_ref="ste_correct_permissions" />
+    <ind:state state_ref="ste_filecreatemode_is_0640_or_stricter" />
   </ind:variable_test>
 
   <ind:variable_object id="obj_filecreatemode_dec" version="1">
@@ -54,9 +54,8 @@
   </ind:variable_object>
 
   <!-- state to compare to -->
-  <ind:variable_state id="ste_correct_permissions" version="1">
+  <ind:variable_state id="ste_filecreatemode_is_0640_or_stricter" version="1">
     <!-- MODE octal 640 converted to decimal: 6 * 64 + 4 * 8 + 0 = 416 -->
     <ind:value operation="bitwise or" datatype="int">416</ind:value>
   </ind:variable_state>
-
 </def-group>

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/oval/shared.xml
@@ -1,0 +1,112 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("rsyslog will create logfiles that do not already exist on the system. This setting controls what permissions will be applied to these newly created files.") }}}
+    <criteria operator="ONE">
+      <criteria operator="AND">
+        <criterion test_ref="tst_filecreatemode_for_rsyslog_conf" comment="rsyslog filecreatemode configured in /etc/rsyslog.conf" />
+        <criterion test_ref="tst_filecreatemode_valid_rsyslog_conf" comment="rsyslog filecreatemode from /etc/rsyslog.conf is valid" />
+      </criteria>
+      <criteria operator="AND">
+        <criterion test_ref="tst_filecreatemode_for_rsyslog_d" comment="rsyslog filecreatemode configured in /etc/rsyslog.d/*" />
+        <criterion test_ref="tst_filecreatemode_valid_rsyslog_d" comment="rsyslog filecreatemode from /etc/rsyslog.d/* is valid" />
+      </criteria>
+    </criteria>
+  </definition>
+
+  <!-- Test /etc/rsyslog.d/* -->
+  <ind:textfilecontent54_test check="all" id="tst_filecreatemode_for_rsyslog_conf" version="1"
+      comment="rsyslog filecreatemode configured in /etc/rsyslog.conf">
+    <ind:object object_ref="obj_filecreatemode_for_rsyslog_conf" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_filecreatemode_for_rsyslog_conf" version="1">
+    <ind:filepath datatype="string">/etc/rsyslog.conf</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">^\$FileCreateMode\s+(\d+)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_filecreatemode_int_rsyslog_conf"
+      comment="decimal conversion of octal filecreatemode"
+      version="1" datatype="int">
+    <arithmetic arithmetic_operation="add">
+      <arithmetic arithmetic_operation="multiply">
+        <literal_component datatype="int">64</literal_component>
+        <regex_capture pattern="\d(\d)\d\d">
+          <object_component object_ref="obj_filecreatemode_for_rsyslog_conf" item_field="subexpression" />
+        </regex_capture>
+      </arithmetic>
+      <arithmetic arithmetic_operation="multiply">
+        <literal_component datatype="int">8</literal_component>
+        <regex_capture pattern="\d\d(\d)\d">
+          <object_component object_ref="obj_filecreatemode_for_rsyslog_conf" item_field="subexpression" />
+        </regex_capture>
+      </arithmetic>
+      <regex_capture pattern="\d\d\d(\d)">
+        <object_component object_ref="obj_filecreatemode_for_rsyslog_conf" item_field="subexpression" />
+      </regex_capture>
+    </arithmetic>
+  </local_variable>
+
+  <ind:variable_test id="tst_filecreatemode_valid_rsyslog_conf" version="1"
+      comment="Test if filecreatemode from /etc/rsyslog.conf is valid" check="all">
+    <ind:object object_ref="obj_filecreatemode_int_rsyslog_conf" />
+    <ind:state state_ref="ste_correct_permissions" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_filecreatemode_int_rsyslog_conf" version="1">
+    <ind:var_ref>var_filecreatemode_int_rsyslog_conf</ind:var_ref>
+  </ind:variable_object>
+
+  <!-- Test /etc/rsyslog.d/* -->
+  <ind:textfilecontent54_test check="all" id="tst_filecreatemode_for_rsyslog_d" version="1"
+      comment="rsyslog filecreatemode configured in /etc/rsyslog.d/*">
+    <ind:object object_ref="obj_filecreatemode_for_rsyslog_d" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_filecreatemode_for_rsyslog_d" version="1">
+    <ind:path datatype="string">/etc/rsyslog.d/</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match" datatype="string">^\$FileCreateMode\s+(\d+)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <local_variable id="var_filecreatemode_int_rsyslog_d"
+      comment="decimal conversion of octal filecreatemode"
+      version="1" datatype="int">
+    <arithmetic arithmetic_operation="add">
+      <arithmetic arithmetic_operation="multiply">
+        <literal_component datatype="int">64</literal_component>
+        <regex_capture pattern="\d(\d)\d\d">
+          <object_component object_ref="obj_filecreatemode_for_rsyslog_d" item_field="subexpression" />
+        </regex_capture>
+      </arithmetic>
+      <arithmetic arithmetic_operation="multiply">
+        <literal_component datatype="int">8</literal_component>
+        <regex_capture pattern="\d\d(\d)\d">
+          <object_component object_ref="obj_filecreatemode_for_rsyslog_d" item_field="subexpression" />
+        </regex_capture>
+      </arithmetic>
+      <regex_capture pattern="\d\d\d(\d)">
+        <object_component object_ref="obj_filecreatemode_for_rsyslog_d" item_field="subexpression" />
+      </regex_capture>
+    </arithmetic>
+  </local_variable>
+
+  <ind:variable_test id="tst_filecreatemode_valid_rsyslog_d" version="1"
+      comment="Test if filecreatemode from /etc/rsyslog.d/* is valid" check="all">
+    <ind:object object_ref="obj_filecreatemode_int_rsyslog_d" />
+    <ind:state state_ref="ste_correct_permissions" />
+  </ind:variable_test>
+
+  <ind:variable_object id="obj_filecreatemode_int_rsyslog_d" version="1">
+    <ind:var_ref>var_filecreatemode_int_rsyslog_d</ind:var_ref>
+  </ind:variable_object>
+
+
+  <!-- state to compare to -->
+  <ind:variable_state id="ste_correct_permissions" version="1">
+    <!-- MODE octal 640 converted to decimal: 6 * 64 + 4 * 8 + 0 = 416 -->
+    <ind:value operation="bitwise or" datatype="int">416</ind:value>
+  </ind:variable_state>
+
+</def-group>

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/rule.yml
@@ -1,0 +1,37 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure rsyslog Default File Permissions Configured'
+
+description: |-
+    rsyslog will create logfiles that do not already exist on the system.
+    This settings controls what permissions will be applied to these newly
+    created files.
+
+rationale: |-
+    It is important to ensure that log files have the correct permissions
+    to ensure that sensitive data is archived and protected.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 4.2.1.4
+    cis@ubuntu2204: 4.2.2.4
+
+ocil_clause: '$FileCreateMode is not set or more permissive than 0640'
+
+ocil: |-
+    Run the following command:
+    <pre># grep ^\$FileCreateMode /etc/rsyslog.conf /etc/rsyslog.d/*.conf</pre>
+    Verify the output matches:
+    <pre>$FileCreateMode 0640</pre>
+    Should a site policy dictate less restrictive permissions, ensure to follow
+    said policy.
+
+fixtext: |-
+    Edit either `/etc/rsyslog.conf` or a dedicated .conf file in `/etc/rsyslog.d/`
+    and set $FileCreateMode to 0640 or more restrictive:
+    $FileCreateMode 0640
+    Restart the service:
+    # systemctl restart rsyslog

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/rule.yml
@@ -19,7 +19,7 @@ references:
     cis@ubuntu2004: 4.2.1.4
     cis@ubuntu2204: 4.2.2.4
 
-ocil_clause: '$FileCreateMode is not set or more permissive than 0640'
+ocil_clause: '$FileCreateMode is not set or is more permissive than 0640'
 
 ocil: |-
     Run the following command:

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0600.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+echo '$FileCreateMode 0600' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0601.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+echo '$FileCreateMode 0601' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0640.pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+echo '$FileCreateMode 0755' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_0755.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_duplicate.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+echo '$FileCreateMode 0640' > /etc/rsyslog.d/99-rsyslog_filecreatemode.conf
+echo '$FileCreateMode 0640' >> /etc/rsyslog.conf
+systemctl restart rsyslog.service

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# platform = multi_platform_ubuntu
 # packages = rsyslog
 
 sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*

--- a/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_filecreatemode/tests/filecreatemode_missing.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# packages = rsyslog
+
+sed -i '/^\s*$FileCreateMode/d' /etc/rsyslog.conf /etc/rsyslog.d/*
+systemctl restart rsyslog.service

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -553,7 +553,7 @@ selections:
     # Skip due to being a manual test
 
     #### 4.2.1.4 Ensure rsyslog default file permissions configured (Automated)
-    - rsyslog_files_permissions
+    - rsyslog_filecreatemode
 
     #### 4.2.1.5 Ensure rsyslog is configured to send logs to a remote log host (Automated)
     - rsyslog_remote_loghost

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -666,8 +666,7 @@ selections:
     # Skip due to being a manual test
 
     #### 4.2.2.4 Ensure rsyslog default file permissions are configured (Automated)
-    # not manual anymore
-    # NEEDS RULE
+    - rsyslog_filecreatemode
 
     #### 4.2.2.5 Ensure logging is configured (Manual)
     # Skip due to being a manual test


### PR DESCRIPTION
#### Description:

- This rule has been missing for a while and should solve issue #7332 
- This PR won't include ansible remediation, I expect other vendors will properly implement it.

#### Rationale:

- This rule is needed for CIS on Ubuntu, RHEL and SLES as far as I know, might be needed for other vendors as well.