### PR TITLE
sudo_require_reauthentication: depend on sudo being installed

### DIFF
--- a/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
+++ b/linux_os/guide/system/software/sudo/sudo_require_reauthentication/rule.yml
@@ -64,3 +64,5 @@ fixtext: |-
     Remove any duplicate or conflicting lines from /etc/sudoers and /etc/sudoers.d/ files.
 
 srg_requirement: '{{{ full_name }}} must require re-authentication when using the "sudo" command.'
+
+platform: package[sudo]


### PR DESCRIPTION
#### Description:

sudo_require_reauthentication: depend on sudo being installed

#### Rationale:

sudo_require_reauthentication only makes sense if sudo is installed.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:22.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_cis_level2_workstation /usr/share/xml/scap/ssg/content/ssg-ubuntu2204-ds.xml`  should yield a report indicating that the "The operating system must require Re-Authentication when using the sudo command. Ensure sudo timestamp_timeout is appropriate - sudo timestamp_timeout" rule is "Not Applicable"