### PR TITLE
Update password hashing algorithm CIS requirement

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1959,9 +1959,12 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    status: partial # our rule does not check for password-auth
+    status: automated
     rules:
-    - set_password_hashing_algorithm_systemauth
+      - set_password_hashing_algorithm_systemauth
+      - set_password_hashing_algorithm_passwordauth
+      - set_password_hashing_algorithm_logindefs
+      - var_password_hashing_algorithm=SHA512
 
   - id: 5.4.4
     title: Ensure password reuse is limited (Automated)

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -2275,6 +2275,8 @@ controls:
     rules:
       - set_password_hashing_algorithm_systemauth
       - set_password_hashing_algorithm_passwordauth
+      - set_password_hashing_algorithm_logindefs
+      - var_password_hashing_algorithm=SHA512
 
   - id: 5.6.1.1
     title: Ensure password expiration is 365 days or less (Automated)

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -2126,6 +2126,8 @@ controls:
     rules:
       - set_password_hashing_algorithm_systemauth
       - set_password_hashing_algorithm_passwordauth
+      - set_password_hashing_algorithm_logindefs
+      - var_password_hashing_algorithm=SHA512
 
   - id: 5.6.1.1
     title: Ensure password expiration is 365 days or less (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_logindefs/rule.yml
@@ -28,6 +28,9 @@ identifiers:
 references:
     anssi: BP28(R32)
     cis-csc: 1,12,15,16,5
+    cis@rhel7: 5.4.3
+    cis@rhel8: 5.5.4
+    cis@rhel9: 5.5.4
     cis@sle12: 5.4.1.1
     cis@sle15: 5.4.1.1
     cis@ubuntu2204: 5.4.4


### PR DESCRIPTION
#### Description:

The `5.4.3` requirement for `RHEL7` is now automated.
The `5.5.4` requirement for `RHEL8 and RHEL9` is now better aligned to the benchmark since newer versions also mention the `/etc/login.defs` file.

#### Rationale:

Better CIS coverage for RHEL.