### PR TITLE
Revert change in test scenario script for enable_authselect rule

### DIFF
--- a/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
@@ -6,7 +6,7 @@
 
 {{{ ansible_instantiate_variables("var_authselect_profile") }}}
 
-- name: Select authselect profile
+- name: {{{ rule_title }}} - Select authselect profile
   ansible.builtin.command:
     cmd: authselect select "{{ var_authselect_profile }}"
   register: result_authselect_select
@@ -20,7 +20,7 @@
   # • 6: No configuration was detected.
   failed_when: false
 
-- name: Verify if PAM has been altered
+- name: {{{ rule_title }}} - Verify if PAM has been altered
   ansible.builtin.command:
     cmd: rpm -qV pam
   register: result_altered_authselect
@@ -32,14 +32,14 @@
   when:
     - result_authselect_select.rc != 0
 
-- name: Informative message based on the authselect integrity check
+- name: {{{ rule_title }}} - Informative message based on the authselect integrity check
   ansible.builtin.assert:
     that:
       - result_altered_authselect is skipped or result_altered_authselect.rc == 0
     fail_msg:
       - Files in the 'pam' package have been altered, so the authselect configuration won't be forced.
 
-- name: Force authselect profile select
+- name: {{{ rule_title }}} - Force authselect profile select
   ansible.builtin.command:
     cmd: authselect select --force "{{ var_authselect_profile }}"
   when:

--- a/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/enable_authselect/ansible/shared.yml
@@ -10,27 +10,32 @@
   ansible.builtin.command:
     cmd: authselect select "{{ var_authselect_profile }}"
   register: result_authselect_select
+  # The authselect can return these exit codes:
+  # • 0: Success.
+  # • 1: Generic error.
+  # • 2: Profile or configuration was not found or the system was not configured with authselect.
+  # • 3: Current configuration is not valid, it was edited without authselect.
+  # • 4: System configuration must be overwritten to activate an authselect profile, --force parameter is needed.
+  # • 5: Executed command must be run as root.
+  # • 6: No configuration was detected.
   failed_when: false
 
 - name: Verify if PAM has been altered
   ansible.builtin.command:
     cmd: rpm -qV pam
   register: result_altered_authselect
-  ignore_errors: yes
   # return:
   # - 0 if no alterations
-  # - otherwise: number of failured packages
+  # - otherwise: number of failed packages
   #   We have 1 package here. So 1 it is.
-  failed_when: result_altered_authselect.rc not in [0, 1]
-  args:
-    warn: False
+  failed_when: false
   when:
-    - result_authselect_select is failed
+    - result_authselect_select.rc != 0
 
 - name: Informative message based on the authselect integrity check
   ansible.builtin.assert:
     that:
-      - result_altered_authselect is success
+      - result_altered_authselect is skipped or result_altered_authselect.rc == 0
     fail_msg:
       - Files in the 'pam' package have been altered, so the authselect configuration won't be forced.
 
@@ -38,5 +43,5 @@
   ansible.builtin.command:
     cmd: authselect select --force "{{ var_authselect_profile }}"
   when:
-    - result_altered_authselect is success
-    - result_authselect_select is failed
+    - result_authselect_select.rc != 0
+    - result_altered_authselect is skipped or result_altered_authselect.rc == 0

--- a/linux_os/guide/system/accounts/enable_authselect/tests/remediable.fail.sh
+++ b/linux_os/guide/system/accounts/enable_authselect/tests/remediable.fail.sh
@@ -1,5 +1,5 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # packages = authselect,pam
 
-rm -f /etc/pam.d/{fingerprint-auth,smartcard-auth,system-auth}
+rm -f /etc/pam.d/{fingerprint-auth,password-auth,postlogin,smartcard-auth,system-auth}
 dnf reinstall -y pam


### PR DESCRIPTION
#### Description:

The d72b598164fffc9a7dfb98f5a383ec6719e4cbce removed two links for `authselect` files among the PAM files.
The approach of removing all `authselect` links was intentional to ensure the an `authselect` profile is not used in that test.
Right after the links removal, the respective PAM files are restored from the `pam` package, as initially designed by this test scenario script.

#### Rationale:

- Fixes #10429
- Fixes #10447