### PR TITLE
make scap-security-guide.spec support RHEL too

### DIFF
--- a/scap-security-guide.spec
+++ b/scap-security-guide.spec
@@ -4,6 +4,14 @@
 %global _vpath_builddir build
 %global _default_patch_fuzz 2
 
+%if 0%{?rhel}
+%global _rhel_like %{rhel}
+%else
+%if 0%{?centos}
+%global _rhel_like %{centos}
+%endif
+%endif
+
 Name:		scap-security-guide
 # Version placeholder. Copr build version is determined by utils/version.sh. See .packit.yaml config
 Version:	0.0.1
@@ -14,7 +22,7 @@ URL:		https://github.com/ComplianceAsCode/content/
 Source0:	https://github.com/ComplianceAsCode/content/releases/download/v%{version}/scap-security-guide-%{version}.tar.bz2
 BuildArch:	noarch
 
-%if 0%{?centos} == 7
+%if 0%{?_rhel_like} == 7
 BuildRequires:  libxslt, openscap-scanner >= 1.2.5, cmake >= 2.8, python, python-jinja2, PyYAML, python-setuptools
 %else
 BuildRequires:  libxslt, openscap-scanner >= 1.2.5, cmake >= 2.8, /usr/bin/python3, python%{python3_pkgversion}, python%{python3_pkgversion}-jinja2, python%{python3_pkgversion}-PyYAML, python%{python3_pkgversion}-setuptools
@@ -49,8 +57,8 @@ present in %{name} package.
 %define cmake_defines_specific %{nil}
 %define centos_8_specific %{nil}
 
-%if 0%{?centos}
-%define cmake_defines_specific -DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE -DSSG_PRODUCT_RHEL%{centos}:BOOLEAN=TRUE -DSSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED:BOOL=OFF -DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=ON
+%if 0%{?_rhel_like}
+%define cmake_defines_specific -DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE -DSSG_PRODUCT_RHEL%{_rhel_like}:BOOLEAN=TRUE -DSSG_SCIENTIFIC_LINUX_DERIVATIVES_ENABLED:BOOL=OFF -DSSG_CENTOS_DERIVATIVES_ENABLED:BOOL=ON
 %endif
 %if 0%{?fedora}
 %define cmake_defines_specific -DSSG_PRODUCT_DEFAULT:BOOLEAN=FALSE -DSSG_PRODUCT_FEDORA:BOOLEAN=TRUE
@@ -58,24 +66,24 @@ present in %{name} package.
 
 mkdir -p build
 %build
-%if 0%{?centos} == 7 || 0%{?centos} == 8
+%if 0%{?_rhel_like} == 7 || 0%{?_rhel_like} == 8
 cd build
 %cmake %{cmake_defines_common} %{cmake_defines_specific} ../
 %else
 %cmake %{cmake_defines_common} %{cmake_defines_specific}
 %endif
 
-%if 0%{?centos} == 7
+%if 0%{?_rhel_like} == 7
 make %{?_smp_mflags}
 %else
 %cmake_build
 %endif
 
 %install
-%if 0%{?centos} == 7 || 0%{?centos} == 8
+%if 0%{?_rhel_like} == 7 || 0%{?_rhel_like} == 8
 cd build
 %endif
-%if 0%{?centos} == 7
+%if 0%{?_rhel_like} == 7
 %make_install
 %else
 %cmake_install
@@ -86,7 +94,7 @@ rm %{buildroot}/%{_docdir}/%{name}/Contributors.md
 %files
 %{_datadir}/xml/scap/ssg/content
 # No kickstarts for Fedora
-%if 0%{?centos}
+%if 0%{?_rhel_like}
 %{_datadir}/%{name}/kickstart
 %endif
 %{_datadir}/%{name}/ansible/*.yml
@@ -96,6 +104,6 @@ rm %{buildroot}/%{_docdir}/%{name}/Contributors.md
 %files doc
 %doc %{_docdir}/%{name}/guides/*.html
 # No tables for Fedora
-%if 0%{?centos}
+%if 0%{?_rhel_like}
 %doc %{_docdir}/%{name}/tables/*.html
 %endif


### PR DESCRIPTION
#### Description:

- Allow the `scap-security-guide.spec` to be used by Packit for RHEL builds (ie. in COPR)

#### Rationale:

- I'd like to have fresh builds of upstream content on https://copr.fedorainfracloud.org/coprs/jjaburek/ssg-nightly/ (the name is a misnomer, see the description, but I can't rename it), and have them build for RHEL and CentOS Stream. This currently fails because the spec file accounts only for CentOS and `%files` leaves kickstarts/guides unpackaged.