### PR TITLE
Fix issue when adding fstab entries with iso9660

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1587,7 +1587,7 @@ if ! grep "$mount_point_match_regexp" /etc/fstab; then
                 | sed -E "s/(rw|defaults|seclabel|{{{ mount_opt }}})(,|$)//g;s/,$//")
     [ "$previous_mount_opts" ] && previous_mount_opts+=","
     # In iso9660 filesystems mtab could describe a "blocksize" value, this should be reflected in fstab as "block"
-    if [  {{{ type }}} == "iso9660" ] ; then
+    if [  "{{{ type }}}" == "iso9660" ] ; then
         previous_mount_opts=$(sed 's/blocksize=/block=/' <<< "$previous_mount_opts")
     fi
     echo "{{{ fs_spec }}} {{{ mount_point }}} {{{ type }}} defaults,${previous_mount_opts}{{{ mount_opt }}} 0 0" >> /etc/fstab

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1586,6 +1586,10 @@ if ! grep "$mount_point_match_regexp" /etc/fstab; then
     previous_mount_opts=$(grep "$mount_point_match_regexp" /etc/mtab | head -1 |  awk '{print $4}' \
                 | sed -E "s/(rw|defaults|seclabel|{{{ mount_opt }}})(,|$)//g;s/,$//")
     [ "$previous_mount_opts" ] && previous_mount_opts+=","
+    # In iso9660 filesystems mtab could describe a "blocksize" value, this should be reflected in fstab as "block"
+    if [  {{{ type }}} == "iso9660" ] ; then
+        previous_mount_opts=$(sed 's/blocksize=/block=/' <<< "$previous_mount_opts")
+    fi
     echo "{{{ fs_spec }}} {{{ mount_point }}} {{{ type }}} defaults,${previous_mount_opts}{{{ mount_opt }}} 0 0" >> /etc/fstab
 # If the mount_opt option is not already in the mount point's /etc/fstab entry, add it
 elif ! grep "$mount_point_match_regexp" /etc/fstab | grep "{{{ mount_opt }}}"; then

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1586,8 +1586,10 @@ if ! grep "$mount_point_match_regexp" /etc/fstab; then
     previous_mount_opts=$(grep "$mount_point_match_regexp" /etc/mtab | head -1 |  awk '{print $4}' \
                 | sed -E "s/(rw|defaults|seclabel|{{{ mount_opt }}})(,|$)//g;s/,$//")
     [ "$previous_mount_opts" ] && previous_mount_opts+=","
-    # In iso9660 filesystems mtab could describe a "blocksize" value, this should be reflected in fstab as "block"
-    if [  "{{{ type }}}" == "iso9660" ] ; then
+    # In iso9660 filesystems mtab could describe a "blocksize" value, this should be reflected in
+    # fstab as "block".  The next variable is to satisfy shellcheck SC2050.
+    fs_type="{{{ type }}}"
+    if [  "$fs_type" == "iso9660" ] ; then
         previous_mount_opts=$(sed 's/blocksize=/block=/' <<< "$previous_mount_opts")
     fi
     echo "{{{ fs_spec }}} {{{ mount_point }}} {{{ type }}} defaults,${previous_mount_opts}{{{ mount_opt }}} 0 0" >> /etc/fstab


### PR DESCRIPTION
#### Description:

- Replace `blocksize` parameter with `block` when retrieving an `iso9660` mount point from mtab and adding it to fstab

#### Rationale:

- It was noticed that `iso9660` file systems, when present in `mtab` file, could include a  `blocksize` parameter. However that's not valid in `fstab` and there the equivalent parameter is called `block`

#### Review Hints:

- I wasn't able to come up with an automated test. But manually it can be tested in next way:
  - Mount a cdrom in the system, E.g.:
```
 # mkdir /mnt/cdrom
 # mount /dev/cdrom /mnt/cdrom/
```
  - Run bash remediation for  `mount_option_nodev_nonroot_local_partitions` E.g.:
   ```
 # oscap xccdf eval --profile stig --rule xccdf_org.ssgproject.content_rule_mount_option_nodev_nonroot_local_partitions --results-arf /tmp/arf.xml /usr/share/xml/scap/ssg/content/ssg-ol8-ds.xml
 # oscap xccdf generate fix --fix-type bash --result-id "" /tmp/arf.xml > bash-fix.sh
 # bash bash-fix.sh
```
  - Reboot system
  - The system won't reboot with previous remediation due to an entry similar to this: 
` /dev/sr0 /mnt/cdrom iso9660 defaults,ro,relatime,nojoliet,check=s,map=n,blocksize=2048,iocharset=utf8,nodev 0 0`
  - Replacing `blocksize` with `block`( as with this change), the system boots normally