### PR TITLE
kernel_module_disable template - regexp matches multiple lines

### DIFF
--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -15,7 +15,7 @@
   lineinfile:
     create: yes
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
-    regexp: '{{{ KERNMODULE }}}'
+    regexp: 'install\s+{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
 {{% if product in ["ol7", "ol8"] or 'rhel' in product %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted


### PR DESCRIPTION
Regular expression matches both lines in the {{KERNMODULE}}.conf file and this causes duplicate lines in Oracle Linux and RHEL every time the ansible script is executed. Regular expression was changed to also search for the keyword "install"

#### Description:

The regular expression for the line "install {{KERNMODULE}} /bin/true" is only "{{KERNMODULE}}"
This causes duplicate lines in the modprobe.d/*.conf files

#### Rationale:

In case of Oracle Linux or RHEL, there are 2 lines in the {{KERNMODULE}}.conf file and the regular expression will match always the last match (according to ansible documentation).

For example for udf:
```
# cat /etc/modprobe.d/udf.conf
install udf /bin/true
blacklist udf
```
Old regexp would be `udf` and would match `blacklist udf`
New regexp would be `install\s+udf` and would match `install udf /bin/true`

With old regexp the file would look like this:
```
# cat /etc/modprobe.d/udf.conf
install udf /bin/true
install udf /bin/true
```

With new regexp the file would look like this:
```
# cat /etc/modprobe.d/udf.conf
install udf /bin/true
blacklist udf
```


#### Review Hints:

The second part of the ansible block takes care of the blacklist line, so with the old regexp the result would be actually:
```
# cat /etc/modprobe.d/udf.conf
install udf /bin/true
install udf /bin/true
blacklist udf
```