### PR TITLE
aide_build_database make Ubuntu ansible similar to bash

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_build_database/ansible/shared.yml
@@ -13,6 +13,8 @@
 - name: "Build and Test AIDE Database"
 {{% if 'sle' in product %}}
   command: /usr/bin/aide --init
+{{% elif 'ubuntu' in product %}}
+  command: /usr/sbin/aideinit -y -f
 {{% else %}}
   command: /usr/sbin/aide --init
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- aide_build_database: ansible: Add ubuntu bits

#### Rationale:

- Fixes #10257