### PR TITLE
Fix in SLE 12/15 rule accounts_passwords_pam_tally2_unlock_time

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -764,6 +764,8 @@ controls:
     - accounts_passwords_pam_tally2_deny_root
     - var_password_pam_tally2=5
     - accounts_passwords_pam_tally2  
+    - accounts_passwords_pam_tally2_unlock_time
+    - var_accounts_passwords_pam_tally2_unlock_time=1800
     # Automatically unlock users after 15 min to prevent DoS
     - var_accounts_passwords_pam_faillock_unlock_time=900
     - accounts_passwords_pam_faillock_unlock_time

--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -1774,6 +1774,8 @@ controls:
       - accounts_passwords_pam_tally2
       - var_password_pam_tally2=5
       - accounts_passwords_pam_tally2_deny_root
+      - accounts_passwords_pam_tally2_unlock_time
+      - var_accounts_passwords_pam_tally2_unlock_time=1800
 
   - id: 5.3.3
     title: Ensure password reuse is limited (Automated)

--- a/controls/cis_sle15.yml
+++ b/controls/cis_sle15.yml
@@ -1968,6 +1968,8 @@ controls:
       - accounts_passwords_pam_tally2
       - var_password_pam_tally2=5
       - accounts_passwords_pam_tally2_deny_root
+      - accounts_passwords_pam_tally2_unlock_time
+      - var_accounts_passwords_pam_tally2_unlock_time=1800
 
   - id: 5.3.3
     title: Ensure password reuse is limited (Automated)

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -6,6 +6,5 @@
 
 {{{ ansible_instantiate_variables("var_accounts_passwords_pam_tally2_unlock_time") }}}
 
