### PR TITLE
bugfix: ssg_test_suite: RuleResult __eq__

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -160,7 +160,7 @@ class RuleResult(object):
 
     def __eq__(self, other):
         return (self.success == other.success
-                and tuple(self.passed_stages) == tuple(self.passed_stages))
+                and tuple(self.passed_stages) == tuple(other.passed_stages))
 
     def __lt__(self, other):
         return self.passed_stages_count > other.passed_stages_count


### PR DESCRIPTION
#### Description:

Simple copy paste error.

#### Rationale:

Should be obvious.

#### Review Hints:

Probably is not used as results have been wrong. I have not tested it as fix is obvious.