### PR TITLE
fix: ensure_logrotate_activated/bash: quote #! with '', avoid history expansion

### DIFF
--- a/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
+++ b/linux_os/guide/system/logging/log_rotation/ensure_logrotate_activated/bash/shared.sh
@@ -20,7 +20,7 @@ sed -i '/^\s*\(weekly\|monthly\|yearly\).*$/d' $LOGROTATE_CONF_FILE
 {{% else %}}
 # configure cron.daily if not already
 if ! grep -q "^[[:space:]]*/usr/sbin/logrotate[[:alnum:][:blank:][:punct:]]*$LOGROTATE_CONF_FILE$" $CRON_DAILY_LOGROTATE_FILE; then
-	echo "#!/bin/sh" > $CRON_DAILY_LOGROTATE_FILE
+	echo '#!/bin/sh' > $CRON_DAILY_LOGROTATE_FILE
 	echo "/usr/sbin/logrotate $LOGROTATE_CONF_FILE" >> $CRON_DAILY_LOGROTATE_FILE
 fi
 {{% endif %}}


### PR DESCRIPTION
#### Description:

Especially if remediation code is copy pasted, this most probably will cause confusion.

#### Rationale:

To be more robust.

#### Review Hints:

Simple change.