### PR TITLE
Refactor audit_rules_privileged_commands to include in CIS

### DIFF
--- a/controls/cis_rhel7.yml
+++ b/controls/cis_rhel7.yml
@@ -1433,7 +1433,9 @@ controls:
     levels:
     - l2_server
     - l2_workstation
-    automated: no # we have audit_rules_privileged_commands, but it does not set perm=x
+    status: automated
+    rules:
+      - audit_rules_privileged_commands
 
   - id: 4.1.12
     title: Ensure successful file system mounts are collected (Automated)

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1502,15 +1502,13 @@ controls:
     rules:
       - audit_rules_networkconfig_modification
 
-  # NEEDS RULE
   - id: 4.1.3.6
     title: Ensure use of privileged commands is collected (Automated)
     levels:
       - l2_server
       - l2_workstation
-    status: planned
-    related_rules:
-      # The rule below is almost correct but cannot be used as it does not set the perm=x flag.
+    status: automated
+    rules:
       - audit_rules_privileged_commands
 
   - id: 4.1.3.7

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1266,15 +1266,13 @@ controls:
     rules:
       - audit_rules_networkconfig_modification
 
-  # NEEDS RULE
   - id: 4.1.3.6
     title: Ensure use of privileged commands is collected (Automated)
     levels:
       - l2_server
       - l2_workstation
-    status: planned
-    related_rules:
-      # The rule below is almost correct but cannot be used as it does not set the perm=x flag.
+    status: automated
+    rules:
       - audit_rules_privileged_commands
 
   - id: 4.1.3.7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -1,58 +1,63 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = false
-# strategy = restrict
+# strategy = configure
 # complexity = low
 # disruption = low
 
-- name: Search for privileged commands
-  shell: |
-    set -o pipefail
-    find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null
-  args:
-    executable: /bin/bash
-  check_mode: no
-  register: find_result
+- name: {{{ rule_title }}} - Set List of Mount Points Which Permits Execution of Privileged Commands
+  ansible.builtin.set_fact:
+    privileged_mount_points: "{{(ansible_facts.mounts | rejectattr('options', 'search', 'noexec|nosuid') | map(attribute='mount') | list ) }}"
+
+- name: {{{ rule_title }}} - Search for Privileged Commands in Eligible Mount Points
+  ansible.builtin.shell:
+    cmd: find {{ item }} -xdev -perm /6000 -type f 2>/dev/null
+  register: result_privileged_commands_search
   changed_when: false
   failed_when: false
+  with_items: "{{ privileged_mount_points }}"
 
-# Inserts/replaces the rule in /etc/audit/rules.d
+- name: {{{ rule_title }}} - Set List of Privileged Commands Found in Eligible Mount Points
+  ansible.builtin.set_fact:
+    privileged_commands: "{{( result_privileged_commands_search.results | map(attribute='stdout_lines') | select() | list )[-1] }}"
 
-- name: Search /etc/audit/rules.d for audit rule entries
-  find:
-    paths: "/etc/audit/rules.d"
-    recurse: no
-    contains: "^.*path={{ item }} .*$"
-    patterns: "*.rules"
-  with_items:
-    - "{{ find_result.stdout_lines }}"
-  register: files_result
+- name: {{{ rule_title }}} - Privileged Commands are Present in the System
+  block:
+    - name: {{{ rule_title }}} - Ensure Rules for All Privileged Commands in augenrules Format
+      ansible.builtin.lineinfile:
+        path: /etc/audit/rules.d/privileged.rules
+        line: '-a always,exit -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+        regexp: "^.*path={{ item | regex_escape() }} .*$"
+        create: yes
+      with_items:
+        - "{{ privileged_commands }}"
 
-- name: Overwrites the rule in rules.d
-  lineinfile:
-    path: "{{ item.1.path }}"
-    line: '-a always,exit -F path={{ item.0.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
-    create: no
-    regexp: "^.*path={{ item.0.item }} .*$"
-  with_subelements:
-    - "{{ files_result.results }}"
-    - files
+    - name: {{{ rule_title }}} - Ensure Rules for All Privileged Commands in auditctl Format
+      ansible.builtin.lineinfile:
+        path: /etc/audit/audit.rules
+        line: '-a always,exit -F path={{ item }} -F perm=x -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
+        regexp: "^.*path={{ item | regex_escape() }} .*$"
+        create: yes
+      with_items:
+        - "{{ privileged_commands }}"
 
-- name: Adds the rule in rules.d
-  lineinfile:
-    path: /etc/audit/rules.d/privileged.rules
-    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
-    create: yes
-  with_items:
-    - "{{ files_result.results }}"
-  when: files_result.results is defined and item.matched == 0
+    - name: {{{ rule_title }}} - Search for Duplicated Rules in Other Files
+      ansible.builtin.find:
+        paths: "/etc/audit/rules.d"
+        recurse: no
+        contains: "^-a always,exit -F path={{ item }} .*$"
+        patterns: "*.rules"
+      with_items:
+        - "{{ privileged_commands }}"
+      register: result_augenrules_files
 
