### PR TITLE
Update CI Repo for CTF

### DIFF
--- a/.github/workflows/automatus-cs8.yaml
+++ b/.github/workflows/automatus-cs8.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout (CTF)
         uses: actions/checkout@v2
         with:
-          repository: mildas/content-test-filtering
+          repository: ComplianceAsCode/content-test-filtering
           path: ctf
       # https://github.com/actions/checkout/issues/766
       - name: Set git safe directory

--- a/.github/workflows/automatus-cs9.yaml
+++ b/.github/workflows/automatus-cs9.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkout (CTF)
         uses: actions/checkout@v2
         with:
-          repository: mildas/content-test-filtering
+          repository: ComplianceAsCode/content-test-filtering
           path: ctf
       # https://github.com/actions/checkout/issues/766
       - name: Set git safe directory

--- a/.github/workflows/automatus.yaml
+++ b/.github/workflows/automatus.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout (CTF)
         uses: actions/checkout@v2
         with:
-          repository: mildas/content-test-filtering
+          repository: ComplianceAsCode/content-test-filtering
           path: ctf
       # https://github.com/actions/checkout/issues/766
       - name: Set git safe directory

--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Checkout (CTF)
         uses: actions/checkout@v2
         with:
-          repository: mildas/content-test-filtering
+          repository: ComplianceAsCode/content-test-filtering
           path: ctf
       - name: Detect content changes in the PR
         run: python3 ./ctf/content_test_filtering.py pr --base ${{ steps.fork_point.outputs.FORK_POINT }} --remote_repo ${{ github.server_url }}/${{ github.repository }}  --verbose --rule --output json ${{ github.event.pull_request.number }} > output.json

--- a/.github/workflows/ctf.yaml
+++ b/.github/workflows/ctf.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout (CTF)
         uses: actions/checkout@v2
         with:
-          repository: mildas/content-test-filtering
+          repository: ComplianceAsCode/content-test-filtering
           path: ctf
       - name: Detect content changes in the PR
         run: python3 ./ctf/content_test_filtering.py pr --base ${{ steps.fork_point.outputs.FORK_POINT }} --remote_repo ${{ github.server_url }}/${{ github.repository }} --verbose --rule --output json ${{ github.event.pull_request.number }} > output.json


### PR DESCRIPTION
This change is done to ensure that we using latest version of CTF

#### Description:
Use [ComplianceAsCode/content-test-filtering](https://github.com/ComplianceAsCode/content-test-filtering) in CI.

#### Rationale:
CTF was moved to the ComplianceAsCode GitHub organization.
