### PR TITLE
Use mkdir -p when creating directories

### DIFF
--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -4,7 +4,7 @@ SSSD_CONF="/etc/sssd/sssd.conf"
 SSSD_CONF_DIR="/etc/sssd/conf.d/*.conf"
 
 if [ ! -f "$SSSD_CONF" ] && [ ! -f "$SSSD_CONF_DIR" ]; then
-    mkdir /etc/sssd
+    mkdir -p /etc/sssd
     touch "$SSSD_CONF"
 fi
 

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_contains_only_whitespaces.fail.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_contains_only_whitespaces.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
 
+mkdir -p /etc/usbguard
 rm -f /etc/usbguard/rules.conf
-mkdir /etc/usbguard
 echo -e "  \t \n\t \n" > /etc/usbguard/rules.conf

--- a/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_empty.fail.sh
+++ b/linux_os/guide/services/usbguard/usbguard_allow_hid_and_hub/tests/file_empty.fail.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
 
+mkdir -p /etc/usbguard
 rm -f /etc/usbguard/rules.conf
-mkdir /etc/usbguard
 touch /etc/usbguard/rules.conf

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value.pass.sh
@@ -5,6 +5,6 @@
 truncate -s 0 /etc/security/faillock.conf
 echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 
-mkdir /var/log/faillock
+mkdir -p /var/log/faillock
 semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
 restorecon -R -v "/var/log/faillock"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value_multiple_dirs.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/correct_value_multiple_dirs.pass.sh
@@ -6,7 +6,7 @@ truncate -s 0 /etc/security/faillock.conf
 echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 echo "auth  required pam_faillock.so dir=/var/log/faillock_admins" >> /etc/pam.d/system-auth
 
-mkdir /var/log/faillock /var/log/faillock_admins
+mkdir -p /var/log/faillock /var/log/faillock_admins
 semanage fcontext -a -t faillog_t "/var/log/faillock(/.*)?"
 semanage fcontext -a -t faillog_t "/var/log/faillock_admins(/.*)?"
 restorecon -R -v "/var/log/faillock"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value.fail.sh
@@ -5,6 +5,6 @@
 truncate -s 0 /etc/security/faillock.conf
 echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 
-mkdir /var/log/faillock
+mkdir -p /var/log/faillock
 semanage fcontext -a -t tmp_t "/var/log/faillock(/.*)?"
 restorecon -R -v "/var/log/faillock"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value_multiple_dirs.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/account_password_selinux_faillock_dir/tests/wrong_value_multiple_dirs.fail.sh
@@ -6,7 +6,7 @@ truncate -s 0 /etc/security/faillock.conf
 echo "dir=/var/log/faillock" > /etc/security/faillock.conf
 echo "auth  required pam_faillock.so dir=/var/log/faillock_admins" >> /etc/pam.d/system-auth
 
-mkdir /var/log/faillock /var/log/faillock_admins
+mkdir -p /var/log/faillock /var/log/faillock_admins
 semanage fcontext -a -t tmp_t "/var/log/faillock(/.*)?"
 semanage fcontext -a -t faillog_t "/var/log/faillock_admins(/.*)?"
 restorecon -R -v "/var/log/faillock"

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/bash/shared.sh
@@ -1,7 +1,8 @@
+#!/bin/bash
 # platform = multi_platform_all
-if ! [ -d /tmp/tmp-inst ] ; then
-    mkdir --mode 000 /tmp/tmp-inst
-fi
+
+# shellcheck disable=SC2174
+mkdir -p --mode 000 /tmp/tmp-inst
 chmod 000 /tmp/tmp-inst
 chcon --reference=/tmp /tmp/tmp-inst
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/correct.pass.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 rm -rf /tmp/tmp-inst
-mkdir --mode 000 /tmp/tmp-inst
+mkdir -p --mode 000 /tmp/tmp-inst
+chmod 000 /tmp/tmp-inst
 echo "/tmp     /tmp/tmp-inst/        level      root,adm" >> /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/directory_doesnt_exist.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/directory_doesnt_exist.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 rm -rf /tmp/tmp-inst
 echo "/tmp     /tmp/tmp-inst/        level      root,adm" >> /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/line_not_there.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 rm -rf /tmp/tmp-inst
-mkdir --mode 000 /tmp/tmp-inst
+mkdir -p --mode 000 /tmp/tmp-inst
+chmod 000 /tmp/tmp-inst
 sed -i "/^\s*\/tmp\s*/d" /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/wrong_mode.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_tmp/tests/wrong_mode.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 rm -rf /tmp/tmp-inst
