### PR TITLE
Drop redundant pam pwquality-based rules for SLE

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -344,18 +344,23 @@ controls:
     # Ensure passwords with minimum of 18 characters
     - var_password_pam_minlen=18
     - accounts_password_pam_minlen
+    - cracklib_accounts_password_pam_minlen
     # Require at Least 1 Special Character in Password
     - var_password_pam_ocredit=1
     - accounts_password_pam_ocredit
+    - cracklib_accounts_password_pam_ocredit
     # Require at Least 1 Numeric Character in Password
     - var_password_pam_dcredit=1
     - accounts_password_pam_dcredit
+    - cracklib_accounts_password_pam_dcredit
     # Require at Least 1 Uppercase Character in Password
     - var_password_pam_ucredit=1
     - accounts_password_pam_ucredit
+    - cracklib_accounts_password_pam_ucredit
     # Require at Least 1 Lowercase Character in Password
     - var_password_pam_lcredit=1
     - accounts_password_pam_lcredit
+    - cracklib_accounts_password_pam_lcredit
 
     # Lock out users after 3 failed authentication attempts within 15 min
     - var_accounts_passwords_pam_faillock_fail_interval=900

--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -1744,11 +1744,6 @@ controls:
       - var_password_pam_minlen=14
       - cracklib_accounts_password_pam_retry
       - var_password_pam_retry=3
-      - accounts_password_pam_minlen
-      - accounts_password_pam_lcredit
-      - accounts_password_pam_ucredit
-      - accounts_password_pam_dcredit
-      - accounts_password_pam_ocredit
 
   - id: 5.3.2
     title: Ensure lockout for failed password attempts is configured (Automated)

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -1921,11 +1921,6 @@ controls:
       - var_password_pam_minlen=14
       - cracklib_accounts_password_pam_retry
       - var_password_pam_retry=3
-      - accounts_password_pam_minlen
-      - accounts_password_pam_lcredit
-      - accounts_password_pam_ucredit
-      - accounts_password_pam_dcredit
-      - accounts_password_pam_ocredit
 
   - id: 5.3.2
     title: Ensure lockout for failed password attempts is configured (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_dcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Digit Characters'
 
@@ -37,8 +37,6 @@ references:
     cis-csc: 1,12,15,16,5
     cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
-    cis@sle12: 5.3.1
-    cis@sle15: 5.3.1
     cis@ubuntu2004: 5.3.1
     cis@ubuntu2204: 5.4.1
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_lcredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Lowercase Characters'
 
@@ -37,8 +37,6 @@ references:
     cis-csc: 1,12,15,16,5
     cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
-    cis@sle12: 5.3.1
-    cis@sle15: 5.3.1
     cis@ubuntu2004: 5.3.1
     cis@ubuntu2204: 5.4.1
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_minlen/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Length'
 

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ocredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Special Characters'
 
@@ -39,8 +39,6 @@ references:
     cis-csc: 1,12,15,16,5
     cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
-    cis@sle12: 5.3.1
-    cis@sle15: 5.3.1
     cis@ubuntu2004: 5.3.1
     cis@ubuntu2204: 5.4.1
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_ucredit/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,ubuntu2004,ubuntu2204
 
 title: 'Ensure PAM Enforces Password Requirements - Minimum Uppercase Characters'
 
@@ -34,8 +34,6 @@ references:
     cis-csc: 1,12,15,16,5
     cis@alinux2: 5.3.1
     cis@rhel7: 5.4.1
-    cis@sle12: 5.3.1
-    cis@sle15: 5.3.1
     cis@ubuntu2004: 5.3.1
     cis@ubuntu2204: 5.4.1
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10


### PR DESCRIPTION
#### Description:

- Drop extra pam_pwquality rules we have in CIS  and ANSSI SLE profiles

#### Rationale:

-  In SLE context the rules based on pam_pwquality are redundant. For now the package providing the pam_pwquality library is not installed by default, but pam_cracklib is used. So instead of duplicating the cracklib based rules better drop the redundant functionality, that needs extra package.
- Free some CCE ids that were allocated for those rules

