### PR TITLE
Add rule package_mailx_installed

### DIFF
--- a/linux_os/guide/services/mail/package_mailx_installed/rule.yml
+++ b/linux_os/guide/services/mail/package_mailx_installed/rule.yml
@@ -1,0 +1,32 @@
+documentation_complete: true
+
+title: 'The mailx package is installed'
+
+description: |-
+    A mail server is required for sending emails.
+    {{{ describe_package_install(package="mailx") }}}
+
+rationale: |-
+    Emails can be used to notify designated personnel about important
+    system events such as failures or warnings.
+
+severity: medium
+
+references:
+    disa: CCI-001744
+    nist: CM-3(5)
+    srg: SRG-OS-000363-GPOS-00150
+    stigid@ol8: OL08-00-010358
+
+ocil_clause: 'the package is not installed'
+
+ocil: '{{{ ocil_package(package="mailx") }}}'
+
+fixtext: '{{{ fixtext_package_installed(package="mailx") }}}'
+
+srg_requirement: '{{{ srg_requirement_package_installed("mailx") }}}'
+
+template:
+    name: package_installed
+    vars:
+        pkgname: mailx

--- a/linux_os/guide/services/mail/package_mailx_installed/rule.yml
+++ b/linux_os/guide/services/mail/package_mailx_installed/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-title: 'The mailx package is installed'
+title: 'The mailx Package Is Installed'
 
 description: |-
     A mail server is required for sending emails.

--- a/linux_os/guide/services/mail/package_mailx_installed/rule.yml
+++ b/linux_os/guide/services/mail/package_mailx_installed/rule.yml
@@ -16,6 +16,7 @@ references:
     disa: CCI-001744
     nist: CM-3(5)
     srg: SRG-OS-000363-GPOS-00150
+    stigid@ol7: OL07-00-020028
     stigid@ol8: OL08-00-010358
 
 ocil_clause: 'the package is not installed'

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -338,3 +338,4 @@ selections:
     - authconfig_config_files_symlinks
     - ensure_oracle_gpgkey_installed
     - dconf_gnome_disable_user_list
+    - package_mailx_installed

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -240,6 +240,9 @@ selections:
     # OL08-00-010351
     - dir_group_ownership_library_dirs
 
+    # OL08-00-010358
+    - package_mailx_installed
+
     # OL08-00-010359
     - package_aide_installed
     - aide_build_database


### PR DESCRIPTION
#### Description:

- Created rule `package_mailx_installed`

#### Rationale:

- This covers `OL08-00-010358` & `OL07-00-020028` STIG ids

#### Review Hints:

- This uses a few well established templates, so automatus results should be enough to validate this.
- This also applies to `RHEL-08-010358` & `RHEL-07-020028` so let me know if you want me to add it to RHEL profiles