### PR TITLE
Update OL9 stig_gui profile

### DIFF
--- a/products/ol9/profiles/stig_gui.profile
+++ b/products/ol9/profiles/stig_gui.profile
@@ -21,5 +21,16 @@ description: |-
 extends: stig
 
 selections:
+    # Unselect rules that remove packages required by "server with GUI" installation
     # OL08-00-040320
     - '!xwindows_remove_packages'
+
+    # SRG-OS-000480-GPOS-00227
+    - '!package_xorg-x11-server-common_removed'
+
+    # SRG-OS-000095-GPOS-00049
+    - '!package_nfs-utils_removed'
+
+    # Unselect to allow the system to start in graphical.target mode
+    # OL08-00-040321
+    - '!xwindows_runlevel_target'


### PR DESCRIPTION
#### Description:

Unselect rules:
  - `package_xorg-x11-server-common_removed`
  - `package_nfs-utils_removed`
  - `xwindows_runlevel_target`
 
from OL9 stig_gui profile. 

#### Rationale:

- Those rules didn't allow a GUI installation of an OL9 system

#### Review Hints:

- Trying to install Ol9 as "Server with GUI" wont be possible, the installation GUI will show a warning saying that the policy has some issues. And the issues are the packages that the existing policy tries to remove