### PR TITLE
apparmor: apply only to platform machine

### DIFF
--- a/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
+++ b/linux_os/guide/system/apparmor/apparmor_configured/rule.yml
@@ -62,5 +62,3 @@ template:
         packagename@ubuntu1604: apparmor
         packagename@ubuntu1804: apparmor
         packagename@ubuntu2004: apparmor
-
-platform: machine

--- a/linux_os/guide/system/apparmor/group.yml
+++ b/linux_os/guide/system/apparmor/group.yml
@@ -21,3 +21,5 @@ description: |-
     For more information on using AppArmor, see
     {{{ weblink(link="https://www.suse.com/documentation/sles-12/book_security/data/cha_apparmor_intro.html") }}}.
     {{% endif %}}
+
+platform: machine

--- a/linux_os/guide/system/apparmor/package_pam_apparmor_installed/rule.yml
+++ b/linux_os/guide/system/apparmor/package_pam_apparmor_installed/rule.yml
@@ -34,5 +34,3 @@ template:
     name: package_installed
     vars:
         pkgname: pam_apparmor
-
-platform: machine


### PR DESCRIPTION
#### Description:
apparmor: apply only to platform machine

The 'Ensure AppArmor is installed' rule should not apply to containers.

None of the apparmor rules should apply to containers, so set "machine: apparmor" for that group.

Cleanup instances of "platform: machine" for rules in that group that already have this restriction to eliminate redundancy.

#### Rationale:

AppArmor is a host technology and doesn't apply to or make sense within containers.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_stig /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Ensure AppArmor is installed" rule is "Not Applicable"