### PR TITLE
Add new rule to limit ssh access

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/oval/shared.xml
@@ -1,0 +1,57 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("One of the following parameters of the sshd configuration file is set:  AllowUsers, DenyUsers, AllowGroups, DenyGroups.") }}}
+    <criteria operator="OR">
+      <criterion test_ref="test_allow_user_is_configured" />
+      <criterion test_ref="test_allow_group_is_configured" />
+      <criterion test_ref="test_deny_user_is_configured" />
+      <criterion test_ref="test_deny_group_is_configured" />
+    </criteria>
+  </definition>
+
+  <ind:textfilecontent54_test check="all"
+      check_existence="only_one_exists"
+      id="test_allow_user_is_configured" version="1"
+      comment="Check if there is an AllowUsers entry">
+    <ind:object object_ref="obj_allow_user" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all"
+      check_existence="only_one_exists"
+      id="test_allow_group_is_configured" version="1"
+      comment="Check if there is an AllowGroups entry">
+    <ind:object object_ref="obj_allow_group" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all"
+      check_existence="only_one_exists"
+      id="test_deny_user_is_configured" version="1"
+      comment="Check if there is a DenyUsers entry">
+    <ind:object object_ref="obj_deny_user" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_test check="all"
+      check_existence="only_one_exists"
+      id="test_deny_group_is_configured" version="1"
+      comment="Check if there is a DenyGroups entry">
+    <ind:object object_ref="obj_deny_group" />
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_allow_user" version="1">
+    <ind:filepath operation="pattern match">^\/etc\/ssh\/sshd_config.*$</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">(?i)^[ ]*AllowUsers[ ]+((?:[^ \n]+[ ]*)+)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="obj_allow_group" version="1">
+    <ind:filepath operation="pattern match">^/etc/ssh/sshd_config.*$</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">(?i)^[ ]*AllowGroups[ ]+((?:[^ \n]+[ ]*)+)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="obj_deny_user" version="1">
+    <ind:filepath operation="pattern match">^/etc/ssh/sshd_config.*$</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">(?i)^[ ]*DenyUsers[ ]+((?:[^ \n]+[ ]*)+)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+  <ind:textfilecontent54_object id="obj_deny_group" version="1">
+    <ind:filepath operation="pattern match">^/etc/ssh/sshd_config.*$</ind:filepath>
+    <ind:pattern operation="pattern match" datatype="string">(?i)^[ ]*DenyGroups[ ]+((?:[^ \n]+[ ]*)+)$</ind:pattern>
+    <ind:instance operation="greater than or equal" datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/rule.yml
@@ -1,0 +1,47 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Restrict sshd User Access via AllowUsers, AllowGroups, DenyUsers or DenyGroups'
+
+description: |-
+    AllowUsers gives the system administrator the option of allowing
+    specific users to ssh into the system.
+    - The list consists of space separated user names
+    - Numeric user IDs are not recognized with this variable
+    - A system administrator may restrict user access further by only
+      allowing the allowed users to log in from a particular host by
+      specifying the entry as user@host.
+    AllowGroups gives the system administrator the option of allowing
+    specific groups to ssh into the system.
+    - The list consists of space separated group names
+    - Numeric group IDs are not recognized with this variable
+    DenyUsers gives the system administrator the option of denying
+    specific users to ssh into the system.
+    - The list consists of space separated user names
+    - Numeric user IDs are not recognized with this variable
+    - A system administrator may restrict user access further by only
+      allowing the allowed users to log in from a particular host by
+      specifying the entry as user@host.
+    DenyGroups gives the system administrator the option of denying
+    specific groups to ssh into the system.
+    - The list consists of space separated group names.
+    - Numeric group IDs are not recognized with this variable.
+
+rationale: |-
+    Restricting which users can remotely access the system via SSH will
+    help ensure that only authorized users access the system.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 5.2.17
+    cis@ubuntu2204: 5.2.4
+
+ocil: 'sshd does not limit the users who can log in'
+
+ocil: |-
+    To ensure sshd limits the users who can log in, run the following:
+    <pre>$ sudo grep -rPi '^\h*(allow|deny)(users|groups)\h+\H+(\h+.*)?$' /etc/ssh/sshd_config*</pre>
+    If properly configured, the output should be a list of usernames
+    allowed to log in to this system.

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/allow_groups.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/allow_groups.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'
+echo "AllowGroups testgroup1 testgroup2 testgroup3" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/allow_users.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/allow_users.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'
+echo "AllowUsers testuser1 testuser2 testuser3" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/allow_users_groups.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/allow_users_groups.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'
+echo "AllowUsers testuser1 testuser2 testuser3" >> /etc/ssh/sshd_config
+echo "AllowGroups testgroup1 testgroup2 testgroup3" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/deny_groups.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/deny_groups.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'
+echo "DenyGroups testgroup1 testgroup2 testgroup3" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/deny_users.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/deny_users.pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'
+echo "DenyUsers testuser1 testuser2 testuser3" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/deny_users_groups.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/deny_users_groups.pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'
+echo "DenyUsers testuser1 testuser2 testuser3" >> /etc/ssh/sshd_config
+echo "DenyGroups testgroup1 testgroup2 testgroup3" >> /etc/ssh/sshd_config

--- a/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/no_entry.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_limit_access/tests/no_entry.fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# remediation = None
+
+find /etc/ssh/ssh_config* -type f -print0 | xargs -0 sed -i '/^(Allow|Deny)(Users|Groups).*/d'

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -688,7 +688,7 @@ selections:
     - sshd_set_login_grace_time
 
     ### 5.2.17 Ensure SSH access is limited (Automated)
-    # Needs rules
+    - sshd_limit_access
 
     ### 5.2.18 Ensure SSH warning banner is configured (Automated)
     - sshd_enable_warning_banner_net

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -748,7 +748,7 @@ selections:
     - file_permissions_sshd_pub_key
 
     ### 5.2.4 Ensure SSH access is limited (Automated)
-    # NEEDS RULE
+    - sshd_limit_access
 
     ### 5.2.5 Ensure SSH LogLevel is appropriate (Automated)
     - sshd_set_loglevel_info


### PR DESCRIPTION
#### Description:

- This new rule is aimed to address CIS requirement to limit SSH access through AllowUsers, AllowGroups, DenyUsers or DenyGroups.
- Currently we have a rule that is being used for that `sshd_limit_user_access` but it doesn't have OVAL, remediation or anything that help us achieve it, therefore I created this new rule.
- I believe this rule will be needed on most, if not all, distributions, so I'm already adding you to reviewers so you are aware of it and also to gather feedback.
- @teacup-on-rockingchair fyi

#### Rationale:

- This rule is needed for CIS