### PR TITLE
Ensure authentication required for single user mode for Ubuntu

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/oval/shared.xml
@@ -1,0 +1,19 @@
+<def-group>
+  <definition class="compliance" id="{{{ rule_id }}}" version="1">
+    {{{ oval_metadata("Ensure root password is configured") }}}
+    <criteria>
+      <criterion comment="verify root password is set"
+          test_ref="test_root_password_etc_shadow" />
+    </criteria>
+  </definition>
+  <ind:textfilecontent54_test check="all" check_existence="only_one_exists"
+      version="1" id="test_root_password_etc_shadow"
+      comment="make sure root password is set in /etc/shadow">
+    <ind:object object_ref="obj_root_password_etc_shadow" />
+  </ind:textfilecontent54_test>
+  <ind:textfilecontent54_object id="obj_root_password_etc_shadow" version="1">
+    <ind:filepath>/etc/shadow</ind:filepath>
+    <ind:pattern operation="pattern match">^root:\$(y|[0-9].+)\$.*$</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>
+  </ind:textfilecontent54_object>
+</def-group>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/rule.yml
@@ -1,0 +1,31 @@
+documentation_complete: true
+
+prodtype: ubuntu2004,ubuntu2204
+
+title: 'Ensure Authentication Required for Single User Mode'
+
+description: |-
+    Single user mode is used for recovery when the system detects an
+    issue during boot or by manual selection from the bootloader.
+
+rationale: |-
+    Requiring authentication in single user mode prevents an unauthorized
+    user from rebooting the system into single user to gain root privileges
+    without credentials.
+
+severity: medium
+
+references:
+    cis@ubuntu2004: 1.5.3
+    cis@ubuntu2204: 1.4.3
+
+ocil: 'root password is not set'
+
+ocil_clause: |-
+    Perform the following to determine if a password is set for the
+    root user:
+    <pre># grep -Eq '^root:\$[0-9]' /etc/shadow || echo "root is locked"</pre>
+    No results should be returned.
+    Otherwise, run the following command and follow the prompts to set a
+    password for the root user:
+    <pre># passwd root</pre>

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/tests/correct.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+
+sed -i "s/^root:[^:]*/root:\$y\$AAAAAAAAAA/" /etc/shadow

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/tests/empty.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/tests/empty.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = None
+
+passwd -d root

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/tests/locked.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/ensure_root_password_configured/tests/locked.fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# remediation = None
+
+passwd -l root

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -137,8 +137,7 @@ selections:
     - file_permissions_grub2_cfg
 
     ### 1.5.3 Ensure authentication required for single user mode (Automated)
-    # Needs variable
-    # Needs rule
+    - ensure_root_password_configured
 
     ## 1.6 Additional Process Hardening ##
     ### 1.6.1 Ensure XD/NX support is enabled (Automated)

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -132,7 +132,7 @@ selections:
     - file_permissions_grub2_cfg
 
     ### 1.4.3 Ensure authentication required for single user mode (Automated)
-    # NEEDS RULE
+    - ensure_root_password_configured
 
     ## 1.5 Additional Process Hardening ##
     ### 1.5.1 Ensure address space layout randomization (ASLR) is enabled (Automated)


### PR DESCRIPTION
#### Description:

- Ubuntu differ from other distros on single user mode authentication, where we only need to verify that a password for `root` is set.

#### Rationale:

- This is CIS item 1.4.3 Ensure authentication required for single user mode (Automated) for Ubuntu 