### PR TITLE
Fix package names for some SUSE packages

### DIFF
--- a/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_client/package_openldap-clients_removed/rule.yml
@@ -43,6 +43,8 @@ template:
     name: package_removed
     vars:
         pkgname: openldap-clients
+        pkgname@sle12: openldap2-client
+        pkgname@sle15: openldap2-client
         pkgname@ubuntu1604: ldap-utils
         pkgname@ubuntu1804: ldap-utils
         pkgname@ubuntu2004: ldap-utils

--- a/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
+++ b/linux_os/guide/services/ldap/openldap_server/package_openldap-servers_removed/rule.yml
@@ -63,6 +63,8 @@ template:
     name: package_removed
     vars:
         pkgname: openldap-servers
+        pkgname@sle12: openldap2
+        pkgname@sle15: openldap2
         pkgname@ubuntu1604: slapd
         pkgname@ubuntu1804: slapd
         pkgname@ubuntu2004: slapd

--- a/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/rule.yml
+++ b/linux_os/guide/system/logging/package_rsyslog-gnutls_installed/rule.yml
@@ -37,6 +37,8 @@ template:
     name: package_installed
     vars:
         pkgname: rsyslog-gnutls
+        pkgname@sle12: rsyslog-module-gtls 
+        pkgname@sle15: rsyslog-module-gtls 
 
 fixtext: |-
     {{{ describe_package_install("rsyslog-gnutls") }}}


### PR DESCRIPTION
#### Description:

- The rules on openldap and rsyslog_gnutls were using wrong package names in the context of the SLE platform

#### Rationale:

- Add sle specific package names for the rules