### PR TITLE
Add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+xmldiff
+yamlpath
+json2html
+types-openpyxl
+types-PyYAML
+openpyxl-stubs
+cmakelint
+-r docs/requirements.txt


### PR DESCRIPTION
#### Description:

Add a requirements.txt file with the Python packages that are not in the Fedora repos.

#### Rationale:
Make it easier to install the python dependacies.
