### PR TITLE
Introduce a Product class, make the project work with it

### DIFF
--- a/build-scripts/build_xccdf.py
+++ b/build-scripts/build_xccdf.py
@@ -11,6 +11,7 @@ import ssg.utils
 import ssg.environment
 import ssg.id_translate
 import ssg.build_renumber
+import ssg.products
 
 
 def parse_args():
@@ -53,7 +54,8 @@ def main():
 
     env_yaml = ssg.environment.open_environment(
         args.build_config_yaml, args.product_yaml)
-    base_dir = os.path.dirname(args.product_yaml)
+    product_yaml = ssg.products.Product(args.product_yaml)
+    base_dir = product_yaml["product_dir"]
     benchmark_root = ssg.utils.required_key(env_yaml, "benchmark_root")
 
     # we have to "absolutize" the paths the right way, relative to the

--- a/build-scripts/compile_all.py
+++ b/build-scripts/compile_all.py
@@ -56,7 +56,7 @@ def get_env_yaml(build_config_yaml, product_yaml):
 
 def get_all_content_directories(env_yaml, product_yaml):
     relative_benchmark_root = ssg.utils.required_key(env_yaml, "benchmark_root")
-    benchmark_root = os.path.join(os.path.dirname(product_yaml), relative_benchmark_root)
+    benchmark_root = os.path.join(product_yaml["product_dir"], relative_benchmark_root)
 
     add_content_dirs = get_additional_content_directories(env_yaml)
     return [benchmark_root] + add_content_dirs
@@ -119,6 +119,9 @@ def main():
     args = parser.parse_args()
 
     env_yaml = get_env_yaml(args.build_config_yaml, args.product_yaml)
+    product_yaml = None
+    if args.product_yaml:
+        product_yaml = ssg.products.Product(args.product_yaml)
     product_cpes = ProductCPEs()
     product_cpes.load_product_cpes(env_yaml)
     product_cpes.load_content_cpes(env_yaml)
@@ -132,9 +135,9 @@ def main():
 
     loader = ssg.build_yaml.BuildLoader(
         None, env_yaml, product_cpes, args.sce_metadata, args.stig_references)
-    load_benchmark_source_data_from_directory_tree(loader, env_yaml, args.product_yaml)
+    load_benchmark_source_data_from_directory_tree(loader, env_yaml, product_yaml)
 
-    profiles_by_id = get_all_resolved_profiles_by_id(env_yaml, args.product_yaml, loader, product_cpes, args.controls_dir)
+    profiles_by_id = get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, args.controls_dir)
 
     save_everything(args.resolved_base, loader, profiles_by_id.values())
 

--- a/build-scripts/compile_all.py
+++ b/build-scripts/compile_all.py
@@ -119,9 +119,7 @@ def main():
     args = parser.parse_args()
 
     env_yaml = get_env_yaml(args.build_config_yaml, args.product_yaml)
-    product_yaml = None
-    if args.product_yaml:
-        product_yaml = ssg.products.Product(args.product_yaml)
+    product_yaml = ssg.products.Product(args.product_yaml)
     product_cpes = ProductCPEs()
     product_cpes.load_product_cpes(env_yaml)
     product_cpes.load_content_cpes(env_yaml)

--- a/build-scripts/compile_product.py
+++ b/build-scripts/compile_product.py
@@ -1,0 +1,30 @@
+import argparse
+
+import ssg.products
+
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--product-yaml", required=True,
+        help="YAML file with information about the product we are building. "
+        "e.g.: ~/scap-security-guide/products/rhel7/product.yml "
+        "needed for autodetection of profile root"
+    )
+    parser.add_argument(
+        "--compiled-product-yaml", required=True,
+        help="Where to save the compiled product yaml."
+    )
+    return parser
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+
+    product = ssg.products.Product(args.product_yaml)
+    product.write(args.compiled_product_yaml)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -319,6 +319,7 @@ macro(ssg_build_sce PRODUCT)
             OUTPUT "${BUILD_CHECKS_DIR}/sce/metadata.json"
             COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/build_sce.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml" --templates-dir "${SSG_SHARED}/templates" --output "${BUILD_CHECKS_DIR}/sce" ${SCE_COMBINE_PATHS}
             COMMENT "[${PRODUCT}-content] generating sce/metadata.json"
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
         )
     else()
         # Here we fake generating SCE metadata by creating an empty file.
