### PR TITLE
Fix changes in Ansible tasks not expected to fail

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
@@ -10,7 +10,7 @@
   ansible.builtin.command:
     cmd: authselect select "{{ var_authselect_profile }}"
   register: result_authselect_select
-  failed_when: result_authselect_select.rc not in [0, 4]
+  failed_when: false
 
 - name: Verify if PAM has been altered
   ansible.builtin.command:

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -641,15 +641,15 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
 - name: "Test for id_provider different than Active Directory (ad)"
   command: grep -qzosP '[[:space:]]*\[domain\/[^]]*]([^(\n)]*(\n)+)+?[[:space:]]*id_provider[[:space:]]*=[[:space:]]*((?i)ad)[[:space:]]*$' /etc/sssd/sssd.conf
   register: test_id_provider
-  failed_when: test_id_provider.rc not in [0, 1]
-  changed_when: False
+  failed_when: false
+  changed_when: false
   check_mode: no
 
 - name: "Test for domain group"
   command: grep '\s*\[domain\/[^]]*]' /etc/sssd/sssd.conf
   register: test_grep_domain
-  failed_when: test_grep_domain.rc not in [0, 1]
-  changed_when: False
+  failed_when: false
+  changed_when: false
   check_mode: no
 
 - name: "Add default domain group and set {{{ parameter }}} in sssd configuration (if no domain there)"

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -748,7 +748,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     cmd: authselect check
   register: result_authselect_check_cmd
   changed_when: false
-  failed_when: result_authselect_check_cmd.rc not in [0, 3, 4]
+  failed_when: false
 
 - name: '{{{ rule_title }}} - Informative message based on the authselect integrity check result'
   ansible.builtin.assert:


### PR DESCRIPTION
#### Description:

The https://github.com/ComplianceAsCode/content/pull/10348 introduced changes in Ansible tasks aiming to satisfy some `ansible-lint` requirements. The most critical change was about the replacement of `ignore_errors: yes` by `failed_when:` with some new condition.

The `ignore_errors: yes` parameter was intentional in some tasks used to simply collect information in a register which is properly assessed by subsequent tasks to properly apply the remediation. When a conditional was included, the impacted tasks were capable to cause fatal errors during the Playbook execution, impacting in several profiles.

This PR fix this situation at the same time the `ansible-lint` related improvements are preserved.

#### Rationale:

Ensure stability of Ansible Playbooks and respect the existing Ansible remediation logic in existing rules.

- Fixes #10423