### PR TITLE
accounts_passwords_pam_faildelay_delay: depend on pam

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_faildelay_delay/rule.yml
@@ -53,3 +53,5 @@ template:
       arguments:
         - variable: delay
           operation: greater than or equal
+
+platform: package[pam]


### PR DESCRIPTION
#### Description:
accounts_passwords_pam_faildelay_delay: depend on pam

#### Rationale:

accounts_passwords_pam_faildelay_delay is dependent on pam being installed, so it should express that with "platform: package[pam]" as other rules (such as accounts_password_pam_unix_remember) already do.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_stig /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Enforce Delay After Failed Logon Attempts" rule is "Not Applicable"