### PR TITLE
Add rsyslog logging configured back to RHEL

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Ensure logging is configured'
 


### PR DESCRIPTION


#### Description:

Add `rsyslog_logging_configured` back to RHEL7-9.

#### Rationale:
Since the product did not have a prodtype before and one was added this is needed to ensure that we don't cause issues with existing tailoring files

