### PR TITLE
templates/mount_option: Switch mount Ansible remediation module's state back to 'mounted'

### DIFF
--- a/shared/templates/mount_option/ansible.template
+++ b/shared/templates/mount_option/ansible.template
@@ -55,7 +55,7 @@
     path: "{{{ MOUNTPOINT }}}"
     src: "{{ mount_info.source }}"
     opts: "{{ mount_info.options }}"
-    state: "present"
+    state: "mounted"
     fstype: "{{ mount_info.fstype }}"
   when:
     - (device_name.stdout is defined and (device_name.stdout | length > 0)) or ("{{{ TABFILE }}}" | length == 0)


### PR DESCRIPTION
#### Description:

- With the way the remediation works (a step for every option to check), it overwrites previously fixed `/etc/fstab` entry with obsolete data if the mount point is not re-mounted.
- This might cause problems for offline systems, but we are not going to use Ansible for offline remediation. At least for now.

#### Rationale:

- Fixes #10391.
- Fixes #10418.