### PR TITLE
SLE 12/15 profile updates

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -733,20 +733,25 @@ controls:
     # Ensure passwords with minimum of 18 characters
     - var_password_pam_minlen=18
     - accounts_password_pam_minlen
+    - cracklib_accounts_password_pam_minlen
     # Enforce password lenght for new accounts
     - var_accounts_password_minlen_login_defs=18
     - accounts_password_minlen_login_defs
     # Require at Least 1 Special Character in Password
     - var_password_pam_ocredit=1
     - accounts_password_pam_ocredit
+    - cracklib_accounts_password_pam_ocredit
     # Require at Least 1 Numeric Character in Password
     - var_password_pam_dcredit=1
+    - cracklib_accounts_password_pam_dcredit
     - accounts_password_pam_dcredit
     # Require at Least 1 Uppercase Character in Password
     - var_password_pam_ucredit=1
     - accounts_password_pam_ucredit
+    - cracklib_accounts_password_pam_ucredit
     # Require at Least 1 Lowercase Character in Password
     - var_password_pam_lcredit=1
+    - cracklib_accounts_password_pam_lcredit
     - accounts_password_pam_lcredit
 
     # Lock out users after 3 failed authentication attempts within 15 min

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -1575,7 +1575,7 @@ controls:
       rules:
         - var_password_pam_dcredit=1
         - var_password_pam_lcredit=1
-        - var_password_pam_minlen=14
+        - var_password_pam_minlen=12
         - var_password_pam_ocredit=1
         - var_password_pam_ucredit=1
         - accounts_password_pam_ucredit

--- a/controls/pcidss_4.yml
+++ b/controls/pcidss_4.yml
@@ -1573,7 +1573,11 @@ controls:
         - base
       status: automated
       rules:
+        - var_password_pam_dcredit=1
         - var_password_pam_lcredit=1
+        - var_password_pam_minlen=14
+        - var_password_pam_ocredit=1
+        - var_password_pam_ucredit=1
         - accounts_password_pam_ucredit
         - accounts_password_pam_dcredit
         - accounts_password_pam_lcredit

--- a/products/sle15/profiles/pcs-hardening.profile
+++ b/products/sle15/profiles/pcs-hardening.profile
@@ -19,6 +19,11 @@ selections:
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min
     - inactivity_timeout_value=15_minutes
+    - var_password_pam_dcredit=1
+    - var_password_pam_lcredit=1
+    - var_password_pam_minlen=15
+    - var_password_pam_ocredit=1
+    - var_password_pam_ucredit=1
     - sshd_idle_timeout_value=15_minutes
     - var_sudo_timestamp_timeout=always_prompt
     - var_password_pam_unix_remember=5

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -19,6 +19,11 @@ selections:
     - var_accounts_fail_delay=4
     - var_accounts_tmout=15_min
     - inactivity_timeout_value=15_minutes
+    - var_password_pam_dcredit=1
+    - var_password_pam_lcredit=1
+    - var_password_pam_minlen=15
+    - var_password_pam_ocredit=1
+    - var_password_pam_ucredit=1
     - var_sudo_timestamp_timeout=always_prompt
     - var_password_pam_unix_remember=5
     - var_accounts_maximum_age_login_defs=60


### PR DESCRIPTION
#### Description:

- _These updates covers SLE 12/15 profiles which include rules cracklib_accounts_password_pam_xxxx _

#### Rationale:

- Some of current profiles do not include rules and variable definitions used by these rules 