### PR TITLE
Add srg to account_passwords_pam_faillock_dir

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_dir/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_passwords_pam_faillock_dir/rule.yml
@@ -17,7 +17,8 @@ identifiers:
 
 references:
     disa: CCI-000044 
-    nist: 'AC-7 (a)'
+    nist: 'AC-7 (ia)'
+    srg: SRG-OS-000021-GPOS-00005
 
 ocil_clause: 'the "dir" option is not set to a non-default documented tally log directory, is missing or commented out'
 


### PR DESCRIPTION
#### Description:

Adds an SRG to account_passwords_pam_faillock_dir
#### Rationale:

Fixes #10310
