### PR TITLE
Add control file for OCP 1.3.0

### DIFF
--- a/controls/cis_ocp_1_3_0.yml
+++ b/controls/cis_ocp_1_3_0.yml
@@ -1,0 +1,10 @@
+policy: CIS RedHat OpenShift Container Platform Benchmark
+title: CIS RedHat OpenShift Container Platform Benchmark
+id: PLACEHOLDER
+version: 1.3.0
+source: https://example.com/benchmark
+levels:
+- id: level_1
+  inherits_from: PLACEHOLDER
+- id: level_2
+  inherits_from: PLACEHOLDER

--- a/controls/cis_ocp_1_3_0/section-1.yml
+++ b/controls/cis_ocp_1_3_0/section-1.yml
@@ -1,0 +1,374 @@
+controls:
+- id: '1'
+  title: Control Plane Components
+  status: pending
+  rules: []
+  controls:
+  - id: '1.1'
+    title: Master Node Configuration Files
+    status: pending
+    rules: []
+    controls:
+    - id: 1.1.1
+      title: Ensure that the API server pod specification file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.2
+      title: Ensure that the API server pod specification file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.3
+      title: Ensure that the controller manager pod specification file permissions
+        are set to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.4
+      title: Ensure that the controller manager pod specification file ownership is
+        set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.5
+      title: Ensure that the scheduler pod specification file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.6
+      title: Ensure that the scheduler pod specification file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.7
+      title: Ensure that the etcd pod specification file permissions are set to 600
+        or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.8
+      title: Ensure that the etcd pod specification file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.9
+      title: Ensure that the Container Network Interface file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.10
+      title: Ensure that the Container Network Interface file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.11
+      title: Ensure that the etcd data directory permissions are set to 700 or more
+        restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.12
+      title: Ensure that the etcd data directory ownership is set to etcd:etcd
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.13
+      title: Ensure that the admin.conf file permissions are set to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.14
+      title: Ensure that the admin.conf file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.15
+      title: Ensure that the scheduler.conf file permissions are set to 600 or more
+        restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.16
+      title: Ensure that the scheduler.conf file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.17
+      title: Ensure that the controller-manager.conf file permissions are set to 600
+        or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.18
+      title: Ensure that the controller-manager.conf file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.19
+      title: Ensure that the OpenShift PKI directory and file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.20
+      title: Ensure that the OpenShift PKI certificate file permissions are set to
+        600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.21
+      title: Ensure that the OpenShift PKI key file permissions are set to 600
+      status: pending
+      rules: []
+      level: level_1
+  - id: '1.2'
+    title: API Server
+    status: pending
+    rules: []
+    controls:
+    - id: 1.2.1
+      title: Ensure that anonymous requests are authorized
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.2
+      title: Ensure that the --basic-auth-file argument is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.3
+      title: Ensure that the --token-auth-file parameter is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.4
+      title: Use https for kubelet connections
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.5
+      title: Ensure that the kubelet uses certificates to authenticate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.6
+      title: Verify that the kubelet certificate authority is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.7
+      title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.8
+      title: Verify that the Node authorizer is enabled
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.9
+      title: Verify that RBAC is enabled
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.10
+      title: Ensure that the APIPriorityAndFairness feature gate is enabled
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.11
+      title: Ensure that the admission control plugin AlwaysAdmit is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.12
+      title: Ensure that the admission control plugin AlwaysPullImages is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.13
+      title: Ensure that the admission control plugin SecurityContextDeny is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.14
+      title: Ensure that the admission control plugin ServiceAccount is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.15
+      title: Ensure that the admission control plugin NamespaceLifecycle is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.16
+      title: Ensure that the admission control plugin SecurityContextConstraint is
+        set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.17
+      title: Ensure that the admission control plugin NodeRestriction is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.18
+      title: Ensure that the --insecure-bind-address argument is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.19
+      title: Ensure that the --insecure-port argument is set to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.20
+      title: Ensure that the --secure-port argument is not set to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.21
+      title: Ensure that the healthz endpoint is protected by RBAC
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.22
+      title: Ensure that the --audit-log-path argument is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.23
+      title: Ensure that the audit logs are forwarded off the cluster for retention
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.24
+      title: Ensure that the maximumRetainedFiles argument is set to 10 or as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.25
+      title: Ensure that the maximumFileSizeMegabytes argument is set to 100 or as
+        appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.26
+      title: Ensure that the --request-timeout argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.27
+      title: Ensure that the --service-account-lookup argument is set to true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.28
+      title: Ensure that the --service-account-key-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.29
+      title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set
+        as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.30
+      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
+        are set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.31
+      title: Ensure that the --client-ca-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.32
+      title: Ensure that the --etcd-cafile argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.33
+      title: Ensure that the --encryption-provider-config argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.34
+      title: Ensure that encryption providers are appropriately configured
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.35
+      title: Ensure that the API Server only makes use of Strong Cryptographic Ciphers
+      status: pending
+      rules: []
+      level: level_1
+  - id: '1.3'
+    title: Controller Manager
+    status: pending
+    rules: []
+    controls:
+    - id: 1.3.1
+      title: Ensure that garbage collection is configured as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.2
+      title: Ensure that controller manager healthz endpoints are protected by RBAC
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.3
+      title: Ensure that the --use-service-account-credentials argument is set to
+        true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.4
+      title: Ensure that the --service-account-private-key-file argument is set as
+        appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.5
+      title: Ensure that the --root-ca-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.6
+      title: Ensure that the RotateKubeletServerCertificate argument is set to true
+      status: pending
+      rules: []
+      level: level_2
+    - id: 1.3.7
+      title: Ensure that the --bind-address argument is set to 127.0.0.1
+      status: pending
+      rules: []
+      level: level_1
+  - id: '1.4'
+    title: Scheduler
+    status: pending
+    rules: []
+    controls:
+    - id: 1.4.1
+      title: Ensure that the healthz endpoints for the scheduler are protected by
+        RBAC
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.4.2
+      title: Verify that the scheduler API service is protected by authentication
+        and authorization
+      status: pending
+      rules: []
+      level: level_1
+

