### PR TITLE
make accounts_password_last_change_is_in_past not applicable to containers

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_last_change_is_in_past/rule.yml
@@ -11,6 +11,8 @@ rationale: |-
 
 severity: medium
 
+platform: machine
+
 identifiers:
     cce@rhel7: CCE-86524-6
     cce@rhel8: CCE-86525-3


### PR DESCRIPTION
#### Description:

- add machine applicability platform to rule accounts_password_last_change_is_in_past

#### Rationale:

The unix:shadow OVAL probe used in the OVAL check is can't be used in offline mode. Moreover, general applicability of such a rule to containers is debatable.

Fixes: #10212 