### PR TITLE
Expand the list of rules skiped by Ansible Lint

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -1,5 +1,12 @@
 skip_list:
   - fqcn-builtins # We should be using fqcn
+  - key-order[task]
+  - no-free-form
+  - risky-file-permissions
+  - no-changed-when
+  - var-naming
+  - ignore-errors
+  - schema[meta]
 warn_list:
   - name[missing]  # Rule for checking task and play names.
   - template-instead-of-copy  # Templated files should use template instead of copy

--- a/.github/workflows/gate-lint-ansible-roles.yaml
+++ b/.github/workflows/gate-lint-ansible-roles.yaml
@@ -7,7 +7,7 @@ jobs:
     name: Build, Lint Ansible Roles on Fedora Latest (Container)
     runs-on: ubuntu-latest
     container:
-      image: fedora:37
+      image: fedora:latest
     steps:
       - name: Install Deps
         run: dnf install -y cmake make ninja-build openscap-utils python3-pyyaml python3-setuptools python3-jinja2 python3-pygithub ansible ansible-lint libxslt git


### PR DESCRIPTION


#### Description:

Add new rules to skip in Ansible Lint to match previous version of Ansible Lint.

#### Rationale:

The goal of this commit is to match what was skipped in older versions of Ansible Lint.

Fixes #10483 

