### PR TITLE
Fix uefi cpe bash condition

### DIFF
--- a/shared/applicability/non-uefi.yml
+++ b/shared/applicability/non-uefi.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:non-uefi
 title: System boot mode is non-UEFI
 check_id: system_boot_mode_is_non_uefi
-bash_conditional: '[ ! -f /sys/firmware/efi ]'
+bash_conditional: '[ ! -d /sys/firmware/efi ]'
 ansible_conditional: '"/boot/efi" not in ansible_mounts | map(attribute="mount") | list'

--- a/shared/applicability/uefi.yml
+++ b/shared/applicability/uefi.yml
@@ -1,5 +1,5 @@
 name: cpe:/a:uefi
 title: System boot mode is UEFI
 check_id: system_boot_mode_is_uefi
-bash_conditional: '[ -f /sys/firmware/efi ]'
+bash_conditional: '[ -d /sys/firmware/efi ]'
 ansible_conditional: '"/boot/efi" in ansible_mounts | map(attribute="mount") | list'

--- a/tests/unit/ssg-module/test_playbook_builder_data/applicability/firmware.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/applicability/firmware.yml
@@ -4,12 +4,12 @@ cpes:
       name: "cpe:/a:uefi"
       title: "System boot mode is UEFI"
       check_id: system_boot_mode_is_uefi
-      bash_conditional: '[ -f /sys/firmware/efi ]'
+      bash_conditional: '[ -d /sys/firmware/efi ]'
       ansible_conditional: '"/boot/efi" in ansible_mounts | map(attribute="mount") | list'
 
   - non-uefi:
       name: "cpe:/a:non-uefi"
       title: "System boot mode is non-UEFI"
       check_id: system_boot_mode_is_non_uefi
-      bash_conditional: '[ ! -f /sys/firmware/efi ]'
+      bash_conditional: '[ ! -d /sys/firmware/efi ]'
       ansible_conditional: '"/boot/efi" not in ansible_mounts | map(attribute="mount") | list'


### PR DESCRIPTION
#### Description:

- Update bash condition introduced here: https://github.com/ComplianceAsCode/content/pull/9575, to check for a directory as OVAL does

#### Rationale:

- The condition should look for a directory and it looks for a file

#### Review Hints:

- The generated bash code when running in a uefi system shows
```
$ sudo bash -x bash-fix.sh
+ echo 'Remediating rule 1/1: '\''xccdf_org.ssgproject.content_rule_mount_option_boot_efi_nosuid'\'''                                                                                  
Remediating rule 1/1: 'xccdf_org.ssgproject.content_rule_mount_option_boot_efi_nosuid'
+ '[' '!' -f /.dockerenv ']'
+ '[' '!' -f /run/.containerenv ']'
+ '[' -f /sys/firmware/efi ']'
+ echo 'Remediation is not applicable, nothing was done'
Remediation is not applicable, nothing was done
```