### PR TITLE
change: ssg/templates: Error if templates generated are not the same

### DIFF
--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -42,6 +42,7 @@ package_samba-common_removed:
     pkgname: samba-common
 
 package_prelink_removed:
+  title: Package "prelink" Must not be Installed
   name: package_removed
   vars:
     pkgname: prelink

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -196,11 +196,31 @@ class Builder(object):
             raise RuntimeError("Unable to generate {0} template language for Templatable {1}: {2}"
                                .format(language.name, templatable, e))
 
+    # These file methods allows us to test write_lang_contents_for_templatable
+    def _write_template(self, filled_template, output_filepath):
+        with open(output_filepath, "w") as f:
+            f.write(filled_template)
+
+    def _read_template(self, output_filepath):
+        if not os.path.exists(output_filepath):
+            return None
+
+        with open(output_filepath, "r") as f:
+            return f.read()
+
+    def _compare_template_to_existing(self, filled_template, output_filepath, templatable):
+        old = self._read_template(output_filepath)
+        if old is not None and old != filled_template:
+            raise RuntimeError(
+                "Rule {0} template {1} differ '{2}' != '{3}'".format(
+                    templatable.id_, output_filepath, old, filled_template))
+
     def write_lang_contents_for_templatable(self, filled_template, lang, templatable):
         output_file_name = templatable.id_ + lang.file_extension
         output_filepath = os.path.join(self.output_dirs[lang.name], output_file_name)
-        with open(output_filepath, "w") as f:
-            f.write(filled_template)
+
+        self._compare_template_to_existing(filled_template, output_filepath, templatable)
+        self._write_template(filled_template, output_filepath)
 
     def build_lang_for_templatable(self, templatable, lang):
         """

--- a/ssg/templates.py
+++ b/ssg/templates.py
@@ -273,12 +273,14 @@ class Builder(object):
         declaration_path = os.path.join(self.templates_dir, "extra_ovals.yml")
         declaration = ssg.yaml.open_raw(declaration_path)
         for oval_def_id, template in declaration.items():
+            # Allow to define title of the template
+            title = template.pop("title", oval_def_id)
             # Since OVAL definition ID in shorthand format is always the same
             # as rule ID, we can use it instead of the rule ID even if no rule
             # with that ID exists
             rule = ssg.build_yaml.Rule.get_instance_from_full_dict({
                 "id_": oval_def_id,
-                "title": oval_def_id,
+                "title": title,
                 "template": template,
             })
             filled_template = self.build_lang_for_templatable(rule, LANGUAGES["oval"])

--- a/tests/unit/ssg-module/data/templates/extra_ovals.yml
+++ b/tests/unit/ssg-module/data/templates/extra_ovals.yml
@@ -5,3 +5,8 @@ package_avahi_installed:
     pkgname@ubuntu2004: avahi-daemon
     pkgname@rhel8: avahi8
 
+package_prelink_installed:
+  title: Package "prelink" Must be Installed
+  name: package_installed
+  vars:
+    pkgname: prelink

--- a/tests/unit/ssg-module/test_templates.py
+++ b/tests/unit/ssg-module/test_templates.py
@@ -1,13 +1,9 @@
 import os
 
-import ssg.utils
-import ssg.products
-import ssg.build_yaml
-import ssg.build_cpe
-import ssg.templates as tpl
+import ssg
+import ssg.templates
 
 from ssg.environment import open_environment
-from ssg.yaml import ordered_load
 
 
 ssg_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))

--- a/tests/unit/ssg-module/test_templates.py
+++ b/tests/unit/ssg-module/test_templates.py
@@ -10,6 +10,7 @@ ssg_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__fil
 DATADIR = os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
 templates_dir = os.path.join(DATADIR, "templates")
 platforms_dir = os.path.join(DATADIR, ".")
+missing_dir = os.path.join(DATADIR, "missing")
 cpe_items_dir = os.path.join(DATADIR, "applicability")
 
 build_config_yaml = os.path.join(ssg_root, "build", "build_config.yml")
@@ -19,8 +20,8 @@ env_yaml = open_environment(build_config_yaml, product_yaml)
 
 def test_render_extra_ovals():
     builder = ssg.templates.Builder(
-        env_yaml, '', templates_dir,
-        '', '', '', cpe_items_dir)
+        env_yaml, None, templates_dir,
+        missing_dir, missing_dir, None, cpe_items_dir)
 
     declaration_path = os.path.join(builder.templates_dir, "extra_ovals.yml")
     declaration = ssg.yaml.open_raw(declaration_path)
@@ -40,11 +41,13 @@ def test_render_extra_ovals():
         assert "<title>%s</title>" % (oval_def_id,) \
                in oval_content
 
+    assert not os.path.exists(missing_dir)
+
 
 def test_platform_templates():
     builder = ssg.templates.Builder(
-        env_yaml, '', templates_dir,
-        '', '', platforms_dir, cpe_items_dir)
+        env_yaml, None, templates_dir,
+        missing_dir, missing_dir, platforms_dir, cpe_items_dir)
 
     platform_path = os.path.join(builder.platforms_dir, "package_ntp.yml")
     platform = ssg.build_yaml.Platform.from_yaml(platform_path, builder.env_yaml,
@@ -59,3 +62,5 @@ def test_platform_templates():
 
         assert "<title>Package %s is installed</title>" % (cpe.template['vars']['pkgname'],) \
                in oval_content
+
+    assert not os.path.exists(missing_dir)


### PR DESCRIPTION
#### Description:

Change so that created templates must be exactly the same per name.

When generating rule files from `extra_ovals.yml` if title is defined, use it instead of always `oval_def_id`. This fixes issues with `package_prelink_removed`.

Change respective test `test_render_extra_ovals` to use actual `build_extra_ovals` and not copy-paste version.

Because it probably is bad idea to create files when testing at this stage, ensure no files were created.

#### Rationale:

There can be multiple ways how a templated file is created.

When there is multiple different templates with same name, there is really confusing and hard problem to debug depending on order of creation.

#### Review Hints:

This modifies and adds new test to test new features in `tests/unit/ssg-module/test_templates.py`. Newly added file modifying methods are not tested, but others have full branch coverage.

If directory is not cleaned there might be regressions. I guess this should be tested over various developer environments.