### PR TITLE
Restart postfix service and add rule has_nonlocal_mta

### DIFF
--- a/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/oval/shared.xml
@@ -1,0 +1,27 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Verify MTA is not listening on any non-loopback address") }}}
+    <criteria>
+      <criterion test_ref="tst_nothing_listening_external_mta_port"
+            comment="mta is not listening on any non-loopbackaddress" />
+    </criteria>
+  </definition>
+  <linux:inetlisteningservers_object id="obj_listening_port_25" version="1">
+    <linux:protocol>tcp</linux:protocol>
+    <linux:local_address operation="not equal">127.0.0.1</linux:local_address>
+    <linux:local_port datatype="int">25</linux:local_port>
+    <filter action="exclude">ste_not_port_25</filter>
+    <filter action="exclude">ste_not_on_localhost</filter>
+  </linux:inetlisteningservers_object>
+  <linux:inetlisteningservers_state id="ste_not_port_25" version="1">
+    <linux:local_port datatype="int" operation="not equal">25</linux:local_port>
+  </linux:inetlisteningservers_state>
+  <linux:inetlisteningservers_state id="ste_not_on_localhost" version="1">
+    <linux:local_address operation="equals">::1</linux:local_address>
+  </linux:inetlisteningservers_state>
+  <linux:inetlisteningservers_test check="all" check_existence="none_exist"
+      id="tst_nothing_listening_external_mta_port" version="1"
+      comment="mta is not listening on any non-loopback address">
+    <linux:object object_ref="obj_listening_port_25" />
+  </linux:inetlisteningservers_test>
+</def-group>

--- a/linux_os/guide/services/mail/has_nonlocal_mta/rule.yml
+++ b/linux_os/guide/services/mail/has_nonlocal_mta/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure Mail Transfer Agent is not Listening on any non-loopback Address'
+
+description: |-
+    Mail Transfer Agents (MTA), such as sendmail and Postfix, are used to
+    listen for incoming mail and transfer the messages to the appropriate
+    user or mail server. If the system is not intended to be a mail server,
+    it is recommended that the MTA be configured to only process local mail.
+
+rationale: |-
+    The software for all Mail Transfer Agents is complex and most have a
+    long history of security issues. While it is important to ensure that
+    the system can process local mail messages, it is not necessary to have
+    the MTA's daemon listening on a port unless the server is intended to
+    be a mail server that receives and processes mail from other systems.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 2.2.15
+    cis@ubuntu2204: 2.2.15
+
+ocil_clause: 'MTA is listening on any non-loopback address'
+
+ocil: |-
+    Run the following command to verify that the MTA is not listening on
+    any non-loopback address (127.0.0.1 or ::1).
+    <pre># ss -lntu | grep -E ':25\s' | grep -E -v '\s(127.0.0.1|::1):25\s'</pre>
+    Nothing should be returned

--- a/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_network_listening_disabled/bash/shared.sh
@@ -3,3 +3,5 @@
 {{{ bash_instantiate_variables("var_postfix_inet_interfaces") }}}
 
 {{{ set_config_file(path="/etc/postfix/main.cf", parameter="inet_interfaces", value="$var_postfix_inet_interfaces", create=true, insensitive=true, separator="=", separator_regex="\s\+=\s\+", prefix_regex="^\s*") }}}
+
+systemctl restart postfix

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -283,6 +283,7 @@ selections:
     ### 2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)
     - var_postfix_inet_interfaces=loopback-only
     - postfix_network_listening_disabled
+    - has_nonlocal_mta
 
     ### 2.2.16 Ensure rsync service is not installed (Automated)
     - package_rsync_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -313,6 +313,7 @@ selections:
     ### 2.2.15 Ensure mail transfer agent is configured for local-only mode (Automated)
     - var_postfix_inet_interfaces=loopback-only
     - postfix_network_listening_disabled
+    - has_nonlocal_mta
 
     ### 2.2.16 Ensure rsync service is not installed (Automated)
     - package_rsync_removed


### PR DESCRIPTION
#### Description:

- The rule `postfix_network_listening_disabled` was missing a restart of postfix service in bash remediation. I didn't touch the ansible for that, hopefully some other vendor can check it and add it if needed.
- Add rule `has_nonlocal_mta` to actually check that the MTA is not listening on any non-loopback address ( 127.0.0.1 or ::1 )

#### Rationale:

- This rule relates to CIS on different distributions.