### PR TITLE
Add URL for ISM

### DIFF
--- a/ssg/constants.py
+++ b/ssg/constants.py
@@ -26,14 +26,13 @@ SSG_REF_URIS = {
     'pcidss': 'https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf',
     'ospp': 'https://www.niap-ccevs.org/Profile/PP.cfm',
     'hipaa': 'https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf',
+    'ism': 'https://www.cyber.gov.au/acsc/view-all-content/ism',
     'iso27001-2013': 'https://www.iso.org/standard/54534.html',
     'nerc-cip': 'https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx',
     'stigid': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux',
     'os-srg': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os',
     'app-srg': 'https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers',
     'stigref': 'https://public.cyber.mil/stigs/srg-stig-tools/',
-    # The following reference URIs were not defined in the XSLT constants
-    'ism': '',
 }
 
 product_directories = [


### PR DESCRIPTION
#### Description:

Add URL for ISM references. 

#### Rationale:
Addresses part of #10332.
