### PR TITLE
Ubuntu2204 CIS move away from FIPS approved rules

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004
 
 title: 'Use Only FIPS 140-2 Validated Ciphers'
 
@@ -59,7 +59,6 @@ references:
     cis@sle12: 5.2.13
     cis@sle15: 5.2.13
     cis@ubuntu2004: 5.2.12
-    cis@ubuntu2204: 5.2.13
     cjis: 5.5.6
     cobit5: APO11.04,APO13.01,BAI03.05,BAI10.01,BAI10.02,BAI10.03,BAI10.05,DSS01.04,DSS05.02,DSS05.03,DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.06,DSS06.10,MEA02.01
     cui: 3.1.13,3.13.11,3.13.8

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: alinux2,ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004
 
 title: 'Use Only FIPS 140-2 Validated MACs'
 
@@ -53,7 +53,6 @@ references:
     cis@sle12: 5.2.14
     cis@sle15: 5.2.14
     cis@ubuntu2004: 5.2.13
-    cis@ubuntu2204: 5.2.14
     cobit5: APO01.06,APO13.01,DSS01.04,DSS05.02,DSS05.03,DSS05.04,DSS05.07,DSS06.02,DSS06.03
     cui: 3.1.13,3.13.11,3.13.8
     disa: CCI-000068,CCI-000803,CCI-000877,CCI-001453,CCI-003123

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_ciphers/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel7,sle12,sle15
+prodtype: ol7,rhel7,sle12,sle15,ubuntu2204
 
 title: 'Use Only Strong Ciphers'
 
@@ -31,6 +31,7 @@ references:
     cis@debian: 9.3.11
     cis@sle12: 5.2.13
     cis@sle15: 5.2.13
+    cis@ubuntu2204: 5.2.13
 
 ocil_clause: 'ciphers are not configured or not using strong ciphers'
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_strong_macs/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: ol7,rhel7,sle12,sle15
+prodtype: ol7,rhel7,sle12,sle15,ubuntu2204
 
 title: 'Use Only Strong MACs'
 
@@ -27,6 +27,7 @@ identifiers:
 references:
     cis@sle12: 5.2.14
     cis@sle15: 5.2.14
+    cis@ubuntu2204: 5.2.14
 
 ocil_clause: 'MACs option is commented out or not using strong hash algorithms'
 

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -776,8 +776,7 @@ selections:
     - sshd_use_strong_ciphers
 
     ### 5.2.14 Ensure only strong MAC algorithms are used (Automated)
-    - sshd_approved_macs=cis_ubuntu
-    - sshd_use_approved_macs
+    - sshd_use_strong_macs
 
     ### 5.2.15 Ensure only strong Key Exchange algorithms are used (Automated)
     - sshd_strong_kex=cis_ubuntu2004

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -773,8 +773,7 @@ selections:
     # Skip due to being Level 2
 
     ### 5.2.13 Ensure only strong Ciphers are used (Automated)
-    - sshd_approved_ciphers=cis_ubuntu
-    - sshd_use_approved_ciphers
+    - sshd_use_strong_ciphers
 
     ### 5.2.14 Ensure only strong MAC algorithms are used (Automated)
     - sshd_approved_macs=cis_ubuntu


### PR DESCRIPTION
#### Description:

- Basically title, as Ubuntu 22.04 isn't yet FIPS certified.

#### Rationale:

- This is needed for CIS