### PR TITLE
OCP4 STIG: SRG-APP-000190-CTR-000500 is covered by setting the OAuth timeout

### DIFF
--- a/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauth_or_oauthclient_inactivity_timeout/rule.yml
@@ -62,6 +62,7 @@ rationale: |-
 references:
   nerc-cip: CIP-004-6 R2.2.3,CIP-007-3 R5.1,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3 R5.3.2,CIP-007-3 R5.3.3
   nist: AC-2(5),IA-5(13),SC-10
+  srg: SRG-APP-000190-CTR-000500
 
 identifiers:
     cce@ocp4: CCE-83702-1

--- a/applications/openshift/authentication/oauthclient_inactivity_timeout/policy/stig/shared.yml
+++ b/applications/openshift/authentication/oauthclient_inactivity_timeout/policy/stig/shared.yml
@@ -1,0 +1,12 @@
+checktext: |-
+  Determine if the session token inactivity timeout is set on the oauthclients by running the following.
+  > oc get oauthclients -ojsonpath='{range .items[*]}{.metadata.name}{"\t"}{.accessTokenInactivityTimeoutSeconds}{"\n"}'
+  The output will list each oauth client name followed by a number.  The number represents the timeout in seconds. If no number is displayed, or the timeout value is greater then the allowed idle timeout duration, this is a finding.
+
+fixtext: |-
+  For each oauth client that does not have the idle timeout set, or the timeout is set to the wrong duration, run the following command to set the idle timeout value to 10 minutes.
+  > oc patch oauthclient/<CLIENT_NAME> --type=merge -p '{"accessTokenInactivityTimeoutSeconds":600}'
+  where CLIENT_NAME is the name of the oauthclient identified in the check.
+
+srg_requirement: |-
+  The application must terminate all network connections associated with a communications session at the end of the session, or as follows: for in-band management sessions (privileged sessions), the session must be terminated after 10 minutes of inactivity;

--- a/applications/openshift/authentication/oauthclient_inactivity_timeout/rule.yml
+++ b/applications/openshift/authentication/oauthclient_inactivity_timeout/rule.yml
@@ -40,6 +40,7 @@ rationale: |-
 references:
   nerc-cip: CIP-004-6 R2.2.3,CIP-007-3 R5.1,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3 R5.3.2,CIP-007-3 R5.3.3
   nist: AC-2(5),SC-10
+  srg: SRG-APP-000190-CTR-000500
 
 identifiers:
     cce@ocp4: CCE-84178-3

--- a/controls/srg_ctr/SRG-APP-000190-CTR-000500.yml
+++ b/controls/srg_ctr/SRG-APP-000190-CTR-000500.yml
@@ -6,4 +6,6 @@ controls:
     communications session at the end of the session, or as follows: for in-band management
     sessions (privileged sessions), the session must be terminated after 10 minutes
     of inactivity;'
-  status: pending
+  status: automated
+  rules:
+  - oauthclient_inactivity_timeout


### PR DESCRIPTION
#### Description:

- Covers SRG-APP-000190-CTR-000500

#### Rationale:

- OCP4 STIG coverage

#### Review Hints:

- I will post link to the SRG export when the GH actions finish
