### PR TITLE
fix: Fix misspelled word infrastruture

### DIFF
--- a/controls/nist_satellite6.yml
+++ b/controls/nist_satellite6.yml
@@ -2486,7 +2486,7 @@ controls:
     the process by wich this determination is made. Once processing
     capacity is reserved in an alternate region for this critical
     functionality, the remainder of the control may be inherited
-    from your infrastruture provider.
+    from your infrastructure provider.
   rules: []
   description: |-
     The organization identifies critical information system assets supporting essential missions and business functions.
@@ -4437,7 +4437,7 @@ controls:
   status: pending
   notes: |-
     Section a: The customer will be responsible for conducting a risk assessment,
-    including a review of controls inherited from infrastruture providers,
+    including a review of controls inherited from infrastructure providers,
     and for those which the customer is responsible. A successful control
     response will need to address the assessment methodology and calculation
     of the likelihood and magnitude of harm that could result from

--- a/controls/nist_satellite6.yml
+++ b/controls/nist_satellite6.yml
@@ -81,7 +81,7 @@ controls:
     Examples of account types include individual, shared, group, system,
     guest/anonymous, emergency, developer/manufacturer/vendor, temporary,
     and service. A successful control response will need to address the
-    specific requirements fulfulled by each account type in use.
+    specific requirements fulfilled by each account type in use.
     Section b: (O) The organization will be responsible for assigning account managers,
     who will have responsibilities related to the creation, management, and
     removal of accounts. A successful control response will need to discuss
@@ -91,7 +91,7 @@ controls:
     outline these conditions and how they are enforced.
     Section d: (O) The organization will be responsible for specifying authorized
     users, group and role memberships, and privileges for each account. A
-    successful control response will need to addess the process by which
+    successful control response will need to address the process by which
     authorized users are specified and privilege levels are determined.
     Section e: (O) The organization will be responsible for requiring approval by
     designated personnel or roles prior to creating information system
@@ -99,7 +99,7 @@ controls:
     personnel or roles responsible for approving information system accounts
     and the process by which those personnel or roles are notified and
     approval is granted.
-    Section f: (O) The organization will be repsonsible for defining and enforcing
+    Section f: (O) The organization will be responsible for defining and enforcing
     procedures or conditions for the creation, management, and removal of
     information system accounts. A successful control response will outline
     the conditions for each action and the tools or procedures used to
@@ -147,7 +147,7 @@ controls:
     process used to review accounts, the means by which compliance is
     verified, and the process for remediation of any accounts found not to
     be in compliance.
-    Section k: (O) The organization will be responsible for reissing shared/group
+    Section k: (O) The organization will be responsible for reissuing shared/group
     account credentials when individuals are removed from the group. A
     successful control response will need to discuss how a triggering event
     is notified, what the process and timeframe for reissuing credentials
@@ -243,7 +243,7 @@ controls:
 - id: AC-2(4)
   status: pending
   notes: |-
-    (S) The information system will be responsible for audting changes to
+    (S) The information system will be responsible for auditing changes to
     accounts and integrity of accounts to improve situational awareness. A
     successful control response Automatically auditing account creation,
     modification, enabling, disabling, and removal actions, and notifying
@@ -269,7 +269,7 @@ controls:
     description of when to log out. A successful control response will
     define account timeout and conditions when users shall log out. This
     control is expected to be addressed at the organizational level for
-    policy guidance, and at the information system level for implimentation.
+    policy guidance, and at the information system level for implementation.
   rules: []
   description: |-
     The organization requires that users log out when [Assignment: organization-defined time-period of expected inactivity or description of when to log out].
@@ -598,9 +598,9 @@ controls:
     will document if wireless connectivity is enabled, and if so,
     how usage and connection requirements were created.
     Section b: A successful control response will document how connections are
-    authorized prior to recieving full connectivity to the wireless
+    authorized prior to receiving full connectivity to the wireless
     network. This is frequently accomplished via WEP2 and other
-    encrption and/or passphrase requirements.
+    encryption and/or passphrase requirements.
   rules: []
   description: |-
     The organization:
@@ -663,7 +663,7 @@ controls:
   notes: |-
     Section a: The organization will be responsible for establishing terms and conditions
     allowing authorized individuals to access the organization application
-    from external information sysetms. A successful control response will
+    from external information systems. A successful control response will
     need to outline the terms and conditions and the external information
     systems to which those terms and conditions apply.
     Section b: The organization will be responsible for establishing terms and conditions
@@ -735,7 +735,7 @@ controls:
     The organization will be responsible for restricting or prohibiting the
     use of customer-controlled portable storage devices on external
     information systems. If such use is not prohibited, a successful
-    control repsonse will need to address specific restrictions on how
+    control response will need to address specific restrictions on how
     or under what conditions such use may occur.
   rules: []
   description: |-
