### PR TITLE
Changes in bash remediation for accounts_password_set_max_life_existi…

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -10,7 +10,7 @@
 while IFS= read -r line; do
     user=$(echo "$line" | cut -d ":" -f 1)
     cur_max_age=$(echo "$line" | cut -d ":" -f 5)
-    if [ -z "$cur_max_age" ] || [ $((cur_max_age)) >  $((var_accounts_maximum_age_login_defs)) ]
+    if [ -z "$cur_max_age" ] || [ $((cur_max_age)) -gt  $((var_accounts_maximum_age_login_defs)) ]
     then
        passwd -q -x $var_accounts_maximum_age_login_defs $user
     fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -7,11 +7,14 @@
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
 {{% if product in ["sle12", "sle15"] %}}
-usrs_max_pass_age=( "$(awk -F: '$5 > $var_accounts_maximum_age_login_defs || $5 == "" {print $1}' /etc/shadow)" )
-for i in "${usrs_max_pass_age[@]}"
-do
-  passwd -q -x $((var_accounts_maximum_age_login_defs)) $i
-done
+while IFS= read -r line; do
+    user=$(echo "$line" | cut -d ":" -f 1)
+    cur_max_age=$(echo "$line" | cut -d ":" -f 5)
+    if [ -z "$cur_max_age" ] || [ $((cur_max_age)) >  $((var_accounts_maximum_age_login_defs)) ]
+    then
+       passwd -q -x $var_accounts_maximum_age_login_defs $user
+    fi
+done < /etc/shadow
 {{% else %}}
 {{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_maximum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($5 > var || $5 == \"\")) {print $1}' /etc/shadow") -%}}
 chage -M $var_accounts_maximum_age_login_defs $i

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/bash/shared.sh
@@ -6,17 +6,10 @@
 
 {{{ bash_instantiate_variables("var_accounts_maximum_age_login_defs") }}}
 
-{{% if product in ["sle12", "sle15"] %}}
-while IFS= read -r line; do
-    user=$(echo "$line" | cut -d ":" -f 1)
-    cur_max_age=$(echo "$line" | cut -d ":" -f 5)
-    if [ -z "$cur_max_age" ] || [ $((cur_max_age)) -gt  $((var_accounts_maximum_age_login_defs)) ]
-    then
-       passwd -q -x $var_accounts_maximum_age_login_defs $user
-    fi
-done < /etc/shadow
-{{% else %}}
 {{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_maximum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($5 > var || $5 == \"\")) {print $1}' /etc/shadow") -%}}
+{{% if product in ["sle12", "sle15"] %}}
+passwd -q -x $var_accounts_maximum_age_login_defs $i
+{{% else %}}
 chage -M $var_accounts_maximum_age_login_defs $i
-{{%- endcall %}}
 {{% endif %}}
+{{%- endcall %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -6,17 +6,10 @@
 
 {{{ bash_instantiate_variables("var_accounts_minimum_age_login_defs") }}}
 
-{{% if product in ["sle12", "sle15"] %}}
-while IFS= read -r line; do
-    user=$(echo "$line" | cut -d ":" -f 1)
-    cur_min_age=$(echo "$line" | cut -d ":" -f 4)
-    if [ -z "$cur_min_age" ] || [ $((var_accounts_minimum_age_login_defs)) -gt $((cur_min_age))  ]
-    then
-       passwd -q -n $var_accounts_minimum_age_login_defs $user
-    fi
-done < /etc/shadow
-{{% else %}}
 {{% call iterate_over_command_output("i", "awk -v var=\"$var_accounts_minimum_age_login_defs\" -F: '(/^[^:]+:[^!*]/ && ($4 < var || $4 == \"\")) {print $1}' /etc/shadow") -%}}
+{{% if product in ["sle12", "sle15"] %}}
+passwd -q -n $var_accounts_minimum_age_login_defs $i
+{{% else %}}
 chage -m $var_accounts_minimum_age_login_defs $i
-{{%- endcall %}}
 {{% endif %}}
+{{%- endcall %}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -10,7 +10,7 @@
 while IFS= read -r line; do
     user=$(echo "$line" | cut -d ":" -f 1)
     cur_min_age=$(echo "$line" | cut -d ":" -f 4)
-    if [ -z "$cur_min_age" ] || [ $((var_accounts_minimum_age_login_defs)) > $((cur_min_age))  ]
+    if [ -z "$cur_min_age" ] || [ $((var_accounts_minimum_age_login_defs)) -gt $((cur_min_age))  ]
     then
        passwd -q -n $var_accounts_minimum_age_login_defs $user
     fi


### PR DESCRIPTION
…ng and accounts_password_set_min_life_existing

#### Description:

- _Correction in bash remediation in accounts_password_set_max_life_existing and accounts_password_set_min_life_existing_

#### Rationale:

- Existing version does not manage correctly all user. For example when user account has minimum age 0 

Notes: Please address my message to Marcus Burghardt as developer of OVAL and Ansible parts for both rules.
1/
I think that both parts (Ansible and OVAL for both rules) need corrections, because ansible parts do not apply min/max age for all users. 
On my test host they changed parameters for root and vagrant users, but not for users which have empty definitions for the age of their accounts.
When I applied ansible remediation for min_life - audit check had status pass - despite of the fact that only of two users min_age parameter was changed - i.e. OVAL part is not correct
When I applied ansible remediation for max_life - audit check had status fail   
2/
The usage of awk - makes the code shorter, but in some cases I had issue to find users which have min_age 0 and to correct this value to the new one.


