### PR TITLE
OCP4: New rule image_pruner_active covers SRG-APP-000454-CTR-001110 and SRG-APP-000454-CTR-001115

### DIFF
--- a/applications/openshift/registry/image_pruner_active/policy/stig/shared.yml
+++ b/applications/openshift/registry/image_pruner_active/policy/stig/shared.yml
@@ -1,0 +1,13 @@
+srg_requirement: |-
+    The container platform registry must remove old container images after updating versions have been made available.
+
+checktext: |-
+    Ensure that the imagepruner is configured and is not in a suspended state.
+    > oc get imagepruners.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec}{"\n"}'
+    Review the settings and if suspend is set to true, this is a finding.
+
+fixtext: |-
+    Enable the image pruner automate the pruning of images from the cluster.
+    > oc patch imagepruners.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"suspend":false}}'
+    For additional details on configuring the image pruner operator see the following document
+    https://docs.openshift.com/container-platform/latest/applications/pruning-objects.html#pruning-images_pruning-objects

--- a/applications/openshift/registry/image_pruner_active/rule.yml
+++ b/applications/openshift/registry/image_pruner_active/rule.yml
@@ -1,0 +1,59 @@
+prodtype: ocp4
+
+title: "Configure ImagePruner so that images that are no longer needed are automatically removed"
+
+description: |-
+  <p>
+  Images from the internal registry that are no longer required by the system due to age, status,
+  or exceed limits are automatically pruned. Cluster administrators can configure the Pruning Custom Resource, or suspend it. 
+  </p>
+  <p>
+  For more information on configuring the ImagePruner, consult the
+  OpenShift documentation:
+  {{{ weblink(link="https://access.redhat.com/documentation/en-us/openshift_container_platform/latest/html/building_applications/pruning-objects") }}}
+  </p>
+
+
+rationale: |-
+  <p>
+  Obsolete and stale images need to be removed from the registry to ensure
+  the container platform maintains a secure posture. While the storing of
+  these images does not directly pose a threat, they do increase the likelihood
+  of these images being deployed.
+  </p>
+  <p>
+  Removing stale or obsolete images and only keeping the most recent versions
+  of those that are still in use removes any possibility of vulnerable images being deployed.
+  </p>
+
+identifiers:
+  cce@ocp4: CCE-86480-1
+
+references:
+  nist: SI-2(6)
+  srg: SRG-APP-000454-CTR-001110,SRG-APP-000454-CTR-001115
+
+ocil_clause: 'ImagePruner is not active'
+
+ocil: |-
+  Ensure that the imagepruner is configured and is not in a suspended state.
+  <pre>oc get imagepruners.imageregistry.operator.openshift.io/cluster -o jsonpath='{.spec}{"\n"}'</pre
+  The output should be non-empty and the <tt>.spec.suspend</tt> field should not be set to false.
+
+severity: medium
+
+warnings:
+- general: |-
+    {{{ openshift_cluster_setting("/apis/imageregistry.operator.openshift.io/v1/imagepruners/cluster") | indent(4) }}}
+
+template:
+  name: yamlfile_value
+  vars:
+    ocp_data: 'true'
+    filepath: /apis/imageregistry.operator.openshift.io/v1/imagepruners/cluster
+    yamlpath: ".spec.suspend"
+    check_existence: "any_exist"
+    values:
+    - value: true
+      type: boolean
+      operation: "not equal"

--- a/applications/openshift/registry/image_pruner_active/tests/correct.pass.sh
+++ b/applications/openshift/registry/image_pruner_active/tests/correct.pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir -p /apis/imageregistry.operator.openshift.io/v1/imagepruners/
+
+cat << EOF > /apis/imageregistry.operator.openshift.io/v1/imagepruners/cluster
+spec:
+  suspend: false
+  schedule: ""
+  logLevel: "Normal"
+EOF

--- a/applications/openshift/registry/image_pruner_active/tests/no_file.fail.sh
+++ b/applications/openshift/registry/image_pruner_active/tests/no_file.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# remediation = none
+
+rm -rf /apis/imageregistry.operator.openshift.io/v1/imagepruners/

--- a/applications/openshift/registry/image_pruner_active/tests/ocp4/e2e.yml
+++ b/applications/openshift/registry/image_pruner_active/tests/ocp4/e2e.yml
@@ -1,0 +1,2 @@
+---
+default_result: PASS

--- a/applications/openshift/registry/image_pruner_active/tests/suspend.fail.sh
+++ b/applications/openshift/registry/image_pruner_active/tests/suspend.fail.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# remediation = none
+
+mkdir -p /apis/imageregistry.operator.openshift.io/v1/imagepruners/
+
+cat << EOF > /apis/imageregistry.operator.openshift.io/v1/imagepruners/cluster
+spec:
+  suspend: true
+  schedule: ""
+  logLevel: "Normal"
+EOF

--- a/controls/srg_ctr/SRG-APP-000454-CTR-001110.yml
+++ b/controls/srg_ctr/SRG-APP-000454-CTR-001110.yml
@@ -4,4 +4,6 @@ controls:
   - medium
   title: {{{ full_name }}} must remove old components after updated versions
     have been installed.
-  status: pending
+  status: automated
+  rules:
+    - image_pruner_active

--- a/controls/srg_ctr/SRG-APP-000454-CTR-001115.yml
+++ b/controls/srg_ctr/SRG-APP-000454-CTR-001115.yml
@@ -4,4 +4,6 @@ controls:
   - medium
   title: {{{ full_name }}} registry must remove old container images after updating
     versions have been made available.
-  status: pending
+  status: automated
+  rules:
+    - image_pruner_active


### PR DESCRIPTION
#### Description:

- A new rule that covers two SRGs

#### Rationale:

- OCP4 STIG

#### Review Hints:

- I will post the SRG export later
