### PR TITLE
Update accounts_password_pam_retry yaml

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/rule.yml
@@ -73,7 +73,7 @@ ocil: |-
     <pre>$ grep pam_pwquality /etc/pam.d/system-auth</pre>
     {{% endif %}}
 
-    <pre>password required pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}</pre>
+    <pre>password requisite pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}</pre>
     {{% endif %}}
 
 platform: package[pam]
@@ -91,7 +91,7 @@ fixtext: |-
     {{% else %}}
     Add the following line to the "/etc/pam.d/system-auth" file (or modify the line to have the required value):
     {{% endif %}}
-    password required pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}
+    password requisite pam_pwquality.so retry={{{ xccdf_value("var_password_pam_retry") }}}
     {{% endif %}}
 
 srg_requirement: |-


### PR DESCRIPTION
#### Description:

- Change the PAM control flag to "requisite"

#### Rationale:

- This aligns the rule's yaml with the value used in both available remediations
- Also the latest release of the DISA STIG (v2r11 for OL7) uses this control flag