### PR TITLE
bugfix: aide_periodic_cron_checking: jinja expansion

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/rule.yml
@@ -1,5 +1,5 @@
 {{% if 'ubuntu' in product %}}
-{{% set config_command_line="--config {{{ aide_conf_path }}} " %}}
+{{% set config_command_line="--config " ~ aide_conf_path ~ " " %}}
 {{% endif %}}
 
 documentation_complete: true


### PR DESCRIPTION
#### Description:

Somehow we still have jinja inside jinja.

#### Rationale:

This does not what is wanted.

#### Review Hints:

Only `Ubuntu` needs to be considered.