### PR TITLE
OCPBUGS 7816: Fix remediation for sshd-set-loglevel-info

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/test/e2e.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_loglevel_info/test/e2e.yml
@@ -1,0 +1,3 @@
+---
+default_result: FAIL
+result_after_remediation: PASS

--- a/shared/macros/10-kubernetes.jinja
+++ b/shared/macros/10-kubernetes.jinja
@@ -39,7 +39,7 @@ RekeyLimit {{.var_rekey_limit_size}} {{.var_rekey_limit_time}}
 # Logging
 #SyslogFacility AUTH
 SyslogFacility AUTHPRIV
-#LogLevel INFO
+LogLevel INFO
 
 # Authentication:
 


### PR DESCRIPTION
#### Description:

This fixes the remediation for rule sshd-set-loglevel-info.

#### Rationale:

The remediation is working correctly for rule `sshd-set-loglevel-info`.

[OCPBUGS 7816](https://issues.redhat.com/browse/OCPBUGS-7816)
