### PR TITLE
Use bash_package_*

### DIFF
--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/tests/dne.pass.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/tests/dne.pass.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = crontabs
 
 FILE=/etc/cron.deny
 

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/tests/exists.fail.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_cron_deny_not_exist/tests/exists.fail.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
+# packages = crontabs
 
 touch /etc/cron.deny

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/tests/missing_file_test.pass.sh
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_permissions_cron_allow/tests/missing_file_test.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-#
+# packages = crontabs
 
 rm -f /etc/cron.allow

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony.pass.sh
@@ -3,7 +3,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 # Remove all pool options
 sed -i "/^pool.*/d" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_no_pool_nor_servers.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_no_pool_nor_servers.pass.sh
@@ -3,7 +3,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 # Remove all pool and server options
 sed -i "/^pool.*/d" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_nothing_done.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_nothing_done.fail.sh
@@ -4,6 +4,6 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 systemctl enable chronyd.service

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_configured.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_configured.pass.sh
@@ -3,7 +3,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 # Remove all server or pool options
 sed -i "/^\(server\|pool\).*/d" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_misconfigured.fail.sh
@@ -3,7 +3,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 # Remove all server or pool options
 sed -i "/^\(server\|pool\).*/d" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_missing_parameter.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_pool_missing_parameter.fail.sh
@@ -3,7 +3,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 # Remove all server options
 sed -i "/^\(server\|pool\).*/d" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_server_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/chrony_one_server_misconfigured.fail.sh
@@ -3,7 +3,7 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_stig
 
-yum remove -y ntp
+{{{ bash_package_remove("ntp") }}}
 
 # Remove all pool options
 sed -i "/^pool.*/d" {{{ chrony_conf_path }}}

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp.pass.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp.pass.sh
@@ -4,7 +4,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
-yum remove -y chrony
+{{{ bash_package_remove("chrony") }}}
 
 if ! grep "^server.*maxpoll 10" /etc/ntp.conf; then
     sed -i "s/^server.*/& maxpoll 10/" /etc/ntp.conf

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_multiple_misconfigured.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_multiple_misconfigured.fail.sh
@@ -4,7 +4,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
-yum remove -y chrony
+{{{ bash_package_remove("chrony") }}}
 
 sed -i "s/^server.*/& maxpoll 17/" /etc/ntp.conf
 echo "server 0.test.ntp.org maxpoll 17 iburst" >> /etc/ntp.conf

--- a/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_wrong_maxpoll.fail.sh
+++ b/linux_os/guide/services/ntp/chronyd_or_ntpd_set_maxpoll/tests/ntp_wrong_maxpoll.fail.sh
@@ -4,7 +4,7 @@
 # profiles = xccdf_org.ssgproject.content_profile_stig
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
-yum remove -y chrony
+{{{ bash_package_remove("chrony") }}}
 
 sed -i "s/^server.*/& maxpoll 17/" /etc/ntp.conf
 

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/missing.pass.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/missing.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
+# packages = net-snmp
 
-yum -y install net-snmp
 rm -f /etc/snmp/snmpd.conf

--- a/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/package_missing.notapplicable.sh
+++ b/linux_os/guide/services/snmp/snmp_configure_server/snmpd_not_default_password/tests/package_missing.notapplicable.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-yum -y remove net-snmp
+{{{ bash_package_remove("net-snmp") }}}

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_configure_cert_checking/bash/shared.sh
@@ -1,7 +1,6 @@
 # platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol,multi_platform_sle
 
-# Install required packages
-if ! rpm --quiet -q pam_pkcs11; then yum -y -d 1 install pam_pkcs11; fi
+{{{ bash_package_install("pam_pkcs11") }}}
 
 if grep "^\s*cert_policy" /etc/pam_pkcs11/pam_pkcs11.conf | grep -qv "ocsp_on"; then
 	sed -i "/^\s*#/! s/cert_policy.*/cert_policy = ca, ocsp_on, signature;/g" /etc/pam_pkcs11/pam_pkcs11.conf

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_offload_logs/tests/correct.pass.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_offload_logs/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = audit
+# packages = audit,crontabs
 # remediation = none
 
 mkdir -p /etc/cron.weekly/

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_offload_logs/tests/nothing.fail.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_offload_logs/tests/nothing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = audit
+# packages = audit,crontabs
 # remediation = none
 
 mkdir -p /etc/cron.weekly/

--- a/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/bind_not_installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_bind_crypto_policy/tests/bind_not_installed.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
-yum remove -y bind || true
+{{{ bash_package_remove("bind") }}}

--- a/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/libreswan_not_installed.pass.sh
+++ b/linux_os/guide/system/software/integrity/crypto/configure_libreswan_crypto_policy/tests/libreswan_not_installed.pass.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 8,Red Hat Enterprise Linux 9
 
-yum remove -y libreswan || true
+{{{ bash_package_remove("libreswan") }}}

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/oval/shared.xml
@@ -22,7 +22,7 @@
     {{% if 'rhel' not in product and 'ubuntu' not in product and product != 'ol8' %}}
     <ind:subexpression operation="equals">p+i+n+u+g+s+b+acl+selinux+xattrs+sha512</ind:subexpression>
     {{% else %}}