-{{{ ansible_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'unlock_time', '${var_accounts_passwords_pam_tally2_unlock_time}', '') }}}
-
+{{{ ansible_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'unlock_time', "{{var_accounts_passwords_pam_tally2_unlock_time}}", '') }}}
 {{{ ansible_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low
@@ -6,6 +6,5 @@
 
 {{{ bash_instantiate_variables("var_accounts_passwords_pam_tally2_unlock_time") }}}
 # Use a non-number regexp to force update of the value of the deny option
-{{{ bash_ensure_pam_module_option('/etc/pam.d/common-auth', 'auth', 'required', 'pam_tally2.so', 'unlock_time', '${var_accounts_passwords_pam_tally2_unlock_time}', '') }}}
-
+{{{ bash_ensure_pam_module_option('/etc/pam.d/login', 'auth', 'required', 'pam_tally2.so', 'unlock_time', "${var_accounts_passwords_pam_tally2_unlock_time}", '') }}}
 {{{ bash_ensure_pam_module_option('/etc/pam.d/common-account', 'account', 'required', 'pam_tally2.so', '', '', '') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/oval/shared.xml
@@ -19,7 +19,7 @@
                      comment="number of failed login attempts allowed" version="1"/>
 
   <ind:textfilecontent54_object id="object_accounts_passwords_pam_tally2_unlock_time" comment="Check unlock_time configuration of pam_tally2" version="1">
-    <ind:filepath>/etc/pam.d/common-auth</ind:filepath>
+    <ind:filepath>/etc/pam.d/login</ind:filepath>
     <ind:pattern operation="pattern match">^\s*auth\s+required\s+pam_tally2\.so\s+[^\n]*unlock_time=([0-9]+)([\s+\S+])*\s*(\\)*$</ind:pattern>
     <ind:instance datatype="int" operation="greater than or equal">1</ind:instance>
   </ind:textfilecontent54_object>

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/rule.yml
@@ -22,6 +22,8 @@ identifiers:
 references:
     anssi: BP28(R18)
     cis-csc: 1,12,15,16
+    cis@sle12: 5.3.2
+    cis@sle15: 5.3.2 
     cobit5: DSS05.04,DSS05.10,DSS06.10
     disa: CCI-002238,CCI-000044
     isa-62443-2009: 4.3.3.6.1,4.3.3.6.2,4.3.3.6.3,4.3.3.6.4,4.3.3.6.5,4.3.3.6.6,4.3.3.6.7,4.3.3.6.8,4.3.3.6.9
@@ -39,13 +41,13 @@ ocil_clause: 'unlock_time is less than the expected value'
 
 ocil: |-
     To ensure the failed password attempt policy is configured correctly, run the following command:
-    <pre>$ grep pam_tally2 /etc/pam.d/system-auth /etc/pam.d/common-auth</pre>
+    <pre>$ grep pam_tally2 /etc/pam.d/login</pre>
     The output should show <tt>unlock_time=&lt;interval-in-seconds&gt;</tt> where <tt>interval-in-seconds</tt> is <tt>{{{ xccdf_value("var_accounts_passwords_pam_faillock_unlock_time") }}}</tt> or greater.
 
 fixtext: |-
     To configure the system to lock out accounts during a specified time period after a number of
     incorrect login attempts using <tt>pam_faillock.so</tt>,
-    Modify the content of both <tt>/etc/pam.d/common-auth</tt>, like this:
+    Modify the content of both <tt>/etc/pam.d/login</tt>, like this:
     <pre>auth required pam_tally2.so deny={{{ xccdf_value("var_accounts_passwords_pam_tally2_deny") }}} <tt>unlock_time={{{ xccdf_value("var_accounts_passwords_pam_tally2_unlock_time") }}}</tt> </pre>
 
 platform: package[pam]

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_absent_account_config.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_absent_account_config.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,Ubuntu 20.04
+# platform = multi_platform_sle
 
 cat >/etc/pam.d/common-account <<CAPTA
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
@@ -7,11 +7,10 @@ account	requisite			pam_deny.so
 account	required			pam_permit.so
 CAPTA
 
-cat >/etc/pam.d/common-auth <<CAPTUTC
+cat >/etc/pam.d/login <<CAPTUTC
 auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTUTC
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_auth_unlock_time_configured.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_auth_unlock_time_configured.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,Ubuntu 20.04
+# platform = multi_platform_sle
 
 cat >/etc/pam.d/common-account <<CAPTC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
@@ -8,11 +8,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CAPTC
 
-cat >/etc/pam.d/common-account <<CAPTUTC
+cat >/etc/pam.d/login <<CAPTUTC
 auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTUTC
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_deny_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_deny_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,Ubuntu 20.04
+# platform = multi_platform_sle
 
 cat >/etc/pam.d/common-account <<CAPTC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
@@ -8,11 +8,10 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CAPTC
 
-cat >/etc/pam.d/common-auth <<CAPTDM
+cat >/etc/pam.d/login <<CAPTDM
 auth required pam_tally2.so onerr=fail audit silent even_deny_root unlock_time=900
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so
 auth	required			pam_permit.so
 auth	optional			pam_cap.so
 CAPTDM
-

--- a/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_unlock_time_missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/locking_out_password_attempts/accounts_passwords_pam_tally2_unlock_time/tests/pam_tally2_unlock_time_missing.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = multi_platform_sle,Ubuntu 20.04
+# platform = multi_platform_sle
 
 cat >/etc/pam.d/common-account <<CAPTC
 account	[success=1 new_authtok_reqd=done default=ignore]	pam_unix.so
@@ -8,7 +8,7 @@ account required                        pam_tally2.so
 account	required			pam_permit.so
 CAPTC
 
-cat >/etc/pam.d/common-auth <<CAPTUTA
+cat >/etc/pam.d/login <<CAPTUTA
 auth required pam_tally2.so onerr=fail audit silent deny=3 even_deny_root
 auth	[success=1 default=ignore]	pam_unix.so nullok_secure
 auth	requisite			pam_deny.so


### PR DESCRIPTION
#### Description:

- _The fix corrects SLE 12/15 rule passwords_pam_tally2_unlock_time_

#### Rationale:

- 1/pam_tally2 keeps configuration parameters in /etc/pam.d/login 2/ansible part was not correct 3/in different profiles the variable var_accounts_passwords_pam_tally2_unlock_time was not set
