### PR TITLE
Add apparmor rule to Ubuntu CIS profiles and minor fixes to profiles

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
@@ -1,9 +1,9 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("var_apparmor_mode") }}}
 
 
-# Reload all AppArmor profiles 
+# Reload all AppArmor profiles
 apparmor_parser -q -r /etc/apparmor.d/
 
 # Set the mode
@@ -12,7 +12,7 @@ APPARMOR_MODE="$var_apparmor_mode"
 if [ "$APPARMOR_MODE" = "enforce" ]
 then
   # Set all profiles to enforce mode
-  aa-enforce /etc/apparmor.d/*    
+  aa-enforce /etc/apparmor.d/*
 fi
 
 if [ "$APPARMOR_MODE" = "complain" ]
@@ -25,11 +25,11 @@ UNCONFINED=$(aa-unconfined)
 if [ ! -z "$UNCONFINED" ]
 then
   echo -e "***WARNING***: There are some unconfined processes:"
-  echo -e "----------------------------" 
+  echo -e "----------------------------"
   echo "The may need to have a profile created or activated for them and then be restarted."
   for PROCESS in "${UNCONFINED[@]}"
   do
-      echo "$PROCESS"  
+      echo "$PROCESS"
   done
   echo -e "----------------------------"
   echo "The may need to have a profile created or activated for them and then be restarted."

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
@@ -1,26 +1,26 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: sle12,sle15,ubuntu2004,ubuntu2204
 
 title:  'All AppArmor Profiles are in enforce or complain mode'
 
 description: |-
     AppArmor profiles define what resources applications are able to access.
-    To set all profiles to either <tt>enforce</tt> or <tt>complain</tt>  mode 
+    To set all profiles to either <tt>enforce</tt> or <tt>complain</tt>  mode
     run the following command to set all profiles to <tt>enforce</tt> mode:
     <pre>$ sudo aa-enforce /etc/apparmor.d/*</pre>
     run the following command to set all profiles to <tt>complain</tt> mode:
     <pre>$ sudo aa-complain /etc/apparmor.d/*</pre>
     To list unconfined processes run the following command:
     <pre>$ sudo aa-unconfined</pre>
-    Any unconfined processes may need to have a profile created or activated 
+    Any unconfined processes may need to have a profile created or activated
     for them and then be restarted.
 
 rationale: |-
-    Security configuration requirements vary from site to site. Some sites may 
-    mandate a policy that is stricter than the default policy, which is perfectly 
-    acceptable. This recommendation is intended to ensure that any policies that 
-    exist on the system are activated. 
+    Security configuration requirements vary from site to site. Some sites may
+    mandate a policy that is stricter than the default policy, which is perfectly
+    acceptable. This recommendation is intended to ensure that any policies that
+    exist on the system are activated.
 
 severity: medium
 
@@ -31,3 +31,5 @@ identifiers:
 references:
     cis@sle12: 1.7.1.3
     cis@sle15: 1.7.1.3
+    cis@ubuntu2004: 1.7.1.3
+    cis@ubuntu2204: 1.6.1.3

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/sce/shared.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+# If apparmor or apparmor-utils are not installed, then this test fails.
+{{{ bash_package_installed("apparmor") }}} && {{{ bash_package_installed("apparmor-utils") }}}
+if [ $? -ne 0 ]; then
+        exit ${XCCDF_RESULT_FAIL}
+fi
+
+loaded_profiles=$(/usr/sbin/aa-status --profiled)
+enforced_profiles=$(/usr/sbin/aa-status --enforced)
+complain=$(/usr/sbin/aa-status --complaining)
+if [ ${loaded_profiles} -ne $((${enforced_profiles} + ${complain})) ]; then
+    exit $XCCDF_RESULT_FAIL
+fi
+
+unconfined=$(/usr/sbin/aa-status | grep "processes are unconfined" | awk '{print $1;}')
+if [ $unconfined -ne 0 ]; then
+    exit $XCCDF_RESULT_FAIL
+fi
+
+exit $XCCDF_RESULT_PASS

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -163,8 +163,8 @@ selections:
     - grub2_enable_apparmor
 
     #### 1.7.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
-    # Needs variable
-    # Needs rule
+    - var_apparmor_mode=complain
+    - all_apparmor_profiles_in_enforce_complain_mode
 
     #### 1.7.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
     # Skip due to being Level 2

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -470,7 +470,7 @@ selections:
 
     ###### 3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)
     - service_nftables_disabled
-    - packages_nftables_removed
+    - package_nftables_removed
 
     ###### 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables (Automated)
     - package_ufw_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -157,7 +157,8 @@ selections:
     - grub2_enable_apparmor
 
     #### 1.6.1.3 Ensure all AppArmor Profiles are in enforce or complain mode (Automated)
-    # NEEDS RULE
+    - var_apparmor_mode=complain
+    - all_apparmor_profiles_in_enforce_complain_mode
 
     #### 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
     # Skip due to being Level 2

--- a/products/ubuntu2204/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2204/profiles/cis_level2_workstation.profile
@@ -1,10 +1,10 @@
 documentation_complete: true
 
-title: 'CIS Ubuntu 20.04 Level 2 Workstation Benchmark'
+title: 'CIS Ubuntu 22.04 Level 2 Workstation Benchmark'
 
 description: |-
     This baseline aligns to the Center for Internet Security
-    Ubuntu 20.04 LTS Benchmark, v1.0.0, released 07-21-2020.
+    Ubuntu 22.04 LTS Benchmark, v1.0.0, released 08-30-2022.
 
 extends: cis_level1_workstation
 


### PR DESCRIPTION
#### Description:

- Add rule all_apparmor_profiles_in_enforce_complain_mode to Ubuntu CIS profiles
- Add SCE check to all_apparmor_profiles_in_enforce_complain_mode
- Fix typo in cis_level1_server profile
- Fix title and description in cis_level2_workstation profile


#### Rationale:

- Rule needed for CIS on Ubuntu 22.04 and 20.04