### PR TITLE
Add rule accounts_password_last_change_is_in_past to Ubuntu CIS profiles

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/rule.yml
@@ -24,6 +24,8 @@ references:
     cis@rhel9: 5.6.1.5
     cis@sle12: 5.4.1.6
     cis@sle15: 5.4.1.6
+    cis@ubuntu2004: 5.4.1.5
+    cis@ubuntu2204: 5.5.1.5
 
 ocil_clause: 'any interactive user password that has last change time in the future'
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -760,7 +760,7 @@ selections:
     - account_disable_post_pw_expiration
 
     #### 5.4.1.5 Ensure all users last password change date is in the past (Automated)
-    # Needs rule: last_change_date_in_past
+    - accounts_password_last_change_is_in_past
 
     ### 5.4.2 Ensure system accounts are secured (Automated)
     - no_shelllogin_for_systemaccounts

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -889,7 +889,7 @@ selections:
     - account_disable_post_pw_expiration
 
     #### 5.5.1.5 Ensure all users last password change date is in the past (Automated)
-    # NEEDS RULE
+    - accounts_password_last_change_is_in_past
 
     ### 5.5.2 Ensure system accounts are secured (Automated)
     - no_shelllogin_for_systemaccounts


### PR DESCRIPTION
#### Description:

- Add rule accounts_password_last_change_is_in_past to Ubuntu CIS profiles

#### Rationale:

- Needed for CIS on Ubuntu 20.04 and 22.04