### PR TITLE
Add rule package_nfs-kernel-server_removed for Ubuntu CIS

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/package_nfs-kernel-server_removed/rule.yml
+++ b/linux_os/guide/services/nfs_and_rpc/package_nfs-kernel-server_removed/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Uninstall nfs-kernel-server Package'
+
+description: |-
+    {{{ describe_package_remove(package="nfs-kernel-server") }}}
+
+rationale: |-
+    If the system does not export NFS shares or act as an NFS client, it is
+    recommended that these services be removed to reduce the remote attack
+    surface.
+
+severity: low
+
+references:
+    cis@ubuntu2004: 2.2.7
+    cis@ubuntu2204: 2.2.6
+
+{{{ complete_ocil_entry_package(package="nfs-kernel-server") }}}
+
+fixtext: '{{{ fixtext_package_removed("nfs-kernel-server") }}}'
+
+template:
+    name: package_removed
+    vars:
+        pkgname: nfs-kernel-server

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -255,7 +255,7 @@ selections:
     - package_openldap-servers_removed
 
     ### 2.2.7 Ensure NFS is not installed (Automated)
-    # Needs rule: package_nfs-kernel-server_removed
+    - package_nfs-kernel-server_removed
 
     ### 2.2.8 Ensure DNS Server is not installed (Automated)
     - package_bind_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -282,7 +282,7 @@ selections:
     - package_openldap-servers_removed
 
     ### 2.2.6 Ensure NFS is not installed (Automated)
-    # NEEDS RULE
+    - package_nfs-kernel-server_removed
 
     ### 2.2.7 Ensure DNS Server is not installed (Automated)
     - package_bind_removed


### PR DESCRIPTION
#### Description:

- Add new rule `package_nfs-kernel-server_removed`. I know that we already have `package_nfs-utils_removed` but since this is quite the package name difference even though the source package name is the same `nfs-utils`, what people install or uninstall in ubuntu is the binary package name `nfs-kernel-server`

#### Rationale:

- This relates to CIS on both Ubuntu 20.04 and 22.04.