### PR TITLE
Fix tests applicablity for ol8 product

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/default_config.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/default_config.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,multi_platform_ol,multi_platform_ubuntu
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,multi_platform_ubuntu
 
 {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
 {{% set pam_lastlog_path = "/etc/pam.d/login" %}}

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/silent_present.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/silent_present.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,multi_platform_ol,multi_platform_ubuntu
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,multi_platform_ubuntu
 
 {{% if product in ["sle12", "sle15"] or 'ubuntu' in product %}}
 {{% set pam_lastlog_path = "/etc/pam.d/login" %}}

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_control.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 pam_file="/etc/pam.d/postlogin"
 

--- a/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/display_login_attempts/tests/wrong_value.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
 rm -f /etc/pam.d/postlogin
 # pamd ansible module has a bug that if there is only one line in the file it raises an Out of Index exception

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/correct_entry.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/correct_entry.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # packages = pam
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 config_file=/etc/pam.d/password-auth
 if [ $(grep -c "^\s*password.*requisite.*pam_pwquality\.so" $config_file) -eq 0 ]; then

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/missing_entry.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/missing_entry.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 # packages = pam
 
 config_file=/etc/pam.d/password-auth

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_pwquality_password_auth/tests/wrong_control.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 pam_file="/etc/pam.d/password-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 pam_file="/etc/pam.d/password-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/missing.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/password-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_passwordauth/tests/wrong_control.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 pam_file="/etc/pam.d/password-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/correct.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 pam_file="/etc/pam.d/system-auth"
 

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/missing.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 sed -i --follow-symlinks '/^password.*sufficient.*pam_unix\.so/ s/sha512//g' "/etc/pam.d/system-auth"

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_control.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_algorithm_systemauth/tests/wrong_control.fail.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# platform = Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol
+# platform = Oracle Linux 7,Red Hat Enterprise Linux 7,Red Hat Virtualization 4,multi_platform_fedora
 
 pam_file="/etc/pam.d/system-auth"
 

--- a/shared/templates/service_enabled/tests/service_disabled.fail.sh
+++ b/shared/templates/service_enabled/tests/service_disabled.fail.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-{{% if SERVICENAME == sshd %}}
+{{% if SERVICENAME == "sshd" %}}
 # platform = Not Applicable
-{{% endif%}}
+{{% endif %}}
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'

--- a/shared/templates/service_enabled/tests/service_enabled.pass.sh
+++ b/shared/templates/service_enabled/tests/service_enabled.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-{{% if SERVICENAME == sshd %}}
+{{% if SERVICENAME == "sshd" %}}
 # platform = Not Applicable
-{{% endif%}}
+{{% endif %}}
 # packages = {{{ PACKAGENAME }}}
 
 SYSTEMCTL_EXEC='/usr/bin/systemctl'


### PR DESCRIPTION
#### Description:

- There were a few tests part of rules in stig profile which were marked as applicable to ol8 but shouldn't. This address those issues

#### Rationale:

- When testing ol8 stig profile with automatus, there were some false positives. Marking tests correctly as nonapplicable to address that

#### Review Hints:

- All these changed tests should be marked as not applicable when testing with automatus in OL8