### PR TITLE
Ensure access to the su command is restricted

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
@@ -2,10 +2,7 @@
 
 {{{ bash_instantiate_variables("var_pam_wheel_group_for_su") }}}
 
-GRP_FILE=/etc/group
-
-grep -q ^${var_pam_wheel_group_for_su}:[^:]*:[^:]*:[^:]* /etc/group
-if [ $? -ne 0 ]; then
+if ! grep -q "^${var_pam_wheel_group_for_su}:[^:]*:[^:]*:[^:]*" /etc/group; then
     groupadd ${var_pam_wheel_group_for_su}
 fi
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/bash/shared.sh
@@ -1,0 +1,18 @@
+# platform = multi_platform_ubuntu
+
+{{{ bash_instantiate_variables("var_pam_wheel_group_for_su") }}}
+
+GRP_FILE=/etc/group
+
+grep -q ^${var_pam_wheel_group_for_su}:[^:]*:[^:]*:[^:]* /etc/group
+if [ $? -ne 0 ]; then
+    groupadd ${var_pam_wheel_group_for_su}
+fi
+
+# group must be empty
+grp_memb=$(groupmems -g ${var_pam_wheel_group_for_su} -l)
+if [ -n "${grp_memb}" ]; then
+    for memb in ${grp_memb}; do
+        deluser ${memb} ${var_pam_wheel_group_for_su}
+    done
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/oval/shared.xml
@@ -1,0 +1,32 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Group referred by variable var_pam_wheel_group_for_su exists and has no members.") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_ensure_pam_wheel_group_exist_and_has_no_member" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="at least one" check_existence="all_exist"
+      comment="check /etc/group for correct setting"
+      id="test_ensure_pam_wheel_group_exist_and_has_no_member" version="1">
+    <ind:object object_ref="object_ensure_pam_wheel_group_exist_and_has_no_member" />
+    <ind:state state_ref="state_ensure_pam_wheel_group_exist_and_has_no_member" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object comment="check /etc/group for empty groups"
+      id="object_ensure_pam_wheel_group_exist_and_has_no_member" version="1">
+    <ind:filepath>/etc/group</ind:filepath>
+    <ind:pattern operation="pattern match">^([^:]+):[^:]+:[0-9]+:\s*$</ind:pattern>
+    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state comment="group must exist"
+      id="state_ensure_pam_wheel_group_exist_and_has_no_member" version="1">
+    <ind:subexpression operation="equals" datatype="string"
+          var_ref="var_pam_wheel_group_for_su" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="Name of the su group" datatype="string"
+      id="var_pam_wheel_group_for_su" version="1" />
+</def-group>
+

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure the Group Used by pam_wheel Module Exists on System and is Empty'
+
+description: |-
+    Ensure that the group {{{ xccdf_value("var_pam_wheel_group_for_su") }}}
+    referenced by the pam_wheel  <tt>group</tt> parameter exists and has no
+    members. This ensures that no user can run commands with altered
+    privileges through the <tt>su</tt> command.
+
+rationale: |-
+    The <tt>su</tt> program allows to run commands with a substitute user and
+    group ID. It is commonly used to run commands as the root user. Limiting
+    access to such command is considered a good security practice.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: '5.6'
+    cis@ubuntu2204: 5.3.7
+
+ocil_clause: 'group {{{ var_pam_wheel_group_for_su }}} exists and has no user members'
+
+ocil: |-
+    Run the following command to check if the group {{{ var_pam_wheel_group_for_su }}}
+    exists:
+    <pre>grep {{{ var_pam_wheel_group_for_su }}} /etc/group</pre>
+    The output should contain the following line:
+    <pre>{{{ var_pam_wheel_group_for_su }}}:x:</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/correct.pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+GRP_NAME=sugroup
+
+groupadd ${GRP_NAME}
+
+# group must be empty
+grp_memb=$(groupmems -g ${GRP_NAME} -l)
+if [ -n "${grp_memb}" ]; then
+    for memb in ${grp_memb}; do
+        deluser ${memb} ${GRP_NAME}
+    done
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/group_has_users.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/group_has_users.fail.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+GRP_NAME=sugroup
+
+groupadd ${GRP_NAME}
+
+
+useradd -m -U testuser1
+useradd -m -U testuser2
+
+usermod -G ${GRP_NAME} -a testuser1
+usermod -G ${GRP_NAME} -a testuser2

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/no_group.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_pam_wheel_group_empty/tests/no_group.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+if grep -q sugroup /etc/group; then
+    groupdel -f sugroup
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_for_su/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15
 
 title: 'Enforce usage of pam_wheel for su authentication'
 
