### PR TITLE
Require OVAL ID to match rule ID

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/rhcos4.xml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/oval/rhcos4.xml
@@ -3,7 +3,7 @@
     {{{ oval_metadata("Check if FIPS mode is enabled on the system") }}}
     <criteria operator="AND">
       <extend_definition comment="check /etc/system-fips exists" definition_ref="etc_system_fips_exists" />
-      <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="proc_sys_crypto_fips_enabled" />
+      <extend_definition comment="check sysctl crypto.fips_enabled = 1" definition_ref="sysctl_crypto_fips_enabled" />
       <extend_definition comment="system cryptography policy is configured" definition_ref="configure_crypto_policy" />
       <criterion comment="check if system crypto policy selection in var_system_crypto_policy in the profile is set to FIPS" test_ref="test_system_crypto_policy_value" />
     </criteria>

--- a/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/oval/rhcos4.xml
+++ b/linux_os/guide/system/software/integrity/fips/sysctl_crypto_fips_enabled/oval/rhcos4.xml
@@ -1,18 +1,18 @@
 <def-group>
-  <definition class="compliance" id="proc_sys_crypto_fips_enabled" version="1">
+  <definition class="compliance" id="sysctl_crypto_fips_enabled" version="1">
     {{{ oval_metadata("The kernel 'crypto.fips_enabled' parameter should be set to '1' in system runtime.") }}}
     <criteria operator="AND">
-      <criterion comment="kernel runtime parameter crypto.fips_enabled set to 1" test_ref="test_proc_sys_crypto_fips_enabled" />
+      <criterion comment="kernel runtime parameter crypto.fips_enabled set to 1" test_ref="test_sysctl_crypto_fips_enabled" />
     </criteria>
   </definition>
 
   <ind:textfilecontent54_test check="all" check_existence="all_exist"
    comment="kernel runtime parameter crypto.fips_enabled set to 1"
-   id="test_proc_sys_crypto_fips_enabled" version="1">
-    <ind:object object_ref="obj_proc_sys_crypto_fips_enabled" />
+   id="test_sysctl_crypto_fips_enabled" version="1">
+    <ind:object object_ref="obj_sysctl_crypto_fips_enabled" />
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_proc_sys_crypto_fips_enabled" version="1">
+  <ind:textfilecontent54_object id="obj_sysctl_crypto_fips_enabled" version="1">
     <ind:filepath>/proc/sys/crypto/fips_enabled</ind:filepath>
     <ind:pattern operation="pattern match">^1$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -425,9 +425,10 @@ class OVALBuilder:
             (os.path.dirname(os.path.dirname(file_path))))
         self._store_intermediate_file(rule_id, xml_content)
         if not _check_rule_id(oval_file_tree, rule_id):
-            msg = "OVAL definition in '%s' doesn't match rule ID '%s'." % (
+            msg = "ERROR: OVAL definition in '%s' doesn't match rule ID '%s'." % (
                 file_path, rule_id)
             print(msg, file=sys.stderr)
+            sys.exit(1)
 
     def _get_context(self, directory, from_benchmark):
         if from_benchmark:


### PR DESCRIPTION
#### Description:

Change behaviour to fail if OVAL ID does not match rule ID. Fix one rule which failed this check.

#### Rationale:

There was only one rule not to meet this requirement. When we meet the
check, it is huge help when debugging / searching rules.

Also currently these kind of messages are easy not to notice.

#### Review Hints:

Especially should check `sysctl_crypto_fips_enabled` / `proc_sys_crypto_fips_enabled` under rhcos4.

Tests should fail simply if there is issues.