### PR TITLE
Some SLE 12/15 fixes related to the rule accounts_passwords_pam_tally2

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -762,6 +762,8 @@ controls:
     - accounts_passwords_pam_faillock_deny_root
     # same as above but for pam_tally2 module
     - accounts_passwords_pam_tally2_deny_root
+    - var_password_pam_tally2=5
+    - accounts_passwords_pam_tally2  
     # Automatically unlock users after 15 min to prevent DoS
     - var_accounts_passwords_pam_faillock_unlock_time=900
     - accounts_passwords_pam_faillock_unlock_time

--- a/controls/pcidss_3.yml
+++ b/controls/pcidss_3.yml
@@ -1312,6 +1312,7 @@ controls:
     status: automated
     rules:
       - accounts_passwords_pam_faillock_deny
+      - var_password_pam_tally2=3
       - accounts_passwords_pam_tally2
 
   - id: Req-8.1.7

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -1547,6 +1547,7 @@ controls:
       status: automated
       rules:
         - accounts_passwords_pam_faillock_deny
+        - var_password_pam_tally2=3
         - accounts_passwords_pam_tally2
         - accounts_passwords_pam_faillock_unlock_time
         - accounts_passwords_pam_tally2_unlock_time

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/ansible/shared.yml
@@ -6,6 +6,12 @@
 
 {{{ ansible_instantiate_variables("var_password_pam_tally2")  }}}
 
