### PR TITLE
Fix data stream component parsing

### DIFF
--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from __future__ import print_function
+import collections
 
 import platform
 import re
@@ -222,23 +223,20 @@ class XMLContent(XMLElement):
         return None
 
     def _find_all_component_contents(self):
-        component_doc_dict = dict()
+        component_doc_dict = collections.defaultdict(dict)
         for component in self.root.findall("ds:component", self.ns):
-            for check_spec in self.check_engines:
-                def_doc = component.find(check_spec[1], self.ns)
-                if def_doc is not None:
-                    def_doc_dict = dict()
-                    comp_id = component.get("id")
-                    comp_href = "#" + comp_id
-                    try:
-                        filename = self.uris["#" + self.component_refs[comp_href]]
-                    except KeyError:
-                        continue
-                    def_doc_dict[filename] = XMLComponent(def_doc)
-                    component_doc_dict[check_spec[0]] = def_doc_dict
-                    # This component matched one of the checking engines,
-                    # thre is no need to continue further
-                    break
+            for check_id, check_tag in self.check_engines:
+                def_doc = component.find(check_tag, self.ns)
+                if def_doc is None:
+                    continue
+                comp_id = component.get("id")
+                comp_href = "#" + comp_id
+                try:
+                    filename = self.uris["#" + self.component_refs[comp_href]]
+                except KeyError:
+                    continue
+                xml_component = XMLComponent(def_doc)
+                component_doc_dict[check_id][filename] = xml_component
         return component_doc_dict
 
 


### PR DESCRIPTION
SCAP source data streams can reference multiple check components usually OCIL, OVAL and CPE OVAL. This commit fixes the situation when there is both OVAL and CPE OVAL needed for an XCCDF Benchmark.

We improve the _find_all_component_contents and make it more generic and also refactor the code.

Fixes: https://github.com/ComplianceAsCode/content/issues/10408
