### PR TITLE
Align rhel7 dracut-fips-aesni remediations

### DIFF
--- a/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/anaconda/shared.anaconda
+++ b/linux_os/guide/system/software/integrity/fips/package_dracut-fips-aesni_installed/anaconda/shared.anaconda
@@ -1,0 +1,3 @@
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7
+
+package --add=dracut-fips-aesni


### PR DESCRIPTION


#### Description:

- Let's update rule rule `package_dracut-fips-aesni_installed` so that it installs the packages too.

#### Rationale:

- The anaconda remediation of rule grub2_enable_fips_mode installs the and dracut-fips-aesni packages even when the cpu doesn't support AESNI. This should not impact the system negatively.
- This causes profiles with rule `package_dracut-fips-aesni_installed` to fail during kickstart install.

#### Review Hints:

- See also https://github.com/ComplianceAsCode/content/pull/4986#issuecomment-552463455