@@ -32,8 +32,6 @@ references:
     cis@rhel9: 5.3.7
     cis@sle12: "5.6"
     cis@sle15: "5.6"
-    cis@ubuntu2004: "5.6"
-    cis@ubuntu2204: "5.6"
     ospp: FMT_SMF_EXT.1.1
     pcidss: Req-8.6.1
     srg: 'SRG-OS-000373-GPOS-00156,SRG-OS-000312-GPOS-00123'

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/bash/shared.sh
@@ -1,0 +1,15 @@
+# platform = multi_platform_ubuntu
+{{{ bash_instantiate_variables("var_pam_wheel_group_for_su") }}}
+
+PAM_CONF=/etc/pam.d/su
+
+pamstr=$(grep -P '^auth\s+required\s+pam_wheel\.so\s+(?=[^#]*\buse_uid\b)(?=[^#]*\bgroup=)' ${PAM_CONF})
+if [ -z "$pamstr" ]; then
+    sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' ${PAM_CONF} # remove any remaining uncommented pam_wheel.so line
+    sed -Ei "/^auth\s+sufficient\s+pam_rootok\.so.*$/a auth required pam_wheel.so use_uid group=${var_pam_wheel_group_for_su}" ${PAM_CONF}
+else
+    group_val=$(echo -n "$pamstr" | egrep -o '\bgroup=[_a-z][-0-9_a-z]*' | cut -d '=' -f 2)
+    if [ -z "${group_val}" ] || [ ${group_val} != ${var_pam_wheel_group_for_su} ]; then
+        sed -Ei "s/(^auth\s+required\s+pam_wheel.so\s+[^#]*group=)[_a-z][-0-9_a-z]*/\1${var_pam_wheel_group_for_su}/" ${PAM_CONF}
+    fi
+fi

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/oval/shared.xml
@@ -1,0 +1,31 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Only members of the group set in variable 'var_pam_wheel_group_for_su' should be able to authenticate through the su command.") }}}
+    <criteria operator="AND">
+      <criterion test_ref="test_use_pam_wheel_group_for_su" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all" check_existence="at_least_one_exists"
+      comment="check /etc/pam.d/su for correct setting"
+      id="test_use_pam_wheel_group_for_su" version="1">
+    <ind:object object_ref="object_use_pam_wheel_group_for_su" />
+    <ind:state state_ref="state_use_pam_wheel_group_for_su" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object comment="check /etc/pam.d/su for correct setting"
+      id="object_use_pam_wheel_group_for_su" version="1">
+    <ind:filepath>/etc/pam.d/su</ind:filepath>
+    <ind:pattern operation="pattern match">^\s*auth\s+required\s+pam_wheel\.so\s+(?=[^#]*\buse_uid\b)[^#]*\bgroup=([_a-z][-0-9_a-z]*)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_state comment="group name must be valid"
+      id="state_use_pam_wheel_group_for_su" version="1">
+    <ind:subexpression operation="equals" datatype="string"
+          var_ref="var_pam_wheel_group_for_su" />
+  </ind:textfilecontent54_state>
+
+  <external_variable comment="Name of the allowed su group"
+      datatype="string" id="var_pam_wheel_group_for_su" version="1" />
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Enforce Usage of pam_wheel with Group Parameter for su Authentication'
+
+description: |-
+    To ensure that only users who are members of the group set in the
+    <tt>group</tt> pam_wheel parameter can run commands with altered
+    privileges through the <tt>su</tt> command, make sure that the
+    following line exists in the file <tt>/etc/pam.d/su</tt>:
+    <pre>auth required pam_wheel.so use_uid group={{{ xccdf_value("var_pam_wheel_group_for_su") }}}</pre>
+
+rationale: |-
+    The <tt>su</tt> program allows to run commands with a substitute
+    user and group ID. It is commonly used to run commands as the root
+    user. Limiting access to such command is considered a good security
+    practice.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: '5.6'
+    cis@ubuntu2204: 5.3.7
+
+ocil_clause: 'the line is not in the file or it is commented'
+
+ocil: |-
+    Run the following command to check if the line is present:
+    <pre>grep pam_wheel /etc/pam.d/su</pre>
+    The output should contain the following line:
+    <pre>auth required pam_wheel.so use_uid group={{{ xccdf_value("var_pam_wheel_group_for_su") }}}</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/correct.pass.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+# remove any remaining uncommented pam_wheel.so line
+sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' /etc/pam.d/su
+
+#apply correct line
+echo "auth required pam_wheel.so use_uid group=sugroup" >> /etc/pam.d/su

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/line_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/line_commented.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+# remove any remaining uncommented pam_wheel.so line
+sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' /etc/pam.d/su
+
+#apply commented line
+echo "#auth required pam_wheel.so use_uid group=sugroup" >> /etc/pam.d/su

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/line_not_there.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+#clean possible lines
+sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' /etc/pam.d/su

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/param_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/tests/param_commented.fail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# variables = var_pam_wheel_group_for_su=sugroup
+
+# remove any remaining uncommented pam_wheel.so line
+sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' /etc/pam.d/su
+
+#apply line with commented parameters
+echo "auth required pam_wheel.so #use_uid group=sugroup" >> /etc/pam.d/su

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/var_pam_wheel_group_for_su.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/var_pam_wheel_group_for_su.var
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'Group name used by pam_wheel group parameter'
+title: 'Group Name Used by pam_wheel Group Parameter'
 
 description: |-
     pam_wheel module has a parameter called group, which controls which groups

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/var_pam_wheel_group_for_su.var
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/var_pam_wheel_group_for_su.var
@@ -1,0 +1,18 @@
+documentation_complete: true
+
+title: 'Group name used by pam_wheel group parameter'
+
+description: |-
+    pam_wheel module has a parameter called group, which controls which groups
+    can access the su command.
+    This variable holds the valid value for the parameter.
+
+type: string
+
+operator: equals
+
+interactive: false
+
+options:
+    default: ""
+    cis: "sugroup"

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -783,7 +783,9 @@ selections:
     # Skip due to being a manual test
 
     ## 5.6 Ensure access to the su command is restricted (Automated)
-    - use_pam_wheel_for_su
+    - var_pam_wheel_group_for_su=cis
+    - use_pam_wheel_group_for_su
+    - ensure_pam_wheel_group_empty
 
     # 6 System Maintenance #
     ## 6.1 System File Permissions ##

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -833,7 +833,9 @@ selections:
     - sudo_require_reauthentication
 
     ### 5.3.7 Ensure access to the su command is restricted (Automated)
-    # NEEDS RULE
+    - var_pam_wheel_group_for_su=cis
+    - use_pam_wheel_group_for_su
+    - ensure_pam_wheel_group_empty
 
     ## 5.4 Configure PAM ##
     ### 5.4.1 Ensure password creation requirements are configured (Automated)


### PR DESCRIPTION
#### Description:

- This CIS item is currently being linked with existing rule `use_pam_wheel_for_su`. But this rule doesn't do what is expected from CIS. In order to address it I created a variable and two new rules:
  - `var_pam_wheel_group_for_su` - variable so users can tweak their `<group_name>` for sudo
  - `use_pam_wheel_group_for_su` - rule to add the line `auth required pam_wheel.so use_uid group=<group_name>` to /etc/pam.d/su
  - `ensure_pam_wheel_group_empty` - to check that `<group_name>` is empty in `/etc/group`

#### Rationale:

- This is needed for CIS on both Ubuntu, RHEL and SLES