### PR TITLE
fix: ssg_test_suite.get_product_context: fake Product

### DIFF
--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -274,7 +274,7 @@ def get_product_context(product=None):
     product_yaml = dict()
     if product:
         yaml_path = product_yaml_path(SSG_ROOT, product)
-        product_yaml = load_product_yaml(yaml_path)
+        product_yaml.update(load_product_yaml(yaml_path))
 
     # We could run into a DocumentationNotComplete error when loading a
     # rule's YAML contents. However, because the test suite isn't executed


### PR DESCRIPTION
#### Description:

Product does not have __setitem__ and here product_yaml is made as dict to mock real product.

But we want to change Product for testing. So just update and thus product_yaml type is not changed.

```
Traceback (most recent call last):
  File "/home/runner/work/content/content/tests/automatus.py", line 511, in <module>
    main()
  File "/home/runner/work/content/content/tests/automatus.py", line 507, in main
    options.func(options)
  File "/home/runner/work/content/content/tests/ssg_test_suite/rule.py", line 686, in perform_rule_check
    checker.test_target()
  File "/home/runner/work/content/content/tests/ssg_test_suite/oscap.py", line 683, in test_target
    self._test_target()
  File "/home/runner/work/content/content/tests/ssg_test_suite/rule.py", line 445, in _test_target
    rules_to_test = self._get_rules_to_test()
  File "/home/runner/work/content/content/tests/ssg_test_suite/rule.py", line 298, in _get_rules_to_test
    product_yaml = common.get_product_context(product)
  File "/home/runner/work/content/content/tests/ssg_test_suite/common.py", line 285, in get_product_context
    product_yaml['cmake_build_type'] = 'Debug'
TypeError: 'Product' object does not support item assignment
Error: Process completed with exit code 1.
```

#### Rationale:

Allow modify `Product` like at `ssg_test_suite` but not at `ssg`.

#### Review Hints:

See failed test at #10574