-    <ind:subexpression operation="pattern match">p\+i\+n\+u\+g\+s\+b\+acl(|\+selinux)\+xattrs\+sha512</ind:subexpression>
+    <ind:subexpression operation="pattern match">^p\+i\+n\+u\+g\+s\+b\+acl(|\+selinux)\+xattrs\+sha512$</ind:subexpression>
     {{% endif %}}
   </ind:textfilecontent54_state>
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/correct_with_selinux.pass.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
-
-yum -y install aide
+# packages = aide
 
 declare -a bins
 bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
 
 for theFile in "${bins[@]}"
 do
-    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha5122" >> /etc/aide.conf
+    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha512" >> /etc/aide.conf
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/extra_suffix.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/extra_suffix.fail.sh
@@ -2,13 +2,10 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
 # packages = aide
 
-aide --init
-
-
 declare -a bins
 bins=('/usr/sbin/auditctl' '/usr/sbin/auditd' '/usr/sbin/augenrules' '/usr/sbin/aureport' '/usr/sbin/ausearch' '/usr/sbin/autrace' '/usr/sbin/rsyslogd')
 
 for theFile in "${bins[@]}"
 do
-    echo "$theFile p+i+n+u+g+s+b+acl+xattrs+sha512"  >> /etc/aide.conf
+    echo "$theFile p+i+n+u+g+s+b+acl+selinux+xattrs+sha5122" >> /etc/aide.conf
 done

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/tests/not_config.fail.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel
+# packages = aide
 
-
-yum -y install aide
 aide --init
 
 declare -a bins

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/ansible/shared.yml
@@ -5,10 +5,10 @@
 # disruption = low
 - name: "Ensure AIDE is installed"
   package:
-    name: "{{ item }}"
+    name:
+      - aide
+      - crontabs
     state: present
-  with_items:
-    - aide
 
 - name: Set cron package name - RedHat
   set_fact:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/shared.sh
@@ -1,6 +1,7 @@
 # platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
 
 {{{ bash_package_install("aide") }}}
+{{{ bash_package_install("crontabs") }}}
 
 if ! grep -q "{{{ aide_bin_path }}} --check" /etc/crontab ; then
     echo "05 4 * * * root {{{ aide_bin_path }}} --check" >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/ubuntu.sh
@@ -1,6 +1,7 @@
 # platform = multi_platform_ubuntu
 
 {{{ bash_package_install("aide") }}}
+{{{ bash_package_install("crontabs") }}}
 
 # AiDE usually adds its own cron jobs to /etc/cron.daily. If script is there, this rule is
 # compliant. Otherwise, we copy the script to the /etc/cron.weekly

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# packages = aide,crontabs
 
 if command -v yum; then
     yum remove -y aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/aide_not_installed.fail.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 # packages = aide,crontabs
 
-if command -v yum; then
-    yum remove -y aide
-elif command -v apt-get; then
-    DEBIAN_FRONTEND=noninteractive apt-get remove -y aide
-fi
+{{{ bash_package_remove("aide") }}}
 
 echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 mkdir -p /etc/cron.daily
 echo "/usr/sbin/aide --check" > /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/cron_daily_complex.pass.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 # This TS is a regression test for https://bugzilla.redhat.com/show_bug.cgi?id=2175684
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 echo '21    21    *    *    *    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_daily_shortcut.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 echo '@daily    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_monthly.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_two_days_week.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 echo '21    21    *    *    1-2    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_on_exact_day.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 echo '21    21    *    *    3    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_shortcut.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 echo '@weekly    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_weekly_word.pass.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 echo '21    21    *    *    mon    root    /usr/sbin/aide --check &>/dev/null' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/crontab_yearly.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/tests/not_in_cron.fail.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-#
-# packages = aide
+# packages = aide,crontabs,cronie
 
 # aide installs automatically a file that is periodically run on /etc/cron.daily/aide
 rm -f /etc/cron.daily/aide

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
@@ -7,10 +7,10 @@
 
 - name: "Ensure AIDE is installed"
   package:
-    name: "{{ item }}"
+    name:
+      - aide
+      - crontabs
     state: present
-  with_items:
-    - aide
 
 - name: "{{{ rule_title }}}"
   cron:

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/bash/shared.sh
@@ -1,6 +1,7 @@
 # platform = multi_platform_all
 
 {{{ bash_package_install("aide") }}}
+{{{ bash_package_install("crontabs") }}}
 {{{ bash_instantiate_variables("var_aide_scan_notification_email") }}}
 
 CRONTAB=/etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/cron_weekly_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide
+# packages = aide,crontabs
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' > /etc/cron.weekly/aidescan

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide
+# packages = aide,crontabs
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/crontab_just_periodic_checking.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide
+# packages = aide,crontabs
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check' >> /etc/crontab

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/tests/var_cron_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = aide
+# packages = aide,cronie
 
 # configured in crontab
 echo '0 5 * * * root /usr/sbin/aide  --check | /bin/mail -s "SSG Test Suite - AIDE Integrity Check" admin@ssgtestsuite' >> /var/spool/cron/root


### PR DESCRIPTION
#### Description:

Fix `aide_check_audit_tools` bug where it did not handle suffixes of prefixes and had bad test, found when testing this.

Use `bash_package_install` or `bash_package_remove` or `# packages =` to manage packages, not plain shell commands.

Add some missing packages seen when test system was bare bones.

#### Rationale:

Simplifies code. Makes it more product independent.

#### Review Hints:

Has potentially functionality changes. Unfortunately somewhat all over. Mainly should check aide.