### PR TITLE
Link api_server_encryption_provider_cipher with CIS 2.8

### DIFF
--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -39,7 +39,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.33,1.2.34
+    cis@ocp4: 1.2.33,1.2.34,2.8
     nerc-cip: CIP-003-8 R4.2
     nist: SC-28,SC-28(1)
     pcidss: Req-2.2

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -113,6 +113,7 @@ selections:
     - api_server_etcd_ca
   # 1.2.33 Ensure that the --encryption-provider-config argument is set as appropriate
   # 1.2.34 Ensure that encryption providers are appropriately configured
+  # 2.8 Encrypt etc
     - api_server_encryption_provider_cipher
   # 1.2.35 Ensure that the API Server only makes use of Strong Cryptographic Ciphers
     - api_server_tls_cipher_suites


### PR DESCRIPTION

#### Description:

Links an OCP rule with the appropriate CIS control

#### Rationale:

CIS 1.3 control encrypt etcd is solved with the rule
api_server_encryption_provider_cipher. Because encrypting etcd is quite
an important control, we should have the rule linked.

#### Review Hints:

- Check out the CIS 1.3 standard PDF
