### PR TITLE
OCP Fix kubelet_enable_streaming_connections rule

### DIFF
--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections_master/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections_master/rule.yml
@@ -55,5 +55,7 @@ template:
         filepath: '/kubeletconfig/role'
         filepath_suffix: var_role_master
         yamlpath: ".streamingConnectionIdleTimeout"
-        check_existence: "all_exist"
-        xccdf_variable: var_streaming_connection_timeouts
+        check_existence: "any_exist"
+        values:
+        - value: "0s"   
+          operation: "not equal"

--- a/applications/openshift/kubelet/kubelet_enable_streaming_connections_worker/rule.yml
+++ b/applications/openshift/kubelet/kubelet_enable_streaming_connections_worker/rule.yml
@@ -55,5 +55,7 @@ template:
         filepath: '/kubeletconfig/role'
         filepath_suffix: var_role_worker
         yamlpath: ".streamingConnectionIdleTimeout"
-        check_existence: "all_exist"
-        xccdf_variable: var_streaming_connection_timeouts
+        check_existence: "any_exist"
+        values:
+        - value: "0s"
+          operation: "not equal"


### PR DESCRIPTION
#### Description:

Change this to match the CIS benchmark. We only want to check that this is not set to 0.

[OCPBUG 8239](https://issues.redhat.com/browse/OCPBUGS-8239)