### PR TITLE
Fixes in SLE 12/15 rule accounts_passwords_pam_tally2_deny_root

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -755,6 +755,8 @@ controls:
     - var_accounts_passwords_pam_faillock_deny=3
     - accounts_passwords_pam_faillock_deny
     - accounts_passwords_pam_faillock_deny_root
+    # same as above but for pam_tally2 module
+    - accounts_passwords_pam_tally2_deny_root
     # Automatically unlock users after 15 min to prevent DoS
     - var_accounts_passwords_pam_faillock_unlock_time=900
     - accounts_passwords_pam_faillock_unlock_time

--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -1770,6 +1770,7 @@ controls:
     rules:
       - accounts_passwords_pam_tally2
       - var_password_pam_tally2=5
+      - accounts_passwords_pam_tally2_deny_root
 
   - id: 5.3.3
     title: Ensure password reuse is limited (Automated)

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -1954,6 +1954,7 @@ controls:
     rules:
       - accounts_passwords_pam_tally2
       - var_password_pam_tally2=5
+      - accounts_passwords_pam_tally2_deny_root
 
   - id: 5.3.3
     title: Ensure password reuse is limited (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/ansible/shared.yml
@@ -4,6 +4,11 @@
 # complexity = low
 # disruption = low
 
+{{% if product in ["sle12","sle15"] %}}
+{{{ ansible_remove_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'onerr=fail') }}}
+{{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'even_deny_root', '', '') }}}
+{{% else %}}
+{{{ ansible_remove_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'onerr=fail') }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'even_deny_root', '', '') }}}
-
+{{% endif %}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/bash/shared.sh
@@ -4,6 +4,11 @@
 # complexity = low
 # disruption = low
 
+{{% if product in ["sle12","sle15"] %}}
+{{{ bash_remove_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'onerr=fail') }}}
+{{{ bash_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'even_deny_root', '', '') }}}
+{{% else %}}
+{{{ bash_remove_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'onerr=fail') }}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'even_deny_root', '', '') }}}
-
+{{% endif %}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/oval/shared.xml
@@ -17,9 +17,13 @@
   </ind:textfilecontent54_test>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_even_deny_root" comment="Check even deny root configuration of pam_tally2" version="1">
+    {{% if product in ["sle12","sle15"] %}}
+    <ind:filepath>/etc/pam.d/login</ind:filepath>
+    {{% else %}}
     <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
-    <ind:pattern operation="pattern match">^\s*auth\s+required\s+pam_tally2\.so\s+[^\n]*deny=[[4-9]|[1-9][0-9]]+([\s+\S+]*)even_deny_root([\s+\S+])*\s*(\\)*$</ind:pattern>
-    <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
+    {{% endif %}}
+    <ind:pattern operation="pattern match">^\s*auth(?:(?!\n)\s)+required(?:(?!\n)\s)+pam_tally2.so(?:(?!\n)\s)+(?:(?:(?:(?!\n)\s)?[^\n]+)?onerr=fail(?:(?:(?!\n)\s)+[^\n]+)?(?:(?!\n)\s)+deny=(\d+)(?:(?:\s+\S+)*\s*$))|(?:(?:(?:(?!\n)\s)?[^\n]+)?deny=(\d+)(?:(?:(?!\n)\s)+[^\n]+)?(?:(?!\n)\s)+even_deny_root(?:(?:\s+\S+)*\s*$))</ind:pattern>
+    <ind:instance datatype="int">1</ind:instance>    
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_test id="test_accounts_passwords_pam_tally2_even_deny_root_account"

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/rule.yml
@@ -21,6 +21,8 @@ identifiers:
 
 references:
     anssi: BP28(R18)
+    cis@sle12: 5.3.2
+    cis@sle15: 5.3.2    
     cis-csc: 1,12,15,16
     cobit5: DSS05.04,DSS05.10,DSS06.10
     disa: CCI-002238,CCI-000044
@@ -38,17 +40,17 @@ ocil_clause: 'limiting the number of failed logon attempts for the root user is 
 ocil: |-
     To ensure that even the <tt>root</tt> account is locked after a defined number of failed password
     attempts, run the following command:
-    <pre>$ grep even_deny_root /etc/pam.d/common-auth</pre>
+    <pre>$ grep even_deny_root /etc/pam.d/login</pre>
     The output should show <tt>even_deny_root</tt>.
 
 fixtext: |-
     To configure the system to lock out the <tt>root</tt> account after a number of incorrect login
-    attempts using <tt>pam_tally2.so</tt>, modify the content of both <tt>/etc/pam.d/common-auth</tt> and
+    attempts using <tt>pam_tally2.so</tt>, modify the content of both <tt>/etc/pam.d/login</tt> and
     <tt>/etc/pam.d/common-account</tt> as follows:
     <br /><br />
     <ul>
     <li> add or modify the <tt>pam_tally2.so</tt> module line in
-    <tt>/etc/pam.d/common-auth</tt> to ensure  <tt>even_deny_root</tt> is present. For example:
+    <tt>/etc/pam.d/login</tt> to ensure  <tt>even_deny_root</tt> is present. For example:
     <pre>auth     required       pam_tally2.so deny=4 even_deny_root unlock_time=1200</pre>
     <li> add or modify the following line in <tt>/etc/pam.d/common-account</tt>:
     <pre>account required pam_tally2.so</pre></li>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_absent_account_config.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_absent_account_config.fail.sh
@@ -7,6 +7,18 @@ account	requisite			pam_deny.so
 account	required			pam_permit.so
 CAPTA
 
+{{% if product in ["sle12","sle15"] %}}
+
+cat >/etc/pam.d/login <<CAPTEDRC
+auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root unlock_time=900
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+auth	requisite			pam_deny.so
+auth	required			pam_permit.so
+auth	optional			pam_cap.so
+CAPTEDRC
+
+{{% else %}}
+
 cat >/etc/pam.d/common-auth <<CAPTEDRC
 auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
@@ -14,3 +26,5 @@ auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTEDRC
+
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_deny_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_deny_missing.fail.sh
@@ -8,6 +8,18 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CAPTAC
 
+{{% if product in ["sle12","sle15"] %}}
+
+cat >/etc/pam.d/login <<CAPTDM
+auth required pam_tally2.so onerr=fail audit silent even_deny_root unlock_time=900
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+auth	requisite			pam_deny.so
+auth	required			pam_permit.so
+auth	optional			pam_cap.so
+CAPTDM
+
+{{% else %}}
+
 cat >/etc/pam.d/common-auth <<CAPTDM
 auth required pam_tally2.so onerr=fail audit silent even_deny_root unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
@@ -15,3 +27,5 @@ auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTDM
+
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_even_deny_root_absent.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_even_deny_root_absent.fail.sh
@@ -8,6 +8,18 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CAPTC
 
+{{% if product in ["sle12","sle15"] %}}
+
+cat >/etc/pam.d/login <<CAPTEDRM
+auth required pam_tally2.so onerr=fail audit silent deny=3 unlock_time=900
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+auth	requisite			pam_deny.so
+auth	required			pam_permit.so
+auth	optional			pam_cap.so
+CAPTEDRM
+
+{{% else %}}
+
 cat >/etc/pam.d/common-auth <<CAPTEDRM
 auth required pam_tally2.so onerr=fail audit silent deny=3 unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
@@ -16,3 +28,4 @@ auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTEDRM
 
+{{% endif %}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_even_deny_root_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_deny_root/tests/pam_tally2_even_deny_root_present.pass.sh
@@ -8,6 +8,18 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CAPTC
 
+{{% if product in ["sle12","sle15"] %}}
+
+cat >/etc/pam.d/login <<CAPTEDRC
+auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root unlock_time=900
+auth	[success=1 default=ignore]	pam_unix.so nullok_secure
+auth	requisite			pam_deny.so
+auth	required			pam_permit.so
+auth	optional			pam_cap.so
+CAPTEDRC
+
+{{% else %}}
+
 cat >/etc/pam.d/common-auth <<CAPTEDRC
 auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
@@ -16,3 +28,4 @@ auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTEDRC
 
+{{% endif %}}


### PR DESCRIPTION
#### Description:

- _This fix corrects some errors related to SLE 12/15 rule accounts_passwords_pam_tally2_deny_root_

#### Rationale:

- 1/In pam_tally2 uses /etc/pam.d/login to set configuration parameters. 2/When we need to have even_deny_root parameter we need to remove onerr=fail configuration parameter