@@ -786,7 +786,7 @@ controls:
     authorized to post information publicly. A successful control response
     will need to address the specific business requirements or job functions
     that justify such access.
-    Section b: The organization will be responsible for trianing designated authorized
+    Section b: The organization will be responsible for training designated authorized
     individuals to prevent disclosure of nonpublic information. A
     successful control response will need to outline the training
     provided.
@@ -795,7 +795,7 @@ controls:
     successful control response will need to address the roles or personnel
     responsible for this review and the process for signoff.
     Section d: The organization will be responsible for reviewing publicly available
-    information at the reqired frequency and removing nonpublic information
+    information at the required frequency and removing nonpublic information
     when discovered. A successful control response will need to address the
     roles or personnel responsible for the review, the process used to
     review publicly available information, and the process for removal of
@@ -864,7 +864,7 @@ controls:
     \ annually or whenever a significant change occurs] \nAT-1 (b) (2) [at least annually\
     \ or whenever a significant change occurs]"
   title: >-
-    AT-1 - SECURITY AWARENESS AND TRAINING POLICY ANDPROCEDURES
+    AT-1 - SECURITY AWARENESS AND TRAINING POLICY AND PROCEDURES
   levels:
   - high
   - moderate
@@ -878,14 +878,14 @@ controls:
     process for ensuring that all users undergo the required training.
     Section b: The customer will be responsible for providing updated basic security
     awareness training as required by information system changes. A
-    succesful control response will discuss the process for determining
+    successful control response will discuss the process for determining
     what information system changes require updated training, how the
     training content is updated, and how users are notified of the need for
     re-training.
     Section c: The customer will be responsible for refreshing the basic security
     awareness training annually. A successful control response will
     discuss the process for ensuring that all users undergo the required
-    re-trianing.
+    re-training.
   rules: []
   description: |-
     The organization provides basic security awareness training to information system users (including managers, senior executives, and contractors):
@@ -939,7 +939,7 @@ controls:
     what information system changes require updated training, how the
     training content is updated, and hw users are notified of the need
     for re-training.
-    Section c: The custmoer will be responsible for refreshing role-based security
+    Section c: The customer will be responsible for refreshing role-based security
     training annually. A successful control response will discuss the
     process for ensuring that all users undergo the required re-training.
   rules: []
@@ -996,7 +996,7 @@ controls:
   notes: |-
     Section a: The organization will be responsible for developing, documenting, and
     disseminating Audit and Accountability policy and procedures. A
