### PR TITLE
fix loops within ansible template for rsyslog_files

### DIFF
--- a/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
+++ b/shared/templates/rsyslog_logfiles_attributes_modify/ansible.template
@@ -30,27 +30,29 @@
 
 - name: '{{{ rule_title }}} - List all config files'
   ansible.builtin.find:
-    paths: "{{ include_config_output | list | map('dirname') }}"
-    patterns: "{{ include_config_output | list | map('basename') }}"
+    paths: "{{ item | dirname }}"
+    patterns: "{{ item | basename }}"
     hidden: no
     follow: yes
+  loop: "{{ include_config_output | list + [rsyslog_etc_config] }}"
   register: rsyslog_config_files
   failed_when: False
   changed_when: False
 
+
 - name: '{{{ rule_title }}} - Extract log files old format'
   ansible.builtin.shell: |
     set -o pipefail
-    grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item }}  |awk '{print $NF}'|sed -e 's/^-//' || true
-  loop: "{{ rsyslog_config_files.files|map(attribute='path')|list|flatten|unique + [ rsyslog_etc_config ] }}"
+    grep -oP '^[^(\s|#|\$)]+[\s]+.*[\s]+-?(/+[^:;\s]+);*\.*$' {{ item.1.path }}  |awk '{print $NF}'|sed -e 's/^-//' || true
+  loop: "{{ rsyslog_config_files.results | subelements('files') }}"
   register: log_files_old
   changed_when: False
 
 - name: '{{{ rule_title }}} - Extract log files new format'
   ansible.builtin.shell: |
     set -o pipefail
-    grep -ozP "action\s*\(\s*type\s*=\s*\"omfile\"[^\)]*\)" {{ item }} | grep -aoP "File\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)"|grep -oE "\"([/[:alnum:][:punct:]]*)\"" |tr -d "\""|| true
-  loop: "{{ rsyslog_config_files.files|map(attribute='path')|list|flatten|unique + [ rsyslog_etc_config ] }}"
+    grep -ozP "action\s*\(\s*type\s*=\s*\"omfile\"[^\)]*\)" {{ item.1.path }} | grep -aoP "File\s*=\s*\"([/[:alnum:][:punct:]]*)\"\s*\)"|grep -oE "\"([/[:alnum:][:punct:]]*)\"" |tr -d "\""|| true
+  loop: "{{ rsyslog_config_files.results | subelements('files') }}"
   register: log_files_new
   changed_when: False
 


### PR DESCRIPTION
#### Description:

- get rid of map functions
- also previous implementation did not account for the fact that variable created in loops have results stored in ".results" data structure

#### Rationale:

- fixes: #10170 

#### Review Hints:

see the issue fixed by this PR

