### PR TITLE
bugfix: dir_perms_world_writable_root_owned: do not modify files under /proc

### DIFF
--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -30,10 +30,11 @@
 
 - name: "Create empty list of excluded paths"
   set_fact:
-    excluded_paths: []
+    excluded_paths:
+      - /proc
 
 - name: "Detect nonlocal file systems and add them to excluded paths"
-  set_fact: 
+  set_fact:
     excluded_paths: "{{ excluded_paths | union([item.mount]) }}"
   loop: "{{ ansible_mounts }}"
   when: item.fstype in excluded_fstypes

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/bash/shared.sh
@@ -1,3 +1,5 @@
 # platform = multi_platform_all
 
-find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type d -perm -0002 -uid +0 -exec chown root {} \;
+# At least under containerized env /proc can have files w/o possilibity to
+# modify even as root. And touching /proc is not good idea anyways.
+find / -path /proc -prune -o -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -not -fstype fuse.sshfs -type d -perm -0002 -uid +0 -exec chown root {} \;

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/all_dirs_ok.pass.sh
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/tests/all_dirs_ok.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-find / -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type d -perm -0002 -uid +0 -exec chown root {} \;
+# At least under containerized env /proc can have files w/o possilibity to
+# modify even as root. And touching /proc is not good idea anyways.
+find / -path /proc -prune -o -not -fstype afs -not -fstype ceph -not -fstype cifs -not -fstype smb3 -not -fstype smbfs -not -fstype sshfs -not -fstype ncpfs -not -fstype ncp -not -fstype nfs -not -fstype nfs4 -not -fstype gfs -not -fstype gfs2 -not -fstype glusterfs -not -fstype gpfs -not -fstype pvfs2 -not -fstype ocfs2 -not -fstype lustre -not -fstype davfs -type d -perm -0002 -uid +0 -exec chown root {} \;


### PR DESCRIPTION
#### Description:

At least under containerized env (podman) /proc can have files that are not modifiable even with root. This makes test or bash remediate fail.

#### Rationale:

This issue would be kernel regression and should be handled in another way.

#### Review Hints:

Probably should see how bash remediation survives.