-{{{ ansible_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'deny', "{{ var_password_pam_tally2 }}", '') }}}
-{{{ ansible_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'onerr', 'fail', '(fail)') }}}
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
+{{{ ansible_ensure_pam_module_option(cfg_file, 'auth', 'required', 'pam_tally2.so', 'deny', "{{ var_password_pam_tally2 }}", '') }}}
+{{{ ansible_ensure_pam_module_option(cfg_file, 'auth', 'required', 'pam_tally2.so', 'onerr', 'fail', '(fail)') }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/bash/shared.sh
@@ -2,6 +2,12 @@
 
 {{{ bash_instantiate_variables("var_password_pam_tally2") }}}
 # Use a non-number regexp to force update of the value of the deny option
-{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'deny', "${var_password_pam_tally2}", '') }}}
-{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'onerr', 'fail', '(fail)') }}}
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
+{{{ bash_ensure_pam_module_option( cfg_file, 'auth', 'required', 'pam_tally2.so', 'deny', "${var_password_pam_tally2}", '') }}}
+{{{ bash_ensure_pam_module_option( cfg_file, 'auth', 'required', 'pam_tally2.so', 'onerr', 'fail', '(fail)') }}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/oval/shared.xml
@@ -17,7 +17,11 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_deny_auth" comment="Check deny configuration of pam_tally2" version="1">
+  {{% if product in ["sle12","sle15" ] %}}
+  <ind:filepath>/etc/pam.d/login</ind:filepath>
+  {{% else %}}  
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+  {{% endif %}}  
     <ind:pattern operation="pattern match">^\s*auth(?:(?!\n)\s)+required(?:(?!\n)\s)+pam_tally2.so(?:(?!\n)\s)+(?:(?:(?:(?!\n)\s)?[^\n]+)?onerr=fail(?:(?:(?!\n)\s)+[^\n]+)?(?:(?!\n)\s)+deny=(\d+)(?:(?:\s+\S+)*\s*$))|(?:(?:(?:(?!\n)\s)?[^\n]+)?deny=(\d+)(?:(?:(?!\n)\s)+[^\n]+)?(?:(?!\n)\s)+onerr=fail(?:(?:\s+\S+)*\s*$))</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/rule.yml
@@ -1,3 +1,10 @@
+{{% if product in ["sle12","sle15"] %}}
+{{% set auth_config="/etc/pam.d/login" %}}
+{{% set audit_cmd="grep -E '^\s*auth\s+\S+\s+pam_(tally2|unix)\.so' /etc/pam.d/login" %}}
+{{% else %}}
+{{% set auth_config="/etc/pam.d/common-auth" %}}
+{{% set audit_cmd="grep pam_tally2.so /etc/pam.d/common-auth" %}}
+{{% endif %}}
 documentation_complete: true
 
 prodtype: sle12,sle15,ubuntu2004
@@ -15,12 +22,12 @@ rationale: |-
 
     To configure the operating system to lock an account after three
     unsuccessful consecutive access attempts using <tt>pam_tally2.so</tt>,
-    modify the content of both <tt>/etc/pam.d/common-auth</tt> and
+    modify the content of both <tt>{{{ auth_config }}}</tt> and
     <tt>/etc/pam.d/common-account</tt> as follows:
     <br /><br />
     <ul>
     <li> add or modify the <tt>pam_tally2.so</tt> module line in
-    <tt>/etc/pam.d/common-auth</tt> to ensure both <tt>onerr=fail</tt> and
+    <tt>{{{ auth_config }}}</tt> to ensure both <tt>onerr=fail</tt> and
     <tt>deny={{{ xccdf_value("var_password_pam_tally2") }}}</tt> are present. For example:
     <pre>auth required pam_tally2.so onerr=fail silent audit deny={{{ xccdf_value("var_password_pam_tally2") }}}</pre></li>
     <li> add or modify the following line in <tt>/etc/pam.d/common-account</tt>:
@@ -52,7 +59,7 @@ ocil: |-
     Check that the systems locks a user account after - at most - <tt>{{{ xccdf_value("var_password_pam_tally2") }}}</tt>
     consecutive failed login attempts with the following command:
 
-    <pre># grep pam_tally2.so /etc/pam.d/common-auth
+    <pre># {{{ audit_cmd }}}
     auth required pam_tally2.so onerr=fail deny={{{ xccdf_value("var_password_pam_tally2") }}}</pre>
 
     If no line is returned, the line is commented out, or the line is missing

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/missing_pam_tally2.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/missing_pam_tally2.fail.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 # platform = multi_platform_sle,Ubuntu 20.04
 
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
 cat >/etc/pam.d/common-account <<CAPCM
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
 account	requisite			pam_deny.so
 account	required			pam_permit.so
 CAPCM
 
-cat >/etc/pam.d/common-auth <<CAUPACM
+cat >{{{ cfg_file }}} <<CAUPACM
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAUPACM
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_big_deny.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_big_deny.fail.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_sle,Ubuntu 20.04
 
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
 cat >/etc/pam.d/common-account <<CACPCC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
 account	requisite			pam_deny.so
@@ -8,11 +14,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CACPCC
 
-cat /etc/pam.d/common-auth <<CAUPCBD
+cat >{{{ cfg_file }}} <<CAUPCBD
 auth required pam_tally2.so onerr=fail audit silent deny=20 unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAUPCBD
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_commented.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_commented.fail.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_sle,Ubuntu 20.04
 
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
 cat >/etc/pam.d/common-account <<CACPCC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
 account	requisite			pam_deny.so
@@ -8,11 +14,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CACPCC
 
-cat >/etc/pam.d/common-auth <<CAUPCCM
+cat >{{{ cfg_file }}} <<CAUPCCM
 #auth required pam_tally2.so onerr=fail audit silent deny=3 unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAUPCCM
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_configured.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_configured.pass.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_sle,Ubuntu 20.04
 
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
 cat >/etc/pam.d/common-account <<CACPCC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
 account	requisite			pam_deny.so
@@ -8,11 +14,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CACPCC
 
-cat >/etc/pam.d/common-auth <<CAUPCC
+cat >{{{ cfg_file }}} <<CAUPCC
 auth required pam_tally2.so onerr=fail audit silent deny=3 unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAUPCC
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_empty_deny.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_empty_deny.fail.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_sle,Ubuntu 20.04
 
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
 cat >/etc/pam.d/common-account <<CACPCC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
 account	requisite			pam_deny.so
@@ -8,11 +14,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CACPCC
 
-cat >/etc/pam.d/common-auth <<CAUPCED
+cat >{{{ cfg_file }}} <<CAUPCED
 auth required pam_tally2.so onerr=fail audit silent deny= unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAUPCED
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_zero_deny.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2/tests/pam_tally2_zero_deny.fail.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # platform = multi_platform_sle,Ubuntu 20.04
 
+{{% if product in ["sle12","sle15"] %}}
+{{% set cfg_file = '/etc/pam.d/login' %}}
+{{% else %}}
+{{% set cfg_file = '/etc/pam.d/common-auth' %}}
+{{% endif %}}
+
 cat >/etc/pam.d/common-account <<CACPCC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
 account	requisite			pam_deny.so
@@ -8,11 +14,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CACPCC
 
-cat >/etc/pam.d/common-auth <<CAPCZD
+cat >{{{ cfg_file }}} <<CAPCZD
 auth required pam_tally2.so onerr=fail audit silent deny=0 unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPCZD
-

--- a/products/sle15/profiles/pcs-hardening.profile
+++ b/products/sle15/profiles/pcs-hardening.profile
@@ -61,6 +61,7 @@ selections:
     - accounts_password_set_min_life_existing
     - accounts_passwords_pam_faildelay_delay
     - accounts_passwords_pam_tally2
+    - var_password_pam_tally2=5
     - accounts_tmout
     - accounts_umask_etc_login_defs
     - accounts_umask_etc_profile

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -58,6 +58,7 @@ selections:
     - accounts_password_set_min_life_existing
     - accounts_passwords_pam_faildelay_delay
     - accounts_passwords_pam_tally2
+    - var_password_pam_tally2=3
     - accounts_password_pam_unix_remember
     - accounts_tmout
     - accounts_umask_etc_login_defs


### PR DESCRIPTION
#### Description:

- _This PR fixes the rule accounts_passwords_pam_tally2 according to SLE 12/15 requirements_

#### Rationale:

- 1/In some profiles the variable var_password_pam_tally2 was not set 2/The rule was excluded from ANSSI profile and 3/the rule in SLE 12/15 uses /etc/pam.d/login file to set configuration parameters 
