### PR TITLE
sudo_custom_logfile: depend on sudo being installed

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/rule.yml
@@ -79,3 +79,5 @@ template:
         # next character isn't yet another word character.
         option_regex_suffix: '=("(?:\\"|\\\\|[^"\\\n])*"\B|[^"](?:(?:\\,|\\"|\\ |\\\\|[^", \\\n])*)\b)'
         variable_name: var_sudo_logfile
+
+platform: package[sudo]

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/broken_defaults.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/broken_defaults.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo "Defaultsabc logfile=/var/log/sudo.log" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_absent.fail.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 touch /etc/sudoers.d/empty
 # Code taken from macro bash_sudo_remove_config()

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo "Defaults logfile=/var/log/sudo.log" >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_dir.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_dir.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo "Defaults logfile=/var/log/sudo.log" >> /etc/sudoers.d/enable_logfile

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_with_noexec.pass.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/logfile_enabled_with_noexec.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo 'Defaults logfile=/var/log/sudo.log,noexec' >> /etc/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/wrong_logfile.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_custom_logfile/tests/wrong_logfile.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # platform = multi_platform_all
+# packages = sudo
 
 echo "Defaults logfile=/var/log/othersudologfile.log" >> /etc/sudoers


### PR DESCRIPTION
#### Description:

sudo_custom_logfile: depend on sudo being installed

#### Rationale:

sudo_custom_logfile only makes sense if sudo is installed, so it should express that with "platform: package[sudo]" as other rules (such as sudo_add_use_pty) already do.

#### Review Hints:
With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_cis_level2_workstation /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Ensure Sudo Logfile Exists - sudo logfile" rule is "Not Applicable"