### PR TITLE
sudo_add_use_pty: depend on sudo being installed

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/rule.yml
@@ -44,3 +44,5 @@ template:
     name: sudo_defaults_option
     vars:
         option: use_pty
+
+platform: package[sudo]

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_absent.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 touch /etc/sudoers.d/empty
 # Code taken from macro bash_sudo_remove_config()

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo "Defaults use_pty" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_add_use_pty/tests/use_pty_enabled_dir.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo "Defaults use_pty" >> /etc/sudoers.d/enable_use_pty


### PR DESCRIPTION
#### Description:

sudo_add_use_pty: depend on sudo being installed

#### Rationale:

sudo_add_use_pty only makes sense if sudo is installed, so it should express that with "platform: package[sudo]" as other rules (such as sudo_add_use_pty) already do.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_cis_level2_workstation /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Ensure Only Users Logged In To Real tty Can Execute Sudo - sudo use_pty" rule is "Not Applicable"