### PR TITLE
Fedora 38

### DIFF
--- a/Dockerfiles/quay_publish
+++ b/Dockerfiles/quay_publish
@@ -1,4 +1,4 @@
-FROM fedora:37 as builder
+FROM fedora:38 as builder
 
 RUN dnf -y install cmake make git /usr/bin/python3 python3-pyyaml python3-jinja2 openscap-utils
 RUN git clone --depth 1 https://github.com/ComplianceAsCode/content

--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/rule.yml
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/rule.yml
@@ -41,5 +41,7 @@ ocil: |-
     To ensure that the GPG key is installed, run:
     <pre>$ rpm -q --queryformat "%{SUMMARY}\n" gpg-pubkey</pre>
     The command should return one of the strings below:
+    <pre>gpg(Fedora {{{ rawhide_version }}} ({{{ rawhide_version }}}) &lt;fedora-{{{ rawhide_version }}}@fedoraproject.org&gt;)</pre>
+    <pre>gpg(Fedora {{{ future_version }}} ({{{ future_version }}}) &lt;fedora-{{{ future_version }}}@fedoraproject.org&gt;)</pre>
     <pre>gpg(Fedora {{{ latest_version }}} ({{{ latest_version }}}) &lt;fedora-{{{ latest_version }}}@fedoraproject.org&gt;)</pre>
     <pre>gpg(Fedora {{{ previous_version }}} ({{{ previous_version }}}) &lt;fedora-{{{ previous_version }}}@fedoraproject.org&gt;)</pre>

--- a/ocp-resources/ds-build-remote.yaml
+++ b/ocp-resources/ds-build-remote.yaml
@@ -17,7 +17,7 @@ spec:
       type: "ImageChange"
   source: 
     dockerfile: |
-      FROM registry.fedoraproject.org/fedora-minimal:37 as builder
+      FROM registry.fedoraproject.org/fedora-minimal:38 as builder
 
       WORKDIR /content
 

--- a/products/fedora/product.yml
+++ b/products/fedora/product.yml
@@ -25,6 +25,16 @@ dconf_gdm_dir: "distro.d"
 
 cpes_root: "../../shared/applicability"
 cpes:
+  - fedora_40:
+      name: "cpe:/o:fedoraproject:fedora:40"
+      title: "Fedora 40"
+      check_id: installed_OS_is_fedora
+
+  - fedora_39:
+      name: "cpe:/o:fedoraproject:fedora:39"
+      title: "Fedora 39"
+      check_id: installed_OS_is_fedora
+
   - fedora_38:
       name: "cpe:/o:fedoraproject:fedora:38"
       title: "Fedora 38"
@@ -40,42 +50,37 @@ cpes:
       title: "Fedora 36"
       check_id: installed_OS_is_fedora
 
-  - fedora_35:
-      name: "cpe:/o:fedoraproject:fedora:35"
-      title: "Fedora 35"
-      check_id: installed_OS_is_fedora
-
 # Retrieve the fingerprint as follows:
 #   gpg --show-keys --with-fingerprint --with-colons "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-primary" | grep '^fpr' | cut -d ":" -f 10
 # For current supported releases, this can be verified by comparing it to the keys published on:
 #   https://getfedora.org/keys/
-rawhide_version: 38
-rawhide_release_fingerprint: "6A51BBABBA3D5467B6171221809A8D7CEB10B464"
+rawhide_version: 40
+rawhide_release_fingerprint: "115DF9AEF857853EE8445D0A0727707EA15B79CC"
 # The shortened version of the key, to be used for the pkg_version variable can be derived as follows:
 #   gpg --show-keys --keyid-format short "/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-primary" | grep 'rsa' | cut -d "/" -f 2 | awk '{print $1}'
 # Alternatively, you can simply take the last 8 digits of the fingerprint above.
 # For currently supported releases, this can also be verified by comparing it to the keyid values published on:
 #   https://getfedora.org/keys/
-rawhide_pkg_version: "eb10b464"
+rawhide_pkg_version: "a15b79cc"
 # The pkg_release can be derived as follows:
 #   rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-<version>-x86_64
 #   rpm -q gpg-pubkey --qf '%{VERSION}-%{RELEASE}-%{SUMMARY}\n' | grep -i <pkg_version> | cut -f 2 -d -
-rawhide_pkg_release: "60242b08"
+rawhide_pkg_release: "63d04c2c"
 
-future_version: 37
-future_release_fingerprint: "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A"
-future_pkg_version: "5323552a"
-future_pkg_release: "6112bcdc"
+future_version: 39
+future_release_fingerprint: "E8F23996F23218640CB44CBE75CF5AC418B8E74C"
+future_pkg_version: "18b8e74c"
+future_pkg_release: "62f2920f"
 
-latest_version: 36
-latest_release_fingerprint: "53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4"
-latest_pkg_version: "38ab71f4"
-latest_pkg_release: "60242b08"
+latest_version: 38
+latest_release_fingerprint: "6A51BBABBA3D5467B6171221809A8D7CEB10B464"
+latest_pkg_version: "eb10b464"
+latest_pkg_release: "6202d9c6"
 
-previous_version: 35
-previous_release_fingerprint: "787EA6AE1147EEE56C40B30CDB4639719867C58F"
-previous_pkg_version: "9867c58f"
-previous_pkg_release: "601c49ca"
+previous_version: 37
+previous_release_fingerprint: "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A"
+previous_pkg_version: "5323552a"
+previous_pkg_release: "6112bcdc"
 
 # Mapping of CPE platform to package
 platform_package_overrides:

