### PR TITLE
Ubuntu 22.04 CIS modify password remember rule

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_pwhistory_remember/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle12,sle15,ubuntu2004,ubuntu2204
+prodtype: sle12,sle15,ubuntu2004
 
 title: 'Limit Password Reuse'
 
@@ -27,7 +27,6 @@ references:
     cis@sle12: 5.3.3
     cis@sle15: 5.3.3
     cis@ubuntu2004: 5.3.3
-    cis@ubuntu2204: 5.4.3
     disa: CCI-000200
     nist@sle12: IA-5(1)(e),IA-5 (1).1(v)
     srg: SRG-OS-000077-GPOS-00045

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/bash/ubuntu.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_password_pam_unix_remember") }}}
 
-{{{ bash_ensure_pam_module_options('/etc/pam.d/common-password', 'password', '[success=1 default=ignore]', 'pam_unix.so', 'obscure sha512 shadow remember', "$var_password_pam_unix_remember", "$var_password_pam_unix_remember") }}}
+{{{ bash_ensure_pam_module_options('/etc/pam.d/common-password', 'password', '\[success=[[:alnum:]].*\]', 'pam_unix.so', 'remember', "$var_password_pam_unix_remember", "$var_password_pam_unix_remember") }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_password_pam_unix_remember/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004
+prodtype: fedora,ol7,ol8,ol9,rhel7,rhel8,rhel9,rhv4,sle12,sle15,ubuntu2004,ubuntu2204
 
 title: 'Limit Password Reuse'
 
@@ -32,6 +32,7 @@ references:
     cis-csc: 1,12,15,16,5
     cis@rhel7: 5.4.4
     cis@rhel8: 5.4.3
+    cis@ubuntu2204: 5.4.3
     cjis: 5.6.2.1.1
     cobit5: DSS05.04,DSS05.05,DSS05.07,DSS05.10,DSS06.03,DSS06.10
     cui: 3.5.8

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -864,7 +864,7 @@ selections:
 
     ### 5.4.3 Ensure password reuse is limited (Automated)
     - var_password_pam_remember=5
-    - accounts_password_pam_pwhistory_remember
+    - accounts_password_pam_unix_remember
 
     ### 5.4.4 Ensure password hashing algorithm is up to date with the latest standards (Automated)
     - var_password_hashing_algorithm=yescrypt


### PR DESCRIPTION
#### Description:

-  Move from pam_pwhistory_remember to pam_unix_remember
- Improve ubuntu bash

#### Rationale:

- Ubuntu 22.04 CIS does not rely on pwhistory, but instead pam_unix