### PR TITLE
Fix in the SLE 12/15 rule sshd_use_strong_kex

### DIFF
--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -1671,6 +1671,7 @@ controls:
     status: automated
     rules:
       - sshd_use_strong_kex
+      - sshd_strong_kex=cis_sle12
 
   - id: 5.2.16
     title: Ensure SSH Idle Timeout Interval is configured (Automated)

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -1855,6 +1855,7 @@ controls:
     status: automated
     rules:
       - sshd_use_strong_kex
+      - sshd_strong_kex=cis_sle15
 
   - id: 5.2.16
     title: Ensure SSH Idle Timeout Interval is configured (Automated)

--- a/linux_os/guide/services/ssh/sshd_strong_kex.var
+++ b/linux_os/guide/services/ssh/sshd_strong_kex.var
@@ -13,6 +13,6 @@ interactive: false
 options:
     default: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
     cis_rhel7: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
-    cis_sle12: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
-    cis_sle15: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+    cis_sle12: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
+    cis_sle15: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
     cis_ubuntu2004: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -76,4 +76,5 @@ selections:
     -  sshd_set_maxstartups
     -  sshd_use_approved_ciphers
     -  sshd_use_approved_macs
+    -  sshd_strong_kex=default
     -  sysctl_fs_suid_dumpable

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -13,7 +13,7 @@ description: |-
 
 selections:
     -  pcidss_4:all:base
-    # remove some rules from profile
-    - '!service_ntp_enabled'
-    - '!service_ntpd_enabled'
-    - '!service_timesyncd_enabled'
+    -  sshd_strong_kex=default
+    -  '!service_ntp_enabled'
+    -  '!service_ntpd_enabled'
+    -  '!service_timesyncd_enabled'


### PR DESCRIPTION
#### Description:

- _Fixes usage of kex for SLE 12/15 _

#### Rationale:

- This fix is necessary because at the moment the rule is using weak keys

