### PR TITLE
Add banner_etc_motd to Ubuntu CIS profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("login_banner_text") }}}
 

--- a/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/banner_etc_motd/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15
+prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Modify the System Message of the Day Banner'
 
@@ -63,6 +63,8 @@ references:
     cis@rhel9: 1.7.1
     cis@sle12: 1.8.1.1
     cis@sle15: 1.8.1.1
+    cis@ubuntu2004: 1.8.1.1
+    cis@ubuntu2204: 1.7.1
 
 ocil_clause: 'it does not display the required banner'
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -172,10 +172,10 @@ selections:
     ## 1.8 Warning Banners ##
     ### 1.8.1 Command Line Warning Banners ###
     #### 1.8.1.1 Ensure message of the day is configured properly (Automated)
-    # Needs rule
+    - login_banner_text=cis_default
+    - banner_etc_motd
 
     #### 1.8.1.2 Ensure local login warning banner is configured properly (Automated)
-    - login_banner_text=cis_default
     - banner_etc_issue
 
     #### 1.8.1.3 Ensure remote login warning banner is configured properly (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -164,10 +164,10 @@ selections:
 
     ## 1.7 Command Line Warning Banners ##
     ### 1.7.1 Ensure message of the day is configured properly (Automated)
-    # NEEDS RULE
+    - login_banner_text=cis_default
+    - banner_etc_motd
 
     ### 1.7.2 Ensure local login warning banner is configured properly (Automated)
-    - login_banner_text=cis_default
     - banner_etc_issue
 
     ### 1.7.3 Ensure remote login warning banner is configured properly (Automated)


### PR DESCRIPTION
#### Description:

- Add banner_etc_motd to Ubuntu CIS profiles

#### Rationale:

- Needed for CIS on Ubuntu 20.04 and 22.04.