### PR TITLE
Add package_cups_removed to Ubuntu CIS Level 2 Worstation profiles

### DIFF
--- a/products/ubuntu2004/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2004/profiles/cis_level2_workstation.profile
@@ -34,8 +34,8 @@ selections:
     # Needs variable; set above appropriately.
 
     ### 2.2.4 Ensure CUPS is not installed (Automated)
-    - 'service_cups_disabled'
-    # Needs rule: 'package_cups_removed'
+    - service_cups_disabled
+    - package_cups_removed
 
     ### 3.1.2 Ensure wireless interfaces are disabled (Automated)
     - 'wireless_disable_interfaces'

--- a/products/ubuntu2204/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2204/profiles/cis_level2_workstation.profile
@@ -48,6 +48,7 @@ selections:
 
     ### 2.2.3 Ensure CUPS is not installed (Automated)
     - service_cups_disabled
+    - package_cups_removed
 
     ### 3.1.2 Ensure wireless interfaces are disabled (Automated)
     - wireless_disable_interfaces


### PR DESCRIPTION
#### Description:

- This rule was missing in the cis_level2_workstation.profile for both Ubuntu 20.04 and 22.04

#### Rationale:

- This is needed for CIS on both Ubuntu 20.04 and 22.04