### PR TITLE
use_pam_wheel_for_su: depend on pam being installed

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -69,3 +69,4 @@ vuldiscussion: |-
     Without re-authentication, users may access resources or perform tasks for which they do not have authorization.
     When operating systems provide the capability to escalate a functional capability, it is critical the user re-authenticate.
 
+platform: package[pam]


### PR DESCRIPTION
#### Description:

use_pam_wheel_for_su: depend on pam being installed

#### Rationale:

use_pam_wheel_for_su only makes sense if pam is installed.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:20.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_cis_level2_workstation /usr/share/xml/scap/ssg/content/ssg-ubuntu2004-ds.xml`  should yield a report indicating that the "Enforce usage of pam_wheel for su authentication" rule is "Not Applicable"