### PR TITLE
bugfix: mount_option: handle commented lines

### DIFF
--- a/shared/templates/mount_option/oval.template
+++ b/shared/templates/mount_option/oval.template
@@ -38,7 +38,7 @@
   <ind:textfilecontent54_object version="1"
     id="object_{{{ local_id }}}_in_fstab">
     <ind:filepath>/etc/fstab</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*[\S]+[\s]+{{{ POINTREGEX }}}[\s]+[\S]+[\s]+([\S]+)</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*(?!#)[\S]+[\s]+{{{ POINTREGEX }}}[\s]+[\S]+[\s]+([\S]+)</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/shared/templates/mount_option/tests/fstab_comment.pass.sh
+++ b/shared/templates/mount_option/tests/fstab_comment.pass.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# platform = multi_platform_all
+. $SHARED/partition.sh
+
+clean_up_partition {{{ MOUNTPOINT }}}
+
+create_partition
+
+make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 defaults
+# comment last line added above to be ignored
+sed -Ei '${s/^/#/}' /etc/fstab
+
+make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 {{{ MOUNTOPTION }}}
+
+mount_partition {{{ MOUNTPOINT }}} || true


### PR DESCRIPTION
#### Description:

From fstab(5):
...
       Each filesystem is described on a separate line. Fields on each
       line are separated by tabs or spaces. Lines starting with '#' are
       comments. Blank lines are ignored.
...

Line like:
```
  # /var needs dev
```
should be ignored.

Add test for this issue.

#### Rationale:

It is feasible `/etc/fstab` contains commented out lines. It is not good if rules confuse commented out lines as real.

#### Review Hints:

There is a new test.