--- a/controls/cis_ocp_1_3_0/section-2.yml
+++ b/controls/cis_ocp_1_3_0/section-2.yml
@@ -1,0 +1,48 @@
+controls:
+- id: '2'
+  title: etcd
+  status: pending
+  rules: []
+  controls:
+  - id: '2.1'
+    title: Ensure that the --cert-file and --key-file arguments are set as appropriate
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.2'
+    title: Ensure that the --client-cert-auth argument is set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.3'
+    title: Ensure that the --auto-tls argument is not set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.4'
+    title: Ensure that the --peer-cert-file and --peer-key-file arguments are set
+      as appropriate
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.5'
+    title: Ensure that the --peer-client-cert-auth argument is set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.6'
+    title: Ensure that the --peer-auto-tls argument is not set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.7'
+    title: Ensure that a unique Certificate Authority is used for etcd
+    status: pending
+    rules: []
+    level: level_2
+  - id: '2.8'
+    title: Encrypt etc
+    status: pending
+    rules: []
+    level: level_2
+

--- a/controls/cis_ocp_1_3_0/section-3.yml
+++ b/controls/cis_ocp_1_3_0/section-3.yml
@@ -1,0 +1,32 @@
+controls:
+- id: '3'
+  title: Control Plane Configuration
+  status: pending
+  rules: []
+  controls:
+  - id: '3.1'
+    title: Authentication and Authorization
+    status: pending
+    rules: []
+    controls:
+    - id: 3.1.1
+      title: Client certificate authentication should not be used for users
+      status: pending
+      rules: []
+      level: level_2
+  - id: '3.2'
+    title: Logging
+    status: pending
+    rules: []
+    controls:
+    - id: 3.2.1
+      title: Ensure that a minimal audit policy is created
+      status: pending
+      rules: []
+      level: level_1
+    - id: 3.2.2
+      title: Ensure that the audit policy covers key security concerns
+      status: pending
+      rules: []
+      level: level_2
+

--- a/controls/cis_ocp_1_3_0/section-4.yml
+++ b/controls/cis_ocp_1_3_0/section-4.yml
@@ -1,0 +1,141 @@
+controls:
+- id: '4'
+  title: Worker Nodes
+  status: pending
+  rules: []
+  controls:
+  - id: '4.1'
+    title: Worker Node Configuration Files
+    status: pending
+    rules: []
+    controls:
+    - id: 4.1.1
+      title: Ensure that the kubelet service file permissions are set to 600 or more
+        restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.2
+      title: Ensure that the kubelet service file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.3
+      title: If proxy kubeconfig file exists ensure permissions are set to 600 or
+        more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.4
+      title: If proxy kubeconfig file exists ensure ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.5
+      title: Ensure that the --kubeconfig kubelet.conf file permissions are set to
+        600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.6
+      title: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.7
+      title: Ensure that the certificate authorities file permissions are set to 600
+        or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.8
+      title: Ensure that the client certificate authorities file ownership is set
+        to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.9
+      title: Ensure that the kubelet --config configuration file has permissions set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.10
+      title: Ensure that the kubelet configuration file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+  - id: '4.2'
+    title: Kubelet
+    status: pending
+    rules: []
+    controls:
+    - id: 4.2.1
+      title: Ensure that the --anonymous-auth argument is set to false
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.2
+      title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.3
+      title: Ensure that the --client-ca-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.4
+      title: Verify that the read only port is not used or is set to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.5
+      title: Ensure that the --streaming-connection-idle-timeout argument is not set
+        to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.6
+      title: Ensure that the --protect-kernel-defaults argument is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.7
+      title: Ensure that the --make-iptables-util-chains argument is set to true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.8
+      title: Ensure that the --hostname-override argument is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.9
+      title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level
+        which ensures appropriate event capture
+      status: pending
+      rules: []
+      level: level_2
+    - id: 4.2.10
+      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
+        are set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.11
+      title: Ensure that the --rotate-certificates argument is not set to false
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.12
+      title: Verify that the RotateKubeletServerCertificate argument is set to true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.13
+      title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+      status: pending
+      rules: []
+      level: level_1
+

--- a/controls/cis_ocp_1_3_0/section-5.yml
+++ b/controls/cis_ocp_1_3_0/section-5.yml
@@ -1,0 +1,160 @@
+controls:
+- id: '5'
+  title: Policies
+  status: pending
+  rules: []
+  controls:
+  - id: '5.1'
+    title: RBAC and Service Accounts
+    status: pending
+    rules: []
+    controls:
+    - id: 5.1.1
+      title: Ensure that the cluster-admin role is only used where required
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.1.2
+      title: Minimize access to secrets
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.1.3
+      title: Minimize wildcard use in Roles and ClusterRoles
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.1.4
+      title: Minimize access to create pods
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.1.5
+      title: Ensure that default service accounts are not actively used.
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.1.6
+      title: Ensure that Service Account Tokens are only mounted where necessary
+      status: pending
+      rules: []
+      level: level_1
+  - id: '5.2'
+    title: Pod Security Policies
+    status: pending
+    rules: []
+    controls:
+    - id: 5.2.1
+      title: Minimize the admission of privileged containers
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.2
+      title: Minimize the admission of containers wishing to share the host process
+        ID namespace
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.3
+      title: Minimize the admission of containers wishing to share the host IPC namespace
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.4
+      title: Minimize the admission of containers wishing to share the host network
+        namespace
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.5
+      title: Minimize the admission of containers with allowPrivilegeEscalation
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.6
+      title: Minimize the admission of root containers
+      status: pending
+      rules: []
+      level: level_2
+    - id: 5.2.7
+      title: Minimize the admission of containers with the NET_RAW capability
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.8
+      title: Minimize the admission of containers with added capabilities
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.2.9
+      title: Minimize the admission of containers with capabilities assigned
+      status: pending
+      rules: []
+      level: level_2
+  - id: '5.3'
+    title: Network Policies and CNI
+    status: pending
+    rules: []
+    controls:
+    - id: 5.3.1
+      title: Ensure that the CNI in use supports Network Policies
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.3.2
+      title: Ensure that all Namespaces have Network Policies defined
+      status: pending
+      rules: []
+      level: level_2
+  - id: '5.4'
+    title: Secrets Management
+    status: pending
+    rules: []
+    controls:
+    - id: 5.4.1
+      title: Prefer using secrets as files over secrets as environment variables
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.4.2
+      title: Consider external secret storage
+      status: pending
+      rules: []
+      level: level_2
+  - id: '5.5'
+    title: Extensible Admission Control
+    status: pending
+    rules: []
+    controls:
+    - id: 5.5.1
+      title: Configure Image Provenance using image controller configuration parameters
+      status: pending
+      rules: []
+      level: level_2
+  - id: '5.7'
+    title: General Policies
+    status: pending
+    rules: []
+    controls:
+    - id: 5.7.1
+      title: Create administrative boundaries between resources using namespaces
+      status: pending
+      rules: []
+      level: level_1
+    - id: 5.7.2
+      title: Ensure that the seccomp profile is set to docker/default in your pod
+        definitions
+      status: pending
+      rules: []
+      level: level_2
+    - id: 5.7.3
+      title: Apply Security Context to Your Pods and Containers
+      status: pending
+      rules: []
+      level: level_2
+    - id: 5.7.4
+      title: The default namespace should not be used
+      status: pending
+      rules: []
+      level: level_2
+


### PR DESCRIPTION
This commit uses a script still under  (see https://github.com/ComplianceAsCode/content/pull/10455) to generate a control
file for the OpenShift CIS 1.3.0 benchmark.

The control file isn't complete, but it does provide the boilerplate
control structure based on the benchmark.

This makes it easier for contributors to come through and fill in the
missing pieces, like rules and status.
