### PR TITLE
Disable logrotate timer in ensure_logrotate_activated tests

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily_no_timer.fail.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/tests/logrotate_no_cron_daily_no_timer.fail.sh
@@ -2,6 +2,9 @@
 
 # packages = logrotate,crontabs
 
+# disable the timer
+systemctl disable logrotate.timer || true
+
 # fix logrotate config
 sed -i "s/weekly/daily/" /etc/logrotate.conf
 


### PR DESCRIPTION


#### Description:

This is needed since #10343 added test for the logrotate timer.

#### Rationale:

Fixes #10375 

#### Review Hints:
This a backport of #10375 