### PR TITLE
Some new rules and  mostly related fixes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,6 +16,12 @@ indent_size = unset
 tab_width = 4
 max_line_length = 99
 
+[**.sh]
+indent_style = space
+indent_size = unset
+tab_width = 4
+max_line_length = 99
+
 [{**.yml, **.yaml, **.jinja}]
 indent_style = space
 indent_size = 4

--- a/linux_os/guide/system/bootloader-grub2/grub2_init_on_free_argument/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/grub2_init_on_free_argument/rule.yml
@@ -1,0 +1,46 @@
+documentation_complete: true
+
+prodtype: fedora,ol9,rhel9
+
+title: 'Configure kernel to zero freed pages and heap objects'
+
+description: |-
+    To enable initialize freed pages and heap objects with zeroes add
+    the argument <tt>init_on_free=1</tt> to the default GRUB 2 command line
+    for the Linux operating system.
+    {{{ describe_grub2_argument("init_on_free=1") | indent(4) }}}
+    This argument is meant to replace
+    <tt>slub_debug=P page_poison=1</tt>
+    when used with <tt>init_on_alloc=1</tt>.
+    Detailed information available at
+    {{{ weblink(link="https://github.com/torvalds/linux/commit/6471384af") }}}
+    and
+    {{{ weblink(link="https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings") }}}.
+
+rationale: |-
+    Initialize newly freed pages and heap objects with zeroes, so any
+    modification or reference to that page before being initialized will be
+    prevented. This prevents possible information leaks and make control-flow
+    bugs that depend on uninitialized values more deterministic.
+
+warnings:
+    - performance: |-
+          Enabling argument can have medium performance penalty, up to at least +25%.
+
+severity: medium
+
+ocil_clause: 'the kernel is not configured to zero out memory after free'
+
+ocil: |-
+    {{{ ocil_grub2_argument("init_on_free=1") | indent(4) }}}
+
+platform: grub2
+
+template:
+    name: grub2_bootloader_argument
+    vars:
+        arg_name: init_on_free
+        arg_value: '1'
+
+fixtext: |-
+    {{{ describe_grub2_argument("init_on_free=1") | indent(4) }}}

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range/rule.yml
@@ -4,7 +4,7 @@ prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Set Kernel Parameter to Increase Local Port Range'
 
-description: '{{{ describe_sysctl_option_value(sysctl="net.ipv4.ip_local_port_range", value="32768 65535") }}}'
+description: '{{{ describe_sysctl_option_value(sysctl="net.ipv4.ip_local_port_range", value=xccdf_value("sysctl_net_ipv4_ip_local_port_range_value")) }}}'
 
 rationale: |-
     This setting defines the local port range that is used by TCP and UDP to
@@ -23,13 +23,12 @@ identifiers:
 references:
     anssi: BP28(R22)
 
-{{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.ip_local_port_range", value="32768 65535") }}}
+{{{ complete_ocil_entry_sysctl_option_value(sysctl="net.ipv4.ip_local_port_range", value=xccdf_value("sysctl_net_ipv4_ip_local_port_range_value")) }}}
 
 template:
     name: sysctl
     vars:
         sysctlvar: net.ipv4.ip_local_port_range
         datatype: string
-        sysctlval: 32768 65535
-        operation: pattern match
-        sysctlval_regex: '32768\s*65535'
+        sysctl_correct_value: 32768 65535
+        sysctl_wrong_value: 48000 60000

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range_value.var
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_ip_local_port_range_value.var
@@ -1,0 +1,17 @@
+documentation_complete: true
+
+title: net.ipv4.ip_local_port_range
+
+description: |-
+    Configure the local port range that is used by TCP and UDP to choose the
+    local port. First number is start of range and last number is last of range.
+
+type: string
+
+operator: equals
+
+interactive: true
+
+options:
+    default: 32768 65535
+    fedora: 32768 60999

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_af_802154_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_af_802154_disabled/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable old AF 802.15.4 Support'
+
+description: |-
+    AF 802.15.4 is old implementation of IEEE 802.15.4.
+    {{{ describe_module_disable(module="af_802154") }}}
+
+rationale: |-
+    Disabling
+    old IEEE 802.15.4 support
+    protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="af_802154") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("af_802154") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: af_802154

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_appletalk_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_appletalk_disabled/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Appletalk protocol Support'
+
+description: |-
+    AppleTalk is the protocol that Apple computers can use to communicate on a network.
+    {{{ describe_module_disable(module="appletalk") }}}
+
+rationale: |-
+    Disabling Appletalk protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="appletalk") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("appletalk") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: appletalk

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_ax25_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_ax25_disabled/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable AX.25 Level 2 protocol Support'
+
+description: |-
+    Amateur Radio AX.25 Level 2 protocol is the protocol used for computer communication over amateur radio.
+    {{{ describe_module_disable(module="ax25") }}}
+
+rationale: |-
+    Disabling Amateur Radio AX.25 Level 2 protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="ax25") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("ax25") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: ax25

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/missing_blacklist.fail.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_dccp_disabled/tests/missing_blacklist.fail.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-# platform = multi_platform_rhel,multi_platform_ol
-
-rm -f /etc/modprobe.d/dccp-blacklist.conf
-echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_decnet_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_decnet_disabled/rule.yml
@@ -1,0 +1,24 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable DECnet protocol support'
+
+description: |-
+    DECnet protocol is the protocol used in many products made by Digital (now Compaq).
+    {{{ describe_module_disable(module="decnet") }}}
+
+rationale: |-
+    Disabling DECnet protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="decnet") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("decnet") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: decnet

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_econet_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_econet_disabled/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Econet network card support'
+
+description: |-
+    Econet is Acorn Computers's low-cost local area network system, intended
+    for use by schools and small businesses.
+    {{{ describe_module_disable(module="econet") }}}
+
+rationale: |-
+    Disabling Econet protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="econet") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("econet") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: econet

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/correct_conversion.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/correct_conversion.pass.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-# Convert - in firewire-core to _
-kernmodule="firewire-core"
-kernmodule_r="${kernmodule/-/_}"
-echo "install ${kernmodule_r} /bin/true" > /etc/modprobe.d/"${kernmodule}".conf
-{{% if product in ["fedora", "ol7", "ol8"] or "rhel" in product %}}
-echo "blacklist ${kernmodule_r}" >> /etc/modprobe.d/"${kernmodule}".conf
-{{% endif %}}
+kernmodule="firewire_core"
+{{{ bash_kernel_module_disable_test(
+    'firewire-core', 'firewire[_-]core',
+    t_blacklist="pass",
+    t_dracut="pass_d",
+    t_dracut_drivers="pass_d",
+    t_modprobe="pass",
+    t_modprobe_d_install="pass",
+    t_modules_load_d="pass",
+) }}}

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/correct_conversion.pass.sh
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_firewire-core_disabled/tests/correct_conversion.pass.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# Convert - in firewire-core to _
+kernmodule="firewire-core"
+kernmodule_r="${kernmodule/-/_}"
+echo "install ${kernmodule_r} /bin/true" > /etc/modprobe.d/"${kernmodule}".conf
+{{% if product in ["fedora", "ol7", "ol8"] or "rhel" in product %}}
+echo "blacklist ${kernmodule_r}" >> /etc/modprobe.d/"${kernmodule}".conf
+{{% endif %}}

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_ieee802154_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_ieee802154_disabled/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable IEEE Std 802.15.4 Low-Rate Wireless Personal Area Networks Support'
+
+description: |-
+    IEEE Std 802.15.4 defines a low data rate, low power and low
+    complexity short range wireless personal area networks.
+    {{{ describe_module_disable(module="ieee802154") }}}
+
+rationale: |-
+    Disabling
+    IEEE Std 802.15.4 Low-Rate Wireless Personal Area Networks support
+    protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="ieee802154") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("ieee802154") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: ieee802154

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_mac802154_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_mac802154_disabled/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Generic IEEE 802.15.4 Soft Networking Stack (mac802154) Support'
+
+description: |-
+    <tt>mac802154</tt> is hardware independent IEEE 802.15.4
+    networking stack for SoftMAC devices.
+    {{{ describe_module_disable(module="mac802154") }}}
+
+rationale: |-
+    Disabling
+    <tt>mac802154</tt>
+    protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="mac802154") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("mac802154") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: mac802154

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_netrom_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_netrom_disabled/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Amateur Radio NET/ROM protocol Support'
+
+description: |-
+    Amateur Radio NET/ROM protocol is network layer protocol on top of AX.25
+    useful for routing.
+    {{{ describe_module_disable(module="netrom") }}}
+
+rationale: |-
+    Disabling
+    Amateur Radio NET/ROM
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="netrom") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("netrom") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: netrom

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_nfc_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_nfc_disabled/rule.yml
@@ -1,0 +1,25 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Near Field Communication (NFC) devices support'
+
+description: |-
+    Near Field Communication (NFC) devices are used for short range communications.
+    {{{ describe_module_disable(module="nfc") }}}
+
+rationale: |-
+    Disabling Near Field Communication (NFC) devices
+    protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="nfc") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("nfc") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: nfc

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_p8022_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_p8022_disabled/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable 802.2 demultiplexing off Ethernet Support'
+
+description: |-
+    Ethernet 802.2 frame type is used by IPX/SPX on Novell NetWare 3.12 and 4.X
+    networks.
+    {{{ describe_module_disable(module="p8022") }}}
+
+rationale: |-
+    Disabling
+    Ethernet 802.2
+    support protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="p8022") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("p8022") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: p8022

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_p8023_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_p8023_disabled/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable 802.3 client Support'
+
+description: |-
+    802.3 data link hooks used for IPX 802.3.
+    {{{ describe_module_disable(module="p8023") }}}
+
+rationale: |-
+    Disabling
+    802.3 data link hooks used for IPX 802.3
+    protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="p8023") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("p8023") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: p8023

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_psnap_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_psnap_disabled/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable SNAP data link layer Support'
+
+description: |-
+    Subnetwork Access Protocol (SNAP) is a mechanism for multiplexing, on
+    networks using IEEE 802.2 LLC.
+    {{{ describe_module_disable(module="psnap") }}}
+
+rationale: |-
+    Disabling
+    SNAP data link layer support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="psnap") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("psnap") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: psnap

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_rose_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_rose_disabled/rule.yml
@@ -1,0 +1,27 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Amateur Radio X.25 PLP (Rose) protocol Support'
+
+description: |-
+    Amateur Radio X.25 Packet Layer Protocol (PLP) (Rose) protocol
+    is a way to route packets over X.25 connections in general and amateur
+    radio AX.25 connections in particular, essentially an alternative to
+    NET/ROM.
+    {{{ describe_module_disable(module="rose") }}}
+
+rationale: |-
+    Disabling Amateur Radio AX.25 Level 2 protects the system against exploitation of any
+    flaws in its implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="rose") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("rose") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: rose

