### PR TITLE
Adapt some apparmor rules for Ubuntu

### DIFF
--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/bash/shared.sh
@@ -1,19 +1,27 @@
-# platform = multi_platform_sle
+# platform = multi_platform_sle,multi_platform_ubuntu
+
+# make sure apparmor-utils is installed for aa-complain and aa-enforce
+{{{ bash_package_install("apparmor-utils") }}}
 
 # Ensure all AppArmor Profiles are enforcing
 apparmor_parser -q -r /etc/apparmor.d/
 aa-enforce /etc/apparmor.d/*
 
+{{% if 'ubuntu' in product %}}
+UNCONFINED=$(aa-status | grep "processes are unconfined" | awk '{print $1;}')
+if [ $UNCONFINED -ne 0 ];
+{{% else %}}
 UNCONFINED=$(aa-unconfined)
 if [ ! -z "$UNCONFINED" ]
+{{% endif %}}
 then
   echo -e "***WARNING***: There are some unconfined processes:"
-  echo -e "----------------------------" 
+  echo -e "----------------------------"
   echo "The may need to have a profile created or activated for them and then be restarted."
   for PROCESS in "${UNCONFINED[@]}"
   do
-      echo "$PROCESS"  
+      echo "$PROCESS"
   done
   echo -e "----------------------------"
   echo "The may need to have a profile created or activated for them and then be restarted."
-fi 
+fi

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15
+prodtype: sle12,sle15,ubuntu2004,ubuntu2204
 
 title:  'Enforce all AppArmor Profiles'
 
@@ -9,15 +9,19 @@ description: |-
     To set all profiles to enforce mode run the following command:
     <pre>$ sudo aa-enforce /etc/apparmor.d/*</pre>
     To list unconfined processes run the following command:
+    {{% if 'ubuntu' in product %}}
+    <pre>$ sudo apparmor_status | grep processes</pre>
+    {{% else %}}
     <pre>$ sudo aa-unconfined</pre>
-    Any unconfined processes may need to have a profile created or activated 
+    {{% endif %}}
+    Any unconfined processes may need to have a profile created or activated
     for them and then be restarted.
 
 rationale: |-
-    Security configuration requirements vary from site to site. Some sites may 
-    mandate a policy that is stricter than the default policy, which is perfectly 
-    acceptable. This recommendation is intended to ensure that any policies that 
-    exist on the system are activated. 
+    Security configuration requirements vary from site to site. Some sites may
+    mandate a policy that is stricter than the default policy, which is perfectly
+    acceptable. This recommendation is intended to ensure that any policies that
+    exist on the system are activated.
 
 severity: medium
 
@@ -28,4 +32,5 @@ identifiers:
 references:
     cis@sle12: 1.7.1.4
     cis@sle15: 1.7.1.4
-
+    cis@ubuntu2004: 1.7.1.4
+    cis@ubuntu2204: 1.6.1.4

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_enforced/sce/shared.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+# If apparmor or apparmor-utils are not installed, then this test fails.
+{{{ bash_package_installed("apparmor") }}} && {{{ bash_package_installed("apparmor-utils") }}}
+if [ $? -ne 0 ]; then
+        exit ${XCCDF_RESULT_FAIL}
+fi
+
+# if number of apparmor profiles loaded not the same as enforced profiles, then it fails.
+loaded_profiles=$(/usr/sbin/aa-status --profiled)
+enforced_profiles=$(/usr/sbin/aa-status --enforced)
+if [ ${loaded_profiles} -ne ${enforced_profiles} ]; then
+    exit $XCCDF_RESULT_FAIL
+fi
+
+unconfined=$(/usr/sbin/aa-status | grep "processes are unconfined" | awk '{print $1;}')
+if [ $unconfined -ne 0 ]; then
+    exit $XCCDF_RESULT_FAIL
+fi
+
+exit $XCCDF_RESULT_PASS

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/bash/shared.sh
@@ -2,6 +2,8 @@
 
 {{{ bash_instantiate_variables("var_apparmor_mode") }}}
 
+# make sure apparmor-utils is installed for aa-complain and aa-enforce
+{{{ bash_package_install("apparmor-utils") }}}
 
 # Reload all AppArmor profiles
 apparmor_parser -q -r /etc/apparmor.d/
@@ -21,8 +23,13 @@ then
   aa-complain /etc/apparmor.d/*
 fi
 
+{{% if 'ubuntu' in product %}}
+UNCONFINED=$(aa-status | grep "processes are unconfined" | awk '{print $1;}')
+if [ $UNCONFINED -ne 0 ];
+{{% else %}}
 UNCONFINED=$(aa-unconfined)
 if [ ! -z "$UNCONFINED" ]
+{{% endif %}}
 then
   echo -e "***WARNING***: There are some unconfined processes:"
   echo -e "----------------------------"

--- a/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
+++ b/linux_os/guide/system/apparmor/all_apparmor_profiles_in_enforce_complain_mode/rule.yml
@@ -12,7 +12,11 @@ description: |-
     run the following command to set all profiles to <tt>complain</tt> mode:
     <pre>$ sudo aa-complain /etc/apparmor.d/*</pre>
     To list unconfined processes run the following command:
+    {{% if 'ubuntu' in product %}}
+    <pre>$ sudo apparmor_status | grep processes</pre>
+    {{% else %}}
     <pre>$ sudo aa-unconfined</pre>
+    {{% endif %}}
     Any unconfined processes may need to have a profile created or activated
     for them and then be restarted.
 

--- a/products/ubuntu2004/profiles/cis_level2_server.profile
+++ b/products/ubuntu2004/profiles/cis_level2_server.profile
@@ -25,7 +25,8 @@ selections:
     - partition_for_home
 
     #### 1.7.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
-    # Needs variable; set above appropriately.
+    - var_apparmor_mode=enforce
+    - all_apparmor_profiles_enforced
 
     ### 3.4.1 Ensure DCCP is disabled (Automated)
     - kernel_module_dccp_disabled

--- a/products/ubuntu2004/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2004/profiles/cis_level2_workstation.profile
@@ -31,7 +31,8 @@ selections:
     - 'kernel_module_usb-storage_disabled'
 
     #### 1.7.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
-    # Needs variable; set above appropriately.
+    - var_apparmor_mode=enforce
+    - all_apparmor_profiles_enforced
 
     ### 2.2.4 Ensure CUPS is not installed (Automated)
     - service_cups_disabled

--- a/products/ubuntu2204/profiles/cis_level2_server.profile
+++ b/products/ubuntu2204/profiles/cis_level2_server.profile
@@ -31,6 +31,8 @@ selections:
     - partition_for_home
 
     #### 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
+    - var_apparmor_mode=enforce
+    - all_apparmor_profiles_enforced
 
     ### 1.8.1 Ensure GNOME Display Manager is removed (Automated)
     - package_gdm_removed

--- a/products/ubuntu2204/profiles/cis_level2_workstation.profile
+++ b/products/ubuntu2204/profiles/cis_level2_workstation.profile
@@ -37,7 +37,8 @@ selections:
     - kernel_module_usb-storage_disabled
 
     #### 1.6.1.4 Ensure all AppArmor Profiles are enforcing (Automated)
-    #- ensure_apparmor_enforce
+    - var_apparmor_mode=enforce
+    - all_apparmor_profiles_enforced
 
     ### 1.8.6 Ensure GDM automatic mounting of removable media is disabled (Automated)
     - dconf_gnome_disable_automount


### PR DESCRIPTION
#### Description:

- Add rule `all_aparmor_profiles_enforced` to Ubuntu profiles, also add SCE check and adapt bash.
- Adapt rule description and bash for `all_apparmor_profiles_in_enforced_or_complain_mode`

#### Rationale:

- This is needed for CIS

@teacup-on-rockingchair @rumch-se fyi, I've added some changes as we seen to differ on how to check for unconfined processes. Let me know if you see issues from it, even though I tried to separate per product.