### PR TITLE
Add package_nginx_removed to Ubuntu CIS profiles

### DIFF
--- a/linux_os/guide/services/http/disabling_nginx/package_nginx_removed/rule.yml
+++ b/linux_os/guide/services/http/disabling_nginx/package_nginx_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: rhel8,rhel9,ubuntu2004,ubuntu2204
 
 title: 'Uninstall nginx Package'
 
@@ -20,6 +20,8 @@ identifiers:
 references:
     cis@rhel8: 2.2.10
     cis@rhel9: 2.2.8
+    cis@ubuntu2004: 2.2.10
+    cis@ubuntu2204: 2.2.9
     cobit5: BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS05.02,DSS05.05,DSS06.06
     isa-62443-2009: 4.3.3.5.1,4.3.3.5.2,4.3.3.5.3,4.3.3.5.4,4.3.3.5.5,4.3.3.5.6,4.3.3.5.7,4.3.3.5.8,4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9,4.3.3.7.1,4.3.3.7.2,4.3.3.7.3,4.3.3.7.4,4.3.4.3.2,4.3.4.3.3
     isa-62443-2013: 'SR 1.1,SR 1.10,SR 1.11,SR 1.12,SR 1.13,SR 1.2,SR 1.3,SR 1.4,SR 1.5,SR 1.6,SR 1.7,SR 1.8,SR 1.9,SR 2.1,SR 2.2,SR 2.3,SR 2.4,SR 2.5,SR 2.6,SR 2.7,SR 7.6'

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -265,6 +265,7 @@ selections:
 
     ### 2.2.10 Ensure HTTP server is not installed (Automated)
     - package_httpd_removed
+    - package_nginx_removed
 
     ### 2.2.11 Ensure IMAP and POP3 server are not installed (Automated)
     - package_dovecot_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -291,6 +291,7 @@ selections:
 
     ### 2.2.9 Ensure HTTP server is not installed (Automated)
     - package_httpd_removed
+    - package_nginx_removed
 
     ### 2.2.10 Ensure IMAP and POP3 server are not installed (Automated)
     - package_dovecot_removed


### PR DESCRIPTION
#### Description:

- Add package_nginx_removed to Ubuntu CIS profiles

#### Rationale:

- Needed for CIS on both Ubuntu 20.04 and 22.04