@@ -329,12 +330,12 @@ macro(ssg_build_sce PRODUCT)
             COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILD_CHECKS_DIR}/sce"
             COMMAND ${CMAKE_COMMAND} -E touch "${BUILD_CHECKS_DIR}/sce/metadata.json"
             COMMENT "[${PRODUCT}-content] generating sce/metadata.json"
+            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
         )
     endif()
     add_custom_target(
         generate-internal-${PRODUCT}-sce-metadata.json
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/checks/sce/metadata.json"
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
     )
 endmacro()
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -89,7 +89,7 @@ macro(ssg_build_man_page)
     )
 endmacro()
 
-macro(ssg_build_xccdf_oval_ocil PRODUCT)
+macro(ssg_build_compiled_artifacts PRODUCT)
     file(GLOB STIG_REFERENCE_FILE_LIST "${SSG_SHARED_REFS}/disa-stig-${PRODUCT}-*-xccdf-manual.xml")
     list(APPEND STIG_REFERENCE_FILE_LIST "not-found")
     list(GET STIG_REFERENCE_FILE_LIST 0 STIG_REFERENCE_FILE)
@@ -123,7 +123,9 @@ macro(ssg_build_xccdf_oval_ocil PRODUCT)
         ${PRODUCT}-compile-all
         DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/profiles"
     )
+endmacro()
 
+macro(ssg_build_xccdf_oval_ocil PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-xccdf.xml"
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ssg-${PRODUCT}-oval.xml"
@@ -330,7 +332,6 @@ macro(ssg_build_sce PRODUCT)
             COMMAND ${CMAKE_COMMAND} -E make_directory "${BUILD_CHECKS_DIR}/sce"
             COMMAND ${CMAKE_COMMAND} -E touch "${BUILD_CHECKS_DIR}/sce/metadata.json"
             COMMENT "[${PRODUCT}-content] generating sce/metadata.json"
-            DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
         )
     endif()
     add_custom_target(
@@ -697,6 +698,7 @@ macro(ssg_build_product PRODUCT)
         set(PRODUCT_${_LANGUAGE}_REMEDIATION_ENABLED TRUE)
     endforeach()
 
+    ssg_build_compiled_artifacts(${PRODUCT})
     ssg_build_sce(${PRODUCT})
     ssg_build_xccdf_oval_ocil(${PRODUCT})
     ssg_make_all_tables(${PRODUCT})

--- a/ssg/build_ovals.py
+++ b/ssg/build_ovals.py
@@ -17,7 +17,7 @@ from .id_translate import IDTranslator
 from .jinja import process_file_with_macros
 from .rule_yaml import parse_prodtype
 from .rules import get_rule_dir_id, get_rule_dir_ovals, find_rule_dirs_in_paths
-from . import utils
+from . import utils, products
 from .utils import mkdir_p
 from .xml import ElementTree, oval_generated_header
 
@@ -300,7 +300,7 @@ class OVALBuilder:
             self, env_yaml, product_yaml_path, shared_directories,
             build_ovals_dir):
         self.env_yaml = env_yaml
-        self.product_yaml_path = product_yaml_path
+        self.product_yaml = products.Product(product_yaml_path)
         self.shared_directories = shared_directories
         self.build_ovals_dir = build_ovals_dir
         self.already_loaded = dict()
@@ -319,7 +319,7 @@ class OVALBuilder:
         return document_body
 
     def _get_checks_from_benchmark(self):
-        product_dir = os.path.dirname(self.product_yaml_path)
+        product_dir = self.product_yaml["product_dir"]
         relative_guide_dir = utils.required_key(self.env_yaml, "benchmark_root")
         guide_dir = os.path.abspath(
             os.path.join(product_dir, relative_guide_dir))

