### PR TITLE
bugfix: package_libselinux_installed custom-package-removed.fail.sh: need to set releasever

### DIFF
--- a/linux_os/guide/system/selinux/package_libselinux_installed/tests/custom-package-removed.fail.sh
+++ b/linux_os/guide/system/selinux/package_libselinux_installed/tests/custom-package-removed.fail.sh
@@ -13,5 +13,6 @@ rpm --initdb
 if grep -q "rhel" /etc/os-release; then
     yum install -y redhat-release
 else
-    dnf install -y fedora-release
+    source /etc/os-release
+    dnf install -y fedora-release --releasever "$VERSION_ID"
 fi


### PR DESCRIPTION
#### Description:

+ rm -rf /var/lib/rpm/rpmdb.sqlite /var/lib/rpm/rpmdb.sqlite-shm /var/lib/rpm/rpmdb.sqlite-wal
+ rpm --initdb
+ grep -q rhel /etc/os-release
+ dnf install -y fedora-release Unable to detect release version (use '--releasever' to specify release version) ...
Error: Failed to download metadata for repo 'fedora': Cannot prepare internal mirrorlist: Status code: 404 for https://mirrors.fedoraproject.org/metalink?repo=fedora-$releasever&arch=x86_64 (IP: ...)

#### Rationale:

Make test work.

#### Review Hints:

Test should work.