### PR TITLE
Various python fixes

### DIFF
--- a/build-scripts/build_sce.py
+++ b/build-scripts/build_sce.py
@@ -28,12 +28,12 @@ will fail to interpret (thinking it is XML)!
 
 from __future__ import print_function
 
-import os
 import argparse
 
 import ssg.build_sce
 import ssg.environment
 import ssg.templates
+from ssg.utils import mkdir_p
 
 
 def parse_args():
@@ -66,8 +66,7 @@ if __name__ == "__main__":
     args = parse_args()
 
     # Create output directory if it doesn't yet exist.
-    if not os.path.exists(args.output):
-        os.makedirs(args.output)
+    mkdir_p(args.output)
 
     env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)

--- a/build-scripts/collect_remediations.py
+++ b/build-scripts/collect_remediations.py
@@ -11,6 +11,7 @@ import ssg.rules
 import ssg.jinja
 import ssg.environment
 import ssg.utils
+from ssg.utils import mkdir_p
 import ssg.xml
 from ssg.build_cpe import ProductCPEs
 
@@ -60,8 +61,7 @@ def prepare_output_dirs(output_dir, remediation_types):
     output_dirs = dict()
     for lang in remediation_types:
         language_output_dir = os.path.join(output_dir, lang)
-        if not os.path.exists(language_output_dir):
-            os.makedirs(language_output_dir)
+        mkdir_p(language_output_dir)
         output_dirs[lang] = language_output_dir
     return output_dirs
 

--- a/build-scripts/profile_tool.py
+++ b/build-scripts/profile_tool.py
@@ -15,6 +15,7 @@ try:
     import ssg.environment
     import ssg.xml
     import ssg.build_yaml
