### PR TITLE
Fix into the rule sysctl_kernel_randomize_va_space

### DIFF
--- a/shared/templates/sysctl/ansible.template
+++ b/shared/templates/sysctl/ansible.template
@@ -8,8 +8,10 @@
 {{% if product in ["sle12","sle15"] %}}
   find:
     paths:
-      - "/etc/sysctl.d/"
       - "/run/sysctl.d/"
+      - "/etc/sysctl.d/"
+      - "/usr/local/lib/sysctl.d/"
+      - "/lib/sysctl.d/"      
 {{% else %}}      
   find:
     paths:

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -6,7 +6,7 @@
 
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product in [ "sle12", "sle15"] %}}
-for f in /run/sysctl.d/*.conf /etc/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do 
+for f in /run/sysctl.d/*.conf /etc/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do
 {{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -6,7 +6,7 @@
 
 # Comment out any occurrences of {{{ SYSCTLVAR }}} from /etc/sysctl.d/*.conf files
 {{% if product in [ "sle12", "sle15"] %}}
-for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
+for f in /run/sysctl.d/*.conf /etc/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf /lib/sysctl.d/*.conf; do 
 {{% elif product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
 for f in /etc/sysctl.d/*.conf /run/sysctl.d/*.conf /usr/local/lib/sysctl.d/*.conf /usr/lib/sysctl.d/*.conf; do
 {{% else %}}

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -170,13 +170,15 @@
   </ind:textfilecontent54_test>
   {{% endif %}}
 
-
   <!-- Avoid directly referencing a possibly empty collection, one empty collection will cause the
        variable to have no value even when there are valid objects. -->
   <ind:textfilecontent54_object id="object_static_user_{{{ rule_id }}}" version="1">
     <set>
       <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
       <object_reference>object_static_run_usr_local_sysctls_{{{ rule_id }}}</object_reference>
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+      <object_reference>object_static_lib_sysctld_{{{ rule_id }}}</object_reference>
+{{% endif %}}
     </set>
   </ind:textfilecontent54_object>
 
@@ -193,7 +195,6 @@
       <object_reference>object_static_run_sysctld_{{{ rule_id }}}</object_reference>
     </set>
   </ind:textfilecontent54_object>
-
   <ind:textfilecontent54_object id="object_static_sysctl_{{{ rule_id }}}" version="1">
     <ind:filepath>/etc/sysctl.conf</ind:filepath>
     {{{ sysctl_match() }}}
@@ -222,7 +223,13 @@
     <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
     {{{ sysctl_match() }}}
   </ind:textfilecontent54_object>
-
+{{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
+  <ind:textfilecontent54_object id="object_static_lib_sysctld_{{{ rule_id }}}" version="1">
+    <ind:path>/lib/sysctl.d</ind:path>
+    <ind:filename operation="pattern match">^.*\.conf$</ind:filename>
+    {{{ sysctl_match() }}}
+  </ind:textfilecontent54_object>
+{{% endif %}}
 {{% if SYSCTLVAL is string %}}
 {{% if SYSCTLVAL == "" %}}
 

--- a/shared/templates/sysctl/oval.template
+++ b/shared/templates/sysctl/oval.template
@@ -174,8 +174,14 @@
        variable to have no value even when there are valid objects. -->
   <ind:textfilecontent54_object id="object_static_user_{{{ rule_id }}}" version="1">
     <set>
-      <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
+      <object_reference>object_static_etc_lib_sysctls_{{{ rule_id }}}</object_reference>
       <object_reference>object_static_run_usr_local_sysctls_{{{ rule_id }}}</object_reference>
+    </set>
+  </ind:textfilecontent54_object>
+
+  <ind:textfilecontent54_object id="object_static_etc_lib_sysctls_{{{ rule_id }}}" version="1">
+    <set>
+      <object_reference>object_static_etc_sysctls_{{{ rule_id }}}</object_reference>
 {{% if product not in [ "ol7", "ol8", "ol9", "rhcos4", "rhel7", "rhel8", "rhel9"] %}}
       <object_reference>object_static_lib_sysctld_{{{ rule_id }}}</object_reference>
 {{% endif %}}


### PR DESCRIPTION
#### Description:

- _A fix of the SLE 15/15 rule sysctl_kernel_randomize_va_space_

#### Rationale:

- The fix requires changes into sysctl template because in SUSE configuration files have the following locations: /run/sysctl.d/
/etc/sysctl.d/
/usr/local/lib/sysctl.d/
/usr/lib/sysctl.d/
/lib/sysctl.d/
/etc/sysctl.conf

