### PR TITLE
Update CIS control file for RHEL8 and RHEL9

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1233,14 +1233,18 @@ controls:
       - l1_workstation
     status: manual
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5248
   - id: 3.4.2.9
     title: Ensure nftables default deny firewall policy (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: pending
+    status: supported
+    notes: |-
+      RHEL systems use firewalld for firewall management. Although nftables is the default
+      back-end for firewalld, it is not recommended to use nftables directly when firewalld
+      is in use.
+    related_rules:
+      - nftables_ensure_default_deny_policy
 
   - id: 3.4.2.10
     title: Ensure nftables service is enabled (Automated)

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1142,14 +1142,18 @@ controls:
       - l1_workstation
     status: manual
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5248
   - id: 3.4.2.7
     title: Ensure nftables default deny firewall policy (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: pending
+    status: supported
+    notes: |-
+      RHEL systems use firewalld for firewall management. Although nftables is the default
+      back-end for firewalld, it is not recommended to use nftables directly when firewalld
+      is in use.
+    related_rules:
+      - nftables_ensure_default_deny_policy
 
   - id: 4.1.1.1
     title: Ensure auditd is installed (Automated)


### PR DESCRIPTION
#### Description:

The `Ensure nftables default deny firewall policy (Automated)` requirement status was updated to `supported`.
The benchmark mentions this requirement is valid `If NFTables utility is in use on your system`.
RHEL products use `firewalld` instead.

#### Rationale:

- Better CIS coverage for RHEL.
- Fixes #5248