### PR TITLE
Revert ansible lint gating job to Fedora 37

### DIFF
--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Build, Lint Ansible Roles on Fedora Latest (Container)
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:37
     steps:
       - name: Install Deps
         run: dnf install -y cmake make ninja-build openscap-utils python3-pyyaml python3-setuptools python3-jinja2 python3-pygithub ansible ansible-lint libxslt git


### PR DESCRIPTION

#### Description:

- There seems to be a newer version in Fedora 38 that is triggering much more linting findings. For now we rollback to Fedora 37 to not block PRs to get merged.

#### Rationale:

- Unblock PRs