### PR TITLE
Fix in service_autofs_disabled - ansible

### DIFF
--- a/shared/templates/service_disabled/ansible.template
+++ b/shared/templates/service_disabled/ansible.template
@@ -19,7 +19,7 @@
           meta: noop
 
 - name: "Unit Socket Exists - {{{ DAEMONNAME }}}.socket"
-  command: systemctl list-unit-files {{{ DAEMONNAME }}}.socket
+  command: systemctl -q list-unit-files {{{ DAEMONNAME }}}.socket | grep "{{{ DAEMONNAME }}}.socket"
   register: socket_file_exists
   changed_when: False
   failed_when: socket_file_exists.rc not in [0, 1]
@@ -31,7 +31,7 @@
     enabled: "no"
     state: "stopped"
     masked: "yes"
-  when: '"{{{ DAEMONNAME }}}.socket" in socket_file_exists.stdout_lines[1]'
+  when: 'socket_file_exists.stdout_lines is search("{{{ DAEMONNAME }}}.socket")' 
 {{%- else %}}
 JINJA TEMPLATE ERROR: Unknown init system '{{{ init_system }}}'
 {{%- endif %}}


### PR DESCRIPTION
#### Description:

- _Fix of ansible remediation of the rule service_autofs_disabled_

#### Rationale:

I.
The rule uses template service_disabled. There are 2 issues with the current version of this template. 1/The command systemctl in the code block Unit Socket Exists  - (i.e. systemctl list-unit-files {{{ DAEMONNAME }}}.socket ) returns more than 1 row - example:    UNIT FILE STATE VENDOR PRESET followed by the result.  2/ The code block Disable socket {{{ SERVICENAME }}} raises error when the socket_file_exists.stdout_lines is empty 
  
II.
The template is used by other rules