### PR TITLE
add python3 to the list of build dependencies for RHEL-8+

### DIFF
--- a/docs/manual/developer/02_building_complianceascode.md
+++ b/docs/manual/developer/02_building_complianceascode.md
@@ -40,7 +40,7 @@ yum install cmake make openscap-utils openscap-scanner PyYAML python-jinja2
 On *Red Hat Enterprise Linux 8* and *Fedora* the package list is the same but python2 packages need to be replaced with python3 ones:
 
 ```bash
-yum install cmake make openscap-utils openscap-scanner python3-pyyaml python3-jinja2 python3-setuptools
+yum install cmake make openscap-utils openscap-scanner python3 python3-pyyaml python3-jinja2 python3-setuptools
 ```
 
 On *Ubuntu* and *Debian*, make sure the packages `libopenscap8`,


### PR DESCRIPTION
#### Description:

RHEL-8 does not, by default, have `/usr/bin/python3` installed, using `/usr/libexec/platform-python` instead for distribution needs.

This causes CMake to fail to find python:

    CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
      Could NOT find PythonInterp (missing: PYTHON_EXECUTABLE)
    Call Stack (most recent call first):
      /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:594 (_FPHSA_FAILURE_MESSAGE)
      /usr/share/cmake/Modules/FindPythonInterp.cmake:169 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
      CMakeLists.txt:128 (find_package)

Note that ie. the SPEC file already has this dependency, it was just missing in the documentation.

#### Rationale:

I presume we would like RHEL-8 users to be able to build content according to the docs .. ?