### PR TITLE
Add RHEL platforms to rsyslog_logging_configured

### DIFF
--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/rule.yml
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_logging_configured/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: rhel7,rhel8,rhel9,sle12,sle15
 
 title: 'Ensure logging is configured'
 


### PR DESCRIPTION


#### Description:
Add `rsyslog_logging_configured` back to RHEL7-9.


#### Rationale:
Backport #10413 