### PR TITLE
Shell quote support for Jinja macros

### DIFF
--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -1097,6 +1097,13 @@ ComplianceAsCode support all built-in Jinja
 There are also some custom filters useful for content authoring defined
 in the project:
 
+banner_anchor_wrap
+-   Wrap banner text as regex, no quoting.
+
+banner_regexify
+-   Wrap banner text in such way that space (' ') is replaced with
+    `[\\s\\n]` and newline ('\n') with `(?:[\\n]+|(?:\\\\n)+)`.
+
 escape_id
 -   Replaces all non-word (regex **\\W**) characters with underscore.
     Useful for sanitizing ID strings as it is compatible with OVAL IDs
@@ -1106,3 +1113,13 @@ escape_regex
 -   Escapes characters in the string for it to be usable as a part of
     some regular expression, behaves similar to the Python 3’s
     [**re.escape**](https://docs.python.org/3/library/re.html#re.escape).
+
+escape_yaml_key
+-   Escape uppercase letters and `^` with additional `^` and convert letters
+    to lovercase. This is because of OVAL's name argument limitations.
+
+quote
+-   Escape string to be used as POSIX shell value. Like Ansible `quote`.
+
+sha256
+-   Get SHA-256 hexdigest of value.

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -89,7 +89,7 @@
 -   Languages: Ansible, Bash, OVAL, Kubernetes
 
 #### audit_rules_syscall_events
--   Ensure there is an audit rule to record for all uses of 
+-   Ensure there is an audit rule to record for all uses of
     specified system call
 
 -   Parameters:
@@ -644,11 +644,11 @@ When the remediation is applied duplicate occurrences of `key` are removed.
            argument needs to be added or modified.
         -  **new_argument** - (optional) the argument to be added if not
            already present, eg, `dcredit=-1`. It is required when the argument
-           is not already present and needs to be added. 
+           is not already present and needs to be added.
         -  **remove_argument** - (optional) the argument will be
            removed, if the argument is present. This parameter must not be
            specified when the argument is being added or modified.
-       
+
 -    Language: Ansible, OVAL
 
 #### sebool
@@ -936,7 +936,7 @@ The selected value can be changed in the profile (consult the actual variable fo
 
     -   **embedded_data** - if set to `"true"` and used combined with `xccdf_variable`, the data retrieved by `yamlpath`
         is considered as a blob and the field `value` has to contain a capture regex.
-   
+
     -   **regex_data** - if set to `"true"` and combined with `xccdf_variable`, it will use the value of `xccdf_variable` as a regex
         and does pattern match operation instead of equal operation.
 
@@ -1044,7 +1044,7 @@ where *LANG* should be the language  identifier in lower case, e.g.
 3) Create a file called `template.yml` within the template directory. This file
 stores template metadata. Currently, it stores list of supported languages. Note
 that each language listed in this file must have associated implementation
-file with the *.template* extension, see above. 
+file with the *.template* extension, see above.
 
     An example can look like this:
 

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -9,6 +9,10 @@ try:
 except ImportError:
     from urllib import quote
 
+try:
+    from shlex import quote as shell_quote
+except ImportError:
+    from pipes import quote as shell_quote
 
 from .constants import JINJA_MACROS_DIRECTORY
 from .utils import (required_key,
@@ -91,6 +95,7 @@ def _get_jinja_environment(substitutions_dict):
         _get_jinja_environment.env.filters['escape_id'] = escape_id
         _get_jinja_environment.env.filters['escape_regex'] = escape_regex
         _get_jinja_environment.env.filters['escape_yaml_key'] = escape_yaml_key
+        _get_jinja_environment.env.filters['quote'] = shell_quote
         _get_jinja_environment.env.filters['sha256'] = sha256
 
     return _get_jinja_environment.env

--- a/ssg/jinja.py
+++ b/ssg/jinja.py
@@ -86,10 +86,10 @@ def _get_jinja_environment(substitutions_dict):
             loader=AbsolutePathFileSystemLoader(),
             bytecode_cache=bytecode_cache
         )
-        _get_jinja_environment.env.filters['banner_regexify'] = banner_regexify
         _get_jinja_environment.env.filters['banner_anchor_wrap'] = banner_anchor_wrap
-        _get_jinja_environment.env.filters['escape_regex'] = escape_regex
+        _get_jinja_environment.env.filters['banner_regexify'] = banner_regexify
         _get_jinja_environment.env.filters['escape_id'] = escape_id
+        _get_jinja_environment.env.filters['escape_regex'] = escape_regex
         _get_jinja_environment.env.filters['escape_yaml_key'] = escape_yaml_key
         _get_jinja_environment.env.filters['sha256'] = sha256
 


### PR DESCRIPTION
#### Description:

Quote a string to safely use as in a POSIX shell.

Handling quoting shell is quite hard when there is complex macro
workflow. This filter allows to quote where ever variable is used.

Name mirrors respective feature in ansible.

I also sorted jinja filters alphabetically for them to be neat.

#### Rationale:

When ever I look at bash remediations, there is multiple ways things can go sideways if variables contain shell metacharacters. There is sometimes extra checks.

If this feature is used, it provides clear security benefit.

#### Review Hints:

For now there is no test suite or any template that uses this.