### PR TITLE
Add some nftables rules to Ubuntu CIS profile

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -116,6 +116,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build
+        env:
+          ADDITIONAL_CMAKE_OPTIONS: "-DSSG_SCE_ENABLED:BOOL=ON"
         run: |-
           ./build_product \
               ubuntu2004 \

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -522,7 +522,7 @@ macro(ssg_build_sds PRODUCT)
         set_tests_properties("missing-references-ssg-${PRODUCT}-ds.xml" PROPERTIES LABELS quick)
 
     endif()
-    if(("${PRODUCT}" MATCHES "ubuntu2004" OR "${PRODUCT}" MATCHES "rhel8") AND SSG_SCE_ENABLED)
+    if(("${PRODUCT}" MATCHES "ubuntu2" OR "${PRODUCT}" MATCHES "rhel8") AND SSG_SCE_ENABLED)
         add_test(
             NAME "ds-sce-${PRODUCT}"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/tests/test_ds_sce.py" "${CMAKE_BINARY_DIR}" "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"

--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -1,17 +1,17 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Verify nftables Service is Enabled'
 
 description: |-
-    The nftables service allows for the loading of nftables rulesets during boot, 
+    The nftables service allows for the loading of nftables rulesets during boot,
     or starting on the nftables service
     {{{ describe_service_enable(service="nftables") }}}
 
 rationale: |-
-    The nftables service restores the nftables rules from the rules files referenced 
-    in the <tt>/etc/sysconfig/nftables.conf</tt> file during boot or the starting of 
+    The nftables service restores the nftables rules from the rules files referenced
+    in the <tt>/etc/sysconfig/nftables.conf</tt> file during boot or the starting of
     the nftables service
 
 
@@ -22,7 +22,8 @@ identifiers:
 
 references:
     cis@sle15: 3.5.2.9
-
+    cis@ubuntu2004: 3.5.2.9
+    cis@ubuntu2204: 3.5.2.9
 
 ocil_clause: '{{{ ocil_clause_service_enabled("nftables") }}}'
 

--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/bash/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/bash/shared.sh
@@ -1,10 +1,10 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 
 #Set nftables family name
 {{{ bash_instantiate_variables("var_nftables_family") }}}
 
 #Set nftables table name
-{{{ bash_instantiate_variables("var_nftables_table") }}} 
+{{{ bash_instantiate_variables("var_nftables_table") }}}
 
 IS_TABLE=$(nft list tables)
 if [ -z "$IS_TABLE" ]

--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/rule.yml
@@ -1,11 +1,11 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Ensure a Table Exists for Nftables'
 
 description: |-
-   Tables in nftables hold chains. Each table only has one address family and only applies 
+   Tables in nftables hold chains. Each table only has one address family and only applies
    to packets of this family. Tables can have one of six families.
 
 rationale: |-
@@ -20,6 +20,8 @@ identifiers:
 
 references:
     cis@sle15: 3.5.2.4
+    cis@ubuntu2004: 3.5.2.4
+    cis@ubuntu2204: 3.5.2.4
 
 ocil_clause: 'a nftables table does not exist'
 

--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/sce/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/sce/shared.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# platform = multi_platform_ubuntu
+# check-import = stdout
+#
+
+tbl_output=$(nft list tables)
+if [ -z "${tbl_output}" ]; then
+    exit ${XCCDF_RESULT_FAIL}
+fi
+
+exit ${XCCDF_RESULT_PASS}

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -429,7 +429,7 @@ selections:
     # Needs rule
 
     #### 3.5.2.9 Ensure nftables service is enabled (Automated)
-    # Needs rule
+    - service_nftables_enabled
 
     #### 3.5.2.10 Ensure nftables rules are permanent (Automated)
     # Needs rule

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -414,7 +414,9 @@ selections:
     # Skip due to being a manual test
 
     #### 3.5.2.4 Ensure a table exists (Automated)
-    # Needs rule
+    - var_nftables_family=inet
+    - var_nftables_table=filter
+    - set_nftables_table
 
     #### 3.5.2.5 Ensure base chains exist (Automated)
     # Needs rule

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -441,7 +441,9 @@ selections:
     # Skip due to being a manual test
 
     #### 3.5.2.4 Ensure a nftables table exists (Automated)
-    # NEEDS RULE
+    - var_nftables_family=inet
+    - var_nftables_table=filter
+    - set_nftables_table
 
     #### 3.5.2.5 Ensure nftables base chains exist (Automated)
     # NEEDS RULE

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -456,7 +456,7 @@ selections:
     # NEEDS RULE
 
     #### 3.5.2.9 Ensure nftables service is enabled (Automated)
-    # NEEDS RULE
+    - service_nftables_enabled
 
     #### 3.5.2.10 Ensure nftables rules are permanent (Automated)
     # NEEDS RULE


### PR DESCRIPTION
#### Description:

- Add the following rules to Ubuntu CIS profiles:
  - `service_nftables_enabled`
  - `set_nftables_table`
- Also add a SCE check for `set_nftables_table`
- Lastly remove some logic from SSGCommon.cmake regarding SCE, I feel like the check for products is unnecessary.

#### Rationale:

- The rules are needed for CIS on Ubuntu 22.04 and 20.04.