### PR TITLE
Turn off avahi and avahi-autoipd fixes during install

### DIFF
--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -710,7 +710,6 @@ controls:
     status: automated
     rules:
       - package_avahi_removed
-      - package_avahi-autoipd_removed
     related_rules:
       - service_avahi-daemon_disabled
 

--- a/products/rhel9/profiles/cis_workstation_l2.profile
+++ b/products/rhel9/profiles/cis_workstation_l2.profile
@@ -21,3 +21,4 @@ description: |-
 
 selections:
     - cis_rhel9:all:l2_workstation
+    - '!package_avahi_removed'


### PR DESCRIPTION

#### Description:

Since gnome-desktop requires libsane-hpaio which requires avahi having avahi removed during the install of the OS causes the install to fail.


#### Rationale:
Fixes #10277 