### PR TITLE
OCP change CatalogSource used to deploy CO

### DIFF
--- a/ocp-resources/compliance-operator-catalog-source.yaml
+++ b/ocp-resources/compliance-operator-catalog-source.yaml
@@ -7,4 +7,4 @@ spec:
   displayName: Compliance Operator Upstream
   publisher: github.com/openshift/compliance-operator
   sourceType: grpc
-  image: quay.io/compliance-operator/compliance-operator-catalog:latest
+  image: ghcr.io/complianceascode/compliance-operator-catalog:latest


### PR DESCRIPTION
#### Description:

We recently have the Compliance Operator build the latest image using the master branch, this PR changes the CatalogSource image reference to that image.
