### PR TITLE
No remediation warning for `fapolicy_default_deny`

### DIFF
--- a/linux_os/guide/services/fapolicyd/fapolicy_default_deny/rule.yml
+++ b/linux_os/guide/services/fapolicyd/fapolicy_default_deny/rule.yml
@@ -74,3 +74,7 @@ fixtext: |-
     permissive = 0
 
 srg_requirement: 'The {{{ full_name }}} fapolicy module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs.'
+
+warnings:
+  - general:
+      This rule doesn't come with a remediation. Before remediating the system administrator needs to create an allowlist of authorized software.


### PR DESCRIPTION
#### Description:
`fapolicy_default_deny` doesn't have remediation because the rule requires to employ deny-all policy and allowing only whitelisted software. Automatic remediation could cause system non-administrable.

#### Rationale:
To inform users, remediation is missing intentionally.