### PR TITLE
fix: aide_string: drop nl at end

### DIFF
--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1071,7 +1071,7 @@ Configure the default Grub2 kernel command line to contain {{{ arg_name_value }}
 p+i+n+u+g+s+b+acl+selinux+xattrs+sha512
 {{%- else -%}}
 p+i+n+u+g+s+b+acl+xattrs+sha512
-{{% endif %}}
+{{%- endif -%}}
 {{%- endmacro -%}}
 
 {{#


### PR DESCRIPTION
#### Description:

`aide_string` got `\n` at end and it messed up later bash remediation.

#### Rationale:

Simple fix issue seen. https://github.com/ComplianceAsCode/content/pull/10557#issuecomment-1547375522

But bash remediations should use `bash_replace_or_accept` after it handles situation like aide regexp paths. Also I wonder why `aide_check_audit_tools` does not use `aide_files`. And why there `autrace` twice for rhel9.

#### Review Hints:

This could fix `aide_check_audit_tools`. Only very lightly tested by me.