--- a/shared/checks/oval/installed_OS_is_fedora.xml
+++ b/shared/checks/oval/installed_OS_is_fedora.xml
@@ -5,10 +5,11 @@
       <affected family="unix">
         <platform>multi_platform_all</platform>
       </affected>
-      <reference ref_id="cpe:/o:fedoraproject:fedora:33" source="CPE" />
-      <reference ref_id="cpe:/o:fedoraproject:fedora:34" source="CPE" />
-      <reference ref_id="cpe:/o:fedoraproject:fedora:35" source="CPE" />
       <reference ref_id="cpe:/o:fedoraproject:fedora:36" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:37" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:38" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:39" source="CPE" />
+      <reference ref_id="cpe:/o:fedoraproject:fedora:40" source="CPE" />
       <description>The operating system installed on the system is Fedora</description>
     </metadata>
     <criteria operator="AND">

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -147,7 +147,7 @@ def main():
 
     if not data.url:
         if data.distro == "fedora":
-            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os"
+            data.url = "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Everything/x86_64/os"
         elif data.distro == "centos7":
             data.url = "http://mirror.centos.org/centos/7/os/x86_64"
         elif data.distro == "centos8":

--- a/tests/unit/bash/bash_os_linux_conditional.bats.jinja
+++ b/tests/unit/bash/bash_os_linux_conditional.bats.jinja
@@ -39,7 +39,7 @@ EOF
     {{{ bash_os_linux_conditional("rhel", "10", "<", "$os_release_path") }}}
     {{{ bash_os_linux_conditional("rhel", "10.2", "<", "$os_release_path") }}}
 
-    ! ( {{{ bash_os_linux_conditional("fedora", "36", "==", "$os_release_path") }}} )
+    ! ( {{{ bash_os_linux_conditional("fedora", "38", "==", "$os_release_path") }}} )
     ! ( {{{ bash_os_linux_conditional("fedora", "9.2", "==", "$os_release_path") }}} )
     ! ( {{{ bash_os_linux_conditional("fedora", "9.4", "<", "$os_release_path") }}} )
 
@@ -80,7 +80,7 @@ EOF
     ! ( {{{ bash_os_linux_conditional("ubuntu", "20.10", "<", "$os_release_path") }}} )
     ! ( {{{ bash_os_linux_conditional("ubuntu", "22.10", ">", "$os_release_path") }}} )
 
-    ! ( {{{ bash_os_linux_conditional("fedora", "36", "==", "$os_release_path") }}} )
+    ! ( {{{ bash_os_linux_conditional("fedora", "38", "==", "$os_release_path") }}} )
     ! ( {{{ bash_os_linux_conditional("fedora", "22.10", "<", "$os_release_path") }}} )
 
     rm -rf "$os_release_path"

--- a/tests/unit/ssg-module/test_playbook_builder_data/product.yml
+++ b/tests/unit/ssg-module/test_playbook_builder_data/product.yml
@@ -11,18 +11,33 @@ pkg_manager: "dnf"
 init_system: "systemd"
 
 # The fingerprints below are retrieved from https://getfedora.org/keys/
-latest_version: 36
-latest_release_fingerprint: "53DED2CB922D8B8D9E63FD18999F7CBF38AB71F4"
-latest_pkg_version: "38ab71f4"
-latest_pkg_release: "60242b08"
+latest_version: 38
+latest_release_fingerprint: "6A51BBABBA3D5467B6171221809A8D7CEB10B464"
+latest_pkg_version: "eb10b464"
+latest_pkg_release: "6202d9c6"
 
-previous_version: 35
-previous_release_fingerprint: "787EA6AE1147EEE56C40B30CDB4639719867C58F"
-previous_pkg_version: "9867c58f"
-previous_pkg_release: "601c49ca"
+previous_version: 37
+previous_release_fingerprint: "ACB5EE4E831C74BB7C168D27F55AD3FB5323552A"
+previous_pkg_version: "5323552a"
+previous_pkg_release: "6112bcdc"
 
 cpes_root: "./applicability"
 cpes:
+  - fedora_40:
+      name: "cpe:/o:fedoraproject:fedora:40"
+      title: "Fedora 40"
+      check_id: installed_OS_is_fedora
+
+  - fedora_39:
+      name: "cpe:/o:fedoraproject:fedora:39"
+      title: "Fedora 39"
+      check_id: installed_OS_is_fedora
+
+  - fedora_38:
+      name: "cpe:/o:fedoraproject:fedora:38"
+      title: "Fedora 38"
+      check_id: installed_OS_is_fedora
+
   - fedora_37:
       name: "cpe:/o:fedoraproject:fedora:37"
       title: "Fedora 37"
@@ -31,9 +46,4 @@ cpes:
   - fedora_36:
       name: "cpe:/o:fedoraproject:fedora:36"
       title: "Fedora 36"
-      check_id: installed_OS_is_fedora
-
-  - fedora_35:
-      name: "cpe:/o:fedoraproject:fedora:35"
-      title: "Fedora 35"
       check_id: installed_OS_is_fedora


### PR DESCRIPTION
#### Description:

Fedora 38 released.

#### Rationale:

Keep up with Fedora release cycle.

#### Review Hints:

Note build changes. Tried to recheck hexes.

F36 EOL should be implemented after 2023-05-16.