### PR TITLE
Update pam_pwquality requirements in CIS

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1931,8 +1931,12 @@ controls:
     levels:
     - l1_server
     - l1_workstation
-    status: partial # rule checking for retry needs modification and we are missing rule for try_first_pass
+    status: automated
     notes: <-
+      The Benchmark mentions that the try_first_pass option should be included in pam_pwquality.so
+      module. However, the pam_pwquality.so module, by default, is always the first module from in
+      the PAM password stack. Therefore, the option is useless and not necessary. It was already
+      proposed to update the requirement in the next CIS version.
       There are two ways how to check this control.
       One way is to check for minclass, this is currently selected.
       Another way is to check for dcredit, lcredit,ocredit, ucredit, this is shown in rleated_rules.

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -2222,15 +2222,17 @@ controls:
     rules:
       - accounts_passwords_pam_faillock_deny
 
-  # NEEDS RULE
-  # try_first_pass
-  # https://github.com/ComplianceAsCode/content/issues/5533
   - id: 5.5.1
     title: Ensure password creation requirements are configured (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: partial
+    status: automated
+    notes: |-
+      The Benchmark mentions that the try_first_pass option should be included in pam_pwquality.so
+      module. However, the pam_pwquality.so module, by default, is always the first module from in
+      the PAM password stack. Therefore, the option is useless and not necessary. It was already
+      proposed to update the requirement in the next CIS version.
     rules:
       - accounts_password_pam_minclass
       - accounts_password_pam_minlen

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -2073,15 +2073,17 @@ controls:
     rules:
       - accounts_passwords_pam_faillock_deny
 
-  # NEEDS RULE
-  # try_first_pass
-  # https://github.com/ComplianceAsCode/content/issues/5533
   - id: 5.5.1
     title: Ensure password creation requirements are configured (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: partial
+    status: automated
+    notes: |-
+      The Benchmark mentions that the try_first_pass option should be included in pam_pwquality.so
+      module. However, the pam_pwquality.so module, by default, is always the first module from in
+      the PAM password stack. Therefore, the option is useless and not necessary. It was already
+      proposed to update the requirement in the next CIS version.
     rules:
       - accounts_password_pam_minclass
       - accounts_password_pam_minlen


### PR DESCRIPTION
#### Description:

The CIS benchmark mentions that the `try_first_pass` option should be present to satisfy the `5.5.1` requirement for RHEL8 and RHEL9 and the `5.4.1` requirement for RHEL7.
However in these systems, the `pam_pwquality.so` module, by default, is always the first module in the password stack,
making the `try_first_pass` useless and unnecessary there.
In addition, the `try_first_pass` is not present in the CIS recommendation to remediate the system.

#### Rationale:

Better CIS accuracy for RHEL.

In parallel to this PR, it was proposed updates for next CIS Benchmark versions.
More details in https://github.com/ComplianceAsCode/content/issues/5533

- Fixes #5533 