### PR TITLE
fix: ensure_fedora_gpgkey_installed/bash: use bash_package_install

### DIFF
--- a/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_fedora_gpgkey_installed/bash/shared.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_fedora
 
-dnf install -y gpg
+{{{ bash_package_install("gpg") }}}
 
 fedora_version=$(grep -oP '[[:digit:]]+' /etc/redhat-release)
 


### PR DESCRIPTION
#### Description:

Use common macro `bash_package_install` to package installs.

#### Rationale:

Even if there is platform limiter and so on I still think it is better to use the macro.

#### Review Hints:

Simple change, the rule remediation should be tested.