### PR TITLE
More product fixes and less variations

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/ansible/shared.yml
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% if product in ["sle12", "sle15", "ubuntu"] %}}
+{{% if product in ["sle12", "sle15"] or "ubuntu" in product %}}
 {{{ ansible_ensure_pam_module_configuration('/etc/pam.d/login', 'session', 'required', 'pam_lastlog.so', 'showfailed', '', 'BOF') }}}
 {{{ ansible_remove_pam_module_option_configuration('/etc/pam.d/login', 'session', '', 'pam_lastlog.so', 'silent') }}}
 {{% else %}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_gshadow/tests/correct_permissions.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-{{% if product in ("ubuntu", "debian") %}}
+{{% if "debian" in product or "ubuntu" in product %}}
     {{% set target_perms_octal="0640" %}}
 {{% else %}}
     {{% set target_perms_octal="0000" %}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_backup_etc_shadow/tests/correct_permissions.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-{{% if product in ("ubuntu", "debian") %}}
+{{% if "debian" in product or "ubuntu" in product %}}
     {{% set target_perms_octal="0640" %}}
 {{% else %}}
     {{% set target_perms_octal="0000" %}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_gshadow/tests/correct_permissions.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-{{% if product in ("ubuntu", "debian") %}}
+{{% if "debian" in product or "ubuntu" in product %}}
     {{% set target_perms_octal="0640" %}}
 {{% else %}}
     {{% set target_perms_octal="0000" %}}

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/tests/correct_permissions.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_permissions_etc_shadow/tests/correct_permissions.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 
-{{% if product in ("ubuntu", "debian") %}}
+{{% if "debian" in product or "ubuntu" in product %}}
     {{% set target_perms_octal="0640" %}}
 {{% else %}}
     {{% set target_perms_octal="0000" %}}

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_not_up_to_date.fail.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_not_up_to_date.fail.sh
@@ -2,7 +2,7 @@
 # packages = dconf,gdm
 
 {{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
+{{% if product not in ["fedora", "rhel9"] %}}
 {{% set dconf_db = "gdm.d" %}}
 {{% endif %}}
 

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_up_to_date.pass.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/db_up_to_date.pass.sh
@@ -2,7 +2,7 @@
 # packages = dconf,gdm
 
 {{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
+{{% if product not in ["fedora", "rhel9"] %}}
 {{% set dconf_db = "gdm.d" %}}
 {{% endif %}}
 

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/no_db_files.fail.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/tests/no_db_files.fail.sh
@@ -2,7 +2,7 @@
 # packages = dconf,gdm
 
 {{% set dconf_db = "distro.d" %}}
-{{% if product not in ("fedora", "rhel9") %}}
+{{% if product not in ["fedora", "rhel9"] %}}
 {{% set dconf_db = "gdm.d" %}}
 {{% endif %}}
 

--- a/linux_os/guide/system/software/updating/security_patches_up_to_date/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/updating/security_patches_up_to_date/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
     Verify {{{ full_name }}} security patches and updates are installed and up to date.
     Updates are required to be applied with a frequency determined by organizational policy.
 
-    {{% if "Red Hat" in full_name or "ol" in product %}}
+    {{% if vendor is defined %}}
     Obtain the list of available package security updates from {{{ vendor }}}. The URL for updates
     is {{{ url }}}. It is important to note that updates provided by {{{ vendor }}} may not be
     present on the system if the underlying packages are not installed.

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -824,7 +824,7 @@ substituting the correct package management software.
 
 #}}
 {{% macro partition_description(part) -%}}
-    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    {{% if product in ["ocp4", "rhcos4"] -%}}
     <p>
     Partitioning Red Hat CoreOS is a Day 1 operation and cannot
     be changed afterwards. For documentation on how to add a

--- a/shared/macros/10-ocil.jinja
+++ b/shared/macros/10-ocil.jinja
@@ -863,7 +863,7 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 #}}
 {{%- macro ocil_file_permissions(file, perms) -%}}
     To check the permissions of <code>{{{ file }}}</code>,
-    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    {{% if product in ["ocp4", "rhcos4"] -%}}
     you'll need to log into a node in the cluster.
     {{{ rhcos_node_login_instructions() }}}
     Then,
@@ -900,7 +900,7 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 #}}
 {{%- macro ocil_file_owner(file, owner) -%}}
     To check the ownership of <code>{{{ file }}}</code>,
-    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    {{% if product in ["ocp4", "rhcos4"] -%}}
     you'll need to log into a node in the cluster.
     {{{ rhcos_node_login_instructions() }}}
     Then,
@@ -937,7 +937,7 @@ JINJA MACRO ERROR - Unknown init system '{{{ init_system }}}'.
 #}}
 {{%- macro ocil_file_group_owner(file, group) -%}}
     To check the group ownership of <code>{{{ file }}}</code>,
-    {{% if product == "rhcos4" or product == "ocp4" -%}}
+    {{% if product in ["ocp4", "rhcos4"] -%}}
     you'll need to log into a node in the cluster.
     {{{ rhcos_node_login_instructions() }}}
     Then,


### PR DESCRIPTION
#### Description:

Fix debian/ubuntu tests and ansible when using bad check. Other minor fixes related to products.

#### Rationale:

When comparing products there should be only limited variations.

Namely what usually is used:
1. 'product in ["<product name1>", "<product name 2>"]: when comparing single products
2. '"<product subsequence1>" in product or "<product subsequence2>" in product': when comparing product name groups, this is brittle as groups are prefix but comparison is string subsequence
3. 'product == "<product name1>": only one product to compare, could be 1st variant
And respective "not in" / != + "and", and combinations of 1+2 or 2+3.

This helps later if there is need to modify multiple checks.

It would be better to define new product property for distributions and then replace current subsequence matches. Current situation just waits when "solus" joins.

There is single product.startswith at `installed_OS_is_vendor_supported`. Maybe all 2. cases should be converted to that.

https://docs.python.org/3/library/stdtypes.html#sequence-types-list-tuple-range

> While the in and not in operations are used only for simple containment testing in the general case, some specialised sequences (such as [str](https://docs.python.org/3/library/stdtypes.html#str), [bytes](https://docs.python.org/3/library/stdtypes.html#bytes) and [bytearray](https://docs.python.org/3/library/stdtypes.html#bytearray)) also use them for subsequence testing:

#### Review Hints:

Ubuntu and debian tests of 
`file_permissions_backup_etc_gshadow`
`file_permissions_backup_etc_shadow`
`file_permissions_etc_gshadow`
`file_permissions_etc_shadow`
have changed and I assume those have not been working as expected.

Ubuntu ansible part was not as expected in `display_login_attempts`.

No other functionality changes expected.