+    from ssg.utils import mkdir_p
 except ImportError:
     print("The ssg module could not be found.")
     print("Run .pyenv.sh available in the project root diretory,"
@@ -229,12 +230,10 @@ def main():
         output_path = "./"
         if args.output:
             output_path = args.output
-            if not os.path.exists(output_path):
-                os.mkdir(output_path)
+            mkdir_p(output_path)
 
         content_path = os.path.join(output_path, "content")
-        if not os.path.exists(content_path):
-            os.mkdir(content_path)
+        mkdir_p(content_path)
 
         content_list = [
             'rules',

--- a/build-scripts/verify_references.py
+++ b/build-scripts/verify_references.py
@@ -252,12 +252,12 @@ def main():
                 # in a list
                 ref_href_list = [ref.get("href") for ref in refs]
                 # print warning if rule does not have a NIST reference
-                if (not nist_ref_href in ref_href_list) and options.rules_without_nistrefs:
+                if (nist_ref_href not in ref_href_list) and options.rules_without_nistrefs:
                     print("ERROR: No valid NIST reference in XCCDF Rule: " +
                           rule.get("id"))
                     exit_value = 1
                 # print warning if rule does not have a DISA reference
-                if (not disa_ref_href in ref_href_list) and options.rules_without_disarefs:
+                if (disa_ref_href not in ref_href_list) and options.rules_without_disarefs:
                     print("ERROR: No valid DISA CCI reference in XCCDF Rule: " +
                           rule.get("id"))
                     exit_value = 1

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -18,6 +18,7 @@ from .jinja import process_file_with_macros
 from .rule_yaml import parse_prodtype
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs_in_paths
 from . import utils
+from .utils import mkdir_p
 from .xml import ElementTree, oval_generated_header
 
 
@@ -289,11 +290,6 @@ def _check_rule_id(oval_file_tree, rule_id):
     return False
 
 
-def _create_output_directory(directory_path=None):
-    if directory_path and not os.path.exists(directory_path):
-        os.makedirs(directory_path)
-
-
 def _list_full_paths(directory):
     full_paths = [os.path.join(directory, x) for x in os.listdir(directory)]
     return sorted(full_paths)
@@ -313,7 +309,8 @@ class OVALBuilder:
         self.product = utils.required_key(env_yaml, "product")
 
     def build_shorthand(self, include_benchmark):
-        _create_output_directory(self.build_ovals_dir)
+        if self.build_ovals_dir:
+            mkdir_p(self.build_ovals_dir)
         all_checks = []
         if include_benchmark:
             all_checks += self._get_checks_from_benchmark()

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -340,7 +340,7 @@ class Benchmark(XCCDFEntity):
         root.set('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance')
         root.set(
             'xsi:schemaLocation',
-            'http://checklists.nist.gov/xccdf/1.2 xccdf-1.2.4.xsd')
+            'http://checklists.nist.gov/xccdf/1.2 xccdf-1.2.xsd')
         root.set('style', 'SCAP_1.2')
         root.set('resolved', 'true')
         root.set('xml:lang', 'en-US')

--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -89,7 +89,7 @@ class StandardContentDiffer(object):
         for remediation_type in FIX_TYPE_TO_SYSTEM.keys():
             self.compare_remediations(old_rule, new_rule, remediation_type, identifier)
 
-    def _get_list_of_platforms(self, cpe_platforms):
+    def _get_list_of_platforms(self, cpe_platforms, idref):
         cpe_list = []
         if len(cpe_platforms) == 0:
             print("Platform {0} not defined in platform specification".format(idref))
@@ -120,7 +120,7 @@ class StandardContentDiffer(object):
                 idref = platform.get("idref")
                 if idref.startswith("#"):
                     cpe_platforms = entry["benchmark"].find_all_cpe_platforms(idref)
-                    entry["cpe"] += self._get_list_of_platforms(cpe_platforms)
+                    entry["cpe"] += self._get_list_of_platforms(cpe_platforms, idref)
                 else:
                     entry["cpe"].append(idref)
 

--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python3
 
 import difflib
-import os
 import re
 import sys
 import xml.etree.ElementTree as ET
 
 import ssg.xml
 from ssg.constants import FIX_TYPE_TO_SYSTEM, XCCDF12_NS
+from ssg.utils import mkdir_p
 
 
 class StandardContentDiffer(object):
@@ -34,12 +34,11 @@ class StandardContentDiffer(object):
             self._ensure_output_dir_exists()
 
     def _ensure_output_dir_exists(self):
-        if os.path.exists(self.output_dir):
-            if not os.path.isdir(self.output_dir):
-                print("Output path '%s' exists and it is not a directory." % self.output_dir)
-                sys.exit(1)
-        else:
-            os.mkdir(self.output_dir)
+        try:
+            mkdir_p(self.output_dir)
+        except OSError:
+            print("Output path '%s' exists and it is not a directory." % self.output_dir)
+            sys.exit(1)
 
     def output_diff(self, identifier, diff, mode="a"):
         if not diff:

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -1,5 +1,7 @@
 from xml.sax.saxutils import escape
 
+from ..build_cpe import CPEDoesNotExist
+
 from ..xml import ElementTree as ET
 
 from .common import XCCDFEntity, SelectionHandler, add_sub_element

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -8,6 +8,7 @@ from collections import OrderedDict
 
 import ssg.rules
 import ssg.utils
+from ssg.utils import mkdir_p
 import ssg.yaml
 import ssg.build_yaml
 import ssg.build_remediations
@@ -198,7 +199,7 @@ class PlaybookBuilder():
         profile_refines = profile.get_variable_selectors()
 
         profile_playbooks_dir = os.path.join(self.output_dir, profile.id_)
-        os.makedirs(profile_playbooks_dir)
+        mkdir_p(profile_playbooks_dir)
 
         for rule_id in profile_rules:
             snippet_path = os.path.join(self.input_dir, rule_id + ".yml")
@@ -217,7 +218,7 @@ class PlaybookBuilder():
         profile_rules = profile.get_rule_selectors()
         profile_refines = profile.get_variable_selectors()
         profile_playbooks_dir = os.path.join(self.output_dir, profile.id_)
-        os.makedirs(profile_playbooks_dir)
+        mkdir_p(profile_playbooks_dir)
         snippet_path = os.path.join(self.input_dir, rule_id + ".yml")
         if rule_id in profile_rules:
             self.create_playbook(
@@ -230,7 +231,7 @@ class PlaybookBuilder():
 
     def create_playbooks_for_all_rules(self, variables):
         profile_playbooks_dir = os.path.join(self.output_dir, "all")
-        os.makedirs(profile_playbooks_dir)
+        mkdir_p(profile_playbooks_dir)
         for rule in sorted(os.listdir(self.rules_dir)):
             rule_id, _ = os.path.splitext(rule)
             snippet_path = os.path.join(self.input_dir, rule_id + ".yml")

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -8,6 +8,7 @@ import glob
 from collections import namedtuple
 
 import ssg.utils
+from ssg.utils import mkdir_p
 import ssg.yaml
 import ssg.jinja
 import ssg.build_yaml
@@ -287,8 +288,7 @@ class Builder(object):
         writing the output to the correct build directories.
         """
         for dir_ in self.output_dirs.values():
-            if not os.path.exists(dir_):
-                os.makedirs(dir_)
+            mkdir_p(dir_)
 
         self.build_extra_ovals()
         self.build_all_rules()

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -344,7 +344,7 @@ def escape_regex(text):
     # In python 3.7 the set of charaters escaped by re.escape is reasonable, so lets mimic it.
     # See https://docs.python.org/3/library/re.html#re.sub
     # '!', '"', '%', "'", ',', '/', ':', ';', '<', '=', '>', '@', and "`" are not escaped.
-    return re.sub(r"([#$&*+-.^`|~:()])", r"\\\1", text)
+    return re.sub(r"([#$&*+.^`|~:()-])", r"\\\1", text)
 
 
 def escape_id(text):

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -325,11 +325,16 @@ def write_list_file(path, contents):
 
 # Taken from https://stackoverflow.com/a/600612/592892
 def mkdir_p(path):
+    if os.path.isdir(path):
+        return False
+    # Python >=3.4.1
+    # os.makedirs(path, exist_ok=True)
     try:
         os.makedirs(path)
+        return True
     except OSError as exc:  # Python >2.5
         if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
+            return False
         else:
             raise
 

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -428,10 +428,6 @@ class XMLOcilQuestionnaire(XMLComponent):
         return self.root.find(
             "ocil:actions/ocil:test_action_ref", self.ns)
 
-    def get_test_action_ref_element(self):
-        return self.root.find(
-            "ocil:actions/ocil:test_action_ref", self.ns)
-
 
 class XMLOcilTestAction(XMLComponent):
     def __init__(self, root):

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -174,9 +174,7 @@ def parse_args():
 
     parser_rule = subparsers.add_parser("rule",
                                         help=("Testing remediations of particular "
-                                              "rule for various situations - "
-                                              "currently not supported "
-                                              "by openscap!"),
+                                              "rule for various situations"),
                                         parents=[common_parser])
     parser_rule.set_defaults(func=ssg_test_suite.rule.perform_rule_check)
     parser_rule.add_argument(

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -435,7 +435,7 @@ def select_templated_tests(test_dir_config, available_scenarios_basenames):
         msg = (
             "Test directory configuration contain inconsistencies: {allowed_and_denied} "
             "scenarios are both allowed and denied."
-            .format(test_dir_config=test_dir_config, allowed_and_denied=allowed_and_denied)
+            .format(allowed_and_denied=allowed_and_denied)
         )
         raise ValueError(msg)
     return available_scenarios_basenames

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -21,6 +21,7 @@ from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml, is_rule_dir
 from ssg.rule_yaml import parse_prodtype
+from ssg.utils import mkdir_p
 from ssg_test_suite.log import LogHelper
 
 import ssg.templates
@@ -346,7 +347,7 @@ def create_tarball(test_content_by_rule_id):
     for rule_id, test_content in test_content_by_rule_id.items():
         short_rule_id = rule_id.replace(OSCAP_RULE, "")
         rule_dir = os.path.join(tmpdir, short_rule_id)
-        os.mkdir(rule_dir)
+        mkdir_p(rule_dir)
         write_rule_test_content_to_dir(rule_dir, test_content)
 
     try:

--- a/tests/ssg_test_suite/log.py
+++ b/tests/ssg_test_suite/log.py
@@ -52,8 +52,8 @@ class LogHelper(object):
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(cls.FORMATTER)
         console_handler.setLevel(level)
-        print('Setting console output to log level {0}'.format(level,
-                                                               sys.stderr))
+        print('Setting console output to log level {0}'.format(level),
+              file=sys.stderr)
         logger.addHandler(console_handler)
 
     @classmethod

--- a/tests/ssg_test_suite/log.py
+++ b/tests/ssg_test_suite/log.py
@@ -4,6 +4,9 @@ import os
 import os.path
 import sys
 
+from ssg.utils import mkdir_p
+
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 
@@ -59,7 +62,7 @@ class LogHelper(object):
 
         Also sets LOG_DIR and LOG_FILE
         """
-        os.makedirs(_dirname)
+        mkdir_p(_dirname)
         logfile = os.path.join(_dirname, 'test_suite.log')
 
         file_handler = logging.FileHandler(logfile)

--- a/tests/test_profile_stability.py
+++ b/tests/test_profile_stability.py
@@ -143,7 +143,7 @@ def main():
             "changes propagate to derived profiles. "
             "If those changes are unwanted, you have to supress them "
             "using explicit selections or !unselections in derived profiles."
-            .format(test_root=args.test_data_root, fixes="\n".join(fix_commands)))
+            .format(fixes="\n".join(fix_commands)))
         print(msg, file=sys.stderr)
     sys.exit(bool(fix_commands))
 

