### PR TITLE
NTP related rules for CIS on Ubuntu 20.04 and 22.04

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/rule.yml
@@ -56,8 +56,6 @@ references:
     cis@ubuntu2004: 2.2.1.3
     cis@ubuntu2204: 2.1.2.2
 
-
-
 ocil_clause: 'chronyd is not running under chrony user account'
 
 ocil: |-

--- a/linux_os/guide/services/ntp/ntpd_configure_restrictions/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_configure_restrictions/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,rhel7,sle12,ubuntu2204
+prodtype: alinux2,fedora,rhel7,sle12,ubuntu2004,ubuntu2204
 
 title: 'Configure server restrictions for ntpd'
 
@@ -27,6 +27,7 @@ references:
     cis@alinux2: 2.1.1.2
     cis@rhel7: 2.2.1.3
     cis@sle12: 2.2.1.4
+    cis@ubuntu2004: 2.2.1.4
     cis@ubuntu2204: 2.1.4.1
 
 identifiers:

--- a/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/rule.yml
+++ b/linux_os/guide/services/ntp/ntpd_run_as_ntp_user/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,fedora,rhel7,sle12,ubuntu2204
+prodtype: alinux2,fedora,rhel7,sle12,ubuntu2004,ubuntu2204
 
 title: 'Configure ntpd To Run As ntp User'
 
@@ -28,6 +28,7 @@ references:
     cis@alinux2: 2.1.1.2
     cis@rhel7: 2.2.1.3
     cis@sle12: 2.2.1.4
+    cis@ubuntu2004: 2.2.1.4
     cis@ubuntu2204: 2.1.4.3
 
 identifiers:

--- a/linux_os/guide/services/ntp/package_ntp_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_ntp_installed/rule.yml
@@ -15,8 +15,8 @@ identifiers:
 references:
     anssi: NT012(R03)
     cis-csc: 1,14,15,16,3,5,6
-    cis@ubuntu2004: 2.2.1.4
-    cis@ubuntu2204: 2.2.1.4
+    cis@ubuntu2004: 2.2.1.1
+    cis@ubuntu2204: 2.1.1.1
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01
     disa: CCI-000160
     isa-62443-2009: 4.3.3.3.9,4.3.3.5.8,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4

--- a/linux_os/guide/services/ntp/package_timesyncd_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_timesyncd_installed/rule.yml
@@ -13,8 +13,8 @@ severity: high
 references:
     anssi: NT012(R03)
     cis-csc: 1,14,15,16,3,5,6
-    cis@ubuntu2004: 2.2.1.4
-    cis@ubuntu2204: 2.2.1.4
+    cis@ubuntu2004: 2.2.1.1
+    cis@ubuntu2204: 2.1.1.1
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01
     disa: CCI-000160
     isa-62443-2009: 4.3.3.3.9,4.3.3.5.8,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -18,7 +18,7 @@ rationale: |-
 
 severity: medium
 
-platform: machine
+platform: package[chrony]
 
 identifiers:
     cce@rhel7: CCE-83420-0

--- a/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_enabled/rule.yml
@@ -28,7 +28,7 @@ identifiers:
 references:
     cis@rhel7: 2.2.1.3
     cis@rhel8: 2.2.1.2
-    cis@ubuntu2004: 2.1.1.1
+    cis@ubuntu2004: 2.2.1.3
     cis@ubuntu2204: 2.1.2.3
     ism: 0988,1405
     srg: SRG-OS-000355-GPOS-00143

--- a/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
@@ -19,6 +19,8 @@ rationale: |-
 
 severity: high
 
+platform: package[ntp]
+
 identifiers:
     cce@sle12: CCE-91657-7
     cce@sle15: CCE-91294-9

--- a/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
@@ -20,6 +20,8 @@ rationale: |-
 
 severity: high
 
+platform: not package[chrony] and not package[ntp]
+
 identifiers:
     cce@sle12: CCE-91659-3
     cce@sle15: CCE-91296-4
@@ -48,5 +50,3 @@ template:
     vars:
         servicename: systemd-timesyncd
         packagename: systemd
-        packagename@ubuntu2004: systemd-timesyncd
-        packagename@ubuntu2204: systemd-timesyncd

--- a/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
@@ -32,7 +32,7 @@ references:
     cis@sle12: 2.2.1.2
     cis@sle15: 2.2.1.2
     cis@ubuntu2004: 2.2.1.2