--- a/linux_os/guide/system/network/network-uncommon/kernel_module_x25_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-uncommon/kernel_module_x25_disabled/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable CCITT X.25 Packet Layer Support'
+
+description: |-
+    CCITT X.25 Packet Layer is a set of standardized network protocols.
+    {{{ describe_module_disable(module="x25") }}}
+
+rationale: |-
+    Disabling
+    X.25
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="x25") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("x25") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: x25

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_dvb_core_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_dvb_core_disabled/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable the dvb-core module'
+
+description: |-
+    Driver support DVB devices.
+    {{{ describe_module_disable(module="dvb-core") }}}
+
+rationale: |-
+    Disabling
+    DVB support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+platform: machine
+
+{{{ complete_ocil_entry_module_disable(module="dvb-core") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("dvb-core") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: dvb-core

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_floppy_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_floppy_disabled/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable the floppy module'
+
+description: |-
+    Driver support floppy disk drive(s) of your PC under Linux.
+    {{{ describe_module_disable(module="floppy") }}}
+
+rationale: |-
+    Disabling
+    floppy support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+platform: machine
+
+{{{ complete_ocil_entry_module_disable(module="floppy") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("floppy") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: floppy

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_ksmbd_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_ksmbd_disabled/rule.yml
@@ -1,0 +1,29 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable the ksmbd module'
+
+description: |-
+    KSMBD is a linux kernel server which implements SMB3 protocol in kernel
+    space for sharing files over network.
+    {{{ describe_module_disable(module="ksmbd") }}}
+
+rationale: |-
+    Disabling
+    KSMBD support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+platform: machine
+
+{{{ complete_ocil_entry_module_disable(module="ksmbd") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("ksmbd") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: ksmbd

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_n_hdlc_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_n_hdlc_disabled/rule.yml
@@ -1,0 +1,26 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable HDLC line discipline Support'
+
+description: |-
+    Allows synchronous HDLC communications with tty device drivers that support
+    synchronous HDLC such as the Microgate SyncLink adapter.
+    {{{ describe_module_disable(module="n_hdlc") }}}
+
+rationale: |-
+    HDLC line discipline support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+{{{ complete_ocil_entry_module_disable(module="n_hdlc") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("n_hdlc") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: n_hdlc

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_snd_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_snd_disabled/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable the snd module'
+
+description: |-
+    Disable support for Advanced Linux Sound Architecture.
+    {{{ describe_module_disable(module="snd") }}}
+
+rationale: |-
+    Disabling
+    Advanced Linux Sound Architecture support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+platform: machine
+
+{{{ complete_ocil_entry_module_disable(module="snd") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("snd") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: snd

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_soundcore_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_soundcore_disabled/rule.yml
@@ -1,0 +1,28 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable the soundcore module'
+
+description: |-
+    Disable core support for audio drivers.
+    {{{ describe_module_disable(module="soundcore") }}}
+
+rationale: |-
+    Disabling
+    audio driver support
+    protects the system against exploitation of any flaws in its
+    implementation.
+
+severity: medium
+
+platform: machine
+
+{{{ complete_ocil_entry_module_disable(module="soundcore") }}}
+
+fixtext: '{{{ fixtext_kernel_module_disabled("soundcore") }}}'
+
+template:
+    name: kernel_module_disabled
+    vars:
+        kernmodule: soundcore

--- a/linux_os/guide/system/permissions/restrictions/sysctl_dev_tty_ldisc_autoload/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_dev_tty_ldisc_autoload/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable Automatically load TTY Line Disciplines'
+
+description: '{{{ describe_sysctl_option_value(sysctl="dev.tty.ldisc_autoload", value="0") }}}'
+
+rationale: |-
+    Historically the kernel has always automatically loaded any line discipline
+    that is in a kernel module when a user asks for it to be loaded with the
+    TIOCSETD ioctl, or through other means. This is not always the best thing
+    to do on systems where you know you will not be using some of the more
+    "ancient" line disciplines, so prevent the kernel from doing this unless
+    the request is coming from a process with the CAP_SYS_MODULE permissions.
+
+severity: medium
+
+{{{ complete_ocil_entry_sysctl_option_value(sysctl="dev.tty.ldisc_autoload", value="0") }}}
+
+fixtext: |-
+    Configure {{{ full_name }}} to prevent automatically load any line discipline.
+
+platform: machine
+
+template:
+    name: sysctl
+    vars:
+        sysctlvar: dev.tty.ldisc_autoload
+        sysctlval: '0'
+        datatype: int

--- a/linux_os/guide/system/permissions/restrictions/sysctl_dev_tty_legacy_tiocsti/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_dev_tty_legacy_tiocsti/rule.yml
@@ -1,0 +1,30 @@
+documentation_complete: true
+
+prodtype: fedora
+
+title: 'Disable legacy TIOCSTI usage'
+
+description: '{{{ describe_sysctl_option_value(sysctl="dev.tty.legacy_tiocsti", value="0") }}}'
+
+rationale: |-
+    Historically the kernel has allowed TIOCSTI, which will push characters
+    into a controlling TTY. This continues to be used as a malicious privilege
+    escalation mechanism, and provides no meaningful real-world utility any
+    more. Its use is considered a dangerous legacy operation, and can be
+    disabled on most systems.
+
+severity: medium
+
+{{{ complete_ocil_entry_sysctl_option_value(sysctl="dev.tty.legacy_tiocsti", value="0") }}}
+
+fixtext: |-
+    Configure {{{ full_name }}} to prevent use of TIOCSTI.
+
+platform: machine
+
+template:
+    name: sysctl
+    vars:
+        sysctlvar: dev.tty.legacy_tiocsti
+        sysctlval: '0'
+        datatype: int

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/rule.yml
@@ -32,7 +32,9 @@ references:
 
 fixtext: |-
     Configure {{{ full_name }}} to only allow root to do kernel profiling.
-    {{{ fixtext_sysctl(sysctl="kernel.perf_event_paranoid", value="2") | indent(4) }}}
+    {{{ fixtext_sysctl(sysctl="kernel.perf_event_paranoid", value=xccdf_value("sysctl_kernel_perf_event_paranoid_value")) | indent(4) }}}
+    If value is "3" and supported by kernel version, then disallowed all
+    unprivileged perf event use.
 
 srg_requirement: '{{{ full_name }}} must prevent kernel profiling by unprivileged users.'
 
@@ -42,5 +44,8 @@ template:
     name: sysctl
     vars:
         sysctlvar: kernel.perf_event_paranoid
-        sysctlval: '2'
+        sysctlval:
+            - '2'
+            - '3'
         datatype: int
+        wrong_sysctlval_for_testing: '0'

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid_value.var
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid_value.var
@@ -1,0 +1,45 @@
+documentation_complete: true
+
+title: kernel.perf_event_paranoid
+
+description: |-
+    Controls use of the performance events system by unprivileged users
+    (without CAP_PERFMON). The default value is 2.
+
+    For backward compatibility reasons access to system performance monitoring
+    and observability remains open for CAP_SYS_ADMIN privileged processes but
+    CAP_SYS_ADMIN usage for secure system performance monitoring and
+    observability operations is discouraged with respect to CAP_PERFMON use
+    cases.
+
+    -1
+    Allow use of (almost) all events by all users.
+    Ignore mlock limit after perf_event_mlock_kb without CAP_IPC_LOCK.
+
+    >=0
+    Disallow ftrace function tracepoint by users without CAP_PERFMON.
+    Disallow raw tracepoint access by users without CAP_PERFMON.
+
+    >=1
+    Disallow CPU event access by users without CAP_PERFMON.
+
+    >=2
+    Disallow kernel profiling by users without CAP_PERFMON.
+
+    >=3
+    Disallow all unprivileged perf event use.
+    This requires patch not yet upstreamed.
+
+type: number
+
+operator: equals
+
+interactive: false
+
+options:
+    -1: "-1"
+    0: "0"
+    1: "1"
+    2: "2"
+    3: "3"
+    default: "2"

--- a/products/fedora/profiles/ospp.profile
+++ b/products/fedora/profiles/ospp.profile
@@ -47,6 +47,8 @@ selections:
     - sysctl_kernel_perf_event_paranoid_value=2
     - sysctl_kernel_unprivileged_bpf_disabled
     - sysctl_net_core_bpf_jit_harden
+    - sysctl_net_ipv4_ip_local_port_range
+    - sysctl_net_ipv4_ip_local_port_range_value=fedora
     - sysctl_kernel_core_pattern
     - coredump_disable_storage
     - coredump_disable_backtraces

--- a/products/fedora/profiles/ospp.profile
+++ b/products/fedora/profiles/ospp.profile
@@ -44,6 +44,7 @@ selections:
     - sysctl_user_max_user_namespaces
     - sysctl_kernel_dmesg_restrict
     - sysctl_kernel_perf_event_paranoid
+    - sysctl_kernel_perf_event_paranoid_value=2
     - sysctl_kernel_unprivileged_bpf_disabled
     - sysctl_net_core_bpf_jit_harden
     - sysctl_kernel_core_pattern

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -12,6 +12,8 @@ args:
     {{% endif %}}
   chrony:
     pkgname: chrony
+  dracut:
+    pkgname: dracut
   gdm:
     {{% if pkg_system == "rpm" %}}
     pkgname: gdm

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2440,3 +2440,248 @@ from /etc/os-release from VERSION_ID variable.
 {{%- macro bash_get_version_os_linux(os_release_path="/etc/os-release") -%}}
 grep -P "^VERSION_ID=[\"']?[\w.]+[\"']?$" {{{ os_release_path }}} | sed "s/^VERSION_ID=[\"']\?\([^\"']\+\)[\"']\?$/\1/"
 {{%- endmacro -%}}
+
+
+{{#
+Generate code for kernel_module_disable tests
+
+:param KERNMODULE: kernel module name
+:param KERNMODULE_RX: kernel module name regexp escaped
+:param t_blacklist: pass and fail conditions
+:param t_dracut: pass and fail conditions
+:param t_dracut_drivers: pass and fail conditions
+:param t_modprobe: pass and fail conditions
+:param t_modprobe_d_install: pass and fail conditions
+:param dir_blacklist: directory prefix config is in
+:param dir_modprobe_d_install: directory prefix config is in
+:param dir_modules_load_d: directory prefix config is in
+
+Idea is to immplement whole test in one parametrized method.
+
+This template has several possible tests, each can have passing or failing
+value in different ways. This should provide clear documentation why test should fail.
+
+There is several possibilities for configuration file names and directories.
+Capsulating all cases here allows to keep variations or parallel
+implementations low and keep copy-paste code minimal.
+
+Implementation uses mix of jinja and bash functions which should allow most
+flexible test generation.
+
+Try to keep system_with, and directory lists, possible tests with OVAL.
+
+I decided not to use default pass / fail condition and instead implemented
+checks with raise.
+#}}
+{{%- macro bash_kernel_module_disable_test(KERNMODULE, KERNMODULE_RX, t_blacklist="", t_dracut="", t_dracut_drivers="", t_modprobe="", t_modprobe_d_install="", t_modules_load_d="", dir_blacklist="/etc", dir_modprobe_d_install="/etc", dir_modules_load_d="/etc") -%}}
+# first line can be commented to allow shellcheck during developement
+set -epu
+{{% set system_with_modprobeconf_supported = false %}}
+{{% set system_with_blacklisted_supported = false %}}
+{{% set system_with_dracut_supported = false %}}
+{{% if product not in ["fedora"] and "ol" not in product and "rhel" not in product and "ubuntu" not in product %}}
+{{% set system_with_modprobeconf_supported = true %}}
+{{% endif %}}
+{{% if product in ["fedora", "ol7", "ol8", "rhcos4", "sle12", "sle15"] or "rhel" in product %}}
+{{% set system_with_blacklisted_supported = true %}}
+{{% endif %}}
+{{% if product in ["fedora", "rhel8", "rhel9"] %}}
+{{% set system_with_dracut_supported = true %}}
+{{% endif %}}
+
+{{% set err_prefix = "KERNMODULE (" + KERNMODULE + ") test with " %}}
+
+{{% if t_blacklist == "" and system_with_blacklisted_supported %}}
+{{{ raise(err_prefix + "system_with_blacklisted_supported support but no pass / fail condition defined") }}}
+{{% endif %}}
+{{% if t_dracut == "" and system_with_dracut_supported %}}
+{{{ raise(err_prefix + "system_with_dracut_supported but no pass / fail condition defined") }}}
+{{% endif %}}
+{{% if t_dracut_drivers == "" and system_with_dracut_supported %}}
+{{{ raise(err_prefix + "system_with_dracut_supported but no pass / fail condition defined") }}}
+{{% endif %}}
+{{% if t_modprobe == "" and system_with_modprobeconf_supported %}}
+{{{ raise(err_prefix + "system_with_modprobeconf_supported but no pass / fail condition defined") }}}
+{{% endif %}}
+{{% if t_modprobe_d_install == "" %}}
+{{{ raise(err_prefix + "modprobe_d support but no pass / fail condition defined") }}}
+{{% endif %}}
+{{% if t_modules_load_d == "" %}}
+{{{ raise(err_prefix + "modules_load_d support but no pass / fail condition defined") }}}
+{{% endif %}}
+
+system_with_modprobeconf_supported={{%- if system_with_modprobeconf_supported -%}}1{{%- else -%}}0{{%- endif %}}
+system_with_blacklisted_supported={{%- if system_with_blacklisted_supported -%}}1{{%- else -%}}0{{%- endif %}}
+system_with_dracut_supported={{%- if system_with_dracut_supported -%}}1{{%- else -%}}0{{%- endif %}}
+
+_kernmodule_base={{{ KERNMODULE | quote }}}
+_kernmodule_rx_base={{{ KERNMODULE_RX | quote }}}
+
+kernmodule="${kernmodule:-"${_kernmodule_base}"}"
+kernmodule_file="${kernmodule_file:-"${_kernmodule_base}"}"
+kernmodule_rx="${kernmodule_rx:-"${_kernmodule_rx_base}"}"
+
+blacklist_pass="${blacklist_pass:-"blacklist ${kernmodule}"}"
+dracut_omit_pass="${dracut_omit_pass:-"$(printf 'omit_drivers+=" %s "' "${kernmodule}")"}"
+install_pass="${install_pass:-"install ${kernmodule} /bin/true"}"
+
+dracut_omit_rx="${dracut_omit_rx:-"$(printf '^omit_drivers\+="[^"]*\s%s\s[^"]*"' "${kernmodule_rx}")"}"
+install_rx="${install_rx:-"^install\s+${kernmodule_rx}(\s|$)"}"
+modules_load_d_rx="${modules_load_d_rx:-"^${kernmodule_rx}$"}"
+
+kmd_empty() {
+    local file="$1"; shift
+    mkdir -p "${file%/*}"
+    printf "" > "${file}"
+}
+
+kmd_remove_rx() {
+    local file="$1"; shift
+    local rx="$1"; shift
+    [[ -f "${file}" ]] || return 0
+    if ! LC_ALL=C grep -E -q -m 1 "${rx}" "${file}"; then
+        LC_ALL=C sed -Ei "/${rx}/d" "${file}"
+    fi
+}
+
+kmd_add() {
+    local file="$1"; shift
+    local msg="$1"; shift
+    mkdir -p "${file%/*}"
+    printf '%s\n' "${msg}" >> "${file}"
+}
+
+kmd_add_missing() {
+    local file="$1"; shift
+    local msg="$1"; shift
+    local rx="$1"; shift
+    if [ -f "${file}" ] && LC_ALL=C grep -E -q -m 1 "${rx}" "${file}"; then
+        return 0
+    fi
+    kmd_add "${file}" "${msg}"
+}
+
+kmd_modprobe_install_commented() {
+    kmd_remove_rx "$1" "${install_rx}"
+    kmd_add "$1" "# ${install_pass}"
+}
+
+kmd_modules_load_commented() {
+    kmd_remove_rx "$1" "${modules_load_d_rx}"
+    kmd_add "$1" "# ${kernmodule}"
+}
+
+{{% set modprobe_d_dir_all = ['/etc', '/run', '/usr/lib'] %}}
+{{% set modules_load_d_dir_all = ['/etc', '/lib', '/run', '/usr/lib', '/usr/local/lib'] %}}
+
+{{% if system_with_blacklisted_supported %}}
+{{% if dir_blacklist not in modprobe_d_dir_all + ["all"] %}}
+{{{ raise(err_prefix + "unknown dir_blacklist value: '" ~ dir_blacklist ~ "'") }}}
+{{% elif dir_blacklist == "all" %}}
+{{% set dirs = modprobe_d_dir_all %}}
+{{% else %}}
+{{% set dirs = [dir_blacklist] %}}
+{{% endif %}}
+{{% for dir in dirs %}}
+file={{{ dir | quote }}}/modprobe.d/"${kernmodule_file}".conf
+{{% if t_blacklist == "pass" %}}
+kmd_add "${file}" "${blacklist_pass}"
+{{% elif t_blacklist == "fail" %}}
+kmd_add "${file}" "x${blacklist_pass}"
+{{% elif t_blacklist == "fail_empty" %}}
+kmd_empty "${file}"
+{{% elif t_blacklist == "fail_miss" %}}
+{{% else %}}
+{{{ raise(err_prefix + "unknown t_blacklist value: '" ~ t_blacklist ~ "'") }}}
+{{% endif %}}
+{{% endfor %}}
+{{% endif %}}
+
+{{% if system_with_dracut_supported %}}
+{{% if t_dracut == "pass" %}}
+kmd_add_missing /etc/dracut.conf "${dracut_omit_pass}" "${dracut_omit_rx}"
+{{% elif t_dracut == "pass_d" %}}
+kmd_add_missing "/etc/dracut.conf.d/omit-${kernmodule_file}.conf" "${dracut_omit_pass}" "${dracut_omit_rx}"
+{{% elif t_dracut == "fail_empty" %}}
+kmd_empty "/etc/dracut.conf.d/omit-${kernmodule_file}.conf"
+{{% elif t_dracut == "fail_miss" %}}
+{{% else %}}
+{{{ raise(err_prefix + "unknown t_dracut value: '" ~ t_dracut ~ "'") }}}
+{{% endif %}}
+
+{{% if t_dracut_drivers == "pass" %}}
+kmd_add "/etc/dracut.conf" "$(printf 'force_drivers+=" x%s "' "${kernmodule}")"
+{{% elif t_dracut_drivers == "pass_d" %}}
+kmd_add "/etc/dracut.conf.d/${kernmodule_file}.conf" "$(printf 'force_drivers+=" x%s "' "${kernmodule}")"
+{{% elif t_dracut_drivers == "pass_empty" %}}
+{{% elif t_dracut_drivers == "fail" %}}
+kmd_add "/etc/dracut.conf.d/${kernmodule_file}.conf" "$(printf 'force_drivers+=" %s "' "${kernmodule}")"
+{{% elif t_dracut_drivers == "fail_add" %}}
+kmd_add "/etc/dracut.conf.d/${kernmodule_file}.conf" "$(printf 'add_drivers+=" %s "' "${kernmodule}")"
+{{% else %}}
+{{{ raise(err_prefix + "unknown t_dracut_drivers value: '" ~ t_dracut_drivers ~ "'") }}}
+{{% endif %}}
+{{% endif %}}
+
+{{% if dir_modprobe_d_install not in modprobe_d_dir_all + ["all"] %}}
+{{{ raise(err_prefix + "unknown dir_modprobe_d_install value: '" ~ dir_modprobe_d_install ~ "'") }}}
+{{% elif dir_modprobe_d_install == "all" %}}
+{{% set dirs = modprobe_d_dir_all %}}
+{{% else %}}
+{{% set dirs = [dir_modprobe_d_install] %}}
+{{% endif %}}
+{{% for dir in dirs %}}
+file={{{ dir | quote }}}/modprobe.d/"${kernmodule_file}".conf
+{{% if t_modprobe_d_install == "pass" %}}
+kmd_add "${file}" "${install_pass}"
+{{% elif t_modprobe_d_install == "fail" %}}
+kmd_add "${file}" "${install_pass} x"
+{{% elif t_modprobe_d_install == "fail_wrong" %}}
+kmd_add "${file}" "$(printf 'install %s /usr/bin/ls' "${kernmodule}")"
+{{% elif t_modprobe_d_install == "fail_commented" %}}
+kmd_modprobe_install_commented "${file}"
+{{% elif t_modprobe_d_install == "fail_empty" %}}
+kmd_empty "${file}"
+{{% elif t_modprobe_d_install == "fail_miss" %}}
+{{% else %}}
+{{{ raise(err_prefix + "unknown t_modprobe_d_install value: '" ~ t_modprobe_d_install ~ "'") }}}
+{{% endif %}}
+{{% endfor %}}
+
+{{% if system_with_modprobeconf_supported %}}
+{{% if t_modprobe == "pass" %}}
+kmod_modprobe_install_pass /etc/modprobe.conf
+{{% elif t_modprobe == "fail_commented" %}}
+kmod_modprobe_install_commented /etc/modprobe.conf
+{{% elif t_modprobe == "fail_miss" %}}
+{{% else %}}
+{{{ raise(err_prefix + "unknown t_modprobe value: '" ~ t_modprobe ~ "'") }}}
+{{% endif %}}
+{{% endif %}}
+
+{{% if dir_modules_load_d not in modules_load_d_dir_all + ["all"] %}}
+{{{ raise(err_prefix + "unknown dir_modules_load_d value: '" ~ dir_modules_load_d ~ "'") }}}
+{{% elif dir_modules_load_d == "all" %}}
+{{% set dirs = modules_load_d_dir_all %}}
+{{% else %}}
+{{% set dirs = [dir_modules_load_d] %}}
+{{% endif %}}
+{{% for dir in dirs %}}
+file={{{ dir | quote }}}/modules-load.d/"${kernmodule_file}".conf
+{{% if t_modules_load_d == "pass" %}}
+kmd_remove_rx "${file}" "${modules_load_d_rx}"
+{{% elif t_modules_load_d == "fail" %}}
+kmd_add "${file}" "${kernmodule}"
+{{% elif t_modules_load_d == "pass_commented" %}}
+kmd_modules_load_commented "${file}"
+{{% elif t_modules_load_d == "pass_empty" %}}
+kmd_empty "${file}"
+{{% elif t_modules_load_d == "pass_miss" %}}
+{{% else %}}
+{{{ raise(err_prefix + "unknown t_modules_load_d value: '" ~ t_modules_load_d ~ "'") }}}
+{{% endif %}}
+{{% endfor %}}
+
+echo "# DONE"
+
+{{%- endmacro -%}}

--- a/shared/macros/10-oval.jinja
+++ b/shared/macros/10-oval.jinja
@@ -1042,3 +1042,44 @@ Generates the :code:`<affected>` tag for OVAL check using correct product platfo
   </ind:textfilecontent54_object>
 {{%- endmacro %}}
 
+{{% macro dracut_conf_criterion(id_tag, directive, comment, additional="") %}}
+          <criterion test_ref="test_{{{ id_tag }}}_dracut_conf_{{{ directive }}}"
+            comment="{{{ comment }}} in {{{ directive }}} directive in dracut.conf"{{{ additional }}}/>
+          <criterion test_ref="test_{{{ id_tag }}}_dracut_conf_d_{{{ directive }}}"
+            comment="{{{ comment }}} in {{{ directive }}} directive in dracut.conf.d"{{{ additional }}}/>
+{{% endmacro %}}
+
+{{% macro dracut_conf_test_object(id_tag, directive, directive_rx, comment, setup=false) %}}
+  {{% if setup %}}
+  <constant_variable datatype="string" comment="Paths where dracut can be configured"
+    id="var_{{{ id_tag }}}_dracut_conf_paths" version="1">
+    <value>/etc/dracut.conf.d</value>
+    <value>/usr/lib/dracut/dracut.conf.d</value>
+  </constant_variable>
+
+  {{% endif %}}
+  <ind:textfilecontent54_test id="test_{{{ id_tag }}}_dracut_conf_{{{ directive }}}"
+    version="1" check="all" comment="{{{ comment }}} in dracut.conf {{{ directive }}}">
+    <ind:object object_ref="obj_{{{ id_tag }}}_dracut_conf_{{{ directive }}}"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ id_tag }}}_dracut_conf_{{{ directive }}}"
+    version="1" comment="{{{ comment }}} in dracut.conf {{{ directive }}}">
+    <ind:filepath>/etc/dracut.conf</ind:filepath>
+    <ind:pattern operation="pattern match">{{{ directive_rx }}}</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_{{{ id_tag }}}_dracut_conf_d_{{{ directive }}}"
+    version="1" check="all" comment="{{{ comment }}} in dracut.conf.d {{{ directive }}}">
+    <ind:object object_ref="obj_{{{ id_tag }}}_dracut_conf_d_{{{ directive }}}"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ id_tag }}}_dracut_conf_d_{{{ directive }}}"
+    version="1" comment="{{{ comment }}} in dracut.conf.d {{{ directive }}}">
+    <ind:path var_ref="var_{{{ id_tag }}}_dracut_conf_paths" var_check="at least one"/>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">{{{ directive_rx }}}</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+{{% endmacro %}}

--- a/shared/templates/extra_ovals.yml
+++ b/shared/templates/extra_ovals.yml
@@ -7,6 +7,11 @@ package_avahi_installed:
     pkgname@ubuntu2004: avahi-daemon
     pkgname@ubuntu2204: avahi-daemon
 
+package_dracut_installed:
+  name: package_installed
+  vars:
+    pkgname: dracut
+
 package_esc_installed:
   name: package_installed
   vars:

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -9,7 +9,7 @@
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
     regexp: 'install\s+{{{ KERNMODULE }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
-{{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if product in ["fedora", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
   lineinfile:
     create: yes

--- a/shared/templates/kernel_module_disabled/ansible.template
+++ b/shared/templates/kernel_module_disabled/ansible.template
@@ -3,17 +3,135 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
+{{% set system_with_blacklisted_supported = false %}}
+{{% set system_with_dracut_supported = false %}}
+{{% if product in ["fedora", "ol7", "ol8", "rhcos4", "sle12", "sle15"] or "rhel" in product %}}
+{{% set system_with_blacklisted_supported = true %}}
+{{% endif %}}
+{{% if product in ["fedora", "rhel8", "rhel9"] %}}
+{{% set system_with_dracut_supported = true %}}
+{{% endif %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is disabled
   lineinfile:
     create: yes
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
-    regexp: 'install\s+{{{ KERNMODULE }}}'
+    regexp: 'install\s+{{{ KERNMODULE_RX }}}'
     line: "install {{{ KERNMODULE }}} /bin/true"
-{{% if product in ["fedora", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+
+- name: "Find modules-load.d files with {{{ KERNMODULE }}} load"
+  find:
+    paths:
+      - /etc/modules-load.d
+      - /lib/modules-load.d
+      - /run/modules-load.d
+      - /usr/lib/modules-load.d
+      - /usr/local/lib/modules-load.d
+    patterns: >-
+      *.conf
+    contains: >-
+      ^\s*{{{ KERNMODULE_RX }}}\s*$
+  register: r_modules_load_d_to_modify
+
+- name: "Remove {{{ KERNMODULE }}} load from modules-load.d files"
+  lineinfile:
+    path: "{{ item.path }}"
+    state: absent
+    regexp: >-
+      ^\s*{{{ KERNMODULE_RX }}}\s*$
+  loop: "{{ r_modules_load_d_to_modify.files }}"
+  loop_control:
+    label: "{{ item.path }}"
+
+- name: "Is {{{ KERNMODULE }}} as loaded module"
+  lineinfile:
+    path: /proc/modules
+    regexp: >-
+      ^{{{ KERNMODULE_RX }}}\s
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: r_in_modules
+
+- name: "Try to remove {{{ KERNMODULE }}}, might fail"
+  when:
+    - r_in_modules.found is defined
+    - r_in_modules.found >= 1
+  command:
+    argv:
+      - modprobe
+      - '-r'
+      - "{{{ KERNMODULE }}}"
+  failed_when: false
+
+{{% if system_with_blacklisted_supported  %}}
 - name: Ensure kernel module '{{{ KERNMODULE }}}' is blacklisted
   lineinfile:
     create: yes
     dest: "/etc/modprobe.d/{{{ KERNMODULE }}}.conf"
-    regexp: '^blacklist {{{ KERNMODULE }}}$'
+    regexp: >-
+      ^blacklist {{{ KERNMODULE_RX }}}$
     line: "blacklist {{{ KERNMODULE }}}"
+{{% endif %}}
+{{% if system_with_dracut_supported %}}
+- name: Block dracut configuration
+  block:
+    - name: Gather the package facts
+      package_facts:
+        manager: auto
+
+    - name: Block dracut package
+      when:
+        - ('dracut' in ansible_facts.packages)
+      block:
+        - name: "Find dracut configs with {{{ KERNMODULE }}} load"
+          find:
+            paths:
+              - /etc/dracut.conf.d
+              - /usr/lib/dracut/dracut.conf.d
+            patterns: >-
+              *.conf
+            contains: >-
+              ^\s*(drivers|add_drivers|force_drivers)\+="[^"]*\s{{{ KERNMODULE_RX }}}\s[^"]*"\s*$
+          register: r_dracut_configs_to_modify
+
+        - name: Replace dracut configs with {{{ KERNMODULE }}} load
+          replace:
+            path: "{{ item.path }}"
+            regexp: >-
+              ^\s*((?:drivers|add_drivers|force_drivers)\+="[^"]*)\s{{{ KERNMODULE_RX }}}\s([^"]*")\s*$
+            replace: >-
+              \g<1> \g<2>
+          loop: "{{ r_dracut_configs_to_modify.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+
+        - name: "Is {{{ KERNMODULE }}} as loaded module"
+          lineinfile:
+            path: /etc/dracut.conf
+            regexp: >-
+              ^\s*((?:drivers|add_drivers|force_drivers)\+="[^"]*)\s{{{ KERNMODULE_RX }}}\s([^"]*")\s*$
+            state: absent
+          check_mode: true
+          changed_when: false
+          register: r_in_dracut_conf
+
+        - name: "Try to remove {{{ KERNMODULE }}}, might fail"
+          when:
+            - r_in_dracut_conf.found is defined
+            - r_in_dracut_conf.found >= 1
+          replace:
+            path: "{{ item.path }}"
+            regexp: >-
+              ^\s*((?:drivers|add_drivers|force_drivers)\+="[^"]*)\s{{{ KERNMODULE_RX }}}\s([^"]*")\s*$
+            replace: >-
+              \g<1> \g<2>
+
+        - name: Ensure kernel module '{{{ KERNMODULE }}}' is in dracut.conf omit_drivers
+          lineinfile:
+            create: yes
+            dest: "/etc/dracut.conf.d/omit-{{{ KERNMODULE }}}.conf"
+            regexp: >-
+              ^omit_drivers\+=" {{{ KERNMODULE_RX }}} "$
+            line: >-
+              omit_drivers+=" {{{ KERNMODULE }}} "
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -12,7 +12,7 @@ else
 	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi
-{{% if product in ["sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if product in ["fedora", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
 if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
 	echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
 fi

--- a/shared/templates/kernel_module_disabled/bash.template
+++ b/shared/templates/kernel_module_disabled/bash.template
@@ -3,17 +3,60 @@
 # strategy = disable
 # complexity = low
 # disruption = medium
-if LC_ALL=C grep -q -m 1 "^install {{{ KERNMODULE }}}" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
-	{{% if '#' in KERNMODULE %}}
-	{{{ raise("KERNMODULE (" + KERNMODULE + ") uses sed path separator (#) in " + rule_id) }}}
-	{{% endif %}}
-	sed -i 's#^install {{{ KERNMODULE }}}.*#install {{{ KERNMODULE }}} /bin/true#g' /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+set -u
+{{% set system_with_blacklisted_supported = false %}}
+{{% set system_with_dracut_supported = false %}}
+{{% if product in ["fedora", "ol7", "ol8", "rhcos4", "sle12", "sle15"] or "rhel" in product %}}
+{{% set system_with_blacklisted_supported = true %}}
+{{% endif %}}
+{{% if product in ["fedora", "rhel8", "rhel9"] %}}
+{{% set system_with_dracut_supported = true %}}
+{{% endif %}}
+{{% if '/' in KERNMODULE %}}
+{{{ raise("KERNMODULE (" + KERNMODULE + ") uses path separator (/) in " + rule_id) }}}
+{{% endif %}}
+{{% if '#' in KERNMODULE %}}
+{{{ raise("KERNMODULE (" + KERNMODULE + ") uses sed path separator (#) in " + rule_id) }}}
+{{% endif %}}
+kernmodule={{{ KERNMODULE | quote }}}
+kernmodule_rx={{{ KERNMODULE_RX | quote }}}
+modprobe_file=/etc/modprobe.d/"${kernmodule}".conf
+rx="^install\s+${kernmodule_rx}(\s|$)"
+if LC_ALL=C grep -E -q -m 1 "${rx}" -- "${modprobe_file}"; then
+    sed -Ei "s#${rx}.*#install ${kernmodule} /bin/true#g" "${modprobe_file}"
 else
-	echo -e "\n# Disable per security requirements" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
-	echo "install {{{ KERNMODULE }}} /bin/true" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+    printf "\n# Disable per security requirements\ninstall %s /bin/true\n" "${kernmodule}" >> "${modprobe_file}"
 fi
-{{% if product in ["fedora", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
-if ! LC_ALL=C grep -q -m 1 "^blacklist {{{ KERNMODULE }}}$" /etc/modprobe.d/{{{ KERNMODULE }}}.conf ; then
-	echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+
+rx="^\s*${kernmodule_rx}\s*$"
+for f in /etc/modules-load.d/*.conf /lib/modules-load.d/*.conf /run/modules-load.d/*.conf /usr/lib/modules-load.d/*.conf /usr/local/lib/modules-load.d/*.conf; do
+    [ -f "${f}" ] || continue
+    if LC_ALL=C grep -E -q -m 1 "${rx}" -- "${f}"; then
+        LC_ALL=C sed -Ei "/${rx}/d" -- "${f}"
+    fi
+done
+
+{{% if system_with_blacklisted_supported %}}
+if ! LC_ALL=C grep -E -q -m 1 "^\s*blacklist\s+${kernmodule_rx}\s*$" "${modprobe_file}"; then
+    printf "blacklist %s\n" "${kernmodule}" >> "${modprobe_file}"
 fi
 {{% endif %}}
+{{% if system_with_dracut_supported %}}
+dracut_file=/etc/dracut.conf.d/omit-"${kernmodule}".conf
+if ! LC_ALL=C grep -E -q -m 1 '^\s*omit_drivers+="[^"]*\s'"${kernmodule_rx}"'\s[^"]*"\s*$' "${dracut_file}"; then
+    printf 'omit_drivers+=" %s "\n' "${kernmodule}" >> "${dracut_file}"
+fi
+
+rx='^\s*((drivers|add_drivers|force_drivers)\+="[^"]*)\s{{{ KERNMODULE_RX }}}\s([^"]*")\s*$'
+for f in /etc/dracut.conf/*.conf /etc/dracut.conf.d/*.conf /usr/lib/dracut/dracut.conf.d/*.conf; do
+    [ -f "${f}" ] || continue
+    if LC_ALL=C grep -E -q -m 1 "${rx}" -- "${f}"; then
+        LC_ALL=C sed -Ei "s/${rx}/\1 \2/" -- "${f}"
+    fi
+done
+{{% endif %}}
+
+# Try to unload, this might fail for various reasons
+if LC_ALL=C grep -E -q -m 1 "^${kernmodule_rx}\s" /proc/modules; then
+    modprobe -r "${kernmodule}" || :
+fi

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -20,6 +20,8 @@
 {{% endif %}}
         <criterion test_ref="test_{{{ local_id }}}_disabled"
           comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
+        <criterion test_ref="test_{{{ local_id }}}_in_modules_load"
+          comment="kernel module {{{ KERNMODULE }}} not in modules_load.d" negate="true"/>
       </criteria>
 {{% if system_with_modprobeconf_supported %}}
       <criterion test_ref="test_{{{ local_id }}}_modprobeconf"
@@ -45,11 +47,31 @@
   <constant_variable id="var_{{{ local_id }}}_paths"
     comment="Other paths where kernel modules can be configured" datatype="string" version="1">
     <value>/etc/modprobe.d</value>
-    <value>/etc/modules-load.d</value>
     <value>/run/modprobe.d</value>
-    <value>/run/modules-load.d</value>
     <value>/usr/lib/modprobe.d</value>
+  </constant_variable>
+
+  <ind:textfilecontent54_test id="test_{{{ local_id }}}_in_modules_load"
+    version="1" check="all" comment="kernel module {{{ KERNMODULE }}} in modules-load.d">
+    <ind:object object_ref="obj_{{{ local_id }}}_in_modules_load"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ local_id }}}_in_modules_load"
+    comment="kernel module {{{ KERNMODULE }}} in modules-load.d" version="1">
+    <ind:path var_ref="var_{{{ local_id }}}_modules_load_paths" var_check="at least one"/>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    <ind:pattern operation="pattern match">^\s*{{{ KERNMODULE_RX }}}\s*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <constant_variable id="var_{{{ local_id }}}_modules_load_paths"
+    comment="Paths where kernel modules loading can be configured by modules-load.d"
+    datatype="string" version="1">
+    <value>/etc/modules-load.d</value>
+    <value>/lib/modules-load.d</value>
+    <value>/run/modules-load.d</value>
     <value>/usr/lib/modules-load.d</value>
+    <value>/usr/local/lib/modules-load.d</value>
   </constant_variable>
 
 {{% if system_with_blacklisted_supported %}}

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -4,17 +4,14 @@
     {{%- set local_id = "kernmod_" ~ KERNMODULE -%}}
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
-{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
       <criteria operator="AND">
+{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
         <criterion test_ref="test_{{{ local_id }}}_blacklisted"
           comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d"/>
+{{% endif %}}
         <criterion test_ref="test_{{{ local_id }}}_disabled"
           comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
       </criteria>
-{{% else %}}
-      <criterion test_ref="test_{{{ local_id }}}_disabled"
-        comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
-{{% endif %}}
 {{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product%}}
       <criterion test_ref="test_{{{ local_id }}}_modprobeconf"
         comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf"/>

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -1,3 +1,11 @@
+{{% set system_with_modprobeconf_supported = false %}}
+{{% set system_with_blacklisted_supported = false %}}
+{{% if product not in ["fedora"] and "ol" not in product and "rhel" not in product and "ubuntu" not in product %}}
+{{% set system_with_modprobeconf_supported = true %}}
+{{% endif %}}
+{{% if product in ["fedora", "rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% set system_with_blacklisted_supported = true %}}
+{{% endif %}}
 <def-group>
   <definition class="compliance"
     id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
@@ -5,14 +13,14 @@
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
       <criteria operator="AND">
-{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if system_with_blacklisted_supported %}}
         <criterion test_ref="test_{{{ local_id }}}_blacklisted"
           comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d"/>
 {{% endif %}}
         <criterion test_ref="test_{{{ local_id }}}_disabled"
           comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
       </criteria>
-{{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product%}}
+{{% if system_with_modprobeconf_supported %}}
       <criterion test_ref="test_{{{ local_id }}}_modprobeconf"
         comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf"/>
 {{% endif %}}
@@ -43,7 +51,7 @@
     <value>/usr/lib/modules-load.d</value>
   </constant_variable>
 
-{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if system_with_blacklisted_supported %}}
   <ind:textfilecontent54_test id="test_{{{ local_id }}}_blacklisted"
     comment="kernel module {{{ KERNMODULE }}} blacklisted" version="1" check="all">
     <ind:object object_ref="obj_{{{ local_id }}}_blacklisted"/>
@@ -58,7 +66,7 @@
   </ind:textfilecontent54_object>
 {{% endif %}}
 
-{{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product %}}
+{{% if system_with_modprobeconf_supported %}}
   <ind:textfilecontent54_test id="test_{{{ local_id }}}_modprobeconf"
     comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" version="1" check="all">
     <ind:object object_ref="obj_{{{ local_id }}}_modprobeconf"/>

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -1,10 +1,84 @@
+{{#
+    There is several ways kernel modules can be loaded or obstacles set to the
+    loading
+
+    Normal userspace configuration:
+        modprobe.d(5) has 2 obstacles to loading, latter only on some distros
+        - run command instead of loading: install <name> /bin/true
+        - ignore all possible aliases: blacklist <name>
+
+        modprobe.conf(5) to have obstacle in other distros with
+        - run command instead of loading: install <name> /bin/true
+
+        modules-load.d(5) loads modules
+        - load module: <name>
+
+        modprobe(8)
+        - udev installs module because of rules
+        - user install module by hand
+
+        insmod(8)
+        - user installs module by hand
+
+    Initramfs
+        dracut.conf(5) has both obstacles and ways to load modules
+        - modules not to add to initramfs: omit_drivers
+        - modules to add to initramfs: drivers
+        - modules to add initramfs: add_drivers
+        - modules to load initramfs: force_drivers
+
+        dracut(8)
+        - any command line option overrules configuration
+
+    Kernel command line
+        systemd-modules-load.service(8) / kernel-command-line(7), check
+        systemd-modules-load.service unit file for additional undocumented
+        cmdline options and paths
+        - modules to load: modules_load=, rd.modules_load=
+        - modules to load: modules-load=, rd.modules-load=
+
+    Runtime
+        proc(5) / lsmod(8)
+        - loaded modules: /proc/modules
+
+    For this modules to be success all methods should be implemented:
+    - add all possible obstackles to make loading modules fail during multiuser
+      phase
+    - ensure modules are not configured to be loaded, like in initramfs /
+      kernel command line
+    - ensure module is not loaded in runtime by any trickery
+    - there could be some order where obstacles ensure module is not loaded,
+      but ensuring fully is just simpler way
+
+    Additionals
+    modprobe(8): there is no difference between _ and - in module names
+    - so when checking module name check always both formats
+    - when adding configuration, only one format is needed
+
+    TODO:
+    - bootloader arguments check, essentially whole
+      grub2_bootloader_argument_absent should be implemented here, and as
+      aspects of that is already in 3 places I'm not too happy to add another
+    - also grub2_bootloader_argument_absent lacks support for regexp based
+      pattern matching
+    - not every sane combination is tested
+    - not every sane combination of remedy is implemented
+    - documentation
+    - any dracut config modification left hanging, no initramfs update triggered
+    - removing modules is not always easy as they might be there because of
+      service etc, or there is module dependencies
+-#}}
 {{% set system_with_modprobeconf_supported = false %}}
 {{% set system_with_blacklisted_supported = false %}}
+{{% set system_with_dracut_supported = false %}}
 {{% if product not in ["fedora"] and "ol" not in product and "rhel" not in product and "ubuntu" not in product %}}
 {{% set system_with_modprobeconf_supported = true %}}
 {{% endif %}}
 {{% if product in ["fedora", "rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
 {{% set system_with_blacklisted_supported = true %}}
+{{% endif %}}
+{{% if product in ["fedora", "rhel8", "rhel9"] %}}
+{{% set system_with_dracut_supported = true %}}
 {{% endif %}}
 {{% set modprobe_d_install_rx = '^\s*install\s+' ~ KERNMODULE_RX ~ '\s+(?:/bin/false|/bin/true)$' %}}
 <def-group>
@@ -18,10 +92,28 @@
         <criterion test_ref="test_{{{ local_id }}}_blacklisted"
           comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d"/>
 {{% endif %}}
+{{% if system_with_dracut_supported %}}
+        <criteria operator="OR">
+          <extend_definition definition_ref="package_dracut_installed"
+            comment="Either no dracut package or check dracut config" negate="true"/>
+          <criteria operator="AND">
+            <criteria operator="OR">
+              {{{ dracut_conf_criterion(local_id, 'omit_drivers', 'kernel module ' ~ KERNMODULE) }}}
+            </criteria>
+{{% for directive in ['drivers', 'add_drivers', 'force_drivers'] %}}
+              {{{ dracut_conf_criterion(local_id, directive, 'kernel module ' ~ KERNMODULE, ' negate="true"') }}}
+{{% endfor %}}
+          </criteria>
+        </criteria>
+{{% endif %}}
         <criterion test_ref="test_{{{ local_id }}}_disabled"
           comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
         <criterion test_ref="test_{{{ local_id }}}_in_modules_load"
           comment="kernel module {{{ KERNMODULE }}} not in modules_load.d" negate="true"/>
+        <criterion test_ref="test_{{{ local_id }}}_runtime"
+          comment="kernel module {{{ KERNMODULE }}} not in /proc/modules" negate="true"/>
+        <criterion test_ref="test_{{{ local_id }}}_cmdline"
+          comment="kernel module {{{ KERNMODULE }}} loading directives not in /proc/cmdline" negate="true"/>
       </criteria>
 {{% if system_with_modprobeconf_supported %}}
       <criterion test_ref="test_{{{ local_id }}}_modprobeconf"
@@ -88,6 +180,37 @@
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}
+
+{{% if system_with_dracut_supported %}}
+  {{% for directive in ['omit_drivers', 'drivers', 'add_drivers', 'force_drivers'] %}}
+  {{% set directive_rx = '^\s*' ~ directive ~ '[+]="[^"]*\s' ~ KERNMODULE_RX ~ '\s[^"]*"\s*$' %}}
+  {{{ dracut_conf_test_object(local_id, directive, directive_rx, "kernel module " ~ KERNMODULE, setup=loop.first) }}}
+  {{% endfor %}}
+{{% endif %}}
+
+  <ind:textfilecontent54_test id="test_{{{ local_id }}}_runtime" version="1" check="all"
+    comment="kernel module {{{ KERNMODULE }}} runtime check from /proc/modules">
+    <ind:object object_ref="obj_{{{ local_id }}}_runtime"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ local_id }}}_runtime"
+    version="1" comment="kernel module {{{ KERNMODULE }}} runtime check from /proc/modules">
+    <ind:filepath>/proc/modules</ind:filepath>
+    <ind:pattern operation="pattern match">^{{{ KERNMODULE_RX }}}\s</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_test id="test_{{{ local_id }}}_cmdline" version="1" check="all"
+    comment="kernel module {{{ KERNMODULE }}} kernel command line check from /proc/cmdline">
+    <ind:object object_ref="obj_{{{ local_id }}}_cmdline"/>
+  </ind:textfilecontent54_test>
+
+  <ind:textfilecontent54_object id="obj_{{{ local_id }}}_cmdline"
+    version="1" comment="kernel module {{{ KERNMODULE }}} kernel command line check from /proc/cmdline">
+    <ind:filepath>/proc/cmdline</ind:filepath>
+    <ind:pattern operation="pattern match">(?:^|\s)(?:rd\.)?modules[_-]load={{{ KERNMODULE_RX }}}(?:\s|$)</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
 
 {{% if system_with_modprobeconf_supported %}}
   <ind:textfilecontent54_test id="test_{{{ local_id }}}_modprobeconf"

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -6,6 +6,7 @@
 {{% if product in ["fedora", "rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
 {{% set system_with_blacklisted_supported = true %}}
 {{% endif %}}
+{{% set modprobe_d_install_rx = '^\s*install\s+' ~ KERNMODULE_RX ~ '\s+(?:/bin/false|/bin/true)$' %}}
 <def-group>
   <definition class="compliance"
     id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
@@ -37,7 +38,7 @@
     comment="kernel module {{{ KERNMODULE }}} disabled" version="1">
     <ind:path var_ref="var_{{{ local_id }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE_RX }}}\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ modprobe_d_install_rx }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -75,7 +76,7 @@
   <ind:textfilecontent54_object id="obj_{{{ local_id }}}_modprobeconf"
     comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}" version="1">
     <ind:filepath>/etc/modprobe.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE_RX }}}\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ modprobe_d_install_rx }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -37,7 +37,7 @@
     comment="kernel module {{{ KERNMODULE }}} disabled" version="1">
     <ind:path var_ref="var_{{{ local_id }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE_RX }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -61,7 +61,7 @@
     comment="kernel module {{{ KERNMODULE }}} blacklisted" version="1">
     <ind:path var_ref="var_{{{ local_id }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^blacklist\s+{{{ KERNMODULE }}}$</ind:pattern>
+    <ind:pattern operation="pattern match">^blacklist\s+{{{ KERNMODULE_RX }}}$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}
@@ -75,7 +75,7 @@
   <ind:textfilecontent54_object id="obj_{{{ local_id }}}_modprobeconf"
     comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}" version="1">
     <ind:filepath>/etc/modprobe.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
+    <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE_RX }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 {{% endif %}}

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -1,41 +1,42 @@
 <def-group>
   <definition class="compliance"
-  id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
+    id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
-      {{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
+{{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
       <criteria operator="AND">
         <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
-        comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d" />
+          comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d"/>
         <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
-        comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
+          comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
       </criteria>
-      {{% else %}}
+{{% else %}}
       <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
-      comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d" />
-      {{% endif %}}
+        comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
+{{% endif %}}
 {{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product%}}
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" />
+      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf"
+        comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf"/>
 {{% endif %}}
 
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_disabled" version="1" check="all"
-  comment="kernel module {{{ KERNMODULE }}} disabled">
-    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_disabled" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_disabled"
+    version="1" check="all" comment="kernel module {{{ KERNMODULE }}} disabled">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_disabled"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_disabled"
-  version="1" comment="kernel module {{{ KERNMODULE }}} disabled">
-    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one" />
+    comment="kernel module {{{ KERNMODULE }}} disabled" version="1">
+    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <constant_variable datatype="string" comment="Other paths where kernel modules can be configured"
-  id="var_kernel_module_{{{ KERNMODULE }}}_paths" version="1">
+  <constant_variable id="var_kernel_module_{{{ KERNMODULE }}}_paths"
+    comment="Other paths where kernel modules can be configured" datatype="string" version="1">
     <value>/etc/modprobe.d</value>
     <value>/etc/modules-load.d</value>
     <value>/run/modprobe.d</value>
@@ -45,14 +46,14 @@
   </constant_variable>
 
 {{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
-  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted" version="1" check="all"
-  comment="kernel module {{{ KERNMODULE }}} blacklisted">
-    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
+    comment="kernel module {{{ KERNMODULE }}} blacklisted" version="1" check="all">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_blacklisted"
-  version="1" comment="kernel module {{{ KERNMODULE }}} blacklisted">
-    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one" />
+    comment="kernel module {{{ KERNMODULE }}} blacklisted" version="1">
+    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^blacklist\s+{{{ KERNMODULE }}}$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -60,13 +61,13 @@
 {{% endif %}}
 
 {{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product %}}
-  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf" version="1" check="all"
-  comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf">
-    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf" />
+  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf"
+    comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" version="1" check="all">
+    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf"/>
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf"
-  version="1" comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}">
+    comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}" version="1">
     <ind:filepath>/etc/modprobe.conf</ind:filepath>
     <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>

--- a/shared/templates/kernel_module_disabled/oval.template
+++ b/shared/templates/kernel_module_disabled/oval.template
@@ -1,41 +1,42 @@
 <def-group>
   <definition class="compliance"
     id="kernel_module_{{{ KERNMODULE }}}_disabled" version="1">
+    {{%- set local_id = "kernmod_" ~ KERNMODULE -%}}
     {{{ oval_metadata("The kernel module " + KERNMODULE + " should be disabled.") }}}
     <criteria operator="OR">
 {{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
       <criteria operator="AND">
-        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
+        <criterion test_ref="test_{{{ local_id }}}_blacklisted"
           comment="kernel module {{{ KERNMODULE }}} blacklisted in modprobe.d"/>
-        <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
+        <criterion test_ref="test_{{{ local_id }}}_disabled"
           comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
       </criteria>
 {{% else %}}
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_disabled"
+      <criterion test_ref="test_{{{ local_id }}}_disabled"
         comment="kernel module {{{ KERNMODULE }}} disabled in modprobe.d"/>
 {{% endif %}}
 {{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product%}}
-      <criterion test_ref="test_kernmod_{{{ KERNMODULE }}}_modprobeconf"
+      <criterion test_ref="test_{{{ local_id }}}_modprobeconf"
         comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf"/>
 {{% endif %}}
 
     </criteria>
   </definition>
 
-  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_disabled"
+  <ind:textfilecontent54_test id="test_{{{ local_id }}}_disabled"
     version="1" check="all" comment="kernel module {{{ KERNMODULE }}} disabled">
-    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_disabled"/>
+    <ind:object object_ref="obj_{{{ local_id }}}_disabled"/>
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_disabled"
+  <ind:textfilecontent54_object id="obj_{{{ local_id }}}_disabled"
     comment="kernel module {{{ KERNMODULE }}} disabled" version="1">
-    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one"/>
+    <ind:path var_ref="var_{{{ local_id }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
-  <constant_variable id="var_kernel_module_{{{ KERNMODULE }}}_paths"
+  <constant_variable id="var_{{{ local_id }}}_paths"
     comment="Other paths where kernel modules can be configured" datatype="string" version="1">
     <value>/etc/modprobe.d</value>
     <value>/etc/modules-load.d</value>
@@ -46,14 +47,14 @@
   </constant_variable>
 
 {{% if product in ["rhcos4", "sle12", "sle15"] or 'ol' in product or 'rhel' in product %}}
-  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_blacklisted"
+  <ind:textfilecontent54_test id="test_{{{ local_id }}}_blacklisted"
     comment="kernel module {{{ KERNMODULE }}} blacklisted" version="1" check="all">
-    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_blacklisted"/>
+    <ind:object object_ref="obj_{{{ local_id }}}_blacklisted"/>
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_blacklisted"
+  <ind:textfilecontent54_object id="obj_{{{ local_id }}}_blacklisted"
     comment="kernel module {{{ KERNMODULE }}} blacklisted" version="1">
-    <ind:path var_ref="var_kernel_module_{{{ KERNMODULE }}}_paths" var_check="at least one"/>
+    <ind:path var_ref="var_{{{ local_id }}}_paths" var_check="at least one"/>
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     <ind:pattern operation="pattern match">^blacklist\s+{{{ KERNMODULE }}}$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
@@ -61,12 +62,12 @@
 {{% endif %}}
 
 {{% if "ubuntu" not in product and "rhel" not in product and "ol" not in product %}}
-  <ind:textfilecontent54_test id="test_kernmod_{{{ KERNMODULE }}}_modprobeconf"
+  <ind:textfilecontent54_test id="test_{{{ local_id }}}_modprobeconf"
     comment="kernel module {{{ KERNMODULE }}} disabled in /etc/modprobe.conf" version="1" check="all">
-    <ind:object object_ref="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf"/>
+    <ind:object object_ref="obj_{{{ local_id }}}_modprobeconf"/>
   </ind:textfilecontent54_test>
 
-  <ind:textfilecontent54_object id="obj_kernmod_{{{ KERNMODULE }}}_modprobeconf"
+  <ind:textfilecontent54_object id="obj_{{{ local_id }}}_modprobeconf"
     comment="Check deprecated /etc/modprobe.conf for disablement of {{{ KERNMODULE }}}" version="1">
     <ind:filepath>/etc/modprobe.conf</ind:filepath>
     <ind:pattern operation="pattern match">^\s*install\s+{{{ KERNMODULE }}}\s+(/bin/false|/bin/true)$</ind:pattern>

--- a/shared/templates/kernel_module_disabled/template.py
+++ b/shared/templates/kernel_module_disabled/template.py
@@ -1,0 +1,12 @@
+import ssg.utils
+
+
+def preprocess(data, lang):
+    # modprobe(5)
+    #    there is no difference between _ and - in module names
+    kernmodule_parts = []
+    for item1 in data['kernmodule'].split('_'):
+        for item2 in item1.split('-'):
+            kernmodule_parts.append(ssg.utils.escape_regex(item2))
+    data['kernmodule_rx'] = '[_-]'.join(kernmodule_parts)
+    return data

--- a/shared/templates/kernel_module_disabled/tests/comment.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/comment.fail.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Paths to configuration files and directories for modprobe
-kernel_mod_files=( "/etc/modprobe.d/*.conf" "/etc/modprobe.conf" "/etc/modules-load.d/*.conf" "/run/modules-load.d/*.conf" "/usr/lib/modules-load.d/*.conf" "/run/modprobe.d/*.conf" "/usr/lib/modprobe.d/*.conf" )
-for filename in "${kernel_mod_files[@]}"; do
-    for file in $filename; do
-        if [[ -f $file ]]; then
-            sed -i '/install {{{ KERNMODULE }}}/d' $file
-            echo "# install {{{ KERNMODULE }}} /bin/true" > $file
-        fi
-    done
-done
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="pass",
+    t_dracut="pass_d",
+    t_dracut_drivers="pass_d",
+    t_modprobe="fail_commented",
+    t_modprobe_d_install="fail_commented",
+    t_modules_load_d="pass_commented",
+    dir_modprobe_d_install="all",
+) }}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_conf.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_conf.pass.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_ubuntu
 
-echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.conf
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="pass",
+    t_dracut="pass",
+    t_dracut_drivers="pass",
+    t_modprobe="pass",
+    t_modprobe_d_install="fail",
+    t_modules_load_d="pass",
+) }}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_modprobe_d.pass.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-echo "install {{{ KERNMODULE }}} /bin/true" > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
-echo "blacklist {{{ KERNMODULE }}}" >> /etc/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% endif %}}
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="pass",
+    t_dracut="pass",
+    t_dracut_drivers="pass",
+    t_modprobe="pass",
+    t_modprobe_d_install="pass",
+    t_modules_load_d="pass",
+) }}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_run_modprobe_d.pass.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
-if [[ ! -d /run/modprobe.d ]]; then
-    mkdir -p /run/modprobe.d
-fi
-echo "install {{{ KERNMODULE }}} /bin/true" > /run/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
-echo "blacklist {{{ KERNMODULE }}}" >> /run/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% endif %}}
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="pass",
+    t_dracut="pass",
+    t_dracut_drivers="pass",
+    t_modprobe="pass",
+    t_modprobe_d_install="pass",
+    t_modules_load_d="pass_empty",
+    dir_modprobe_d_install="/run",
+) }}}

--- a/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
+++ b/shared/templates/kernel_module_disabled/tests/correct_value_usr_lib_modprobe_d.pass.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-echo "install {{{ KERNMODULE }}} /bin/true" > /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% if "ol" in product or 'rhel' in product %}}
-echo "blacklist {{{ KERNMODULE }}}" >> /usr/lib/modprobe.d/{{{ KERNMODULE }}}.conf
-{{% endif %}}
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="pass",
+    t_dracut="pass",
+    t_dracut_drivers="pass",
+    t_modprobe="pass",
+    t_modprobe_d_install="pass",
+    t_modules_load_d="pass",
+    dir_modprobe_d_install="/usr/lib",
+) }}}

--- a/shared/templates/kernel_module_disabled/tests/dracut_drivers.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/dracut_drivers.fail.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 {{{ bash_kernel_module_disable_test(
     KERNMODULE, KERNMODULE_RX,
-    t_blacklist="fail",
-    t_dracut="pass",
-    t_dracut_drivers="pass",
+    t_blacklist="pass",
+    t_dracut="pass_d",
+    t_dracut_drivers="fail",
     t_modprobe="pass",
     t_modprobe_d_install="pass",
     t_modules_load_d="pass",

--- a/shared/templates/kernel_module_disabled/tests/dracut_drivers_add.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/dracut_drivers_add.fail.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 {{{ bash_kernel_module_disable_test(
     KERNMODULE, KERNMODULE_RX,
-    t_blacklist="fail",
-    t_dracut="pass",
-    t_dracut_drivers="pass",
+    t_blacklist="pass",
+    t_dracut="pass_d",
+    t_dracut_drivers="fail_add",
     t_modprobe="pass",
     t_modprobe_d_install="pass",
     t_modules_load_d="pass",

--- a/shared/templates/kernel_module_disabled/tests/empty.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/empty.fail.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-echo > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="fail_empty",
+    t_dracut="pass",
+    t_dracut_drivers="pass_empty",
+    t_modprobe="fail_miss",
+    t_modprobe_d_install="fail_empty",
+    t_modules_load_d="pass",
+) }}}

--- a/shared/templates/kernel_module_disabled/tests/file_not_there.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/file_not_there.fail.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
 # Paths to configuration files and directories for modprobe
-kernel_mod_files=( "/etc/modprobe.d/*.conf" "/etc/modprobe.conf" "/etc/modules-load.d/*.conf" "/run/modules-load.d/*.conf" "/usr/lib/modules-load.d/*.conf" "/run/modprobe.d/*.conf" "/usr/lib/modprobe.d/*.conf" )
-for filename in "${kernel_mod_files[@]}"; do
-    for file in $filename; do
-        if [[ -f $file ]]; then
-            rm -f $file
-        fi
-    done
-done
+rm -f -- \
+    /etc/modprobe.conf \
+    /etc/modprobe.d/*.conf /run/modprobe.d/*.conf /usr/lib/modprobe.d/*.conf \
+    /etc/modules-load.d/*.conf /run/modules-load.d/*.conf /usr/lib/modules-load.d/*.conf \
+    /etc/dracut.conf /etc/dracut.conf.d/*.conf

--- a/shared/templates/kernel_module_disabled/tests/have_etc_modules-load_d.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/have_etc_modules-load_d.fail.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 
 {{{ bash_kernel_module_disable_test(
     KERNMODULE, KERNMODULE_RX,
-    t_blacklist="fail",
+    t_blacklist="pass",
     t_dracut="pass",
-    t_dracut_drivers="pass",
+    t_dracut_drivers="pass_empty",
     t_modprobe="pass",
     t_modprobe_d_install="pass",
-    t_modules_load_d="pass",
+    t_modules_load_d="fail",
 ) }}}

--- a/shared/templates/kernel_module_disabled/tests/missing_dracut.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/missing_dracut.fail.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# platform = Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9,multi_platform_fedora
+# packages = dracut
 
 {{{ bash_kernel_module_disable_test(
     KERNMODULE, KERNMODULE_RX,
-    t_blacklist="fail",
-    t_dracut="pass",
+    t_blacklist="pass",
+    t_dracut="fail_empty",
     t_dracut_drivers="pass",
     t_modprobe="pass",
     t_modprobe_d_install="pass",

--- a/shared/templates/kernel_module_disabled/tests/modprobe.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/modprobe.fail.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-# platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# Only virtual machines can load modules
+# skip_test_env = podman-based
+
+modprobe {{{ KERNMODULE | quote }}}
 
 {{{ bash_kernel_module_disable_test(
     KERNMODULE, KERNMODULE_RX,
-    t_blacklist="fail",
+    t_blacklist="pass",
     t_dracut="pass",
     t_dracut_drivers="pass",
     t_modprobe="pass",

--- a/shared/templates/kernel_module_disabled/tests/wrong_value.fail.sh
+++ b/shared/templates/kernel_module_disabled/tests/wrong_value.fail.sh
@@ -1,3 +1,11 @@
 #!/bin/bash
 
-echo {{{ KERNMODULE }}} > /etc/modprobe.d/{{{ KERNMODULE }}}.conf
+{{{ bash_kernel_module_disable_test(
+    KERNMODULE, KERNMODULE_RX,
+    t_blacklist="pass",
+    t_dracut="pass",
+    t_dracut_drivers="pass_empty",
+    t_modprobe="pass",
+    t_modprobe_d_install="fail_wrong",
+    t_modules_load_d="pass",
+) }}}

--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -10,7 +10,7 @@
     paths:
       - "/etc/sysctl.d/"
       - "/run/sysctl.d/"
-{{% else %}}      
+{{% else %}}
   find:
     paths:
       - "/etc/sysctl.d/"
@@ -60,4 +60,4 @@
 {{% endif %}}
     state: present
     reload: yes
-
+    sysctl_set: true

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -20,6 +20,37 @@
     <ind:pattern operation="pattern match">^[\s]*{{{ SYSCTLVAR }}}[\s]*=[\s]*(.*)[\s]*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
 {{%- endmacro -%}}
+{{%- macro sysctl_local_variables(suffix) -%}}
+{{% if SYSCTLVAR == "net.ipv4.ip_local_port_range" %}}
+  <local_variable id="var_{{{ rule_id }}}_first_value{{{ suffix }}}"
+      comment="port range first element"
+      version="1" datatype="string">
+    <regex_capture pattern="^\s*(\d+)\s+\d+\s*$">
+      <variable_component var_ref="{{{ rule_id }}}_value"/>
+    </regex_capture>
+  </local_variable>
+
+  <local_variable id="var_{{{ rule_id }}}_last_value{{{ suffix }}}"
+      comment="port range last element"
+      version="1" datatype="string">
+    <regex_capture pattern="^\s*\d+\s+(\d+)\s*$">
+      <variable_component var_ref="{{{ rule_id }}}_value"/>
+    </regex_capture>
+  </local_variable>
+
+  <local_variable id="var_{{{ rule_id }}}_regex{{{ suffix }}}"
+      comment="port range first element"
+      version="1" datatype="string">
+    <concat>
+      <literal_component>^\s*</literal_component>
+      <variable_component var_ref="var_{{{ rule_id }}}_first_value{{{ suffix }}}"/>
+      <literal_component>\s+</literal_component>
+      <variable_component var_ref="var_{{{ rule_id }}}_last_value{{{ suffix }}}"/>
+      <literal_component>\s*$</literal_component>
+    </concat>
+  </local_variable>
+{{% endif %}}
+{{%- endmacro -%}}
 {{%- if "P" in FLAGS -%}}
 
 <def-group>
@@ -88,9 +119,15 @@
 {{% if SYSCTLVAL is string %}}
 {{% if SYSCTLVAL == "" %}}
   <unix:sysctl_state id="state_{{{ rule_id }}}_runtime" version="1">
+{{% if SYSCTLVAR == "net.ipv4.ip_local_port_range" %}}
+    <unix:value datatype="string" operation="pattern match"
+                var_ref="var_{{{ rule_id }}}_regex"/>
+{{% else %}}
     <unix:value datatype="{{{ DATATYPE }}}" operation="equals"
                 var_ref="{{{ rule_id }}}_value"/>
+{{% endif %}}
   </unix:sysctl_state>
+{{{ sysctl_local_variables("") }}}
 
   <external_variable id="{{{ rule_id }}}_value" version="1"
                      comment="External variable for {{{ SYSCTLVAR }}}" datatype="{{{ DATATYPE }}}"/>
@@ -260,9 +297,15 @@
 {{% if SYSCTLVAL == "" %}}
 
   <ind:textfilecontent54_state id="state_static_sysctld_{{{ rule_id }}}" version="1">
+{{% if SYSCTLVAR == "net.ipv4.ip_local_port_range" %}}
+    <ind:subexpression operation="pattern match" datatype="string"
+                       var_ref="var_{{{ rule_id }}}_regex_static"/>
+{{% else %}}
     <ind:subexpression operation="{{{ OPERATION }}}" var_ref="{{{ rule_id }}}_value"
                        datatype="{{{ DATATYPE }}}" />
+{{% endif %}}
   </ind:textfilecontent54_state>
+{{{ sysctl_local_variables("_static") }}}
 
   <external_variable id="{{{ rule_id }}}_value" version="1"
                      comment="External variable for {{{ SYSCTLVAR }}}" datatype="{{{ DATATYPE }}}"/>

--- a/shared/templates/sysctl/tests/comment.fail.sh
+++ b/shared/templates/sysctl/tests/comment.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "# {{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/correct_value.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
@@ -3,12 +3,11 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-{{% if product not in ["sle12","sle15"] %}}
-rm -rf /usr/lib/sysctl.d/* /usr/local/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
+{{% if product not in ["sle12","sle15"] %}}
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
-mkdir -p /usr/local/lib/sysctl.d
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /usr/local/lib/sysctl.d/correct.conf
 
 # set correct runtime value to check if the filesystem configuration is evaluated properly

--- a/shared/templates/sysctl/tests/line_not_there.fail.sh
+++ b/shared/templates/sysctl/tests/line_not_there.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d.pass.sh
+++ b/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/one_sysctl_conf_one_sysctl_d_conflicting.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_conflicting.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_different_option.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_different_option.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_repeated_sysctl_conf.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_repeated_sysctl_conf.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_root_duplicate.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_root_duplicate.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_root_duplicate_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_duplicate_conflicting.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
+++ b/shared/templates/sysctl/tests/symlink_root_incompliant.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlink_same_option.pass.sh
+++ b/shared/templates/sysctl/tests/symlink_same_option.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/symlinks_to_same_file.pass.sh
+++ b/shared/templates/sysctl/tests/symlinks_to_same_file.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/two_sysctls_on_d.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_d.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_d_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_d_conflicting.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file_name.pass.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file_name.pass.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/two_sysctls_on_same_file_name_conflicting.fail.sh
+++ b/shared/templates/sysctl/tests/two_sysctls_on_same_file_name_conflicting.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 

--- a/shared/templates/sysctl/tests/wrong_runtime.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_runtime.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/wrong_value.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.conf

--- a/shared/templates/sysctl/tests/wrong_value_d_directory.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_d_directory.fail.sh
@@ -3,8 +3,8 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /etc/sysctl.d/98-sysctl.conf

--- a/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
@@ -3,12 +3,11 @@
 # variables = sysctl_{{{ SYSCTLID }}}_value={{{ SYSCTL_CORRECT_VALUE }}}
 {{% endif %}}
 
-# Clean sysctl config directories
-{{% if product not in ["sle12","sle15"] %}}
-rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+. $SHARED/sysctl.sh
+sysctl_reset
 
+{{% if product not in ["sle12","sle15"] %}}
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
-mkdir -p /usr/local/lib/sysctl.d
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /usr/local/lib/sysctl.d/wrong.conf
 
 # Setting correct runtime value

--- a/tests/shared/sysctl.sh
+++ b/tests/shared/sysctl.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Sets the kernel setting using sysctl exec as well as in sysctl config file.
+# $1: The setting name without the leading 'kernel.'
+# $2: The value to set the setting to
+function sysctl_set_kernel_setting_to {
+	local setting_name="kernel.$1" setting_value="$2"
+	sysctl -w "$setting_name=$setting_value"
+	if grep -q "^$setting_name" /etc/sysctl.conf; then
+		sed -i "s/^$setting_name.*/$setting_name = $setting_value/" /etc/sysctl.conf
+	else
+		echo "$setting_name = $setting_value" >> /etc/sysctl.conf
+	fi
+}
+
+# Clean sysctl config directories, but also ensure barest configuration infra
+# exists
+function sysctl_reset {
+	mkdir -p /lib/sysctl.d /usr/lib/sysctl.d /usr/local/lib/sysctl.d /run/sysctl.d /etc/sysctl.d
+	rm -rf /lib/sysctl.d/* /usr/lib/sysctl.d/* /usr/local/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
+	touch /etc/sysctl.conf
+}


### PR DESCRIPTION
#### Description:

Support `init_on_free`, more rules to disable rarely used kernel module, subsystems not usually in use in servers, and some newer sysctls.

#### Rationale:

Just expand rules to match my view.

#### Review Hints:

Docustrings should be checked for validity and readability.

I enabled most new features only on fedora and there is no linkage to any external documents.