--- a/tests/unit/ssg-module/test_build_remediations.py
+++ b/tests/unit/ssg-module/test_build_remediations.py
@@ -68,8 +68,6 @@ def test_parse_from_file_with_jinja():
 def test_process_fix(env_yaml, cpe_platforms):
     remediation_cls = sbr.REMEDIATION_TO_CLASS["bash"]
 
-    fixes = {}
-
     remediation_obj = remediation_cls(rhel_bash)
     result = sbr.process(remediation_obj, env_yaml, cpe_platforms)
 

--- a/tests/unit/ssg-module/test_id_translate.py
+++ b/tests/unit/ssg-module/test_id_translate.py
@@ -180,7 +180,7 @@ def test_idtranslator_translate_oval_xmldiff(idtranslator, oval_tree):
     uacrittref = xmldiff_actions.UpdateAttrib(
         node=(
             '/{o}:oval_definitions/{o}:definitions/{o}:definition/'
-            '{o}:criteria/{o}:criterion[1]'.format(ou=ou, o=o)),
+            '{o}:criteria/{o}:criterion[1]'.format(o=o)),
         name='test_ref',
         value='oval:ssg-test_kerberos_disable_no_keytab:tst:1')
     assert uacrittref in diff

--- a/tests/unit/ssg_test_suite/test_matches_platform.py
+++ b/tests/unit/ssg_test_suite/test_matches_platform.py
@@ -6,91 +6,91 @@ from ssg_test_suite import common
 def test_simple_match():
     scenario_platforms = ["Red Hat Enterprise Linux 7"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_simple_no_match():
     scenario_platforms = ["Red Hat Enterprise Linux 7"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:8"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_multi_platform_all():
     scenario_platforms = ["multi_platform_all"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_multi_platform_match():
     scenario_platforms = ["multi_platform_rhel"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_multi_platform_no_match():
     scenario_platforms = ["multi_platform_fedora"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_list_simple_match_first():
     scenario_platforms = ["Red Hat Enterprise Linux 7",
                           "Red Hat Enterprise Linux 8"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_list_simple_match_second():
     scenario_platforms = ["Red Hat Enterprise Linux 7",
                           "Red Hat Enterprise Linux 8"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:8"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_list_simple_no_match():
     scenario_platforms = ["Red Hat Enterprise Linux 7",
                           "Red Hat Enterprise Linux 8"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:9"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_list_multi_platform_match_first():
     scenario_platforms = ["multi_platform_rhel", "multi_platform_debian"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:8"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_list_multi_platform_match_second():
     scenario_platforms = ["multi_platform_rhel", "multi_platform_debian"]
     benchmark_cpes = {"cpe:/o:debian:debian_linux:11"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_list_multi_platform_no_match():
     scenario_platforms = ["multi_platform_debian", "multi_platform_ubuntu"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:8"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_list_combined_match():
     scenario_platforms = ["multi_platform_debian", "multi_platform_ubuntu",
                           "Red Hat Enterprise Linux 8"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:8"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_list_combined_match_2():
     scenario_platforms = ["Debian 11", "multi_platform_ubuntu", "openSUSE",
                           "Red Hat Enterprise Linux 8"]
     benchmark_cpes = {"cpe:/o:debian:debian_linux:11"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_list_combined_no_match():
     scenario_platforms = ["multi_platform_ubuntu", "multi_platform_fedora",
                           "Red Hat Enterprise Linux 8", "openSUSE"]
     benchmark_cpes = {"cpe:/o:debian:debian_linux:11"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_simple_multiple_benchmark_cpes():
@@ -98,14 +98,14 @@ def test_simple_multiple_benchmark_cpes():
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7",
                       "cpe:/o:redhat:enterprise_linux:7::client",
                       "cpe:/o:redhat:enterprise_linux:7::computenode"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_simple_multiple_unrelated_benchmark_cpes():
     scenario_platforms = ["Red Hat Enterprise Linux 7"]
     benchmark_cpes = {"cpe:/o:redhat:enterprise_linux:7",
                       "cpe:/o:redhat:enterprise_linux:8"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 
 def test_simple_multiple_bogus_benchmark_cpes():
@@ -113,14 +113,14 @@ def test_simple_multiple_bogus_benchmark_cpes():
     benchmark_cpes = {"cpe:/o:abcdef:ghijklm:42"
                       "cpe:/o:zzzzz:xxxx:77",
                       "cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == True
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is True
 
 def test_simple_multiple_bogus_benchmark_cpes_no_match():
     scenario_platforms = ["Fedora"]
     benchmark_cpes = {"cpe:/o:abcdef:ghijklm:42"
                       "cpe:/o:zzzzz:xxxx:77",
                       "cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_multiple_multiple_bogus_benchmark_cpes_no_match():
@@ -128,7 +128,7 @@ def test_multiple_multiple_bogus_benchmark_cpes_no_match():
     benchmark_cpes = {"cpe:/o:abcdef:ghijklm:42"
                       "cpe:/o:zzzzz:xxxx:77",
                       "cpe:/o:redhat:enterprise_linux:7"}
-    assert common.matches_platform(scenario_platforms, benchmark_cpes) == False
+    assert common.matches_platform(scenario_platforms, benchmark_cpes) is False
 
 
 def test_typo():

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -2,11 +2,13 @@
 
 import argparse
 import subprocess
-import pathlib
 import sys
 import textwrap
 import os
 import time
+
+from ssg.utils import mkdir_p
+
 
 PROG_DESC = (''' Create and test content files for Kubernetes API checks.
 
@@ -237,7 +239,7 @@ def createFunc(args):
         url, args.yamlpath, args.match))
     rule_yaml_path = os.path.join(rule_path, 'rule.yml')
 
-    pathlib.Path(rule_path).mkdir(parents=True, exist_ok=True)
+    mkdir_p(rule_path)
     with open(rule_yaml_path, 'w') as f:
         f.write(RULE_TEMPLATE.format(URL=url, TITLE=args.title, SEV=args.severity, IDENT=args.identifiers,
                                      DESC=args.description, YAMLPATH=args.yamlpath, MATCH=args.match,
@@ -344,9 +346,10 @@ def testFunc(args):
 
     # mock a passing result for the implicit ocp4 version check
     version_dir = args.objectdir + '/apis/config.openshift.io/v1/clusteroperators'
-    if not os.path.exists(version_dir):
-        pathlib.Path(version_dir).mkdir(parents=True, exist_ok=True)
-        with open(version_dir + '/openshift-apiserver', 'w') as f:
+    mock_version_file = os.path.join(version_dir, 'openshift-apiserver')
+    if not os.path.exists(mock_version_file):
+        mkdir_p(version_dir)
+        with open(mock_version_file, 'w') as f:
             f.write(MOCK_VERSION)
 
     oscap_cmd_opts = OSCAP_CMD_TEMPLATE % (args.verbosity)

--- a/utils/add_platform_rule.py
+++ b/utils/add_platform_rule.py
@@ -231,7 +231,7 @@ def createFunc(args):
         if len(url_part) > 0 and '/api' in url_part:
             url = url_part
 
-    if url == None:
+    if url is None:
         print('there was a problem finding the URL from the oc debug output. Hint: override this automatic check with --url')
         return 1
 
@@ -322,7 +322,7 @@ def clusterTestFunc(args):
             break
         time.sleep(2)
 
-    if scan_result == None:
+    if scan_result is None:
         print('ERROR: Timeout waiting for scan to finish')
         return 1
 

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -16,7 +16,7 @@ import yaml
 import collections
 
 try:
-    from github import Github, InputGitAuthor
+    from github import Github, InputGitAuthor, UnknownObjectException
 except ImportError:
     sys.stderr.write("Please install PyGithub, on Fedora it's in the "
                      "python-PyGithub package.\n")

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -25,6 +25,7 @@ except ImportError:
 
 import ssg.ansible
 import ssg.yaml
+from ssg.utils import mkdir_p
 
 
 def memoize(f):
@@ -394,7 +395,7 @@ class PlaybookToRoleConverter():
         print("Converting Ansible Playbook {} to Ansible Role {}".format(self._local_playbook_filename, os.path.join(directory, self.name)))
         for filename in self.PRODUCED_FILES:
             abs_path = os.path.join(directory, self.name, filename)
-            ssg.utils.mkdir_p(os.path.dirname(abs_path))
+            mkdir_p(os.path.dirname(abs_path))
             open(abs_path, 'wb').write(self.file(filename).encode("utf-8"))
 
 

--- a/utils/ansible_playbook_to_role.py
+++ b/utils/ansible_playbook_to_role.py
@@ -264,7 +264,7 @@ class PlaybookToRoleConverter():
         if platform in PRODUCT_ALLOWLIST:
             # For RHEL, we can get what version
             if 'rhel' in platform:
-                return platform[len(platform)-1]
+                return platform[-1]
             return "7\n    - 8"
         return "TBD"
 

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -14,6 +14,7 @@ import yaml
 import ssg.build_yaml
 import ssg.environment
 import ssg.rules
+from ssg.utils import mkdir_p
 import ssg.yaml
 
 
@@ -166,8 +167,7 @@ def main():
         output_dir_name = output_path.stem
         output_root = output_path.parent
         output_dir = os.path.join(output_root, output_dir_name)
-        if not os.path.exists(output_dir):
-            os.mkdir(output_dir)
+        mkdir_p(output_dir)
         for control in controls:
             out = dict()
             out['controls'] = [control, ]

--- a/utils/create-stig-overlay.py
+++ b/utils/create-stig-overlay.py
@@ -10,6 +10,8 @@ import ssg.xml
 import xml.dom.minidom
 
 from ssg.constants import XCCDF11_NS, XCCDF12_NS, OSCAP_RULE
+from ssg.utils import mkdir_p
+
 
 ET = ssg.xml.ElementTree
 
@@ -119,10 +121,8 @@ def new_stig_overlay(xccdftree, ssgtree, outfile, quiet):
     pretty_xml_as_string = dom.toprettyxml(indent='  ', encoding="UTF-8")
 
     overlay_directory = os.path.dirname(outfile)
-    if not os.path.exists(overlay_directory):
-        os.makedirs(overlay_directory)
-        if not quiet:
-            print("\nOverlay directory created: %s" % overlay_directory)
+    if mkdir_p(overlay_directory) and not quiet:
+        print("\nOverlay directory created: %s" % overlay_directory)
 
     with open(outfile, 'wb') as f:
         f.write(pretty_xml_as_string)

--- a/utils/import_srg_spreadsheet.py
+++ b/utils/import_srg_spreadsheet.py
@@ -11,7 +11,7 @@ from openpyxl.worksheet.worksheet import Worksheet
 from openpyxl import load_workbook
 
 from ssg.rule_yaml import find_section_lines, get_yaml_contents
-from ssg.utils import read_file_list
+from ssg.utils import mkdir_p, read_file_list
 from utils.srg_utils import get_full_name, get_stigid_set, get_cce_dict_to_row_dict, \
     get_cce_dict, get_rule_dir_json
 
@@ -44,11 +44,9 @@ def get_cac_status(disa: str) -> str:
 
 def create_output(rule_dir: str) -> str:
     path_dir_parent = os.path.join(rule_dir, "policy")
-    if not os.path.exists(path_dir_parent):
-        os.mkdir(path_dir_parent)
+    mkdir_p(path_dir_parent)
     path_dir = os.path.join(path_dir_parent, "stig")
-    if not os.path.exists(path_dir):
-        os.mkdir(path_dir)
+    mkdir_p(path_dir)
     path = os.path.join(path_dir, 'shared.yml')
     Path(path).touch()
     return path

--- a/utils/mod_checks.py
+++ b/utils/mod_checks.py
@@ -156,7 +156,7 @@ def main():
     json_file = open(args.json, 'r')
     known_rules = json.load(json_file)
 
-    if not args.rule_id in known_rules:
+    if args.rule_id not in known_rules:
         print("Error: rule_id:%s is not known!" % args.rule_id, file=sys.stderr)
         print("If you think this is an error, try regenerating the JSON.", file=sys.stderr)
         sys.exit(1)

--- a/utils/mod_fixes.py
+++ b/utils/mod_fixes.py
@@ -160,7 +160,7 @@ def main():
     json_file = open(args.json, 'r')
     known_rules = json.load(json_file)
 
-    if not args.rule_id in known_rules:
+    if args.rule_id not in known_rules:
         print("Error: rule_id:%s is not known!" % args.rule_id, file=sys.stderr)
         print("If you think this is an error, try regenerating the JSON.", file=sys.stderr)
         sys.exit(1)

--- a/utils/mod_prodtype.py
+++ b/utils/mod_prodtype.py
@@ -166,7 +166,7 @@ def main():
     json_file = open(args.json, 'r')
     known_rules = json.load(json_file)
 
-    if not args.rule_id in known_rules:
+    if args.rule_id not in known_rules:
         print("Error: rule_id:%s is not known!" % args.rule_id, file=sys.stderr)
         print("If you think this is an error, try regenerating the JSON.", file=sys.stderr)
         sys.exit(1)

--- a/utils/srg_audit.py
+++ b/utils/srg_audit.py
@@ -97,11 +97,11 @@ def create_reduction_dicts() -> (dict, dict, dict, dict):
 
 def check_paths(file: str) -> None:
     if not os.path.exists(file):
-        sys.stderr.write(f"Unable to perform audit.\n")
+        sys.stderr.write("Unable to perform audit.\n")
         sys.stderr.write(f"File not found: {file}\n")
         exit(1)
     if not os.path.isfile(file):
-        sys.stderr.write(f"Unable to perform audit.\n")
+        sys.stderr.write("Unable to perform audit.\n")
         sys.stderr.write(f"Input must be a file: {file}\n")
         exit(2)
 


### PR DESCRIPTION
#### Description:

Collection of various python code fixes and some style changes.

#### Rationale:

Improve `mkdir_p` and then use it everywhere. There was duplicate implementations. Now also handle errors when directory already exists if there is issues with parallelism for example. Patch could further improved if only recent python versions are used.

Fix `escape_regex` to match comment.

Probably search and replace fix with xccdf version.

Some duplicate code. Some codes I wonder how it was previously working as intended.

Bad helper in automatus. 

And then some style changes that I see as obvious.

#### Review Hints:

pyflakes / flake8 issues are only reduced before and after this patch. If you ignore file length.

Parallel builds to check `mkdir_p` before and after. It might be possible to effectively and repeatedly to see issues this might require cmake modifications to allow further parallelism. 

`escape_regex` change might cause xml modifications.

Sofar only built and run ctest with this.