### PR TITLE
Disable logrotate timer in ensure_logrotate_activated tests

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily_no_timer.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily_no_timer.fail.sh
@@ -2,6 +2,9 @@
 
 # packages = logrotate,crontabs
 
+# disable the timer
+systemctl disable logrotate.timer || true
+
 # fix logrotate config
 sed -i "s/weekly/daily/" /etc/logrotate.conf
 


### PR DESCRIPTION

#### Description:

This is needed since #10343 added an OVAL check for the logrotate systemd timer OR'ed with the cron check.

We may want to adjust the OVAL (and this test) if we want to limit the checking of the timer to OSs that have it, seems to RHEL 9+, I have not checked Ubuntu or SUSE.
#### Rationale:
Fixes #10371 

### Reviewer Hints:
The logrotate timer is only in RHEL 9.