-    cis@ubuntu2204: 2.2.1.2
+    cis@ubuntu2204: 2.1.3.2
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01
     disa: CCI-000160
     isa-62443-2009: 4.3.3.3.9,4.3.3.5.8,4.3.4.4.7,4.4.2.1,4.4.2.2,4.4.2.4

--- a/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_timesyncd_enabled/rule.yml
@@ -49,3 +49,4 @@ template:
         servicename: systemd-timesyncd
         packagename: systemd
         packagename@ubuntu2004: systemd-timesyncd
+        packagename@ubuntu2204: systemd-timesyncd

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -217,25 +217,22 @@ selections:
     ## 2.2 Special Purpose Services ##
     ### 2.2.1 Time Synchronization ###
     #### 2.2.1.1 Ensure time synchronization is in use (Automated)
-    # Needs variable: var_time_synchronization_daemon=chrony
+    - '!package_ntp_installed'
+    - '!package_timesyncd_installed'
     - package_chrony_installed
-    # Needs rule: package_ntp_removed
-    - service_chronyd_enabled
 
     #### 2.2.1.2 Ensure systemd-timesyncd is configured (Manual)
-    # Needs rule: package_chrony_removed
-    # Needs rule: package_ntp_removed
-    # '!package_timesyncd_installed'
-    # '!service_timesyncd_enabled'
+    - service_timesyncd_enabled
 
     #### 2.2.1.3 Ensure chrony is configured (Automated)
+    - service_chronyd_enabled
     - chronyd_run_as_chrony_user
     - chronyd_specify_remote_server
 
     #### 2.2.1.4 Ensure ntp is configured (Automated)
-    - package_ntp_installed
-    # Needs rule: package_chrony_removed
     - service_ntp_enabled
+    - ntpd_configure_restrictions
+    - ntpd_run_as_ntp_user
 
     ### 2.2.2 Ensure X Window System is not installed (Automated)
     - package_xorg-x11-server-common_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -230,7 +230,9 @@ selections:
     ## 2.1 Configure Time Synchronization ##
     ### 2.1.1 Ensure time synchronization is in use ###
     #### 2.1.1.1 Ensure a single time synchronization is in use (Automated)
-    - package_chrony_installed
+    - '!package_chrony_installed'
+    - '!package_ntp_installed'
+    - package_timesyncd_installed
 
     ### 2.1.2 Configure chrony ###
     #### 2.1.2.1 Ensure chrony is configured with autorized timeserver (Manual)
@@ -247,22 +249,20 @@ selections:
     # Skip due to being a manual test
 
     #### 2.1.3.2 Ensure systemd-timesyncd is enabled and running (Automated)
-    # - service_timesyncd_enabled
+    - service_timesyncd_enabled
 
     ### 2.1.4 Configure ntp ###
     #### 2.1.4.1 Ensure ntp access control is configured (Automated)
-    #- ntpd_configure_restrictions
+    - ntpd_configure_restrictions
 
     #### 2.1.4.2 Ensure ntp is configured with authorized timeserver (Manual)
     # Skip due to being a manual test
 
     #### 2.1.4.3 Ensure ntp is running as user ntp (Automated)
-    #- ntpd_run_as_ntp_user
+    - ntpd_run_as_ntp_user
 
     #### 2.1.4.4 Ensure ntp is enabled and running (Automated)
-    #- package_ntp_installed
-    #- package_chrony_removed
-    #- service_ntp_enabled
+    - service_ntp_enabled
 
     ## 2.2 Special Purpose Services ##
     ### 2.2.1 Ensure X Window System is not installed (Automated)


### PR DESCRIPTION
#### Description:

- This PR does a few things:
  - Add packagename@ubuntu2204 to service_timesyncd_enabled
  - Add `platform: not package[chrony] and not package[ntp]` to service_timesyncd_enabled
  - Add `platform: package[ntp]` to service_ntp_enabled
  - Alter platform to `platform: package[chrony]` in service_chrony_enabled. Let me know if this should be an `and` instead
  - Add ubuntu2004 platform to some ntp rules and fix cis references
  - Add ntp related rules to ubuntu2004 cis_level1_server profile
  - Make timesyncd the default ntp in ubuntu2204 cis_level1_server profile

#### Rationale:

- This is needed for CIS