### PR TITLE
package_pam_pwquality_installed: depend on pam being installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/package_pam_pwquality_installed/rule.yml
@@ -40,3 +40,5 @@ template:
     vars:
         pkgname: libpwquality
         pkgname@ubuntu2004: libpam-pwquality
+
+platform: package[pam]


### PR DESCRIPTION
#### Description:

package_pam_pwquality_installed: depend on pam being installed

#### Rationale:

package_pam_pwquality_installed only makes sense if pam is installed, so it should express that with "platform: package[pam]" as other rules (such as accounts_password_pam_unix_remember) already do.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_stig /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Install pam_pwquality Package" rule is "Not Applicable"