### PR TITLE
Fix Automatus on Python 3.6

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -60,8 +60,8 @@ product_directories = [
     'uos20',
 ]
 
-JINJA_MACROS_DIRECTORY = os.path.join(os.path.dirname(os.path.dirname(
-    __file__)), "shared", "macros")
+JINJA_MACROS_DIRECTORY = os.path.abspath(os.path.join(os.path.dirname(os.path.dirname(
+    __file__)), "shared", "macros"))
 
 xml_version = """<?xml version="1.0" encoding="UTF-8"?>"""
 


### PR DESCRIPTION
#### Description:
This PR ensures that `JINJA_MACROS_DIRECTORY` in `ssg/constants.py` is always an ABS path.


Fixes #10267 

#### Rationale:
The os.path.dirname(__file__) on Python 3.6 seems to return an relative path and on newer Pythons it returns an absolute path. This commit ensures that the JINJA_MACROS_DIRECTORY is always an abssolute path. This is needed because the AbsolutePathFileSystemLoader for Jinja will throw a TemplateNotFound if the template path is not absolute

#### Review Hints:
To reproduce the error use a RHEL 8.7 machine to run the tests as described in #10267.