--- a/ssg/build_sce.py
+++ b/ssg/build_sce.py
@@ -14,7 +14,7 @@ from .constants import (
 from .jinja import process_file_with_macros
 from .rule_yaml import parse_prodtype
 from .rules import get_rule_dir_id, get_rule_dir_sces, find_rule_dirs_in_paths
-from . import utils
+from . import utils, products
 
 
 def load_sce_and_metadata(file_path, local_env_yaml):
@@ -111,7 +111,8 @@ def checks(env_yaml, yaml_path, sce_dirs, template_builder, output):
 
     # We maintain the same search structure as build_ovals.py even though we
     # don't currently have any content under shared/checks/sce.
-    product_dir = os.path.dirname(yaml_path)
+    product_yaml = products.Product(yaml_path)
+    product_dir = product_yaml["product_dir"]
     relative_guide_dir = utils.required_key(env_yaml, "benchmark_root")
     guide_dir = os.path.abspath(os.path.join(product_dir, relative_guide_dir))
     additional_content_directories = env_yaml.get("additional_content_directories", [])

--- a/ssg/playbook_builder.py
+++ b/ssg/playbook_builder.py
@@ -13,6 +13,7 @@ import ssg.yaml
 import ssg.build_yaml
 import ssg.build_remediations
 import ssg.environment
+import ssg.products
 
 COMMENTS_TO_PARSE = ["strategy", "complexity", "disruption"]
 
@@ -25,8 +26,8 @@ class PlaybookBuilder():
         self.rules_dir = rules_dir
         self.build_config_yaml = build_config_yaml
         self.product_yaml_path = product_yaml_path
-        product_yaml = ssg.yaml.open_raw(product_yaml_path)
-        product_dir = os.path.dirname(product_yaml_path)
+        product_yaml = ssg.products.Product(product_yaml_path)
+        product_dir = product_yaml["product_dir"]
         relative_guide_dir = ssg.utils.required_key(product_yaml,
                                                     "benchmark_root")
         self.guide_dir = os.path.abspath(os.path.join(product_dir,

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -132,6 +132,9 @@ class Product(object):
     def __len__(self):
         return len(self.primary_data)
 
+    def get(self, key, default=None):
+        return self.primary_data.get(key, default)
+
     def _load_from_filename(self, filename):
         self.primary_data = open_raw(filename)
 
@@ -201,7 +204,7 @@ def get_profile_files_from_root(env_yaml, product_yaml):
     profile_files = []
     if env_yaml:
         profiles_root = get_profiles_directory(env_yaml)
-        base_dir = os.path.dirname(product_yaml)
+        base_dir = product_yaml["product_dir"]
         profile_files = sorted(glob("{base_dir}/{profiles_root}/*.profile"
                                .format(profiles_root=profiles_root, base_dir=base_dir)))
     return profile_files

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -26,7 +26,7 @@ from .constants import (DEFAULT_PRODUCT, product_directories,
                         XCCDF_PLATFORM_TO_PACKAGE,
                         SSG_REF_URIS)
 from .utils import merge_dicts, required_key
-from .yaml import open_raw
+from .yaml import open_raw, ordered_dump
 
 
 def _validate_product_oval_feed_url(contents):
@@ -109,29 +109,58 @@ def product_yaml_path(ssg_root, product):
     return os.path.join(ssg_root, "products", product, "product.yml")
 
 
+class Product(object):
+    def __init__(self, filename):
+        self.primary_data = dict()
+        self._load_from_filename(filename)
+        if "basic_properties_derived" not in self.primary_data:
+            self._derive_basic_properties(filename)
+
+    def write(self, filename):
+        with open(filename, "w") as f:
+            ordered_dump(self.primary_data, f)
+
+    def __getitem__(self, key):
+        return self.primary_data[key]
+
+    def __contains__(self, key):
+        return key in self.primary_data
+
+    def __iter__(self):
+        return iter(self.primary_data.items())
+
+    def __len__(self):
+        return len(self.primary_data)
+
+    def _load_from_filename(self, filename):
+        self.primary_data = open_raw(filename)
+
+    def _derive_basic_properties(self, filename):
+        _validate_product_oval_feed_url(self.primary_data)
+
+        # The product directory is necessary to get absolute paths to benchmark, profile and
+        # cpe directories, which are all relative to the product directory
+        self.primary_data["product_dir"] = os.path.dirname(filename)
+
+        platform_package_overrides = self.primary_data.get("platform_package_overrides", {})
+        # Merge common platform package mappings, while keeping product specific mappings
+        self.primary_data["platform_package_overrides"] = merge_dicts(
+                XCCDF_PLATFORM_TO_PACKAGE, platform_package_overrides)
+        self.primary_data.update(_get_implied_properties(self.primary_data))
+
+        reference_uris = self.primary_data.get("reference_uris", {})
+        self.primary_data["reference_uris"] = merge_dicts(SSG_REF_URIS, reference_uris)
+
+        self.primary_data["basic_properties_derived"] = True
+
+
 def load_product_yaml(product_yaml_path):
     """
     Reads a product data from disk and returns it.
     The returned product dictionary also contains derived useful information.
     """
 
-    product_yaml = open_raw(product_yaml_path)
-    _validate_product_oval_feed_url(product_yaml)
-
-    # The product directory is necessary to get absolute paths to benchmark, profile and
-    # cpe directories, which are all relative to the product directory
-    product_yaml["product_dir"] = os.path.dirname(product_yaml_path)
-
-    platform_package_overrides = product_yaml.get("platform_package_overrides", {})
-    # Merge common platform package mappings, while keeping product specific mappings
-    product_yaml["platform_package_overrides"] = merge_dicts(XCCDF_PLATFORM_TO_PACKAGE,
-                                                             platform_package_overrides)
-    product_yaml.update(_get_implied_properties(product_yaml))
-
-    reference_uris = product_yaml.get("reference_uris", {})
-    product_yaml["reference_uris"] = merge_dicts(SSG_REF_URIS,
-                                                 reference_uris)
-
+    product_yaml = Product(product_yaml_path)
     return product_yaml
 
 
@@ -146,8 +175,8 @@ def get_all(ssg_root):
     other_products = set()
 
     for product in product_directories:
-        product_yaml_path = os.path.join(ssg_root, "products", product, "product.yml")
-        product_yaml = load_product_yaml(product_yaml_path)
+        path = product_yaml_path(ssg_root, product)
+        product_yaml = load_product_yaml(path)
 
         guide_dir = os.path.join(product_yaml["product_dir"], product_yaml['benchmark_root'])
         guide_dir = os.path.abspath(guide_dir)

--- a/tests/unit/ssg-module/test_products.py
+++ b/tests/unit/ssg-module/test_products.py
@@ -41,9 +41,18 @@ def test_product_yaml(testing_product_yaml_path):
     assert copied_product["pkg_system"] == "rpm"
 
 
-def test_product_yaml_write(testing_product_yaml_path, tmp_path):
+@pytest.fixture
+def product_filename_py2(tmpdir):
+    return str(tmpdir.join("tmp_product.yml"))
+
+
+@pytest.fixture
+def product_filename_py3(tmp_path):
+    return tmp_path / "tmp_product.yml"
+
+
+def test_product_yaml_write(testing_product_yaml_path, product_filename_py2):
     product = ssg.products.Product(testing_product_yaml_path)
-    filename = tmp_path / "tmp_product.yml"
-    product.write(filename)
-    second_product = ssg.products.Product(filename)
+    product.write(product_filename_py2)
+    second_product = ssg.products.Product(product_filename_py2)
     assert product["product_dir"] == second_product["product_dir"]

--- a/tests/unit/ssg-module/test_products.py
+++ b/tests/unit/ssg-module/test_products.py
@@ -5,8 +5,17 @@ import pytest
 import ssg.products
 
 
-def test_get_all():
-    ssg_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+@pytest.fixture
+def ssg_root():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+
+
+@pytest.fixture
+def testing_product_yaml_path():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "product.yml"))
+
+
+def test_get_all(ssg_root):
     products = ssg.products.get_all(ssg_root)
 
     assert "fedora" in products.linux
@@ -17,3 +26,23 @@ def test_get_all():
 
     assert "firefox" in products.other
     assert "firefox" not in products.linux
+
+
+def test_product_yaml_load(testing_product_yaml_path):
+    product = ssg.products.Product(testing_product_yaml_path)
+    assert "product" in product
+    assert product["product"] == "rhel7"
+    assert product["pkg_system"] == "rpm"
+    assert product["product_dir"].endswith("data")
+
+    copied_product = dict()
+    copied_product.update(product)
+    assert copied_product["pkg_system"] == "rpm"
+
+
+def test_product_yaml_write(testing_product_yaml_path, tmp_path):
+    product = ssg.products.Product(testing_product_yaml_path)
+    filename = tmp_path / "tmp_product.yml"
+    product.write(filename)
+    second_product = ssg.products.Product(filename)
+    assert product["product_dir"] == second_product["product_dir"]

--- a/tests/unit/ssg-module/test_products.py
+++ b/tests/unit/ssg-module/test_products.py
@@ -28,12 +28,13 @@ def test_get_all(ssg_root):
     assert "firefox" not in products.linux
 
 
-def test_product_yaml_load(testing_product_yaml_path):
+def test_product_yaml(testing_product_yaml_path):
     product = ssg.products.Product(testing_product_yaml_path)
     assert "product" in product
     assert product["product"] == "rhel7"
     assert product["pkg_system"] == "rpm"
     assert product["product_dir"].endswith("data")
+    assert product.get("X", "x") == "x"
 
     copied_product = dict()
     copied_product.update(product)

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -151,12 +151,11 @@ def find_rules_generator(args, func):
         product = rule_obj['products'][0]
 
         if product not in product_yamls:
-            product_path = os.path.join(args.root, "products", product, 'product.yml')
+            product_path = ssg.products.product_yaml_path(args.root, product)
             product_yaml = ssg.products.load_product_yaml(product_path)
-            product_yaml['cmake_build_type'] = 'Debug'
             product_yamls[product] = product_yaml
 
-        local_env_yaml = dict()
+        local_env_yaml = dict(cmake_build_type='Debug')
         local_env_yaml.update(product_yamls[product])
         local_env_yaml['rule_id'] = rule_id
 

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -109,8 +109,9 @@ def main():
         raise ValueError(msg)
 
     product_base = os.path.join(SSG_ROOT, "products", args.product)
-    product_yaml = os.path.join(product_base, "product.yml")
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
+    product_yaml_path = os.path.join(product_base, "product.yml")
+    product_yaml = ssg.products.Product(product_yaml_path)
+    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml_path)
 
     controls_manager = None
     if os.path.exists(args.controls):

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -93,9 +93,10 @@ def handle_rule_yaml(product_list, product_yamls, rule_id, rule_dir, guide_dir):
     rule_file = ssg.rules.get_rule_dir_yaml(rule_dir)
 
     prod_type = product_list[0]
