### PR TITLE
bugfix: packages: delim is comma

### DIFF
--- a/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
+++ b/linux_os/guide/services/cron_and_at/service_atd_disabled/tests/service_disabled_rpcstatd_enabled.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = nfs-utils at
+# packages = nfs-utils,at
 #
 
 # this test ensures that only the atd.service is matched, not for example the service rpc-statd

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/tests/openssh-7.4.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
-# packages = openssh-7.4p1 openssh-clients-7.4p1 openssh-server-7.4p1
+# packages = openssh-7.4p1,openssh-clients-7.4p1,openssh-server-7.4p1
 #
 
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_all_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_all_disabled.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
-
-
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl disable pcscd.socket
 systemctl disable pcscd.service

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled.pass.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
-
-
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl enable pcscd.socket
 systemctl start pcscd.socket

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled_with_faillock.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_enabled_with_faillock.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl enable pcscd.socket
 systemctl start pcscd.socket

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_socket_disabled.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_socket_disabled.fail.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
-
-
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl disable pcscd.socket
 

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_authconfig.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl enable pcscd.socket
 systemctl start pcscd.socket

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_pam_faildelay.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_pam_faildelay.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl enable pcscd.socket
 systemctl start pcscd.socket

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_without_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_without_authconfig.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = pcsc-lite pam_pkcs11 esc
+# packages = pcsc-lite,pam_pkcs11,esc
 
 systemctl enable pcscd.socket
 systemctl start pcscd.socket

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/tests/grub_cmdline_linux_correct_value.pass.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/tests/grub_cmdline_linux_correct_value.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = dracut-fips dracut-fips-aesni
+# packages = dracut-fips,dracut-fips-aesni
 
 if grep -q '^GRUB_CMDLINE_LINUX=.*fips=.*"'  /etc/default/grub; then
 	sed -i 's/\(^GRUB_CMDLINE_LINUX=".*\)fips=[^[:space:]]*\(.*"\)/\1 fips=1 \2/'  /etc/default/grub

--- a/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/tests/grub_cmdline_linux_wrong_value.fail.sh
+++ b/linux_os/guide/system/software/integrity/fips/grub2_enable_fips_mode/tests/grub_cmdline_linux_wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# packages = dracut-fips dracut-fips-aesni
+# packages = dracut-fips,dracut-fips-aesni
 
 
 if grep -q '^GRUB_CMDLINE_LINUX=.*fips=.*"'  /etc/default/grub; then


### PR DESCRIPTION
#### Description:

Test files `# <parameter> = ` delimiter is `,`.

#### Rationale:

There might be issues when installing packages.

#### Review Hints:

Changes all over, so expect some breakage when rules is not fit to be tested in some test env.