### PR TITLE
accounts_passwords_pam_tally2: depend on pam being installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/rule.yml
@@ -66,3 +66,5 @@ ocil: |-
     account required pam_tally2.so deny={{{ xccdf_value("var_password_pam_tally2") }}}</pre>
 
     If the account option is missing, or commented out, this is a finding.
+
+platform: package[pam]


### PR DESCRIPTION
#### Description:

accounts_passwords_pam_tally2: depend on pam being installed

#### Rationale:

accounts_passwords_pam_tally2 is dependent on pam being installed, so it should express that with "platform: package[pam]" as other rules (such as accounts_password_pam_unix_remember) already do.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_stig /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Set Deny For Failed Password Attempts" rule is "Not Applicable"