### PR TITLE
OCP4: Don't limit prometheus rules to 500

### DIFF
--- a/applications/openshift/general/compliance_notification_enabled/rule.yml
+++ b/applications/openshift/general/compliance_notification_enabled/rule.yml
@@ -33,14 +33,14 @@ severity: medium
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/apis/monitoring.coreos.com/v1/prometheusrules?limit=500': jqfilter}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/apis/monitoring.coreos.com/v1/prometheusrules': jqfilter}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path('/apis/monitoring.coreos.com/v1/prometheusrules?limit=500', jqfilter) }}}
+      {{{ openshift_filtered_path('/apis/monitoring.coreos.com/v1/prometheusrules', jqfilter) }}}
     yamlpath: "[:]"
     check_existence: "at_least_one_exists"
     entity_check: "at least one"

--- a/applications/openshift/general/file_integrity_notification_enabled/rule.yml
+++ b/applications/openshift/general/file_integrity_notification_enabled/rule.yml
@@ -32,14 +32,14 @@ ocil: |-
 
 warnings:
 - general: |-
-    {{{ openshift_filtered_cluster_setting({'/apis/monitoring.coreos.com/v1/prometheusrules?limit=500': jqfilter}) | indent(4) }}}
+    {{{ openshift_filtered_cluster_setting({'/apis/monitoring.coreos.com/v1/prometheusrules': jqfilter}) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
     filepath: |-
-      {{{ openshift_filtered_path('/apis/monitoring.coreos.com/v1/prometheusrules?limit=500', jqfilter) }}}
+      {{{ openshift_filtered_path('/apis/monitoring.coreos.com/v1/prometheusrules', jqfilter) }}}
     yamlpath: "[:]"
     check_existence: "at_least_one_exists"
     entity_check: "at least one"

--- a/applications/openshift/logging/audit_error_alert_exists/rule.yml
+++ b/applications/openshift/logging/audit_error_alert_exists/rule.yml
@@ -77,14 +77,14 @@ ocil: |-
 warnings:
 - general: |-
     {{{ openshift_filtered_cluster_setting({
-            "/apis/monitoring.coreos.com/v1/prometheusrules?limit=500": '[.items[].spec.groups[].rules[].expr]',
+        "/apis/monitoring.coreos.com/v1/prometheusrules": '[.items[].spec.groups[].rules[].expr]',
         }) | indent(4) }}}
 
 template:
   name: yamlfile_value
   vars:
     ocp_data: "true"
-    filepath: "{{{ openshift_filtered_path('/apis/monitoring.coreos.com/v1/prometheusrules?limit=500', '[.items[].spec.groups[].rules[].expr]') }}}"
+    filepath: "{{{ openshift_filtered_path('/apis/monitoring.coreos.com/v1/prometheusrules', '[.items[].spec.groups[].rules[].expr]') }}}"
     yamlpath: "[:]"
     entity_check: "all"
     values:


### PR DESCRIPTION

#### Description:

The rules were fetching only the first 500 prometheus rules in an
attempt to limit the API server load, but this seems to be missing some
rules and ultimately failing the rules.

Let's just fetch them all.

#### Rationale:

- Fixes OCPBUGS-11477

#### Review Hints:

- I guess create many prometheus rule but only one would be addressing the checks
