### PR TITLE
Fix parsing of /etc/redhat-releases

### DIFF
--- a/shared/checks/oval/installed_OS_is_rhel7.xml
+++ b/shared/checks/oval/installed_OS_is_rhel7.xml
@@ -86,7 +86,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_rhevh_rhel7_version" version="1">
     <ind:filepath>/etc/redhat-release</ind:filepath>
-    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux(?: Server)? release (\d)\.\d+(?: \(\w+\))?$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_rhevh_rhel7_version" version="1">

--- a/shared/checks/oval/installed_OS_is_rhel8.xml
+++ b/shared/checks/oval/installed_OS_is_rhel8.xml
@@ -79,7 +79,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_rhevh_rhel8_version" version="1">
     <ind:filepath>/etc/redhat-release</ind:filepath>
-    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux(?: Server)? release (\d)\.\d+(?: \(\w+\))?$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_rhevh_rhel8_version" version="1">

--- a/shared/checks/oval/installed_OS_is_rhel9.xml
+++ b/shared/checks/oval/installed_OS_is_rhel9.xml
@@ -50,7 +50,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="obj_rhevh_rhel9_version" version="1">
     <ind:filepath>/etc/redhat-release</ind:filepath>
-    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux release (\d)\.\d+$</ind:pattern>
+    <ind:pattern operation="pattern match">^Red Hat Enterprise Linux(?: Server)? release (\d)\.\d+(?: \(\w+\))?$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
   <ind:textfilecontent54_state id="state_rhevh_rhel9_version" version="1">


### PR DESCRIPTION
#### Description:

Fix parsing of /etc/redhat-releases

#### Rationale:

The content of /etc/redhat-releases can be any of the following: Red Hat Enterprise Linux Server release 6.10 (Santiago) Red Hat Enterprise Linux Server release 7.9 (Maipo) Red Hat Enterprise Linux release 8.6 (Ootpa)
Red Hat Enterprise Linux release 8.5 (Ootpa)

The regex previously would only match values that did not have a release code name and did not have "Server", handling only values like this: Red Hat Enterprise Linux release 8.6

Meaning that the regex didn't match many /etc/redhat-releases, such as that in the ubi images:
registry.access.redhat.com/ubi7/ubi:latest
registry.access.redhat.com/ubi8/ubi:latest
registry.access.redhat.com/ubi9/ubi:latest

With this commit, ubi (and other Red Hat installations) are now matched by the regex resulting in correct detect as being Red Hat enabling rules to be applied appropriately.

#### Review Hints:
