### PR TITLE
Fix into ansible part of the rule audit_rules_suid_privilege_function

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -11,6 +11,8 @@
   command:
     grep '^ExecStartPost' /usr/lib/systemd/system/auditd.service
   register: check_rules_scripts_result
+  changed_when: false
+  failed_when: false
 
 - name: Set suid_audit_rules fact
   set_fact:


### PR DESCRIPTION
#### Description:

- _The PR makes a small correction into ansible part of the rule  audit_rules_suid_privilege_function_

#### Rationale:

- In the existing version the execution of ansible playbook for remediation generates an error. 