-mkdir --mode 600 /tmp/tmp-inst
+mkdir -p --mode 600 /tmp/tmp-inst
+chmod 600 /tmp/tmp-inst
 echo "/tmp     /tmp/tmp-inst/        level      root,adm" >> /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/bash/shared.sh
@@ -1,9 +1,10 @@
+#!/bin/bash
 # platform = multi_platform_all
-if ! [ -d /tmp-inst ] ; then
-    mkdir --mode 000 /var/tmp/tmp-inst
-fi
+
+# shellcheck disable=SC2174
+mkdir -p --mode 000 /var/tmp/tmp-inst
 chmod 000 /var/tmp/tmp-inst
-chcon --reference=/var/tmp/ /var/tmp/tmp-inst
+chcon --reference=/var/tmp /var/tmp/tmp-inst
 
 if ! grep -Eq '^\s*/var/tmp\s+/var/tmp/tmp-inst/\s+level\s+root,adm$' /etc/security/namespace.conf ; then
     if grep -Eq '^\s*/var/tmp\s+' /etc/security/namespace.conf ; then

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/correct.pass.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 rm -rf /var/tmp/tmp-inst
-mkdir --mode 000 /var/tmp/tmp-inst
+mkdir -p --mode 000 /var/tmp/tmp-inst
+chmod 000 /var/tmp/tmp-inst
 echo "/var/tmp /var/tmp/tmp-inst/    level      root,adm" >> /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/directory_doesnt_exist.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/directory_doesnt_exist.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+
 rm -rf /var/tmp/tmp-inst
 echo "/var/tmp /var/tmp/tmp-inst/    level      root,adm" >> /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/line_not_there.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/line_not_there.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 rm -rf /var/tmp/tmp-inst
-mkdir --mode 000 /var/tmp/tmp-inst
+mkdir -p --mode 000 /var/tmp/tmp-inst
+chmod 000 /var/tmp/tmp-inst
 sed -i "/^\s*\/var\/tmp\s*/d" /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/wrong_mode.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_polyinstantiated_var_tmp/tests/wrong_mode.fail.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+
 rm -rf /var/tmp/tmp-inst
-mkdir --mode 600 /var/tmp/tmp-inst
+mkdir -p --mode 600 /var/tmp/tmp-inst
+chmod 600 /var/tmp/tmp-inst
 echo "/var/tmp /var/tmp/tmp-inst/    level      root,adm" >> /etc/security/namespace.conf

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/lenient_permissions_directory.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/lenient_permissions_directory.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 USER="cac_user"
-useradd -m $USER
-mkdir /home/$USER/folder
-chmod -Rf 700 /home/$USER/.*
-chmod -f o+r /home/$USER/folder
+useradd -m "${USER}"
+mkdir -p /home/"${USER}"/folder
+chmod -Rf 700 /home/"${USER}"/.*
+chmod -f o+r /home/"${USER}"/folder

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/hidden_folder_ignored.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/hidden_folder_ignored.pass.sh
@@ -2,4 +2,4 @@
 
 USER="cac_user"
 useradd -m $USER
-mkdir /home/$USER/.hiddenfolder
+mkdir -p /home/"${USER}"/.hiddenfolder

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_log_file.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/correct_value_log_file.pass.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 # packages = audit
 
-
 sed -i "/\s*log_group.*/d" /etc/audit/auditd.conf
 sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf
 echo "log_file = /var/log/audit2/audit.log" >> /etc/audit/auditd.conf
 
-mkdir /var/log/audit2
+mkdir -p /var/log/audit2
 groupadd group_test
 
 chgrp root /var/log/audit2

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value_log_file.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_group_ownership_var_log_audit/tests/wrong_value_log_file.fail.sh
@@ -6,7 +6,7 @@ sed -i "/\s*log_file.*/d" /etc/audit/auditd.conf
 echo "log_group = root" >> /etc/audit/auditd.conf
 echo "log_file = /var/log/audit2/audit.log" >> /etc/audit/auditd.conf
 
-mkdir /var/log/audit2
+mkdir -p /var/log/audit2
 groupadd group_test
 
 chgrp root /var/log/audit

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/common_0700.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_permissions_var_log_audit/tests/common_0700.sh
@@ -5,4 +5,4 @@ sed -i "/^\s*log_file.*/d" /etc/audit/auditd.conf
 DIR1=/var/log/audit/
 DIR2=/var/log/audit2/
 
