### PR TITLE
vlock_installed: apply only to platform machine

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/vlock_installed/rule.yml
@@ -58,3 +58,5 @@ template:
         pkgname@ubuntu1604: vlock
         pkgname@ubuntu1804: vlock
         pkgname@ubuntu2004: vlock
+
+platform: machine


### PR DESCRIPTION
#### Description:
vlock_installed: apply only to platform machine

#### Rationale:

The 'Check that vlock is installed to allow session locking' rule should not apply to containers.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_stig /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Check that vlock is installed to allow session locking" rule is "Not Applicable"