### PR TITLE
Add CPE OVAL to the checklist catalog

### DIFF
--- a/build-scripts/compose_ds.py
+++ b/build-scripts/compose_ds.py
@@ -240,7 +240,7 @@ def compose_ds(
     cpe_dict_dependencies = [cpe_oval_file_name]
     add_component(
         ds_collection, dictionaries, cpe_dict_file_name, cpe_dict_dependencies)
-    xccdf_dependencies = [oval_file_name, ocil_file_name]
+    xccdf_dependencies = [oval_file_name, ocil_file_name, cpe_oval_file_name]
     add_component(
         ds_collection, checklists, xccdf_file_name, xccdf_dependencies)
     add_component(ds_collection, checks, oval_file_name)


### PR DESCRIPTION
According to section 5.4 "The cpe:check-fact-ref Element" of the NIST IR 7698 (CPE Applicability Language), the @href attribute indicates "The location of the check content, such as the OVAL or OCIL document holding the desired check." Within a source data stream, the @href SHALL be resolved in the context of the XML Catalog specified as part of the ds:component-ref.

Fixes: https://github.com/ComplianceAsCode/content/issues/10370

This is only a backport of the PR https://github.com/ComplianceAsCode/content/pull/10379 to the 0.1.67 stabilization branch.