### PR TITLE
Update accounts_user_dot_no_world_writable_programs OVAL

### DIFF
--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/oval/shared.xml
@@ -36,18 +36,16 @@
     <unix:owrite datatype="boolean">true</unix:owrite>
   </unix:file_state>
 
-  <unix:file_object id="object_world_writable_programs" version="1">
+  <unix:file_object id="object_world_writable_programs" version="2">
     <unix:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
-      recurse_file_system="local"/>
+      recurse_file_system="defined"/>
     <unix:path>/</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
     <filter action="include">state_world_writable_programs</filter>
   </unix:file_object>
 
   <ind:textfilecontent54_object id="object_accounts_user_dot_no_world_writable_programs_init_files"
-      version="2">
-    <ind:behaviors recurse="directories" recurse_direction="down" max_depth="-1"
-      recurse_file_system="local"/>
+      version="3">
     <ind:path var_ref="var_accounts_user_dot_no_world_writable_programs_dirs"
       var_check="at least one"/>
     <ind:filename operation="pattern match" var_ref="var_user_initialization_files_regex"/>

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/common.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/common.sh
@@ -4,11 +4,13 @@ USER="cac_user"
 world_writable_file="/wwf.exec"
 initialization_dot_file="/home/$USER/.profile"
 not_initialization_dot_file="/home/$USER/.notinitfile"
+alt_non_initialization_dot_file="/home/$USER/custom.bashrc"
 
 useradd -m $USER
 
 touch $world_writable_file
 touch $initialization_dot_file
 touch $not_initialization_dot_file
+touch $alt_non_initialization_dot_file
 
 chmod o+w $world_writable_file

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/init_file_in_subdir.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/init_file_in_subdir.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+source common.sh
+
+subdir="/home/$USER/Documents/deep-down"
+
+mkdir -p "$subdir"
+
+echo "$world_writable_file" >> "$subdir"/.bashrc

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/no_world_writable_in_dot_file.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/no_world_writable_in_dot_file.pass.sh
@@ -4,3 +4,4 @@ source common.sh
 
 echo "# sudo bash $world_writable_file" >> $initialization_dot_file
 echo "sudo bash $world_writable_file" >> $not_initialization_dot_file
+echo "sudo bash $world_writable_file" >> $alt_non_initialization_dot_file

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/world_writable_in_custom_dot_file.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/world_writable_in_custom_dot_file.fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# variables = var_user_initialization_files_regex=^\.[\w\- ]+$
+
+source common.sh
+
+echo "$world_writable_file" >> $not_initialization_dot_file

--- a/linux_os/guide/system/accounts/accounts-session/var_user_initialization_files_regex.var
+++ b/linux_os/guide/system/accounts/accounts-session/var_user_initialization_files_regex.var
@@ -11,4 +11,4 @@ type: string
 interactive: false
 
 options:
-    default: '(\.bashrc|\.zshrc|\.cshrc|\.profile|\.bash_login|\.bash_profile)'
+    default: '^(\.bashrc|\.zshrc|\.cshrc|\.profile|\.bash_login|\.bash_profile)$'

--- a/linux_os/guide/system/accounts/accounts-session/var_user_initialization_files_regex.var
+++ b/linux_os/guide/system/accounts/accounts-session/var_user_initialization_files_regex.var
@@ -12,3 +12,4 @@ interactive: false
 
 options:
     default: '^(\.bashrc|\.zshrc|\.cshrc|\.profile|\.bash_login|\.bash_profile)$'
+    'all_dotfiles': '^\.[\w\- ]+$'


### PR DESCRIPTION
#### Description:

- Update the regex defined in var_user_initialization_files_regex.var to add the `^` and `$` anchors to avoid matching substrings like in `some.bashrc`
- Update OVAL content for rule `accounts_user_dot_no_world_writable_programs` to prevent elements that look for files from looking into file systems other than that defined by 'path' or 'filepath' elements.
- Also limit the search for dot initialization files to the users' homedirs only without recursing further down
- Add an `all_dotfiles` option to the `var_user_initialization_files_regex` variable in case all dotfiles want to be searched instead of an arbitrary list
- Add and update tests accordingly

#### Rationale:

- It was observed that on systems with a large number of processes running, the scans take hours to finish because a big number of files in `/proc` are gathered as world-writables
- Fixes #9028

#### Review Hints:

- The DISA STIG requirement(s) that this rule implement use the following command to locate world-writables:
```
find / -xdev -perm -002 -type f -exec ls -ld {} \; 
```
- From `find`'s manpage:
```
-xdev  Don't descend directories on other filesystems.
```
- From OVAL [documentation](https://oval-community-guidelines.readthedocs.io/en/latest/oval-schema-documentation/unix-definitions-schema.html#filebehaviors-1):
```
‘recurse_file_system’ defines the file system limitation of any searching [...]
The value of ‘defined’ keeps any recursion within the file system that the file_object
(path+filename or filepath) has specified. For example, if the path specified was
“/”, you would search only the filesystem mounted there, not other filesystems mounted
to descendant paths
```
- So using `recurse_file_system='defined'` more closely aligns with the command used by DISA. And it also prevents files from `/proc` to be taken into account.