### PR TITLE
Corrections in rule chronyd_specify_remote_server

### DIFF
--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -573,6 +573,8 @@ controls:
     rules:
     - chronyd_specify_remote_server
     - chronyd_run_as_chrony_user
+    - var_multiple_time_servers=suse
+
 
   - id: 2.2.1.4
     title: Ensure ntp is configured (Automated)

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -571,6 +571,7 @@ controls:
     rules:
       - chronyd_specify_remote_server
       - chronyd_run_as_chrony_user
+      - var_multiple_time_servers=suse
 
   - id: 2.2.2
     title: Ensure X11 Server components are not installed (Automated)

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/ansible/shared.yml
@@ -5,18 +5,41 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_multiple_time_servers") }}}
 
-- name: "Detect if chrony is already configured with pools or servers"
-  find:
-    path: /etc
-    patterns: chrony.conf
-    contains: '^[\s]*(?:server|pool)[\s]+[\w]+'
-  register: chrony_servers
+- name: {{{ rule_title }}} Remove file for remediation
+  ansible.builtin.file:
+    path: ~/set_time_servers.sh
+    state: absent
 
-- name: "Configure remote time servers"
-  lineinfile:
-    path: {{{ chrony_conf_path }}}
-    line: 'server {{ item }}'
-    state: present
-    create: True
-  loop: '{{ var_multiple_time_servers.split(",") }}'
-  when: chrony_servers.matched == 0
+- name: {{{ rule_title }}} Generation of script for remediation
+  ansible.builtin.copy:
+    dest: "~/set_time_servers.sh"
+    content: |
+      #!/bin/bash
+
+      var_multiple_time_servers='{{var_multiple_time_servers}}'
+      config_file="{{{ chrony_conf_path }}}"
+
+      IFS="," read -a SERVERS <<< $var_multiple_time_servers
+      for srv in "${SERVERS[@]}"
+      do
+        NTP_SRV=$(grep -w $srv $config_file)
+        if [[ ! "$NTP_SRV" == "server "* ]]
+        then
+          time_server="server $srv"
+          echo $time_server >> "$config_file"
+        fi
+      done
+
+- name: {{{ rule_title }}} - Change mode of file for remediation
+  ansible.builtin.file:
+    path: ~/set_time_servers.sh
+    state: touch
+    mode: u=rwx,g=rx,o=rx
+
+- name: {{{ rule_title }}} - Apply remediation
+  ansible.builtin.command: sh ~/set_time_servers.sh
+
+- name: {{{ rule_title }}} - Remove file for remediation
+  ansible.builtin.file:
+    path: ~/set_time_servers.sh
+    state: absent

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/ansible/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/ansible/shared.yml
@@ -5,41 +5,11 @@
 # disruption = low
 {{{ ansible_instantiate_variables("var_multiple_time_servers") }}}
 
-- name: {{{ rule_title }}} Remove file for remediation
-  ansible.builtin.file:
-    path: ~/set_time_servers.sh
-    state: absent
-
-- name: {{{ rule_title }}} Generation of script for remediation
-  ansible.builtin.copy:
-    dest: "~/set_time_servers.sh"
-    content: |
-      #!/bin/bash
-
-      var_multiple_time_servers='{{var_multiple_time_servers}}'
-      config_file="{{{ chrony_conf_path }}}"
-
-      IFS="," read -a SERVERS <<< $var_multiple_time_servers
-      for srv in "${SERVERS[@]}"
-      do
-        NTP_SRV=$(grep -w $srv $config_file)
-        if [[ ! "$NTP_SRV" == "server "* ]]
-        then
-          time_server="server $srv"
-          echo $time_server >> "$config_file"
-        fi
-      done
-
-- name: {{{ rule_title }}} - Change mode of file for remediation
-  ansible.builtin.file:
-    path: ~/set_time_servers.sh
-    state: touch
-    mode: u=rwx,g=rx,o=rx
-
-- name: {{{ rule_title }}} - Apply remediation
-  ansible.builtin.command: sh ~/set_time_servers.sh
-
-- name: {{{ rule_title }}} - Remove file for remediation
-  ansible.builtin.file:
-    path: ~/set_time_servers.sh
-    state: absent
+- name: {{{ rule_title }}} - Add missing / update wrong records for time servers
+  ansible.builtin.lineinfile:
+    path: {{{ chrony_conf_path }}}
+    regexp: '^\s*\bserver\b\s*\b{{ item }}\b$'
+    state: present
+    line: 'server {{ item }}'
+  with_items: 
+    - '{{ var_multiple_time_servers.split(",") }}'

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
@@ -4,6 +4,13 @@
 
 config_file="{{{ chrony_conf_path }}}"
 
-if ! grep -q '^[\s]*(?:server|pool)[\s]+[\w]+' "$config_file" ; then
-  {{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") | indent(2) }}}
-fi
+IFS="," read -a SERVERS <<< $var_multiple_time_servers
+for srv in "${SERVERS[@]}"
+do
+   NTP_SRV=$(grep -w $srv $config_file)
+   if [[ ! "$NTP_SRV" == "server "* ]]
+   then
+     time_server="server $srv"
+     echo $time_server >> "$config_file"
+   fi
+done

--- a/products/sle12/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle12/profiles/anssi_bp28_enhanced.profile
@@ -23,3 +23,4 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - var_multiple_time_servers=suse

--- a/products/sle12/profiles/anssi_bp28_high.profile
+++ b/products/sle12/profiles/anssi_bp28_high.profile
@@ -23,3 +23,4 @@ description: |-
 
 selections:
     - anssi:all:high
+    - var_multiple_time_servers=suse

--- a/products/sle12/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle12/profiles/anssi_bp28_intermediary.profile
@@ -23,4 +23,4 @@ description: |-
 
 selections:
   - anssi:all:intermediary
-
+  - var_multiple_time_servers=suse

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -13,6 +13,7 @@ description: |-
 
 selections:
     -  pcidss_3:all:base
+    -  var_multiple_time_servers=suse    
     -  account_unique_id
     -  coredump_disable_backtraces
     -  coredump_disable_storage

--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -23,3 +23,4 @@ description: |-
 
 selections:
     - anssi:all:enhanced
+    - var_multiple_time_servers=suse

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -23,3 +23,4 @@ description: |-
 
 selections:
     - anssi:all:high
+    - var_multiple_time_servers=suse

--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -23,3 +23,4 @@ description: |-
 
 selections:
   - anssi:all:intermediary
+  - var_multiple_time_servers=suse


### PR DESCRIPTION
#### Description:

- _Correction is rule chronyd_specify_remote_server as a part of CIS profile for SLE 12/15 _

#### Rationale:

In the current version:
- The bash part did not add server + list of time servers to /etc/chrony.conf. 
- The variable var_multiple_time_servers was not included in different profiles which belong to SLE 12/15

Note: Please send this PR to Vojtech Polasek for review. Probably "grep -q" returns empty string and because of that every execution of remediation will add server to /etc/chrony.conf. Also I am not sure if the remediation will add the word server in from of list of time servers in  /etc/chrony.conf.  
