### PR TITLE
coredump_disable_storage: depend on systemd being installed

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/coredumps/coredump_disable_storage/rule.yml
@@ -64,3 +64,5 @@ warnings:
         If the <tt>/etc/systemd/coredump.conf</tt> file
         does not already contain the <tt>[Coredump]</tt> section,
         the value will not be configured correctly.
+
+platform: package[systemd]


### PR DESCRIPTION
#### Description:

coredump_disable_storage: depend on systemd being installed

#### Rationale:

coredump_disable_storage only makes sense if systemd is installed because it checks systemd configuration files and relies on systemd behavior.

#### Review Hints:

With this change applied, `oscap-podman ubuntu:22.04 xccdf eval --report report.html --profile xccdf_org.ssgproject.content_profile_standard /usr/share/xml/scap/ssg/content/ssg-ubuntu2204-ds.xml`  should yield a report indicating that the "Disable storing core dump" rule is "Not Applicable