-mkdir ${DIR2}
+mkdir -p "${DIR2}"

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/common.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_group_ownership_var_log_audit/tests/common.sh
@@ -5,7 +5,7 @@ sed -i "/^\s*log_group.*/d" /etc/audit/auditd.conf
 
 groupadd group_test
 rm -f /var/log/audit/*
-mkdir /var/log/audit2/
+mkdir -p /var/log/audit2
 
 FILE1=/var/log/audit/audit.log
 FILE2=/var/log/audit2/audit.log

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/common.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/tests/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
+mkdir -p /etc/audit
 truncate -s 0 /etc/audit/auditd.conf
-mkdir /etc/audit/
 touch /etc/audit/auditd.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/common.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/tests/common.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
+mkdir -p /etc/audit
 truncate -s 0 /etc/audit/auditd.conf
-mkdir /etc/audit/
 touch /etc/audit/auditd.conf

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/all_facilities_set_rsyslog_conf.pass.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_cron_logging/tests/all_facilities_set_rsyslog_conf.pass.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # platform = Oracle Linux 7,Oracle Linux 8
+
 . set_cron_logging.sh
 
 RSYSLOG_CONF='/etc/rsyslog.conf'
 RSYSLOG_D_FOLDER='/etc/rsyslog.d'
-RSYSLOG_D_FILES='/etc/rsyslog.d/*'
+RSYSLOG_D_FILES=("${RSYSLOG_D_FOLDER}"/*)
 
-mkdir $RSYSLOG_D_FOLDER
-rm $RSYSLOG_D_FILES
-truncate -s 0 $RSYSLOG_CONF
+mkdir -p "${RSYSLOG_D_FOLDER}"
+rm -rf "${RSYSLOG_D_FILES[@]}"
+truncate -s 0 "${RSYSLOG_CONF}"
 
-echo '*.*    /var/log/messages' >> $RSYSLOG_CONF
+echo '*.*    /var/log/messages' >> "${RSYSLOG_CONF}"

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/tests/setup.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdriverauthmode/tests/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Use this script to ensure the rsyslog directory structure and rsyslog conf file
 # exist in the test env.
 config_file=/etc/rsyslog.conf
@@ -6,4 +7,4 @@ config_file=/etc/rsyslog.conf
 # Ensure directory structure exists (useful for container based testing)
 test -f $config_file || touch $config_file
 
-test -d /etc/rsyslog.d/ || mkdir /etc/rsyslog.d/
+mkdir -p /etc/rsyslog.d

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/tests/setup.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_actionsendstreamdrivermode/tests/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Use this script to ensure the rsyslog directory structure and rsyslog conf file
 # exist in the test env.
 config_file=/etc/rsyslog.conf
@@ -6,4 +7,4 @@ config_file=/etc/rsyslog.conf
 # Ensure directory structure exists (useful for container based testing)
 test -f $config_file || touch $config_file
 
-test -d /etc/rsyslog.d/ || mkdir /etc/rsyslog.d/
+mkdir -p /etc/rsyslog.d

--- a/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/tests/setup.sh
+++ b/linux_os/guide/system/logging/ensure_rsyslog_log_file_configuration/rsyslog_encrypt_offload_defaultnetstreamdriver/tests/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+
 # Use this script to ensure the rsyslog directory structure and rsyslog conf file
 # exist in the test env.
 config_file=/etc/rsyslog.conf
@@ -6,4 +7,4 @@ config_file=/etc/rsyslog.conf
 # Ensure directory structure exists (useful for container based testing)
 test -f $config_file || touch $config_file
 
-test -d /etc/rsyslog.d/ || mkdir /etc/rsyslog.d/
+mkdir -p /etc/rsyslog.d

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_include_file.pass.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/correct_singleline_include_file.pass.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ ! -d /etc/rsyslog.d/ ]; then
-    mkdir /etc/rsyslog.d
-fi
+mkdir -p /etc/rsyslog.d
 
 cat >> /etc/rsyslog.d/test.conf <<EOF
 action(type="omfwd" protocol="tcp" Target="remote.system.com" port="6514" StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="x509/name" streamdriver.CheckExtendedKeyPurpose="on")

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls/tests/missing_option_include_file.fail.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-if [ ! -d /etc/rsyslog.d/ ]; then
-    mkdir /etc/rsyslog.d
-fi
+mkdir -p /etc/rsyslog.d
 
 cat >> /etc/rsyslog.d/test.conf <<EOF
 action(type="omfwd"

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/world_writable_dir_on_nonlocal_fs.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/world_writable_dir_on_nonlocal_fs.fail.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # packages = nfs-utils
 
-mkdir -p /tmp/testdir/testdir2
-mkdir /tmp/testmount
+mkdir -p /tmp/testdir/testdir2 /tmp/testmount
 chown 2 /tmp/testdir/testdir2
 chmod 777 /tmp/testdir/testdir2
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/world_writable_dir_owned_by_uid_2.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/world_writable_dir_owned_by_uid_2.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-
-mkdir /test
+mkdir -p /test
 chown 2 /test
 chmod 777 /test

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_sticky_bits/tests/correct.pass.sh
@@ -7,9 +7,9 @@ df --local -P | awk '{if (NR!=1) print $6}' \
 -exec chmod a+t {} +
 
 # Create a new dir that has sticky bit but is not word-writable
-mkdir /test_dir_1
+mkdir -p /test_dir_1
 chmod 1770 /test_dir_1
 
 # Create a new dir that is word-writable but doesn't have sticky bit
-mkdir /test_dir_2
+mkdir -p /test_dir_2
 chmod 0774 /test_dir_2

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/tests/wrong_setting.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned/tests/wrong_setting.fail.sh
@@ -3,7 +3,7 @@
 
 useradd testUser
 
-mkdir testDir
+mkdir -p testDir
 
 chown testUser  testDir/
 

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/tests/wrong_setting.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_system_owned_group/tests/wrong_setting.fail.sh
@@ -3,7 +3,7 @@
 
 groupadd testGrp
 
-mkdir testDir
+mkdir -p testDir
 
 chgrp testGrp  testDir/
 

--- a/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/tests/incorrect_group_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_group_root_owned/tests/incorrect_group_owner.fail.sh
@@ -2,9 +2,6 @@
 
 for TESTDIR in /bin/test_me /sbin/test_me /usr/bin/test_me /usr/sbin/test_me /usr/local/bin/test_me /usr/local/sbin/test_me
 do
-   if [[ ! -d $TESTDIR ]]
-   then
-     mkdir $TESTDIR
-   fi
-   chown nobody.nobody $TESTDIR
+   mkdir -p "${TESTDIR}"
+   chown nobody.nobody "${TESTDIR}"
 done

--- a/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/tests/incorrect_owner.fail.sh
+++ b/linux_os/guide/system/permissions/files/dir_system_commands_root_owned/tests/incorrect_owner.fail.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
-  
-for TESTDIR in /bin/test_1 /sbin/test_1 /usr/bin/test_1 /usr/sbin/test_1 /usr/local/bin/test_1 /usr/local/sbin/test_1
-do
-   if [[ ! -d $TESTDIR ]]
-   then
-     mkdir $TESTDIR
-   fi
-   chown nobody.nobody $TESTDIR
-done
+
+TESTDIRS=(
+    /bin/test_1
+    /sbin/test_1
+    /usr/bin/test_1
+    /usr/sbin/test_1
+    /usr/local/bin/test_1
+    /usr/local/sbin/test_1
+)
+mkdir -p "${TESTDIRS[@]}"
+chown nobody.nobody "${TESTDIRS[@]}"

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_ownership_library_dirs/tests/incorrect_owner_within_dir.fail.sh
@@ -4,6 +4,6 @@ useradd user_test
 
 TESTDIR="/usr/lib/dir/"
 
-mkdir $TESTDIR
-touch $TESTDIR/test_me
-chown user_test $TESTDIR/test_me
+mkdir -p "${TESTDIR}"
+touch "${TESTDIR}"/test_me
+chown user_test "${TESTDIR}"/test_me

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_dir_perm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_dir_perm.pass.sh
@@ -9,7 +9,7 @@ chmod -R u-s,g-ws,o-wt /lib /lib64 /usr/lib /usr/lib64
 # Let's setup a symlink to a directory,whose permissions are incompliant
 
 # Directory with incorrect perms
-mkdir /home/user_test/directory
+mkdir -p /home/user_test/directory
 chmod 0766 /home/user_test/directory
 
 # File with correct perms

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_file_perm.pass.sh
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_permissions_library_dirs/tests/dir_symlink_incorrect_file_perm.pass.sh
@@ -9,7 +9,7 @@ chmod -R u-s,g-ws,o-wt /lib /lib64 /usr/lib /usr/lib64
 # Let's setup a symlink to a directory that contains an incomplient file
 
 # Directory with correct perms
-mkdir /home/user_test/directory
+mkdir -p /home/user_test/directory
 chmod 0755 /home/user_test/directory
 
 # File with incorrect perms

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/local_mounted_during_runtime.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/local_mounted_during_runtime.fail.sh
@@ -15,5 +15,5 @@ for partition in ${partitions[@]}; do
 done
 
 PARTITION="/dev/new_partition1"; create_partition
-mkdir /tmp/test_dir
+mkdir -p /tmp/test_dir
 mount $PARTITION /tmp/test_dir

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/remote_without_nodev.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/remote_without_nodev.pass.sh
@@ -15,8 +15,7 @@ for partition in ${partitions[@]}; do
     mount -o remount "$partition"
 done
 
-mkdir /tmp/testdir
-mkdir /tmp/testmount
+mkdir -p /tmp/testdir /tmp/testmount
 chown 2 /tmp/testdir
 chmod 777 /tmp/testdir
 

--- a/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_no_authenticate/tests/wrong_value.fail.sh
@@ -3,6 +3,6 @@
 echo "Defaults !authenticate" >> /etc/sudoers
 chmod 440 /etc/sudoers
 
-mkdir /etc/sudoers.d/
+mkdir -p /etc/sudoers.d
 echo "Defaults !authenticate" >> /etc/sudoers.d/sudoers
 chmod 440 /etc/sudoers.d/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_remove_nopasswd/tests/wrong_value.fail.sh
@@ -3,6 +3,6 @@
 echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 chmod 440 /etc/sudoers
 
-mkdir /etc/sudoers.d/
+mkdir -p /etc/sudoers.d
 echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers.d/sudoers
 chmod 440 /etc/sudoers.d/sudoers

--- a/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/software/sudo/sudo_require_authentication/tests/wrong_value.fail.sh
@@ -4,7 +4,7 @@ echo "%wheel        ALL=(ALL)       NOPASSWD: ALL" >> /etc/sudoers
 echo "Defaults !authenticate" >> /etc/sudoers
 chmod 440 /etc/sudoers
 
-mkdir /etc/sudoers.d/
+mkdir -p /etc/sudoers.d
 echo "%wheel        ALL=(ALL)       !authenticate ALL" >> /etc/sudoers.d/sudoers
 echo "Defaults !authenticate" >> /etc/sudoers.d/sudoers
 chmod 440 /etc/sudoers.d/sudoers

--- a/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
+++ b/shared/templates/sysctl/tests/correct_value_usr_local_lib.pass.sh
@@ -8,7 +8,7 @@
 rm -rf /usr/lib/sysctl.d/* /usr/local/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
-mkdir /usr/local/lib/sysctl.d/
+mkdir -p /usr/local/lib/sysctl.d
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_CORRECT_VALUE }}}" >> /usr/local/lib/sysctl.d/correct.conf
 
 # set correct runtime value to check if the filesystem configuration is evaluated properly

--- a/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
+++ b/shared/templates/sysctl/tests/wrong_value_usr_local_lib.fail.sh
@@ -8,7 +8,7 @@
 rm -rf /usr/lib/sysctl.d/* /run/sysctl.d/* /etc/sysctl.d/*
 
 sed -i "/{{{ SYSCTLVAR }}}/d" /etc/sysctl.conf
-mkdir /usr/local/lib/sysctl.d/
+mkdir -p /usr/local/lib/sysctl.d
 echo "{{{ SYSCTLVAR }}} = {{{ SYSCTL_WRONG_VALUE }}}" >> /usr/local/lib/sysctl.d/wrong.conf
 
 # Setting correct runtime value

--- a/utils/build_profiler.sh
+++ b/utils/build_profiler.sh
@@ -13,14 +13,12 @@ fi
 product_string="$1"
 
 # Create and change to .build_profiling dir 
-[ ! -d ".build_profiling" ] && (mkdir .build_profiling || die \
-"Creating the .build_profiling directory failed")
+mkdir -p .build_profiling || die "Creating the .build_profiling directory failed"
 
 cd .build_profiling || die "Changing to the .build_profiling directory failed"
 
 # Create and change to product_string dir 
-[ ! -d "$product_string" ] && (mkdir "$product_string" || die \
-"Creating the $product_string directory failed")
+mkdir -p "$product_string" || die "Creating the $product_string directory failed"
 
 cd "$product_string" || die "Changing to the $product_string directory failed"
 


### PR DESCRIPTION
#### Description:

This ensure mkdir does not fail if directory already exists.

Also avoid unnecessary tests.

Added simple style changes.

#### Rationale:

Simplify code.

#### Review Hints:

Changes are all over unfortunately.