### PR TITLE
Include aide_check_audit_tools rule in CIS for RHEL9

### DIFF
--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -355,7 +355,9 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: planned
+    status: automated
+    rules:
+      - aide_check_audit_tools
     related_rules:
       - aide_use_fips_hashes
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_check_audit_tools/rule.yml
@@ -38,6 +38,7 @@ identifiers:
 
 references:
     cis@alinux3: 4.1.4.11
+    cis@rhel9: 1.3.3
     cis@ubuntu2204: 4.1.4.11
     disa: CCI-001496
     nist: AU-9(3),AU-9(3).1


### PR DESCRIPTION
#### Description:

The existing `aide_check_audit_tools` rule satisfies the `1.3.3` CIS requirement for RHEL 9.

#### Rationale:

Better CIS coverage for RHEL 9.