### PR TITLE
Include warning for NetworkManager keyfiles in RHEL9

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/firewalld_sshd_port_enabled/rule.yml
@@ -56,3 +56,12 @@ warnings:
         the respective file. If the default SSH port is modified, it is on the administrator
         responsibility to ensure the firewalld customizations in the service port level are
         properly configured.
+{{% if product in [ 'rhel9' ] %}}
+    - management: |-
+        {{{ full_name }}} prefers and recommends to use NetworkManager keyfiles instead of the
+        <tt>ifcfg</tt> files stored in <tt>/etc/sysconfig/network-scripts</tt>. Therefore, if the
+        system was upgraded from a previous release, make sure the NIC configuration files are
+        properly migrated from <tt>ifcfg</tt> format to NetworkManager keyfiles. Otherwise, this
+        rule won't be able to check the configuration. The migration can be accomplished by
+        <tt>nmcli connection migrate</tt> command.
+{{% endif %}}


### PR DESCRIPTION
#### Description:

RHEL9 prefers and recommends to use NetworkManager `keyfiles` instead of the `ifcfg` format for NIC configuration.
New NICs will be automatically configured in the NM keyfiles format by default.
However, if the system was upgraded from a RHEL8, for example, the settings for existing NICs will remain stored in `ifcfg` format and the `firewalld_sshd_port_enabled` will fail.

They NIC settings should be migrated to the NM keyfiles format by the Admins.
It was included a warning in the `firewalld_sshd_port_enabled` rule to create more awareness for admins.

#### Rationale:

More awareness for corner cases.

- Fixes [#RHBZ](https://bugzilla.redhat.com/show_bug.cgi?id=2172555)