### PR TITLE
Add OVAL check for rule ensure_shadow_group_empty

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
 
-grep '^shadow:[^:]*:[^:]*:[^:]+' /etc/group
-awk -F: '($4 == "<shadow-gid>") { print }' /etc/passwd
+sed -ri 's/(^shadow:[^:]*:[^:]*:)([^:]+$)/\1/' /etc/group
+awk -F: -v GID="$(awk -F: '($1=="shadow") {print $3}' /etc/group)" '($4==GID) {print $1}' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/bash/shared.sh
@@ -1,4 +1,3 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
 
 sed -ri 's/(^shadow:[^:]*:[^:]*:)([^:]+$)/\1/' /etc/group
-awk -F: -v GID="$(awk -F: '($1=="shadow") {print $3}' /etc/group)" '($4==GID) {print $1}' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
@@ -20,7 +20,7 @@
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_state id="ste_shadow_group_members" version="1">
-      <ind:subexpression operation="pattern match" />
+      <ind:subexpression operation="pattern match">^\s*$</ind:subexpression>
   </ind:textfilecontent54_state>
 
   <local_variable id="var_shadow_gid" datatype="string"

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
@@ -3,7 +3,8 @@
     {{{ oval_metadata("Ensure shadow group is empty") }}}
     <criteria>
       <criterion test_ref="tst_shadow_group_empty" comment="shadow group is empty" />
-      <criterion test_ref="tst_no_user_assigned_shadow_group" comment="no user is assigned to the shadow group" />
+      <criterion test_ref="tst_no_user_assigned_shadow_group"
+          comment="no user has the shadow as primary group" />
     </criteria>
   </definition>
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
@@ -7,7 +7,7 @@
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+  <ind:textfilecontent54_test check="all" check_existence="any_exist"
       id="tst_shadow_group_empty" version="1" comment="shadow group is empty">
     <ind:object object_ref="obj_shadow_group_members" />
     <ind:state state_ref="ste_shadow_group_members" />

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/oval/shared.xml
@@ -1,0 +1,48 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure shadow group is empty") }}}
+    <criteria>
+      <criterion test_ref="tst_shadow_group_empty" comment="shadow group is empty" />
+      <criterion test_ref="tst_no_user_assigned_shadow_group" comment="no user is assigned to the shadow group" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+      id="tst_shadow_group_empty" version="1" comment="shadow group is empty">
+    <ind:object object_ref="obj_shadow_group_members" />
+    <ind:state state_ref="ste_shadow_group_members" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_shadow_group_members" version="1">
+    <ind:filepath datatype="string">/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">^shadow:.*:.*:(.*)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state id="ste_shadow_group_members" version="1">
+      <ind:subexpression operation="pattern match" />
+  </ind:textfilecontent54_state>
+
+  <local_variable id="var_shadow_gid" datatype="string"
+      comment="regex with shadow group id" version="1">
+      <concat>
+          <literal_component>^.*:.*:.*:</literal_component>
+          <regex_capture pattern="^shadow:.*:(.*):.*$">
+              <object_component object_ref="obj_shadow_group_members" item_field="text"  />
+          </regex_capture>
+          <literal_component>:.*:.*:.*$</literal_component>
+      </concat>
+  </local_variable>
+
+  <ind:textfilecontent54_test check="all" check_existence="none_exist"
+      id="tst_no_user_assigned_shadow_group" version="1"
+      comment="no user is assigned to the shadow group">
+    <ind:object object_ref="obj_etc_passwd_user_has_shadow_group" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_etc_passwd_user_has_shadow_group" version="1">
+    <ind:filepath datatype="string">/etc/passwd</ind:filepath>
+    <ind:pattern operation="pattern match" var_ref="var_shadow_gid" />
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/correct.pass.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_sle,multi_platform_ubuntu
 
+if ! grep -q "^shadow" /etc/group; then
+    groupadd shadow
+fi
 sed -ri 's/(^shadow:[^:]*:[^:]*:)([^:]+$)/\1/' /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/correct.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
+
+sed -ri 's/(^shadow:[^:]*:[^:]*:)([^:]+$)/\1/' /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/no_shadow_group.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/no_shadow_group.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
+
+sed -i '/^shadow:[^:]*:[^:]*:.*/d' /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_not_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_not_empty.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
+
+sed -i '/^shadow:[^:]*:[^:]*:/ s/$/vnc/' /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_not_empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_not_empty.fail.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_sle,multi_platform_ubuntu
 
+if ! grep -q "^shadow" /etc/group; then
+    groupadd shadow
+fi
 sed -i '/^shadow:[^:]*:[^:]*:/ s/$/vnc/' /etc/group

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_user_member.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_user_member.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# platform = multi_platform_sle,multi_platform_ubuntu
+# remediation = none
+
+useradd testuser_123
+usermod -g shadow testuser_123

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_user_member.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/ensure_shadow_group_empty/tests/shadow_user_member.fail.sh
@@ -2,5 +2,8 @@
 # platform = multi_platform_sle,multi_platform_ubuntu
 # remediation = none
 
+if ! grep -q "^shadow" /etc/group; then
+    groupadd shadow
+fi
 useradd testuser_123
 usermod -g shadow testuser_123


### PR DESCRIPTION
#### Description:

- Add OVAL check for rule ensure_shadow_group_empty
- Also improve remediation for same rule

#### Rationale:

- This OVAL was missing and is needed for CIS on both Ubuntu 20.04 and 22.04 as well as SUSE.