### PR TITLE
Mitigate xmldiff package upgrade problem. #10417

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -135,7 +135,7 @@ jobs:
       - name: Install Deps
         run: dnf install -y cmake make openscap-utils python3-pyyaml python3-setuptools python3-jinja2 bats python3-pytest python3-pytest-cov ansible python3-pip ShellCheck git python3-mypy python3-lxml
       - name: Install deps python
-        run: pip install ruamel.yaml yamlpath types-openpyxl types-PyYAML xmldiff openpyxl openpyxl-stubs pandas
+        run: pip install ruamel.yaml yamlpath types-openpyxl types-PyYAML xmldiff==2.5 openpyxl openpyxl-stubs pandas
       - name: Checkout
         uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
Mitigate xmldiff package upgrade problem.

Version 2.6 of this package triggers #10417 which blocks PRs to get merged. This fix is a temporary solution to unblock PRs.

- Mitigates #10417