### PR TITLE
Set service_nftables_enabled as machine only

### DIFF
--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -36,6 +36,8 @@ ocil: |-
 fixtext: |-
     {{{ fixtext_service_enabled("nftables") }}}
 
+platform: machine
+
 template:
     name: service_enabled
     vars:


### PR DESCRIPTION
#### Description:

- When scanning containers,  rule `service_nftables_enabled` cannot be remediated and always results in `fail`.
  - This adds a `platform: machine` to the rule.

#### Rationale:
- The services enabled/disabled rules are not applicable to machines.
- This aligns the rule with `service_nftables_disabled`.
