### PR TITLE
Add package_cyrus-imapd_removed to Ubuntu CIS profiles

### DIFF
--- a/linux_os/guide/services/imap/disabling_cyrus-imapd/package_cyrus-imapd_removed/rule.yml
+++ b/linux_os/guide/services/imap/disabling_cyrus-imapd/package_cyrus-imapd_removed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: rhel8,rhel9
+prodtype: rhel8,rhel9,ubuntu2004,ubuntu2204
 
 title: 'Uninstall cyrus-imapd Package'
 
@@ -20,6 +20,8 @@ identifiers:
 references:
     cis@rhel8: 2.2.11
     cis@rhel9: 2.2.9
+    cis@ubuntu2004: 2.2.11
+    cis@ubuntu2204: 2.2.10
 
 {{{ complete_ocil_entry_package(package="cyrus-imapd") }}}
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -268,6 +268,7 @@ selections:
 
     ### 2.2.11 Ensure IMAP and POP3 server are not installed (Automated)
     - package_dovecot_removed
+    - package_cyrus-imapd_removed
 
     ### 2.2.12 Ensure Samba is not installed (Automated)
     - package_samba_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -294,6 +294,7 @@ selections:
 
     ### 2.2.10 Ensure IMAP and POP3 server are not installed (Automated)
     - package_dovecot_removed
+    - package_cyrus-imapd_removed
 
     ### 2.2.11 Ensure Samba is not installed (Automated)
     - package_samba_removed


### PR DESCRIPTION
#### Description:

- Add package_cyrus-imapd_removed to Ubuntu CIS profiles

#### Rationale:

- Needed for CIS on both Ubuntu 20.04 and 22.04