-    product_yaml = product_yamls[prod_type]
+    env_yaml = dict()
+    env_yaml.update(product_yamls[prod_type])
 
-    rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, product_yaml)
+    rule_yaml = ssg.build_yaml.Rule.from_yaml(rule_file, env_yaml)
     rule_products = set()
     for product in product_list:
         if ssg.utils.is_applicable(rule_yaml.prodtype, product):
@@ -155,8 +156,10 @@ def handle_remediations(product_list, product_yamls, rule_obj):
                 prod_type = r_product
             product_yaml = product_yamls[prod_type]
 
+            env_yaml = dict()
+            env_yaml.update(product_yaml)
             _, config = ssg.build_remediations.parse_from_file_with_jinja(
-                r_path, product_yaml
+                r_path, env_yaml
             )
             platforms = config['platform']
             if not platforms:


### PR DESCRIPTION
#### Description:

The project uses the concept of "product yaml" data - essentially product properties s.a. name, package manager and so on. Up until now, the format was a simple dictionary, which was enough to hold the data and to expose them later, but as products can have a lot of properties that can be

1. shared between products, and that are
2. fully known only at runtime, e.g. because they depend on a package version,

a smarter approach is needed.
See https://complianceascode.github.io/template/2023/04/25/mrac.html#go-declarative for context - the aim is to be able to define and use product properties to be able to write e.g. `{{% if product.prefers_single_file_sshd_configuration %}}` instead of `{{% if product in ("rhel8", "rhel9", "ol8", ...) %}}`.


#### Rationale:

A new class Product has been introduced, and it mimics a dictionary for the time being.
If this gets accepted, the next goal would be to introduce files that are read during the build process that allow to specify m:n product-property relationship.
As of now, this mapping is partially present in [ssg/constants.py](https://github.com/ComplianceAsCode/content/blob/master/ssg/constants.py), and I am sure you will agree that source code is no place for defining what should be the default `grub2` path, and so on.


#### Review Hints:

- Check out tests for an idea of what regressions are ruled out.
- Majority of the changes were around determination of product directory - from examining the yaml path to opening the file and looking into the data.
- That code should either receive the product directory directly as an argument, or it should indeed read the yaml - examining the filename is the worst possible combination.
- The aim of this PR is to make changes under the hood without introducing regressions.