### PR TITLE
Explicitly set SELinux type

### DIFF
--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/regular_file_device_t.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/regular_file_device_t.pass.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2175290
+# see https://github.com/ComplianceAsCode/content/issues/10232
+chcon -t zero_device_t /dev/userfaultfd
+
 touch /dev/foo
 restorecon -F /dev/foo

--- a/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/symlink_with_wrong_label.pass.sh
+++ b/linux_os/guide/system/selinux/selinux_all_devicefiles_labeled/tests/symlink_with_wrong_label.pass.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
 
+# workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2175290
+# see https://github.com/ComplianceAsCode/content/issues/10232
+chcon -t zero_device_t /dev/userfaultfd
+
 ln -s /dev/cpu /dev/foo
 restorecon -F /dev/foo


### PR DESCRIPTION
As a workaround for https://bugzilla.redhat.com/show_bug.cgi?id=2175290 we can explicitly set the type of /dev/userfaultfd to prevent test suite errors.

Addressing:
ERROR - Script regular_file_device_t.pass.sh using profile (all) found issue: ERROR - Rule evaluation resulted in fail, instead of expected pass during initial stage ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_selinux_all_devicefiles_labeled'. ERROR - Script symlink_with_wrong_label.pass.sh using profile (all) found issue: ERROR - Rule evaluation resulted in fail, instead of expected pass during initial stage ERROR - The initial scan failed for rule 'xccdf_org.ssgproject.content_rule_selinux_all_devicefiles_labeled'.

Fixes: https://github.com/ComplianceAsCode/content/issues/10232


