### PR TITLE
Modify SLE remediation for ensure_logrotate_activated

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/ansible/shared.yml
@@ -18,6 +18,13 @@
     regexp: '^[\s]*(weekly|monthly|yearly)$'
     state: absent
 
+{{% if 'sle' in product %}}
+- name: Enable timer logrotate
+  systemd:
+    name: "logrotate.timer"
+    enabled: "yes"
+    state: "started"
+{{% else %}}
 - name: Configure cron.daily if not already
   block:
     - name: Add shebang
@@ -31,3 +38,4 @@
         path: "/etc/cron.daily/logrotate"
         line: '/usr/sbin/logrotate /etc/logrotate.conf'
         regexp: '^[\s]*/usr/sbin/logrotate[\s\S]*/etc/logrotate.conf$'
+{{% endif %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -9,8 +9,15 @@ grep -q "^daily$" $LOGROTATE_CONF_FILE|| echo "daily" >> $LOGROTATE_CONF_FILE
 # remove any line configuring weekly, monthly or yearly rotation
 sed -i '/^\s*\(weekly\|monthly\|yearly\).*$/d' $LOGROTATE_CONF_FILE
 
+{{% if 'sle' in product %}}
+# enable logrotate timer service
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+"$SYSTEMCTL_EXEC" start 'logrotate.timer'
+"$SYSTEMCTL_EXEC" enable 'logrotate.timer'
+{{% else %}}
 # configure cron.daily if not already
 if ! grep -q "^[[:space:]]*/usr/sbin/logrotate[[:alnum:][:blank:][:punct:]]*$LOGROTATE_CONF_FILE$" $CRON_DAILY_LOGROTATE_FILE; then
 	echo "#!/bin/sh" > $CRON_DAILY_LOGROTATE_FILE
 	echo "/usr/sbin/logrotate $LOGROTATE_CONF_FILE" >> $CRON_DAILY_LOGROTATE_FILE
 fi
+{{% endif %}}

--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -1,7 +1,11 @@
 # platform = multi_platform_all
 
 LOGROTATE_CONF_FILE="/etc/logrotate.conf"
+{{% if 'sle' in product %}}
+SYSTEMCTL_EXEC='/usr/bin/systemctl'
+{{% else %}}
 CRON_DAILY_LOGROTATE_FILE="/etc/cron.daily/logrotate"
+{{% endif %}}
 
 # daily rotation is configured
 grep -q "^daily$" $LOGROTATE_CONF_FILE|| echo "daily" >> $LOGROTATE_CONF_FILE
@@ -11,7 +15,6 @@ sed -i '/^\s*\(weekly\|monthly\|yearly\).*$/d' $LOGROTATE_CONF_FILE
 
 {{% if 'sle' in product %}}
 # enable logrotate timer service
-SYSTEMCTL_EXEC='/usr/bin/systemctl'
 "$SYSTEMCTL_EXEC" start 'logrotate.timer'
 "$SYSTEMCTL_EXEC" enable 'logrotate.timer'
 {{% else %}}


### PR DESCRIPTION
#### Description:

- For logrotate enabled rule, in SLE context, prefer timer service over cron schedule

#### Rationale:

- In SLE platforms it is preferred to utilize logrotate timer service for log rotation functionality. OVAL check remains sam, and will accept cron-based configuration, but in case of missing scheduled timer, timer service is preferred over cron.
