### PR TITLE
OCP4 NIST: Fix typo in rule selection

### DIFF
--- a/controls/nist_rhcos4.yml
+++ b/controls/nist_rhcos4.yml
@@ -6957,7 +6957,7 @@ controls:
   rules:
   - package_usbguard_installed
   - service_usbguard_enabled
-  - configure_usbguard_audit_backend
+  - configure_usbguard_auditbackend
   - usbguard_allow_hid_and_hub
   description: |-
     The information system uniquely identifies and authenticates [Assignment: organization- defined specific and/or types of devices] before establishing a [Selection (one or more): local; remote; network] connection.


### PR DESCRIPTION
#### Description:

- The rule name ends with `auditbackend` not `audit_backend`

#### Rationale:

- Let's select the right rule

#### Review Hints:

- Just confirm the rule name is correct