-    successful control repsonse will need to address the content of the
+    successful control response will need to address the content of the
     policy (which must include purpose, scope, roles, responsibilities,
     management commitment, coordination, and compliance) and procedures
     (which must facilitate the implementation of the policies and
@@ -1046,19 +1046,19 @@ controls:
     interested parties (such as an internal SOC or security team) and
     incorporation of their input into business requirements in order to
     determine the selection of auditable events.
-    Section c: The organization will be responsible for implimenting this control. A
+    Section c: The organization will be responsible for implementing this control. A
     successful control response will include a discussion of the decision
     process behind the selection of auditable events and a justification for
     the selected events being sufficient to support after-the-fact
     investigation.
-    Section d: The customer will be responsible for selecting a subsec of the events
+    Section d: The customer will be responsible for selecting a subset of the events
     listed in AU-2(a) to be audited by the system. For FedRAMP compliance,
     these events must be monitored continuously. A successful control
     response will include a discussion of the rationale for the events
     chosen.
 
     Note this control only identifies which events are relevant for this
-    information sysem. Technical implimentation, at a information system
+    information system. Technical implementation, at a information system
     component level, is documented in AU-12(a).
   rules: []
   description: |-
@@ -1106,8 +1106,8 @@ controls:
   status: pending
   notes: |-
     The organization is responsible for generating audit records that contain
-    information that establishes what type of event occured, when the event
-    occurred, where the event occured, the source of the event, the
+    information that establishes what type of event occurred, when the event
+    occurred, where the event occurred, the source of the event, the
     outcome of the event, and the identity of any individuals or subjects
     associated with the event. A successful control response will outline
     what metadata the organization requires audit records to contain.
@@ -1128,11 +1128,11 @@ controls:
   status: pending
   notes: |-
     The organization is responsible ensuring that the information system
-    audit records conain all of the information required to meet
+    audit records contain all of the information required to meet
     FedRAMP requirements. A successful control response will outline the
     systems audit generation, and the content that it includes.
 
-    Note: This control defines what supplimentary data audit records must
+    Note: This control defines what supplementary data audit records must
     contain, such as full text recording of privileged commands. Metadata
     elements of audit logs are defined in AU-3. Component configuration is
     established through AU-12(c).
@@ -1202,7 +1202,7 @@ controls:
     \ IR-6, MA-4, MP-4, PE-3, PE-6, PE-14, PE-16, RA-5, SC-7, SC-18, SC-19, SI-3,\
     \ SI-4, SI-7.\n\nReferences: None.\n\nAU-6 (a)-1 [at least weekly] \nAU-6 Requirement:\
     \ Coordination between service provider and consumer shall be documented and accepted\
-    \ by the JAB/AO. In multi-tennant environments, capability and means for providing\
+    \ by the JAB/AO. In multi-tenant environments, capability and means for providing\
     \ review, analysis, and reporting to consumer for data pertaining to consumer\
     \ shall be documented."
   title: >-
@@ -1234,7 +1234,7 @@ controls:
   status: pending
   notes: |-
     Customers are responsible for analyzing and correlating audit records
-    accross different repositories to gain organiational-wide situational
+    across different repositories to gain organizational-wide situational
     awareness. A successful control response will discuss how the organization
     correlates and analyzes audit records from different sources. This can
     include processes and tools used to meet these goals.
@@ -1380,7 +1380,7 @@ controls:
   notes: |-
     Section a: The organization will be responsible for developing a Security Assessment
     Plan. A successful control response will need to address the
-    involement of a FedRAMP-accredited 3PAO (see CA-2(1)), the scope
+    involvement of a FedRAMP-accredited 3PAO (see CA-2(1)), the scope
     of the assessment, and any specific requirements the organization has
     for the 3PAO.
   rules: []
@@ -1636,7 +1636,7 @@ controls:
     Section a: The organization will be responsible for working with FedRAMP to designate
     an authorizing official. A successful control response will need to
     address how an appropriate authorizing official is selected.
-    Section b: The organization will be responsible for recieving official authorizaiton
+    Section b: The organization will be responsible for receiving official authorization
     from the authorizing official prior to commencing operations for
     federal customers. A successful control response will need to address
     the inputs provided to the authorizing official so that an
@@ -1772,7 +1772,7 @@ controls:
   notes: |-
     The customer will be responsible for monitoring security controls on
     an ongoing basis with the assistance of an assessment team with a
-    control-defined level of independance. Note that this may be the 3PAO
+    control-defined level of independence. Note that this may be the 3PAO
     used for recurring assessments, it may be a different independent
     assessor, or it may be a team of personnel employed by the customer. A
     successful control response will need to address the nature of this team
@@ -1888,7 +1888,7 @@ controls:
     Configuration Management policy every 3 years, and procedures
     annually. A successful control response will need to address
     the review and update process, including the role(s) responsible
-    for initiating the review process, updaitng the policy and
+    for initiating the review process, updating the policy and
     procedures, and providing approval of the updates
   rules: []
   description: |-
@@ -2053,7 +2053,7 @@ controls:
     go through.
     Section b: The customer will be responsible for reviewing and reevaluating
     privileges at least quarterly. A successful control response will
-    include how often reviews are performed for presonnel with privileges
+    include how often reviews are performed for personnel with privileges
     to change the information system within the production environment.
   rules: []
   description: |-
@@ -2145,7 +2145,7 @@ controls:
     customer has deemed necessary to achieve effective accountability.
     Section b: The customer will responsible for reviewing and updating the system
     inventory at least monthly. This may be performed in conjunction with
-    continuous monitoring and POA&M tracking activities. A sucessful control
+    continuous monitoring and POA&M tracking activities. A successful control
     response will need to address the personnel or roles responsible for
     updating the system inventory and the process for correcting gaps or
     discrepancies found.
@@ -2483,7 +2483,7 @@ controls:
     The customer will be responsible for identifying critical
     functionality for which processing capacity must be reserved in an
     alternate region. A successful control response will need to discuss
-    the process by wich this determination is made. Once processing
+    the process by which this determination is made. Once processing
     capacity is reserved in an alternate region for this critical
     functionality, the remainder of the control may be inherited
     from your infrastructure provider.
@@ -2772,9 +2772,9 @@ controls:
 - id: CP-8(1)
   status: pending
   notes: |-
-    Section a: The custimer will be responsible for developing primary and
+    Section a: The customer will be responsible for developing primary and
     alternate telecommunication service agreements that contain
-    priority-of-service provisions in accordance with organiational
+    priority-of-service provisions in accordance with organizational
     availability requirements (including recovery time objectives). This
     control is often inherited from IaaS and PaaS providers.
     Section b: The customer will be responsible to request telecommunications
@@ -2797,7 +2797,7 @@ controls:
 - id: CP-8(2)
   status: pending
   notes: |-
-    The customer will be responsible for obtaining alernate
+    The customer will be responsible for obtaining alternate
     telecommunications services to reduce the likelihood of sharing a
     single point of failure with primary telecommunications services. This
     control is often inherited from IaaS and PaaS providers.
@@ -2974,7 +2974,7 @@ controls:
     the responsibility of the customer relating to shared touch points
     included in the customers authorization boundary and any customer
     applications leveraging the providers infrastructure. Incident handling
-    for customer applications is the responsiblity of the customer unless
+    for customer applications is the responsibility of the customer unless
     an incident is caused by platform providers (e.g. IaaS). A successful
     control response will need to address the required steps in incident
     response (preparation, detection and analysis, containment, eradication,
@@ -3043,7 +3043,7 @@ controls:
 - id: IR-5
   status: pending
   notes: |-
-    The customer will be responisble for tracking and documenting
+    The customer will be responsible for tracking and documenting
     information system security incidents. A successful control response
     will need to address the tools and processes used for documentation,
     and relate these tools and processes to the automated mechanisms
@@ -3117,7 +3117,7 @@ controls:
   notes: |-
     The customer will be responsible for providing incident response
     resources to their users. These resources may be, for example, web
-    pages, helpdesk resources, or assistanceg groups. A successful
+    pages, helpdesk resources, or assistance groups. A successful
     control response will need to outline the resources available and
     discuss how users are notified of the existence of these resources.
   rules: []
@@ -3134,7 +3134,7 @@ controls:
 - id: IR-7(1)
   status: pending
   notes: |-
-    The customer will be responislbe for using automated mechanisms
+    The customer will be responsible for using automated mechanisms
     (such as websites or email distribution lists) to increase the
     availability of incident response support resources. A successful
     control response will need to discuss the mechanisms used and the
@@ -3184,7 +3184,7 @@ controls:
   notes: |-
     Section a: The customer will be responsible for developing an incident response
     plan that includes consideration for any controls that are the
-    responsibility of the customer relating to shared touch points inclduded
+    responsibility of the customer relating to shared touch points included
     in the customers authorization boundary and any customer applications
     leveraging the providers infrastructure. A successful control response
     will need to address how the plan meets each of the specified
@@ -3248,7 +3248,7 @@ controls:
 - id: IR-9
   status: pending
   notes: |-
-    Section a: The customer will be repsonsible for identifying the specific
+    Section a: The customer will be responsible for identifying the specific
     information involved in an information spill. A successful control
     response will need to address how spills are detected and the tools
     or processes used to identify the specific information involved.
@@ -3259,14 +3259,14 @@ controls:
     Section c: The customer will be responsible for isolating the contaminated
     system or component. This may involved, for example, disabling
     connections to the component or shutting it down. A successful
-    contorl response will need to address the types of components that
+    control response will need to address the types of components that
     could potentially be contaminated and the mechanism for isolating
     each type.
     Section d: The customer will be responsible for eradicating the spilled
     information from the contaminated system or component. A successful
     control response will need to address the means by which
     eradication is carried out and confirmed.
-    Section e: The customer will be repsonsible for identifying other systems or
+    Section e: The customer will be responsible for identifying other systems or
     components that may have been contaminated subsequent to the initial
     spill. A successful control response will need to outline the
     investigative process used to make this determination.
@@ -3334,7 +3334,7 @@ controls:
     The customer will be responsible for defining and implementing
     procedures to allow personnel affected by information spills to continue
     carrying out assigned tasks during the information spill response
-    process. A successful contorl response will need to addres, for example,
+    process. A successful control response will need to address, for example,
     alternate means of connection to affected systems and changes to
     processes required to employ those alternate means.
   rules: []
@@ -3411,12 +3411,12 @@ controls:
   status: pending
   notes: |-
     Section c: The customer will be responsible for requiring that datacenter
-    management and property asset owners explicity approve the removal
+    management and property asset owners explicitly approve the removal
     of the information system or system components from organizational
     facilities for off-site maintenance repairs. This is frequently an
     inherited control from IaaS providers and not applicable to OpenShift
     deployments.
-    Section d: The customer will be responsible for santizing equipment to remove
+    Section d: The customer will be responsible for sanitizing equipment to remove
     all information from the associated media prior to removal from
     organizational facilities. This is frequently an inherited control
     from IaaS providers and not applicable to OpenShift deployments.
@@ -3503,13 +3503,13 @@ controls:
 - id: MA-3(3)
   status: pending
   notes: |-
-    The customer will be responsible for prevengint unauthorized removal
-    of manteance equipment containing organizational information. A
+    The customer will be responsible for preventing unauthorized removal
+    of maintenance equipment containing organizational information. A
     successful control response will address (a) process to verify there
     is no organizational information contained on the equipment; (b) how
     equipment is sanitized or destroyed; (c) process to retain the
     equipment within the facility; (d) process to obtain an exception
-    from these processes from the information owner that explicity
+    from these processes from the information owner that explicitly
     authorizes removal of equipment from the facility
   rules: []
   description: "The organization prevents the unauthorized removal of maintenance\
@@ -3534,7 +3534,7 @@ controls:
     non-local maintenance and diagnostic activities. Because of the nature
     of a cloud system, all maintenance and diagnostic activities will be
     considered non-local. Therefore, this control can largely be
-    addressed by reference to acess control authorizations (see AC-2)
+    addressed by reference to access control authorizations (see AC-2)
     and the auditing and monitoring discussions in the AU family and SI-4. A
     successful control response will need to address the personnel or roles
     who are authorized to perform maintenance and diagnostic activities,
@@ -3565,7 +3565,7 @@ controls:
     and diagnostic connections. A successful control response will need to
     address when non-local maintenance and diagnostic connections are
     allowed, what personnel are authorized to establish and use them, and
-    udner what circumstances connections must be terminated.
+    under what circumstances connections must be terminated.
   rules: []
   description: |-
     The organization documents in the security plan for the information system, the policies and procedures for the establishment and use of nonlocal maintenance and diagnostic connections.
@@ -3578,7 +3578,7 @@ controls:
   status: pending
   notes: |-
     Section a: The customer will be responsible for establishing a process for
-    maintenance personnel authorizationa and maintains a list of authorized
+    maintenance personnel authorizations and maintains a list of authorized
     maintenance organizations/personnel. A successful control response will
     document this process and where the records are kept.
     Section b: The customer will be responsible for ensuring that non-escorted
@@ -3589,7 +3589,7 @@ controls:
     Section c: The customer will be responsible for designating organizational
     personnel with required access authorizations and technical
     competence to supervise the maintenance personnel. A successful
-    control response will document the process for becoming an escore, and
+    control response will document the process for becoming an escort, and
     how technical competence is established.
   rules: []
   description: |-
@@ -3611,20 +3611,20 @@ controls:
   status: pending
   notes: |-
     Section a: The customer will be responsible for implementing procedures for
-    the use of maintenace personnel that lack appropriate security
+    the use of maintenance personnel that lack appropriate security
     clearances or are not U.S. citizens. These procures must address
     (1) personnel who do not have needed access authorizations are escorted
     by those who do; optionally (2) prior to initiating maintenance or
     diagnostic activities by personnel lacking access authorizations, all
     volatile information storage components within the information system
-    are santized and all nonvolatile storage media are removed or physically
+    are sanitized and all nonvolatile storage media are removed or physically
     disconnected from the system and secured.
-    Section b: The customer will be responsible for developing and implimenting
+    Section b: The customer will be responsible for developing and implementing
     alternate security safeguards in the event an information system
-    component cannot be santized, removed, or disconnected from the system.
+    component cannot be sanitized, removed, or disconnected from the system.
     A successful control response will document how maintenance staff
     lacking appropriate authorizations will not be able to access
-    data residing on the informarion system.
+    data residing on the information system.
   rules: []
   description: |-
     The organization:
@@ -3714,7 +3714,7 @@ controls:
     disseminating Security Planning policy and procedures. A successful
     control response will need to address the content of the policy
     (which must include purpose, scope, roles, responsibilities,
-    management commitment, coordination, and compliance) and proecures
+    management commitment, coordination, and compliance) and procedures
     (which must facilitate the implementation of the policies and
     associated controls).
     Section b: The organization will be responsible for reviewing and updating the
@@ -3864,7 +3864,7 @@ controls:
     distributing rules of behavior. A successful control response will need
     to outline the rules of behavior and discuss the process for making them
     available to users requiring access to the system.
-    Section b: The customer will be repsonsible for obtaining signed acknowledgement
+    Section b: The customer will be responsible for obtaining signed acknowledgement
     of the rules of behavior from its users. A successful control response
     will need to address the process for withholding authorization until
     signatures are obtained.
@@ -3918,14 +3918,14 @@ controls:
   status: pending
   notes: |-
     Section a: The customer will be responsible for developing their information
-    security architecture. A successful contrl response will need to
+    security architecture. A successful control response will need to
     discuss the guiding principles used to protect confidentiality,
     integrity, and availability of system information and the dependencies
     on external services (such as Microsoft Azure). Additionally, a
     description of the information security architecture should be included
     in the introductory sections of this system security plan.
     Section b: The customer will be responsible for reviewing and updating the
-    security architecture at a required frequency. A succesful control
+    security architecture at a required frequency. A successful control
     response will need to address the process for initiating review, as well
     as the individuals or roles responsible for carrying out the review,
     managing updates, and approving the final version.
@@ -4042,7 +4042,7 @@ controls:
   status: pending
   notes: |-
     Section a: The customer will be responsible for assigning risk designations to
-    all positions of cusomer personnel using IaaS that are consistent
+    all positions of customer personnel using IaaS that are consistent
     with the customers internal policies and procedures. A successful
     control response will need to address the criteria used in risk
     designation assignments (for example, specific responsibilities, access
@@ -4086,7 +4086,7 @@ controls:
     requirements established in PS-2.
     Section b: The customer will be responsible for rescreening individuals at the
     required frequency. A successful control response will need to discuss
-    the process for iniating rescreening, as well as for disabling or
+    the process for initiating rescreening, as well as for disabling or
     removing access if rescreening is not completed in a timely manner.
   rules: []
   description: |-
@@ -4134,19 +4134,19 @@ controls:
 - id: PS-4
   status: pending
   notes: |-
-    Section c: The customerw ill be responsible for conducting exit interviews. A
+    Section c: The customer will be responsible for conducting exit interviews. A
     successful control response will need to address the topics discussed
     during the interviews and the personnel responsible for conducting
     the interviews.
     Section d: The customer will be responsible for retrieving all security related,
     information system related, organizational property from terminated
-    indviduals. A successful control response will need to address the
-    prcess and personnel responsible for ensuring that all such property
+    individuals. A successful control response will need to address the
+    process and personnel responsible for ensuring that all such property
     is retrieved.
     Section e: The customer will be responsible for retaining access to information
     and information systems formerly controlled by terminated individuals. A
     successful control response will need to address how this retention
-    occures, personnel responsible for retention, and any minimum or
+    occurs, personnel responsible for retention, and any minimum or
     maximum retention periods.
     Section f: The customer will be responsible for notifying relevant personnel
     within a defined time period after an individual is terminated. A
@@ -4179,18 +4179,18 @@ controls:
   notes: |-
     Section a: The customer will be responsible for reviewing access authorizations
     for individuals when those individuals are reassigned or transferred. A
-    successful control response will need to address the intiation of this
-    review and individuals or roles responsible for perfoming and validating
+    successful control response will need to address the initiation of this
+    review and individuals or roles responsible for performing and validating
     the results of reviews.
     Section b: The customer will be responsible for initiating reassignments or
     transfers within a customer-defined time period after the formal
-    reaassignment or transfer. A successful control response will need to
-    address the specific ations taken, personnel responsible for those
+    reassignment or transfer. A successful control response will need to
+    address the specific actions taken, personnel responsible for those
     actions, and timeframes for initiation of those actions.
     Section c: The customer will be responsible for modifying access authorizations
     based on the results of the review carried out in Part A. A successful
     control response will need to address the process by which
-    authorizations are modified, personnel responsible for intiating the
+    authorizations are modified, personnel responsible for initiating the
     change, and any technical means of enforcement of the change.
     Section d: The customer will be responsible for notifying relevant personnel
     within the required timeframe after a formal reassignment or transfer. A
@@ -4241,7 +4241,7 @@ controls:
     review and sign access agreements prior to initial access and to
     maintain access after updates. A successful control response will need
     to address the process for withholding access until after the initial
-    signature is recieved, as well as for disabling or removing access if
+    signature is received, as well as for disabling or removing access if
     the access agreement changes and an individual does not re-sign it in
     a timely manner.
   rules: []
@@ -4280,7 +4280,7 @@ controls:
     requirements for third-party providers. A successful control response
     will need to discuss the process for creating documentation and sharing
     it with the providers.
-    Section d: The customer will be responsible for including nofication of
+    Section d: The customer will be responsible for including notification of
     terminations and transfers within the personnel security requirements. A
     successful control response will need to discuss the specific
     notification requirements, in particular the requirement for
@@ -4329,8 +4329,8 @@ controls:
     when the sanctions process is initiated. A successful control response
     will need to delineate the relevant personnel to be notified, the
     roles or individuals responsible for notification, and the information
-    convayed as part of the notification (to include, at a minimum the
-    indivual sanctioned and the reason for the sanction).
+    conveyed as part of the notification (to include, at a minimum the
+    individual sanctioned and the reason for the sanction).
   rules: []
   description: |-
     The organization:
@@ -4358,12 +4358,12 @@ controls:
     control response will need to address the content of the policy
     (which must include purpose, scope, roles, responsibilities,
     management commitment, coordination, and compliance) and procedures
-    (which must facilitate the implimentation of the policies and
+    (which must facilitate the implementation of the policies and
     associated controls).
     Section b: The organization will be responsible for reviewing and updating the
     Risk Assessment policy every 3 years, and procedures annually. A
-    successful control repsonse will need to address the reiew and update
-    process, including the role(s) repsonsible for initiating the review
+    successful control response will need to address the review and update
+    process, including the role(s) responsible for initiating the review
     process, updating the policy and procedures, and providing approval
     of the updates.
   rules: []
@@ -4407,12 +4407,12 @@ controls:
     Resources related to information categorization include FIPS 199,
     Standards for Security Categorization of Federal Information and
     Information Systems, and NIST SP 800-61, Rev. 1, Guide for Mapping
-    Types of Information and Inforation Systems to Security Categories.
+    Types of Information and Information Systems to Security Categories.
     Section b: The customer will be responsible for documenting the security
     categorization. A successful response will need to address supporting
     rationale, including types of information considered, risk impact
     analysis, and input from stakeholders and organizational officials.
-    Section c: The customer will be responsible for presneting the security
+    Section c: The customer will be responsible for presenting the security
     categorization decision to the Authorizing Official or a
     designated representative for review and approval.
   rules: []
@@ -4455,7 +4455,7 @@ controls:
     risk assessment in a Security Assessment Report. A successful control
     response will need to address specific requirements for the report
     (e.g., it should include controls that are considered "other than
-    satisfied," potential weaknesses in control sthat meet minimum
+    satisfied," potential weaknesses in controls that meet minimum
     requirements, recommended remediation steps, and risks associated with
     the system). The customer may with to employ a 3PAO to assist with
     the initial risk assessment (see CA-2).
@@ -4470,7 +4470,7 @@ controls:
     Section e: The customer will be responsible for updating the risk assessment
     at the required frequency of when a significant change occurs. (Note
     that "significant change" is defined in NIST 800-37 Rev 1, Appendix F).
-    A successful control respinse will need to discuss examples of
+    A successful control response will need to discuss examples of
     significant changes that might occur within the customer application,
     as well as the specific actions that will be taken when the risk
     assessment is updated (such as updating system security plans and
@@ -4531,7 +4531,7 @@ controls:
     using an operating system image will be responsible for scanning
     for vulnerabilities in the operating system. A successful control
     response will need to address the tools used to perform scans as well
-    as the additional FedRAMP requirement for independant assessors to
+    as the additional FedRAMP requirement for independent assessors to
     scan the system on an annual basis.
     Section b: The customer will be responsible for ensuring that vulnerability
     scanning tools use standards for enumerating components, flaws, and
@@ -4727,14 +4727,14 @@ controls:
   status: pending
   notes: |-
     Section a: The organization will be responsible for developing, documenting, and
-    disseminating System and Services Aquisition policy and procedures. A
+    disseminating System and Services Acquisition policy and procedures. A
     successful control response will need to address the content of the
     policy (which must include purpose, scope, roles, responsibilities,
     management commitment, coordination, and compliance) and procedures
     (which must facilitate the implementation of the policies and
     associated controls).
     Section b: The organization will be responsible for reviewing and updating the Audit
-    and Accountability policy every 3 years, and procedures annualy. A
+    and Accountability policy every 3 years, and procedures annually. A
     successful control response will need to address the review and update
     process, including the role(s) responsible for initiating the review
     process, updating the policy and procedures, and providing approval
@@ -4863,13 +4863,13 @@ controls:
     guidelines, and organizational mission/business needs in the creation
     of the contracts.
     Section d: The customer will be responsible for including security-related
-    documentation requirements in acquistion contracts. A successful control
+    documentation requirements in acquisition contracts. A successful control
     response will need to address consideration of applicable laws,
     Executive Orders, directives, policies, regulations, standards,
     guidelines, and organizational mission/business needs in the creation
     of the contracts.
     Section e: The customer will be responsible for including requirements for
-    protecting security-related documentation in acqusition contracts. A
+    protecting security-related documentation in acquisition contracts. A
     successful control response will need to address consideration of
     applicable laws, Executive Orders, directives, policies, regulations,
     standards, guidelines, and organizational mission/business needs in the
@@ -5000,7 +5000,7 @@ controls:
   notes: |-
     The customer is responsible for employing only information
     technology products on the FIPS 201-approved products list for
-    Personal Identity Vertification (PIV) capability implemented within
+    Personal Identity Verification (PIV) capability implemented within
     organizational information systems. A successful control response will
     indicate that all system components have been selected from this list,
     and if not, document waivers with appropriate organizational authorities
@@ -5039,7 +5039,7 @@ controls:
     Section e: Customers are responsible for distributing documentation for
     customer-controlled software and operating systems to appropriate
     personnel. A successful control response will discuss the means
-    of distribution and the process for designating appropraite personnel
+    of distribution and the process for designating appropriate personnel
     or roles.
   rules: []
   description: "The organization:\n a. Obtains administrator documentation for the\
@@ -5109,19 +5109,19 @@ controls:
   status: pending
   notes: |-
     Section a: Customers are responsible to require that external information systems
-    comply with organiziational security requirements and FedRAMP
+    comply with organizational security requirements and FedRAMP
     Security Controls Baseline(s) if Federal information is processed or
     stored within the external system. A successful control response will
     indicate how this is enforced, procedurally and technically, for
     external information systems.
     Section b: Customers are responsible for defining and documenting government
     oversight and user roles and responsibilities regarding external
-    information system services. A successful contro response will address
+    information system services. A successful control response will address
     the procedures for this oversight.
     Section c: Customers are responsible for employing Federal/FedRAMP Continuous
     Monitoring Requirements on external systems where Federal information
     is processed or stored, and monitor security control compliance by
-    external serice providers on an ongoing basis. A successful control
+    external service providers on an ongoing basis. A successful control
     response will address the procedural and technical processes used to
     accomplish this.
   rules: []
@@ -5150,7 +5150,7 @@ controls:
     of risk prior to the acquisition or outsourcing of dedicated
     information security services. A successful control response will
     address the process of the risk assessment and analysis of findings.
-    Section b: Customers are responsible for ensuring that the aquisition or
+    Section b: Customers are responsible for ensuring that the acquisition or
     outsourcing of dedicated information security services is approved
     by organizational authorities. A successful control response will
     address formal approval processes.
@@ -5307,7 +5307,7 @@ controls:
     The customer will be responsible for producing, controlling, and
     distributing symmetric cryptographic keys (if any are used within
     the customer application) using NIST FIPS-compliant key management
-    technology and proesses. A successful control response will need to
+    technology and processes. A successful control response will need to
     address the processes and tools used for key generation and discuss
     the reasons they are considered compliant.
   rules: []
@@ -5325,8 +5325,8 @@ controls:
 - id: SC-12(3)
   status: pending
   notes: |-
-    The customer will be responsible for producign, controlling, and
-    distributing asymetric cryptographic keys (if any are used within the
+    The customer will be responsible for producing, controlling, and
+    distributing asymmetric cryptographic keys (if any are used within the
     customer application) using one of the specified tools or processes. A
     successful control response will need to address the process and tools
     used for key generation and discuss the reasons they are considered
@@ -5498,7 +5498,7 @@ controls:
 - id: SI-5
   status: pending
   notes: |-
-    Section b: The organization will be responsible for generatign internal security
+    Section b: The organization will be responsible for generating internal security
     alerts, advisories and directives. A successful control response will
     need to address the criteria used to determine what alerts, advisories,
     and directives are necessary, based on the specifics of the customer
@@ -5507,7 +5507,7 @@ controls:
     advisories and directives within the customer organization and to
     external organizations as necessary. A successful control response will
     need to address the personnel or roles within the organization who
-    require notificiation.
+    require notification.
   rules: []
   description: |-
     The organization:

--- a/linux_os/guide/services/ntp/chronyd_server_directive/policy/stig/shared.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/policy/stig/shared.yml
@@ -6,7 +6,7 @@ vuldiscussion: |-
 
     Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
 
-    Depending on the infrastruture being used the "pool" directive may not be supported.
+    Depending on the infrastructure being used the "pool" directive may not be supported.
 
 checktext: |-
     Verify {{{ full_name }}} is securely comparing internal information system clocks at least every 24 hours with an NTP server with the following commands:

--- a/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
@@ -6,7 +6,7 @@ description: |-
     Check that Chrony only has time sources configured with the <tt>server</tt> directive.
 
 rationale: |-
-    Depending on the infrastruture being used the <tt>pool</tt> directive may not be supported.
+    Depending on the infrastructure being used the <tt>pool</tt> directive may not be supported.
 
 severity: medium
 

--- a/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
@@ -13,7 +13,7 @@ severity: medium
 platform: package[chrony]
 
 warnings:
-  - general: This rule doesn't come with a remediation, the time source needs to be added by the adminstrator.
+  - general: This rule doesn't come with a remediation, the time source needs to be added by the administrator.
 
 identifiers:
     cce@rhel8: CCE-86077-5

--- a/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_server_directive/rule.yml
@@ -28,7 +28,7 @@ references:
 ocil_clause: 'an authoritative remote time server is not configured or configured with pool directive'
 
 ocil: |-
-    Run the following command and verify that time sources are only configure with <tt>server</tt> directive:
+    Run the following command and verify that time sources are only configured with <tt>server</tt> directive:
     <pre># grep -E "^(server|pool)" {{{ chrony_conf_path }}}</pre>
     A line with the appropriate server should be returned, any line returned starting with <tt>pool</tt> is a finding.
 


### PR DESCRIPTION
#### Description:

Fix typo in the word `infrastructure`, which is misspelled as `infrastruture`.

#### Rationale:

Fixing a typo.

- Fixes #10530
- Fixes #10532 

#### Review Hints:

Found the same typo in 3 locations:

``` console
$ find . -type f -print0 | xargs -0 grep -i infrastruture
./controls/nist_satellite6.yml:    from your infrastruture provider.
./controls/nist_satellite6.yml:    including a review of controls inherited from infrastruture providers,
./linux_os/guide/services/ntp/chronyd_server_directive/policy/stig/shared.yml:    Depending on the infrastruture being used the "pool" directive may not be supported.
./linux_os/guide/services/ntp/chronyd_server_directive/rule.yml:    Depending on the infrastruture being used the <tt>pool</tt> directive may not be supported.
```