### PR TITLE
Fix in sshd_use_approved_ciphers

### DIFF
--- a/linux_os/guide/services/ssh/sshd_approved_ciphers.var
+++ b/linux_os/guide/services/ssh/sshd_approved_ciphers.var
@@ -14,7 +14,7 @@ options:
     stig: aes256-ctr,aes192-ctr,aes128-ctr
     default: aes128-ctr,aes192-ctr,aes256-ctr,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc,rijndael-cbc@lysator.liu.se
     cis_rhel7: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
-    cis_sle12: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
-    cis_sle15: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,aes128-cbc,aes192-cbc,aes256-cbc,blowfish-cbc,cast128-cbc,3des-cbc
+    cis_sle12: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+    cis_sle15: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
     cis_alinux2: chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
     cis_ubuntu: chacha20-poly1305@openssh.com,aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -75,5 +75,6 @@ selections:
     -  sshd_set_max_sessions
     -  sshd_set_maxstartups
     -  sshd_use_approved_ciphers
+    -  sshd_approved_ciphers=cis_sle12
     -  sshd_use_approved_macs
     -  sysctl_fs_suid_dumpable

--- a/products/sle12/profiles/pci-dss.profile
+++ b/products/sle12/profiles/pci-dss.profile
@@ -13,3 +13,4 @@ description: |-
 
 selections:
     - pcidss_3:all:base
+    - sshd_approved_ciphers=cis_sle12

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -15,6 +15,7 @@ description: |-
 
 selections:
     - sshd_approved_macs=stig
+    - sshd_approved_ciphers=stig
     - var_account_disable_post_pw_expiration=35
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -13,7 +13,7 @@ description: |-
 
 selections:
     -  pcidss_4:all:base
-    # remove some rules from profile
-    - '!service_ntp_enabled'
-    - '!service_ntpd_enabled'
-    - '!service_timesyncd_enabled'
+    -  sshd_approved_ciphers=cis_sle15 
+    -  '!service_ntp_enabled'
+    -  '!service_ntpd_enabled'
+    -  '!service_timesyncd_enabled'

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -13,3 +13,4 @@ description: |-
 
 selections:
     - pcidss_3:all:base
+    - sshd_approved_ciphers=cis_sle15


### PR DESCRIPTION
#### Description:

- _The fix corrects some of SLE 12/15 profiles_

#### Rationale:

- The current ciphers in use are not recommended because they are not strong enough

