### PR TITLE
audit_rules_privileged commands: skip /proc directory

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/ansible/shared.yml
@@ -6,7 +6,7 @@
 
 - name: {{{ rule_title }}} - Set List of Mount Points Which Permits Execution of Privileged Commands
   ansible.builtin.set_fact:
-    privileged_mount_points: "{{(ansible_facts.mounts | rejectattr('options', 'search', 'noexec|nosuid') | map(attribute='mount') | list ) }}"
+    privileged_mount_points: "{{(ansible_facts.mounts | rejectattr('options', 'search', 'noexec|nosuid') | rejectattr('mount', 'match', '/proc($|/.*$)') | map(attribute='mount') | list ) }}"
 
 - name: {{{ rule_title }}} - Search for Privileged Commands in Eligible Mount Points
   ansible.builtin.shell:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/bash/shared.sh
@@ -11,7 +11,7 @@ KEY="privileged"
 SYSCALL_GROUPING=""
 
 FILTER_NODEV=$(awk '/nodev/ { print $2 }' /proc/filesystems | paste -sd,)
-PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | grep -Pv "noexec|nosuid" | awk '{ print $1 }')
+PARTITIONS=$(findmnt -n -l -k -it $FILTER_NODEV | grep -Pv "noexec|nosuid|/proc($|/.*$)" | awk '{ print $1 }')
 for PARTITION in $PARTITIONS; do
   PRIV_CMDS=$(find "${PARTITION}" -xdev -perm /6000 -type f 2>/dev/null)
   for PRIV_CMD in $PRIV_CMDS; do

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/oval/shared.xml
@@ -37,13 +37,14 @@
       operation="equals">noexec</linux:mount_options>
   </linux:partition_state>
 
+
   <!-- This object is created mainly to improve performance when collecting file objects.
        Here all mount points are collected and filtered to include only devices under /dev in
        order to ignore special file systems. Then, the mount options are checked to exclude
        file systems mounted with nosuid or noexec. The privileged commands can't execute on these
        file systems, so there is no reason to proble these file systems. -->
   <linux:partition_object id="object_audit_rules_privileged_commands_exec_partitions" version="1">
-    <linux:mount_point operation="pattern match">^/.*$</linux:mount_point>
+    <linux:mount_point operation="pattern match">^(?!/proc(/.*|$)).*$</linux:mount_point>
     <filter action="include">state_audit_rules_privileged_commands_dev_partitons</filter>
     <filter action="exclude">state_audit_rules_privileged_commands_nosuid_partitons</filter>
     <filter action="exclude">state_audit_rules_privileged_commands_noexec_partitons</filter>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/rule.yml
@@ -97,3 +97,9 @@ warnings:
         <li><tt>audit_rules_privileged_commands_umount</tt></li>
         <li><tt>audit_rules_privileged_commands_passwd</tt></li>
         </ul>
+    - general: |-
+        Note that OVAL check and Bash / Ansible remediation of this rule
+        explicitly excludes file systems mounted at <pre>/proc</pre> directory
+        and its subdirectories. It is a virtual file system and it doesn't
+        contain executable applications. At the same time, interacting with this
+        file system during check or remediation caused undesirable errors.


### PR DESCRIPTION
#### Description:

- modify OVAL, Ansible, Bash to skip this directory and any subdirectories
- add warning to the rule stating this fact

#### Rationale:

- this directory should not be scanned anyway - it is a virtual file system and it should not contain any executable programs.
- Scanning of this directory caused undesirable side effects, e.g. Openscap showing a confusing error.

- Fixes #10450 

#### Review Hints:

There is no test scenario as you can't effectively modify the /proc file system by standard means.

I suggest to review changes to OVAL, Bash and Ansible.
