### PR TITLE
nist_rhcos4: Fix typo in rule name

### DIFF
--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -5480,7 +5480,7 @@ controls:
   rules:
   - package_usbguard_installed
   - service_usbguard_enabled
-  - configure_usbguard_audit_backend
+  - configure_usbguard_auditbackend
   - usbguard_allow_hid_and_hub
   description: |-
     The organization:


### PR DESCRIPTION
#### Description:

- We used a wrong rule name in the `nist_rhcos4` control file

#### Rationale:

- Let's use the corrent rule name

#### Review Hints:

- Just check the rule path
