### PR TITLE
Update ansible in file_permissions_binary_dirs

### DIFF
--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_binary_dirs/ansible/shared.yml
@@ -4,15 +4,16 @@
 # complexity = medium
 # disruption = medium
 - name: "Read list of world and group writable system executables"
-  command: "find /bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec -perm /022 -type f"
+  ansible.builtin.command: "find /bin /usr/bin /usr/local/bin /sbin /usr/sbin /usr/local/sbin /usr/libexec -perm /022 -type f"
   register: world_writable_library_files
   changed_when: False
   failed_when: False
   check_mode: no
 
 - name: "Remove world/group writability of system executables"
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     mode: "go-w"
+    state: "file"
   with_items: "{{ world_writable_library_files.stdout_lines }}"
   when: world_writable_library_files.stdout_lines | length > 0


### PR DESCRIPTION
#### Description:

- Add explicit state in file module for the ansible task in `file_permissions_binary_dirs`

#### Rationale:

- This ansible task was failing when hard links where detected between the files being modified.
- When leaving empty ansible tries to guess it, and if it detects it is a hard link it will require an src, which is not given so it'll fail. So setting the state to 'file' it only changes the permissions, as expected

#### Review Hints:

- I only observed the error when running automatus on a libvirt environment