### PR TITLE
Update mount_option_remote_filesystems template's ansible

### DIFF
--- a/shared/templates/mount_option_remote_filesystems/ansible.template
+++ b/shared/templates/mount_option_remote_filesystems/ansible.template
@@ -6,7 +6,7 @@
 
 - name: "Get nfs and nfs4 mount points, that don't have {{{ MOUNTOPTION }}}"
   # 'no' before MOUNTOPTION isn't omission, it means a negation
-  command: findmnt --fstab --types nfs,nfs4 -O no{{{ MOUNTOPTION }}} -n
+  command: findmnt --fstab --types nfs,nfs4 -O no{{{ MOUNTOPTION }}} -n -P
   register: points_register
   check_mode: no
   changed_when: False
@@ -15,10 +15,10 @@
 
 - name: "Add {{{ MOUNTOPTION }}} to nfs and nfs4 mount points"
   mount:
-    path: "{{ item.split()[0] }}"
-    src: "{{ item.split()[1] }}"
-    fstype: "{{ item.split()[2] }}"
-    state: mounted
-    opts: "{{ item.split()[3] }},{{{ MOUNTOPTION }}}"
+    path: "{{ item | regex_search('TARGET=\"([^\"]+)\"','\\1') | first | replace('\\x09','\t') }}"
+    src: "{{ item | regex_search('SOURCE=\"([^\"]+)\"','\\1') | first }}"
+    fstype: "{{ item | regex_search('FSTYPE=\"([^\"]+)\"','\\1') | first }}"
+    state: present
+    opts: "{{ item | regex_search('OPTIONS=\"([^\"]+)\"','\\1') | first }},{{{ MOUNTOPTION }}}"
   when: (points_register.stdout | length > 0)
   with_items: "{{ points_register.stdout_lines }}"

--- a/shared/templates/mount_option_remote_filesystems/ansible.template
+++ b/shared/templates/mount_option_remote_filesystems/ansible.template
@@ -15,10 +15,11 @@
 
 - name: "Add {{{ MOUNTOPTION }}} to nfs and nfs4 mount points"
   mount:
-    path: "{{ item | regex_search('TARGET=\"([^\"]+)\"','\\1') | first | replace('\\x09','\t') }}"
+    path: "{{ item | regex_search('TARGET=\"([^\"]+)\"','\\1') | first }}"
     src: "{{ item | regex_search('SOURCE=\"([^\"]+)\"','\\1') | first }}"
     fstype: "{{ item | regex_search('FSTYPE=\"([^\"]+)\"','\\1') | first }}"
     state: present
     opts: "{{ item | regex_search('OPTIONS=\"([^\"]+)\"','\\1') | first }},{{{ MOUNTOPTION }}}"
-  when: (points_register.stdout | length > 0)
+  # ansible doesn't escape correctly the tab character
+  when: (points_register.stdout | length > 0) and '\\x09' not in item
   with_items: "{{ points_register.stdout_lines }}"

--- a/shared/templates/mount_option_remote_filesystems/tests/wrong_option.fail.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/wrong_option.fail.sh
@@ -5,7 +5,6 @@ if [ -f "/etc/fstab" ]; then
 fi
 
 echo "UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d /mount/point nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
-echo "label=remote /store\040mount\011point nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
 echo "host:/dir /host\040dir nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
 
 sed -i -E "s/(^\s*\S+\s+\S+\s+nfs.*)(,{{{ MOUNTOPTION }}}|{{{ MOUNTOPTION }}},)(.*)/\1\3/g" /etc/fstab

--- a/shared/templates/mount_option_remote_filesystems/tests/wrong_option_with_tab.fail.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/wrong_option_with_tab.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Tab character breaks ansible's mount module, in current status ansible will leave this fstab line as is
+# remediation = bash
+
+if [ -f "/etc/fstab" ]; then
+    sed -i -E "/^\s*\S+\s+\S+\s+nfs/d" /etc/fstab
+fi
+
+echo "label=remote /store\040mount\011point nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
+
+sed -i -E "s/(^\s*\S+\s+\S+\s+nfs.*)(,{{{ MOUNTOPTION }}}|{{{ MOUNTOPTION }}},)(.*)/\1\3/g" /etc/fstab


### PR DESCRIPTION
#### Description:

- Update ansible for the template mount_option_remote_filesystems so it handles correctly spaces in mount point string

#### Rationale:

- In the way it is implemented now, when there is a space in the mount point string, it is interpreted that the filed ends, and because of that interprets all further information wrongly
- Left an issue with tabs, as this is an issue from mount module implementation. This module is intended to escape all characters that need to, but it doesn't escape tabs. Created issue: https://github.com/ansible-collections/ansible.posix/issues/427

#### Review Hints:

- The updated tests should be enough to test this changes. The exact issue can be spotted in remediation log, when running automatus, with the flags `--dontclean --remediate-using ansible`