### PR TITLE
bugfix: configure_etc_hosts_deny/tests/file_missing.fail.sh: typo

### DIFF
--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/tests/file_missing.fail.sh
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/configure_etc_hosts_deny/tests/file_missing.fail.sh
@@ -1,4 +1,4 @@
-#!(bin/bash
+#!/bin/bash
 
 # this is done to ensure that we don't lose ssh connection to the machine
 echo "ALL: ALL" > /etc/hosts.allow


### PR DESCRIPTION
#### Description:

Simple typo

#### Rationale:

This line is not used other than to recognize file format.

#### Review Hints:

simple change