-# Adds/overwrites the rule in /etc/audit/audit.rules
-
-- name: Inserts/replaces the rule in audit.rules
-  lineinfile:
-    path: /etc/audit/audit.rules
-    line: '-a always,exit -F path={{ item.item }} -F auid>={{{ auid }}} -F auid!=unset -F key=privileged'
-    create: yes
-    regexp: "^.*path={{ item.item }} .*$"
-  with_items:
-    - "{{ files_result.results }}"
+    - name: {{{ rule_title }}} - Ensure Rules for Privileged Commands are Defined Only in One File
+      ansible.builtin.lineinfile:
+        path: "{{ item.1.path }}"
+        regexp: "^-a always,exit -F path={{ item.0.item }} .*$"
+        state: absent
+      with_subelements:
+        - "{{ result_augenrules_files.results }}"
+        - files
+      when:
+        - item.1.path != '/etc/audit/rules.d/privileged.rules'
+  when: privileged_commands is defined

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
@@ -1,5 +1,23 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
+# platform = multi_platform_all
+# reboot = false
+# strategy = configure
+# complexity = low
+# disruption = low
 
-# Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
-{{{ bash_perform_audit_rules_privileged_commands_remediation("auditctl", auid) }}}
-{{{ bash_perform_audit_rules_privileged_commands_remediation("augenrules", auid) }}}
+ACTION_ARCH_FILTERS="-a always,exit"
+AUID_FILTERS="-F auid>={{{ auid }}} -F auid!=unset"
+SYSCALL=""
+KEY="privileged"
+SYSCALL_GROUPING=""
+
+FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | grep -Pv "noexec|nosuid" | awk '{ print $1 }')
+for PARTITION in $PARTITIONS; do
+  PRIV_CMDS=$(find "${PARTITION}" -xdev -perm /6000 -type f 2>/dev/null)
+  for PRIV_CMD in $PRIV_CMDS; do
+    OTHER_FILTERS="-F path=$PRIV_CMD -F perm=x"
+    # Perform the remediation for both possible tools: 'auditctl' and 'augenrules'
+    {{{ bash_fix_audit_syscall_rule("augenrules", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") | indent(4) }}}
+    {{{ bash_fix_audit_syscall_rule("auditctl", "$ACTION_ARCH_FILTERS", "$OTHER_FILTERS", "$AUID_FILTERS", "$SYSCALL", "$SYSCALL_GROUPING", "$KEY") | indent(4) }}}
+  done
+done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -65,10 +65,9 @@
   <!-- The intention of the first test is to ensure that exists at one rule for each privileged
     command found in the system. Therefore, a list of objects will be extracted from auditd rules
     and compared to the previous object. -->
-
   <local_variable id="var_audit_rules_privileged_commands_rule_regex" version="1"
     datatype="string" comment="Regex for auditd rule.">
-    <literal_component>^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</literal_component>
+    <literal_component>^[\s]*-a always,exit (?:-F path=([\S]+))+(?: -F perm=x)? -F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</literal_component>
   </local_variable>
 
   <ind:textfilecontent54_state id="state_not_relevant_cmds" version="1">

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -60,13 +60,13 @@
     <unix:sgid datatype="boolean">true</unix:sgid>
   </unix:file_state>
 
-  <!-- This file_object should include all privileged commands located only in file systems
-       that permit execution of priviledeg commands. The recurse_file_system parameter is set to
-       defined in order to make sure the probe doesn't leave the scope of that mount point.
-       For example, when probing "/", the probe will ignore any child directory which is a mount
-       point for any other partition. This will ensure considerable performance improvement. -->
+  <!-- This file_object will only find privileged commands located only in file systems that allow
+       their execution. The recurse_file_system parameter is set to defined in order to make sure
+       the probe doesn't leave the scope of that mount point. For example, when probing "/", the
+       probe will ignore any child directory which is a mount point for any other partition.
+       This will ensure considerable performance improvement. -->
   <unix:file_object id="object_audit_rules_privileged_commands" version="1"
-    comment="Files with setuid or setgid permission set">
+    comment="Files with setuid or setgid permission in file systems that allow their execution">
     <unix:behaviors recurse="directories" recurse_direction="down"
       recurse_file_system="defined" max_depth="-1"/>
     <unix:path operation="equals" var_check="at least one"
@@ -97,7 +97,7 @@
        privileged command found in the system. Therefore, a list of objects will be extracted
        from auditd rules and compared to privileged commands found in relevant partitions. -->
   <local_variable id="var_audit_rules_privileged_commands_rule_regex" version="1"
-    datatype="string" comment="Regex for auditd rule.">
+    datatype="string" comment="Regex for auditd rule">
     <literal_component>^[\s]*-a always,exit (?:-F path=([\S]+))+(?: -F perm=x)? -F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</literal_component>
   </local_variable>
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -65,6 +65,12 @@
   <!-- The intention of the first test is to ensure that exists at one rule for each privileged
     command found in the system. Therefore, a list of objects will be extracted from auditd rules
     and compared to the previous object. -->
+
+  <local_variable id="var_audit_rules_privileged_commands_rule_regex" version="1"
+    datatype="string" comment="Regex for auditd rule.">
+    <literal_component>^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</literal_component>
+  </local_variable>
+
   <ind:textfilecontent54_state id="state_not_relevant_cmds" version="1">
     <ind:subexpression datatype="string" operation="not equal" var_check="all"
       var_ref="var_audit_rules_privileged_commands_priv_cmds"/>
@@ -72,7 +78,7 @@
 
   <ind:textfilecontent54_object id="object_priv_cmds_from_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rules_privileged_commands_rule_regex"/>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_not_relevant_cmds</filter>
   </ind:textfilecontent54_object>
@@ -111,7 +117,7 @@
   <!-- auditctl -->
   <ind:textfilecontent54_object id="object_priv_cmds_from_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match" var_ref="var_audit_rules_privileged_commands_rule_regex"/>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
     <filter action="exclude">state_not_relevant_cmds</filter>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -23,25 +23,56 @@
   </definition>
 
   <!-- First define OVAL entities that can be reused across tests below -->
-  <unix:file_state id="state_setuid_or_setgid_set" version="1" operator="OR">
+  <linux:partition_state id="state_audit_rules_privileged_commands_dev_partitons" version="1">
+    <linux:device operation="pattern match">^/dev/.*$</linux:device>
+  </linux:partition_state>
+
+  <linux:partition_state id="state_audit_rules_privileged_commands_nosuid_partitons" version="1">
+    <linux:mount_options datatype="string" entity_check="at least one"
+      operation="equals">nosuid</linux:mount_options>
+  </linux:partition_state>
+
+<linux:partition_state id="state_audit_rules_privileged_commands_noexec_partitons" version="1">
+    <linux:mount_options datatype="string" entity_check="at least one"
+      operation="equals">noexec</linux:mount_options>
+  </linux:partition_state>
+
+  <!-- This object is created mainly to improve performance when collecting file objects.
+       Here all mount points are collected and filtered to include only devices under /dev in
+       order to ignore special file systems. Then, the mount options are checked to exclude
+       file systems mounted with nosuid or noexec. The privileged commands can't execute on these
+       file systems, so there is no reason to proble these file systems. -->
+  <linux:partition_object id="object_audit_rules_privileged_commands_exec_partitions" version="1">
+    <linux:mount_point operation="pattern match">^/.*$</linux:mount_point>
+    <filter action="include">state_audit_rules_privileged_commands_dev_partitons</filter>
+    <filter action="exclude">state_audit_rules_privileged_commands_nosuid_partitons</filter>
+    <filter action="exclude">state_audit_rules_privileged_commands_noexec_partitons</filter>
+  </linux:partition_object>
+
+  <local_variable id="var_audit_rules_privileged_commands_exec_mountpoints" version="1"
+    datatype="string" comment="Mount points where suid or sgid files can be executed">
+    <object_component item_field="mount_point"
+      object_ref="object_audit_rules_privileged_commands_exec_partitions"/>
+  </local_variable>
+
+  <unix:file_state id="state_setuid_or_setgid_set" operator="OR" version="1">
     <unix:suid datatype="boolean">true</unix:suid>
     <unix:sgid datatype="boolean">true</unix:sgid>
   </unix:file_state>
 
-  <unix:file_state id="state_dev_proc_sys_dirs" version="1">
-    <unix:filepath operation="pattern match">^\/(dev|proc|sys)\/.*$</unix:filepath>
-  </unix:file_state>
-
-  <!-- augenrules -->
+  <!-- This file_object should include all privileged commands located only in file systems
+       that permit execution of priviledeg commands. The recurse_file_system parameter is set to
+       defined in order to make sure the probe doesn't leave the scope of that mount point.
+       For example, when probing "/", the probe will ignore any child directory which is a mount
+       point for any other partition. This will ensure considerable performance improvement. -->
   <unix:file_object id="object_audit_rules_privileged_commands" version="1"
-    comment="files with setuid or setgid permission set">
+    comment="Files with setuid or setgid permission set">
     <unix:behaviors recurse="directories" recurse_direction="down"
-      recurse_file_system="local" max_depth="-1"/>
-    <unix:path operation="equals">/</unix:path>
-    <!-- [a-z]+ regex below is a workaround for OpenSCAP https://fedorahosted.org/openscap/ticket/457 bug -->
-    <unix:filename operation="pattern match">[a-z]+</unix:filename>
+      recurse_file_system="defined" max_depth="-1"/>
+    <unix:path operation="equals" var_check="at least one"
+      var_ref="var_audit_rules_privileged_commands_exec_mountpoints"/>
+    <unix:filename operation="pattern match">^\w+</unix:filename>
     <filter action="include">state_setuid_or_setgid_set</filter>
-    <filter action="exclude">state_dev_proc_sys_dirs</filter>
   </unix:file_object>
 
   <local_variable id="var_audit_rules_privileged_commands_priv_cmds" version="1"
@@ -53,7 +84,7 @@
     datatype="int" comment="Count all privileged commands present in the system">
     <count>
       <object_component item_field="filepath"
-      object_ref="object_audit_rules_privileged_commands"/>
+        object_ref="object_audit_rules_privileged_commands"/>
     </count>
   </local_variable>
 
@@ -62,24 +93,30 @@
     <ind:var_ref>var_audit_rules_privileged_commands_priv_cmds_count</ind:var_ref>
   </ind:variable_object>
 
-  <!-- The intention of the first test is to ensure that exists at one rule for each privileged
-    command found in the system. Therefore, a list of objects will be extracted from auditd rules
-    and compared to the previous object. -->
+  <!-- The intention of the first test is to ensure that exists at least one rule for each
+       privileged command found in the system. Therefore, a list of objects will be extracted
+       from auditd rules and compared to privileged commands found in relevant partitions. -->
   <local_variable id="var_audit_rules_privileged_commands_rule_regex" version="1"
     datatype="string" comment="Regex for auditd rule.">
     <literal_component>^[\s]*-a always,exit (?:-F path=([\S]+))+(?: -F perm=x)? -F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</literal_component>
   </local_variable>
 
-  <ind:textfilecontent54_state id="state_not_relevant_cmds" version="1">
+  <!-- This state is used to filter out all the auditd rules related to non privileged commands.
+       When collectiong the paths in the textfilecontent54_object objects below, this state will
+       ensure that the list is composed only by privileged commands present in the system. Other
+       paths values will be ignored. -->
+  <ind:textfilecontent54_state id="state_unprivileged_commands" version="1">
     <ind:subexpression datatype="string" operation="not equal" var_check="all"
       var_ref="var_audit_rules_privileged_commands_priv_cmds"/>
   </ind:textfilecontent54_state>
 
+  <!-- augenrules -->
   <ind:textfilecontent54_object id="object_priv_cmds_from_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match" var_ref="var_audit_rules_privileged_commands_rule_regex"/>
+    <ind:pattern operation="pattern match"
+      var_ref="var_audit_rules_privileged_commands_rule_regex"/>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="exclude">state_not_relevant_cmds</filter>
+    <filter action="exclude">state_unprivileged_commands</filter>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="state_priv_cmds_from_system" version="1">
@@ -116,9 +153,10 @@
   <!-- auditctl -->
   <ind:textfilecontent54_object id="object_priv_cmds_from_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match" var_ref="var_audit_rules_privileged_commands_rule_regex"/>
+    <ind:pattern operation="pattern match"
+      var_ref="var_audit_rules_privileged_commands_rule_regex"/>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="exclude">state_not_relevant_cmds</filter>
+    <filter action="exclude">state_unprivileged_commands</filter>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test id="test_auditctl_all_priv_cmds_covered" version="1"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -1,36 +1,28 @@
 <def-group>
-  <definition class="compliance" id="audit_rules_privileged_commands" version="1">
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
     {{{ oval_metadata("Audit rules about the information on the use of privileged commands are enabled.") }}}
-
     <criteria operator="OR">
-
-      <!-- Test the augenrules case -->
       <criteria operator="AND">
-        <extend_definition comment="audit augenrules" definition_ref="audit_rules_augenrules" />
-        <criterion comment="audit augenrules suid sgid" test_ref="test_arpc_suid_sgid_augenrules" />
-        <criterion comment="audit augenrules binaries count matches rules count" test_ref="test_arpc_bin_count_equals_rules_count_augenrules" />
+        <extend_definition definition_ref="audit_rules_augenrules"
+          comment="audit augenrules format is used"/>
+        <criterion test_ref="test_augenrules_all_priv_cmds_covered"
+          comment="augenrules cover all privileged commands on the system"/>
+        <criterion test_ref="test_augenrules_count_matches_system_priv_cmds"
+          comment="count of augenrules for priv cmds matches count of priv cmds in the system"/>
       </criteria>
 
-      <!-- Test the auditctl case -->
       <criteria operator="AND">
-        <extend_definition comment="audit auditctl" definition_ref="audit_rules_auditctl" />
-        <criterion comment="audit auditctl suid sgid" test_ref="test_arpc_suid_sgid_auditctl" />
-        <criterion comment="audit auditctl binaries count matches rules count" test_ref="test_arpc_bin_count_equals_rules_count_auditctl" />
+        <extend_definition definition_ref="audit_rules_auditctl"
+          comment="audit auditctl format is used"/>
+        <criterion test_ref="test_auditctl_all_priv_cmds_covered"
+          comment="auditctl covers all privileged commands on the system"/>
+        <criterion test_ref="test_auditctl_count_matches_system_priv_cmds"
+          comment="count of auditctl for priv cmds matches count of priv cmds in the system"/>
       </criteria>
-
     </criteria>
   </definition>
 
   <!-- First define OVAL entities that can be reused across tests below -->
-  <unix:file_object id="object_system_privileged_commands" comment="system files with setuid or setgid permission set" version="1">
-    <unix:behaviors recurse="directories" recurse_direction="down" recurse_file_system="local" max_depth="-1" />
-    <unix:path operation="equals">/</unix:path>
-    <!-- [a-z]+ regex below is a workaround for OpenSCAP https://fedorahosted.org/openscap/ticket/457 bug -->
-    <unix:filename operation="pattern match">[a-z]+</unix:filename>
-    <filter action="include">state_setuid_or_setgid_set</filter>
-    <filter action="exclude">state_dev_proc_sys_dirs</filter>
-  </unix:file_object>
-
   <unix:file_state id="state_setuid_or_setgid_set" version="1" operator="OR">
     <unix:suid datatype="boolean">true</unix:suid>
     <unix:sgid datatype="boolean">true</unix:sgid>
@@ -40,74 +32,113 @@
     <unix:filepath operation="pattern match">^\/(dev|proc|sys)\/.*$</unix:filepath>
   </unix:file_state>
 
-  <local_variable id="variable_all_privileged_commands" comment="All privileged commands" datatype="string" version="1">
-    <object_component object_ref="object_system_privileged_commands" item_field="filepath" />
+  <!-- augenrules -->
+  <unix:file_object id="object_audit_rules_privileged_commands" version="1"
+    comment="files with setuid or setgid permission set">
+    <unix:behaviors recurse="directories" recurse_direction="down"
+      recurse_file_system="local" max_depth="-1"/>
+    <unix:path operation="equals">/</unix:path>
+    <!-- [a-z]+ regex below is a workaround for OpenSCAP https://fedorahosted.org/openscap/ticket/457 bug -->
+    <unix:filename operation="pattern match">[a-z]+</unix:filename>
+    <filter action="include">state_setuid_or_setgid_set</filter>
+    <filter action="exclude">state_dev_proc_sys_dirs</filter>
+  </unix:file_object>
+
+  <local_variable id="var_audit_rules_privileged_commands_priv_cmds" version="1"
+    datatype="string" comment="Filepath of all privileged commands found in the system">
+    <object_component item_field="filepath" object_ref="object_audit_rules_privileged_commands"/>
   </local_variable>
 
-  <local_variable id="variable_count_of_suid_sgid_binaries_on_system" comment="count of suid / sgid binaries actually present on the system" datatype="int" version="1">
+  <local_variable id="var_audit_rules_privileged_commands_priv_cmds_count" version="1"
+    datatype="int" comment="Count all privileged commands present in the system">
     <count>
-      <object_component object_ref="object_system_privileged_commands" item_field="filepath" />
+      <object_component item_field="filepath"
+      object_ref="object_audit_rules_privileged_commands"/>
     </count>
   </local_variable>
 
-  <ind:variable_object id="object_count_of_suid_sgid_binaries_on_system" version="1">
-    <ind:var_ref>variable_count_of_suid_sgid_binaries_on_system</ind:var_ref>
+  <ind:variable_object id="object_audit_rules_privileged_commands_priv_cmds_count" version="1"
+    comment="Number of all privileged commands in the system, regardless of audit rules.">
+    <ind:var_ref>var_audit_rules_privileged_commands_priv_cmds_count</ind:var_ref>
   </ind:variable_object>
 
-  <ind:textfilecontent54_state id="state_proper_audit_rule_but_for_unprivileged_command" version="1">
-    <ind:subexpression operation="not equal" datatype="string" var_ref="variable_all_privileged_commands" var_check="all" />
+  <!-- The intention of the first test is to ensure that exists at one rule for each privileged
+    command found in the system. Therefore, a list of objects will be extracted from auditd rules
+    and compared to the previous object. -->
+  <ind:textfilecontent54_state id="state_not_relevant_cmds" version="1">
+    <ind:subexpression datatype="string" operation="not equal" var_check="all"
+      var_ref="var_audit_rules_privileged_commands_priv_cmds"/>
   </ind:textfilecontent54_state>
 
-  <ind:textfilecontent54_state id="state_audit_rules_privileged_commands" version="1">
-    <ind:subexpression operation="pattern match" datatype="string" var_ref="variable_all_privileged_commands" var_check="at least one"/>
-  </ind:textfilecontent54_state>
-
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit augenrules suid sgid" id="test_arpc_suid_sgid_augenrules" version="1">
-    <ind:object object_ref="object_arpc_suid_sgid_augenrules" />
-    <ind:state state_ref="state_audit_rules_privileged_commands" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arpc_suid_sgid_augenrules" version="1">
+  <ind:textfilecontent54_object id="object_priv_cmds_from_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
+    <filter action="exclude">state_not_relevant_cmds</filter>
   </ind:textfilecontent54_object>
 
-  <local_variable id="variable_count_of_privileged_commands_having_audit_definition_augenrules" comment="count of suid / sgid binaries having full audit rule definition in some of /etc/audit/rules.d/*.rules files" datatype="int" version="1">
+  <ind:textfilecontent54_state id="state_priv_cmds_from_system" version="1">
+    <ind:subexpression datatype="string" operation="pattern match" var_check="at least one"
+      var_ref="var_audit_rules_privileged_commands_priv_cmds"/>
+  </ind:textfilecontent54_state>
+
+  <ind:textfilecontent54_test id="test_augenrules_all_priv_cmds_covered" version="1"
+    check="all" check_existence="all_exist"
+    comment="There is one augenrules rule for each privileged command on the system.">
+    <ind:object object_ref="object_priv_cmds_from_augenrules" />
+    <ind:state state_ref="state_priv_cmds_from_system" />
+  </ind:textfilecontent54_test>
+
+  <local_variable id="var_priv_cmds_from_augenrules_count" version="1"
+    datatype="int" comment="Count privileged commands found in audit rules in augenrules format">
     <count>
-      <object_component object_ref="object_arpc_suid_sgid_augenrules" item_field="subexpression" />
+      <object_component item_field="subexpression" object_ref="object_priv_cmds_from_augenrules"/>
     </count>
   </local_variable>
-  <ind:variable_state id="state_count_of_privileged_commands_having_audit_definition_augenrules" version="1">
-    <ind:value operation="equals" datatype="int" var_ref="variable_count_of_privileged_commands_having_audit_definition_augenrules" var_check="at least one" />
+
+  <ind:variable_state id="state_priv_cmds_from_augenrules_count" version="1">
+    <ind:value datatype="int" operation="equals" var_check="at least one"
+      var_ref="var_priv_cmds_from_augenrules_count"/>
   </ind:variable_state>
-  <ind:variable_test check="all" check_existence="all_exist" id="test_arpc_bin_count_equals_rules_count_augenrules" comment="audit augenrules binaries count matches rules count" version="1">
-    <ind:object object_ref="object_count_of_suid_sgid_binaries_on_system" />
-    <ind:state state_ref="state_count_of_privileged_commands_having_audit_definition_augenrules" />
+
+  <ind:variable_test id="test_augenrules_count_matches_system_priv_cmds" version="1"
+    check="all" check_existence="all_exist"
+    comment="Count of augenrules for priv cmds matches the count of priv cmds in the system">
+    <ind:object object_ref="object_audit_rules_privileged_commands_priv_cmds_count"/>
+    <ind:state state_ref="state_priv_cmds_from_augenrules_count"/>
   </ind:variable_test>
 
-  <ind:textfilecontent54_test check="all" check_existence="all_exist" comment="audit auditctl suid sgid" id="test_arpc_suid_sgid_auditctl" version="1">
-    <ind:object object_ref="object_arpc_suid_sgid_auditctl" />
-    <ind:state state_ref="state_audit_rules_privileged_commands" />
-  </ind:textfilecontent54_test>
-  <ind:textfilecontent54_object id="object_arpc_suid_sgid_auditctl" version="1">
+  <!-- auditctl -->
+  <ind:textfilecontent54_object id="object_priv_cmds_from_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     <ind:pattern operation="pattern match">^[\s]*-a always,exit (?:-F path=([\S]+) )+-F auid>={{{ auid }}} -F auid!=(?:4294967295|unset)[\s]+(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
-    <filter action="exclude">state_proper_audit_rule_but_for_unprivileged_command</filter>
+    <filter action="exclude">state_not_relevant_cmds</filter>
   </ind:textfilecontent54_object>
 
-  <local_variable id="variable_count_of_privileged_commands_having_audit_definition_auditctl" comment="count of suid / sgid binaries having full audit rule definition in /etc/audit/audit.rules file" datatype="int" version="1">
+  <ind:textfilecontent54_test id="test_auditctl_all_priv_cmds_covered" version="1"
+    check="all" check_existence="all_exist"
+    comment="There is one auditctl rule for each privileged command on the system.">
+    <ind:object object_ref="object_priv_cmds_from_auditctl"/>
+    <ind:state state_ref="state_priv_cmds_from_system"/>
+  </ind:textfilecontent54_test>
+
+  <local_variable id="var_priv_cmds_from_auditctl_count" version="1"
+    datatype="int" comment="Count privileged commands found in audit rules in auditctl format">
     <count>
-      <object_component object_ref="object_arpc_suid_sgid_auditctl" item_field="subexpression" />
+      <object_component object_ref="object_priv_cmds_from_auditctl" item_field="subexpression"/>
     </count>
   </local_variable>
-  <ind:variable_state id="state_count_of_privileged_commands_having_audit_definition_auditctl" version="1">
-    <ind:value operation="equals" datatype="int" var_ref="variable_count_of_privileged_commands_having_audit_definition_auditctl" var_check="at least one" />
-  </ind:variable_state>
-  <ind:variable_test check="all" check_existence="all_exist" id="test_arpc_bin_count_equals_rules_count_auditctl" comment="audit auditctl binaries count matches rules count" version="1">
-    <ind:object object_ref="object_count_of_suid_sgid_binaries_on_system" />
-    <ind:state state_ref="state_count_of_privileged_commands_having_audit_definition_auditctl" />
-  </ind:variable_test>
 
+  <ind:variable_state id="state_priv_cmds_from_auditctl_count" version="1">
+    <ind:value datatype="int" operation="equals" var_check="at least one"
+      var_ref="var_priv_cmds_from_auditctl_count"/>
+  </ind:variable_state>
+
+  <ind:variable_test id="test_auditctl_count_matches_system_priv_cmds" version="1"
+    check="all" check_existence="all_exist"
+    comment="Count of auditctl rules for priv cmds matches the count of priv cmds in the system">
+    <ind:object object_ref="object_audit_rules_privileged_commands_priv_cmds_count" />
+    <ind:state state_ref="state_priv_cmds_from_auditctl_count" />
+  </ind:variable_test>
 </def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -3,36 +3,39 @@ documentation_complete: true
 title: 'Ensure auditd Collects Information on the Use of Privileged Commands'
 
 description: |-
-    The audit system should collect information about usage of privileged
-    commands for all users and root. To find the relevant setuid /
-    setgid programs, run the following command for each local partition
-    <i>PART</i>:
-    <pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2&gt;/dev/null</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt>
-    program to read audit rules during daemon startup (the default), add a line of
-    the following form to a file with suffix <tt>.rules</tt> in the directory
-    <tt>/etc/audit/rules.d</tt> for each setuid / setgid program on the system,
-    replacing the <i>SETUID_PROG_PATH</i> part with the full path of that setuid /
-    setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
-    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt>
-    utility to read audit rules during daemon startup, add a line of the following
-    form to <tt>/etc/audit/audit.rules</tt> for each setuid / setgid program on the
-    system, replacing the <i>SETUID_PROG_PATH</i> part with the full path of that
-    setuid / setgid program in the list:
-    <pre>-a always,exit -F path=<i>SETUID_PROG_PATH</i> -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+    The audit system should collect information about usage of privileged commands for all users.
+    These are commands with suid or sgid bits on and they are specially risky in partitions not
+    mounted with noexec and nosuid options. Therefore, these partitions should be first identified
+    by the following command:
+    <pre>findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,) | grep -Pv "noexec|nosuid"</pre>
+
+    For all partitions listed by the previous command, it is necessary to search for
+    setuid / setgid programs using the following command:
+    <pre>$ sudo find <i>PARTITION</i> -xdev -perm /6000 -type f 2&gt;/dev/null</pre>
+
+    For each setuid / setgid program identified by the previous command, an audit rule must be
+    present in the appropriate place using the following line structure:
+    <pre>-a always,exit -F path=<i>PROG_PATH</i> -F perm=x -F auid&gt;={{{ auid }}} -F auid!=unset -F key=privileged</pre>
+
+    If the <tt>auditd</tt> daemon is configured to use the <tt>augenrules</tt> program to read
+    audit rules during daemon startup, add the line to a file with suffix <tt>.rules</tt> in the
+    <tt>/etc/audit/rules.d</tt> directory, replacing the <i>PROG_PATH</i> part with the full path
+    of that setuid / setgid identified program.
+
+    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility instead, add
+    the line to the <tt>/etc/audit/audit.rules</tt> file, also replacing the <i>PROG_PATH</i> part
+    with the full path of that setuid / setgid identified program.
 
 rationale: |-
-    Misuse of privileged functions, either intentionally or unintentionally by
-    authorized users, or by unauthorized external entities that have compromised system accounts,
-    is a serious and ongoing concern and can have significant adverse impacts on organizations.
-    Auditing the use of privileged functions is one way to detect such misuse and identify
-    the risk from insider and advanced persistent threats.
+    Misuse of privileged functions, either intentionally or unintentionally by authorized users,
+    or by unauthorized external entities that have compromised system accounts, is a serious and
+    ongoing concern that can have significant adverse impacts on organizations.
+    Auditing the use of privileged functions is one way to detect such misuse and identify the
+    risk from insider and advanced persistent threats.
     <br /><br />
-    Privileged programs are subject to escalation-of-privilege attacks,
-    which attempt to subvert their normal role of providing some necessary but
-    limited capability. As such, motivation exists to monitor these programs for
-    unusual activity.
+    Privileged programs are subject to escalation-of-privilege attacks, which attempt to subvert
+    their normal role of providing some necessary but limited capability. As such, motivation
+    exists to monitor these programs for unusual activity.
 
 severity: medium
 
@@ -46,8 +49,8 @@ identifiers:
 
 references:
     cis-csc: 1,11,12,13,14,15,16,19,2,3,4,5,6,7,8,9
-    cis@rhel7: 4.1.12
-    cis@rhel8: 4.1.13
+    cis@rhel7: 4.1.11
+    cis@rhel8: 4.1.3.6
     cis@rhel9: 4.1.3.6
     cis@sle12: 4.1.11
     cis@sle15: 4.1.11
@@ -69,21 +72,25 @@ references:
 ocil_clause: "any setuid or setgid programs doesn't have a line in the audit rules"
 
 ocil: |-
-    To verify that auditing of privileged command use is configured, run the
-    following command for each local partition <i>PART</i> to find relevant
-    setuid / setgid programs:
-    <pre>$ sudo find <i>PART</i> -xdev -type f -perm -4000 -o -type f -perm -2000 2&gt;/dev/null</pre>
-    Run the following command to verify entries in the audit rules for all programs
-    found with the previous command:
-    <pre>$ sudo grep path /etc/audit/audit.rules</pre>
-    All relevant setuid / setgid programs have a line
-    in the audit rules.
+    To verify that auditing of privileged command use is configured, run the following command
+    to search privileged commands in relevant partitions and check if they are covered by auditd
+    rules:
+
+    FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
+    PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | grep -Pv "noexec|nosuid" | awk '{ print $1 }')
+    for PARTITION in $PARTITIONS; do
+      for PRIV_CMD in $(find "${PARTITION}" -xdev -perm /6000 -type f 2&gt;/dev/null); do
+        grep -qr "${PRIV_CMD}" /etc/audit/rules.d /etc/audit/audit.rules &amp;&amp;
+          printf "OK: ${PRIV_CMD}\n" || printf "WARNING - rule not found for: ${PRIV_CMD}\n"
+      done
+    done
+
+    The output should not contain any WARNING.
 
 warnings:
     - general: |-
-        This rule checks for multiple syscalls related to privileged commands;
-        it was written with DISA STIG in mind. Other policies should use a
-        separate rule for each syscall that needs to be checked. For example:
+        This rule checks for multiple syscalls related to privileged commands. If needed to check
+        specific privileged commands, other more specific rules should be considered. For example:
         <ul>
         <li><tt>audit_rules_privileged_commands_su</tt></li>
         <li><tt>audit_rules_privileged_commands_umount</tt></li>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -4,9 +4,9 @@ title: 'Ensure auditd Collects Information on the Use of Privileged Commands'
 
 description: |-
     The audit system should collect information about usage of privileged commands for all users.
-    These are commands with suid or sgid bits on and they are specially risky in partitions not
-    mounted with noexec and nosuid options. Therefore, these partitions should be first identified
-    by the following command:
+    These are commands with suid or sgid bits on and they are specially risky in local block
+    device partitions not mounted with noexec and nosuid options. Therefore, these partitions
+    should be first identified by the following command:
     <pre>findmnt -n -l -k -it $(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,) | grep -Pv "noexec|nosuid"</pre>
 
     For all partitions listed by the previous command, it is necessary to search for

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_default.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i '/newgrp/d' /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
-sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/audit.rules
+sed -i -E 's/^(.*path=[[:graph:]]+) -F perm=x(.*$)/\1\2/' /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_default.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 # augenrules is default for rhel7

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # packages = audit
-# Remediation for this rule cannot remove the duplicates
 # remediation = none
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /tmp/privileged.rules
 
+# Remediation for this rule cannot remove the duplicates
 cp /tmp/privileged.rules /etc/audit/rules.d/privileged.rules
 sed 's/unset/4294967295/' /tmp/privileged.rules >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_with_perm_x.fail.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# packages = audit
-# remediation = bash
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
-
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
-sed -i -E 's/^(.*path=[[:graph:]]+ )(.*$)/\1-F perm=x \2/' /etc/audit/rules.d/privileged.rules
-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_without_perm_x.pass.sh
@@ -3,3 +3,4 @@
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+sed -i -E 's/^(.*path=[[:graph:]]+) -F perm=x(.*$)/\1\2/' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/newgrp -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/notrelevant -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/generate_privileged_commands_rule.sh
@@ -4,5 +4,5 @@ AUID=$1
 KEY=$2
 RULEPATH=$3
 for file in $(find / -not \( -fstype afs -o -fstype ceph -o -fstype cifs -o -fstype smb3 -o -fstype smbfs -o -fstype sshfs -o -fstype ncpfs -o -fstype ncp -o -fstype nfs -o -fstype nfs4 -o -fstype gfs -o -fstype gfs2 -o -fstype glusterfs -o -fstype gpfs -o -fstype pvfs2 -o -fstype ocfs2 -o -fstype lustre -o -fstype davfs -o -fstype fuse.sshfs \) -type f \( -perm -4000 -o -perm -2000 \) 2> /dev/null); do
-     echo "-a always,exit -F path=$file -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
+     echo "-a always,exit -F path=$file -F perm=x -F auid>=$AUID -F auid!=unset -k $KEY" >> $RULEPATH
 done

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # packages = audit
-# remediation = bash
-# platform = Fedora,Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8
+# platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
 ./generate_privileged_commands_rule.sh 1000 own_key /etc/audit/rules.d/privileged.rules


### PR DESCRIPTION
#### Description:

The `4.1.3.6` CIS requirement for RHEL8 and RHEL9 and the `4.1.11` CIS requirement for RHEL7 are now satisfied by the
`audit_rules_privileged_commands` rule.

Initially, the rule demanded an update to consider `-F perm=x` in `audit` rules since the rule is about execution of Privileged Commands which, according to the CIS Benchmark, are commands with `suidbit` or `sgidbit`.

However, when reviewing this rule, I found enough issues to consider a complete review and refactoring of this rule.
The main points of this refactoring are:
- More accurate rule description, rationale, ocil and warning.
- Much better readability and maintainability for OVAL.
- Improve OVAL efficiency when searching for Privileged Commands only in relevant mount points.
- More efficient Bash remediation aligned to common approach in the project
- More efficient Ansible remediation taking advantage of Ansible Facts instead of `shell` commands.
- Review and update of all test scenario scripts to ensure all cases are properly covered.

#### Rationale:

- Remove rule inefficiency and consequently increasing performance
- Better user experience
- Better CIS coverage for RHEL.

#### Review Hints:

I refactored the rule step by step and committed the changes in a logical flow. Therefore, I recommend to review commit by commit in order and check the commit message for more context about the changes.