### PR TITLE
Add nftables rules to Ubuntu and make it the default firewall for CIS Level 1 Server

### DIFF
--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ip6tables_default_rule/rule.yml
@@ -20,6 +20,8 @@ rationale: |-
 
 severity: medium
 
+platform: not package[nftables] and not package[ufw]
+
 identifiers:
     cce@rhel7: CCE-86718-4
     cce@rhel8: CCE-85965-2

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_ipv6_loopback_traffic/rule.yml
@@ -16,6 +16,8 @@ rationale: |-
 
 severity: medium
 
+platform: not package[nftables] and not package[ufw]
+
 identifiers:
     cce@sle12: CCE-92215-3
     cce@sle15: CCE-91346-7

--- a/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_activation/set_loopback_traffic/rule.yml
@@ -16,6 +16,8 @@ rationale: |-
 
 severity: medium
 
+platform: not package[nftables] and not package[ufw]
+
 identifiers:
     cce@sle12: CCE-92214-6
     cce@sle15: CCE-91345-9

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/ip6tables_rules_for_open_ports/rule.yml
@@ -14,6 +14,8 @@ rationale: |-
 
 severity: medium
 
+platform: not package[nftables] and not package[ufw]
+
 identifiers:
     cce@rhel7: CCE-86800-0
     cce@rhel8: CCE-86801-8

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_rules_for_open_ports/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/iptables_rules_for_open_ports/rule.yml
@@ -14,6 +14,8 @@ rationale: |-
 
 severity: medium
 
+platform: not package[nftables] and not package[ufw]
+
 identifiers:
     cce@rhel7: CCE-86770-5
     cce@rhel8: CCE-86771-3

--- a/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-iptables/iptables_ruleset_modifications/set_iptables_default_rule/rule.yml
@@ -18,6 +18,8 @@ rationale: |-
 
 severity: medium
 
+platform: not package[nftables] and not package[ufw]
+
 identifiers:
     cce@rhel7: CCE-86719-2
     cce@rhel8: CCE-85968-6

--- a/linux_os/guide/system/network/network-nftables/nftables_ensure_default_deny_policy/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/nftables_ensure_default_deny_policy/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Ensure nftables Default Deny Firewall Policy'
 
@@ -20,6 +20,8 @@ identifiers:
 
 references:
     cis@sle15: 3.5.2.8
+    cis@ubuntu2004: 3.5.2.8
+    cis@ubuntu2204: 3.5.2.8
 
 ocil_clause: 'default policy is not set for nftables rules'
 

--- a/linux_os/guide/system/network/network-nftables/nftables_ensure_default_deny_policy/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/nftables_ensure_default_deny_policy/rule.yml
@@ -15,6 +15,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[nftables]
+
 identifiers:
     cce@sle15: CCE-92507-3
 

--- a/linux_os/guide/system/network/network-nftables/nftables_ensure_default_deny_policy/sce/ubuntu.sh
+++ b/linux_os/guide/system/network/network-nftables/nftables_ensure_default_deny_policy/sce/ubuntu.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+# Check if default policy is drop
+output=$(nft list ruleset)
+
+if ! (grep 'hook input' "$output" |& grep -w 'policy drop' &>/dev/null &&\
+     grep 'hook forward' "$output" |&  grep -w 'policy drop' &>/dev/null &&\
+     grep 'hook output' "$output" |& grep -w 'policy drop' &>/dev/null); then
+    exit "${XCCDF_RESULT_FAIL}"
+fi
+
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/rule.yml
@@ -17,6 +17,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[nftables]
+
 identifiers:
     cce@sle15: CCE-92485-2
 

--- a/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Ensure nftables Rules are Permanent'
 
@@ -22,6 +22,8 @@ identifiers:
 
 references:
     cis@sle15: 3.5.2.10
+    cis@ubuntu2004: 3.5.2.10
+    cis@ubuntu2204: 3.5.2.10
 
 ocil_clause: 'no nftables configuration exist'
 

--- a/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/sce/ubuntu.sh
+++ b/linux_os/guide/system/network/network-nftables/nftables_rules_permanent/sce/ubuntu.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+# Check rules in input chain
+filename="/etc/nftables.conf"
+
+in_regexp="chain input {[^}]+}"
+grep -Ezo "${in_regexp}" ${filename} | grep -Ezqw "policy drop" &&\
+    grep -Ezo "${in_regexp}" ${filename} | grep -Ezqw "iif \"lo\" accept" &&\
+    grep -Ezo "${in_regexp}" ${filename} | grep -Ezqw "ip saddr 127.0.0.0/8"
+if [ $? -ne 0 ]; then
+    exit ${XCCDF_RESULT_FAIL}
+fi
+
+# Only verify IPv6 rules if IPv6 support is enabled
+if [ -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" -eq 0 ]; then
+    grep -Ezo "${in_regexp}" ${filename} | grep -Ezqw "ip6 saddr ::1"
+    if [ $? -ne 0 ]; then
+        exit ${XCCDF_RESULT_FAIL}
+    fi
+fi
+
+out_regexp="chain output {[^}]+}"
+grep -Ezo "${out_regexp}" ${filename} | grep -Ezqw "policy drop"
+if [ $? -ne 0 ]; then
+    exit ${XCCDF_RESULT_FAIL}
+fi
+
+fwd_regexp="chain forward {[^}]+}"
+grep -Ezo "${fwd_regexp}" ${filename} | grep -Ezqw "policy drop"
+if [ $? -ne 0 ]; then
+    exit ${XCCDF_RESULT_FAIL}
+fi
+
+exit ${XCCDF_RESULT_PASS}

--- a/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/service_nftables_enabled/rule.yml
@@ -16,6 +16,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[nftables]
+
 identifiers:
     cce@rhel7: CCE-86723-4
     cce@rhel8: CCE-86725-9

--- a/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/rule.yml
@@ -1,14 +1,14 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Ensure Base Chains Exist for Nftables'
 
 description: |-
-   Tables in nftables hold chains. Each table only has one address family and only applies 
+   Tables in nftables hold chains. Each table only has one address family and only applies
    to packets of this family. Tables can have one of six families.
-   Chains are containers for rules. They exist in two kinds, base chains and regular chains. 
-   A base chain is an entry point for packets from the networking stack, a regular chain may 
+   Chains are containers for rules. They exist in two kinds, base chains and regular chains.
+   A base chain is an entry point for packets from the networking stack, a regular chain may
    be used as jump target and is used for better rule organization.
 
 rationale: |-
@@ -22,18 +22,20 @@ identifiers:
 
 references:
     cis@sle15: 3.5.2.5
+    cis@ubuntu2004: 3.5.2.5
+    cis@ubuntu2204: 3.5.2.5
 
 ocil_clause: 'base chains do not exist for nftables'
 
 warnings:
-   - general: "Configuring rules over ssh, by creating a base chain with policy drop will cause loss of connectivity. 
+   - general: "Configuring rules over ssh, by creating a base chain with policy drop will cause loss of connectivity.
                Ensure that a rule allowing ssh has been added to the base chain prior to setting the base cahin's policy to drop"
 
 ocil: |-
     To verify that base chains exist for INPUT, FORWARD, and OUTPUT, run the following commands:
     <pre>$ sudo nft list ruleset | grep 'hook input'</pre>
     <pre>$ sudo nft list ruleset | grep 'hook forward'</pre>
-    <pre>$ sudo nft list ruleset | grep 'hook output'</pre> 
+    <pre>$ sudo nft list ruleset | grep 'hook output'</pre>
     Output should be similar to:
     <tt>
       type filter hook input priority 0;

--- a/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/rule.yml
@@ -17,6 +17,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[nftables]
+
 identifiers:
     cce@sle15: CCE-92578-4
 

--- a/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/sce/shared.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_base_chain/sce/shared.sh
@@ -2,19 +2,12 @@
 # platform = multi_platform_all
 # check-import = stdout
 
-chain_hook=$(nft list ruleset | grep 'hook input')
-if [ -z "${chain_hook}" ]; then
-    exit ${XCCDF_RESULT_FAIL}
+output=$(nft list ruleset)
+# Check if there are base chains
+if ! (grep -q 'hook input' "$output" &&\
+    grep -q 'hook forward' "$output" &&\
+    grep -q 'hook output' "$output"); then
+    exit "${XCCDF_RESULT_FAIL}"
 fi
 
-chain_hook=$(nft list ruleset | grep 'hook forward')
-if [ -z "${chain_hook}" ]; then
-    exit ${XCCDF_RESULT_FAIL}
-fi
-
-chain_hook=$(nft list ruleset | grep 'hook output')
-if [ -z "${chain_hook}" ]; then
-    exit ${XCCDF_RESULT_FAIL}
-fi
-
-exit ${XCCDF_RESULT_PASS}
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: sle15
+prodtype: sle15,ubuntu2004,ubuntu2204
 
 title: 'Set nftables Configuration for Loopback Traffic'
 
@@ -22,7 +22,9 @@ identifiers:
     cce@sle15: CCE-92481-1
 
 references:
-    cis@sle15: 3.5.2.6 
+    cis@sle15: 3.5.2.6
+    cis@ubuntu2004: 3.5.2.6
+    cis@ubuntu2204: 3.5.2.6
     pcidss: Req-1.4.1
 
 warnings:

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/rule.yml
@@ -18,6 +18,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[nftables]
+
 identifiers:
     cce@sle15: CCE-92481-1
 

--- a/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/sce/ubuntu.sh
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_loopback_traffic/sce/ubuntu.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# platform = multi_platform_ubuntu
+# check-import = stdout
+
+output=$(nft list ruleset | awk '/hook input/,/}/')
+if ! grep 'iif "lo" accept' "$output"; then
+    exit "${XCCDF_RESULT_FAIL}"
+fi
+
+if ! grep 'ip saddr' "$output"; then
+    exit "${XCCDF_RESULT_FAIL}"
+fi
+
+if [ -e /proc/sys/net/ipv6/conf/all/disable_ipv6 ] && [ "$(cat /proc/sys/net/ipv6/conf/all/disable_ipv6)" -eq 0 ]; then
+    if ! grep 'ip6 saddr' "$output"; then
+        exit "${XCCDF_RESULT_FAIL}"
+    fi
+fi
+
+exit "${XCCDF_RESULT_PASS}"

--- a/linux_os/guide/system/network/network-nftables/set_nftables_table/rule.yml
+++ b/linux_os/guide/system/network/network-nftables/set_nftables_table/rule.yml
@@ -15,6 +15,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[nftables]
+
 identifiers:
     cce@rhel7: CCE-86161-7
     cce@rhel8: CCE-86162-5

--- a/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/service_ufw_enabled/rule.yml
@@ -27,4 +27,4 @@ template:
     vars:
         servicename: ufw
 
-platform: machine
+platform: machine and package[ufw]

--- a/linux_os/guide/system/network/network-ufw/set_ufw_default_rule/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_default_rule/rule.yml
@@ -18,6 +18,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[ufw]
+
 references:
     cis@ubuntu2004: 3.5.1.7
     cis@ubuntu2204: 3.5.1.7

--- a/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/set_ufw_loopback_traffic/rule.yml
@@ -18,6 +18,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[ufw]
+
 references:
     cis@ubuntu2004: 3.5.1.4
     cis@ubuntu2204: 3.5.1.4

--- a/linux_os/guide/system/network/network-ufw/ufw_rules_for_open_ports/rule.yml
+++ b/linux_os/guide/system/network/network-ufw/ufw_rules_for_open_ports/rule.yml
@@ -14,6 +14,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[ufw]
+
 references:
     cis@ubuntu2204: 3.5.1.6
 

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -416,7 +416,7 @@ selections:
     - set_nftables_table
 
     #### 3.5.2.5 Ensure base chains exist (Automated)
-    # Needs rule
+    - set_nftables_base_chain
 
     #### 3.5.2.6 Ensure loopback traffic is configured (Automated)
     - set_nftables_loopback_traffic

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -425,7 +425,7 @@ selections:
     # Skip due to being a manual test
 
     #### 3.5.2.8 Ensure default deny firewall policy (Automated)
-    # Needs rule
+    - nftables_ensure_default_deny_policy
 
     #### 3.5.2.9 Ensure nftables service is enabled (Automated)
     - service_nftables_enabled

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -431,7 +431,8 @@ selections:
     - service_nftables_enabled
 
     #### 3.5.2.10 Ensure nftables rules are permanent (Automated)
-    # Needs rule
+    - var_nftables_master_config_file=etc
+    - nftables_rules_permanent
 
     ### 3.5.3 Configure iptables ###
     #### 3.5.3.1 Configure software ####

--- a/products/ubuntu2004/profiles/cis_level1_server.profile
+++ b/products/ubuntu2004/profiles/cis_level1_server.profile
@@ -419,7 +419,7 @@ selections:
     # Needs rule
 
     #### 3.5.2.6 Ensure loopback traffic is configured (Automated)
-    # Needs rule
+    - set_nftables_loopback_traffic
 
     #### 3.5.2.7 Ensure outbound and established connections are configured (Manual)
     # Skip due to being a manual test

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -464,7 +464,8 @@ selections:
     - service_nftables_enabled
 
     #### 3.5.2.10 Ensure nftables rules are permanent (Automated)
-    # NEEDS RULE
+    - var_nftables_master_config_file=etc
+    - nftables_rules_permanent
 
     ### 3.5.3 Configure iptables ###
     #### 3.5.3.1 Configure iptables software ####

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -449,7 +449,7 @@ selections:
     - set_nftables_table
 
     #### 3.5.2.5 Ensure nftables base chains exist (Automated)
-    # NEEDS RULE
+    - set_nftables_base_chain
 
     #### 3.5.2.6 Ensure nftables loopback traffic is configured (Automated)
     - set_nftables_loopback_traffic

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -452,7 +452,7 @@ selections:
     # NEEDS RULE
 
     #### 3.5.2.6 Ensure nftables loopback traffic is configured (Automated)
-    # NEEDS RULE
+    - set_nftables_loopback_traffic
 
     #### 3.5.2.7 Ensure nftables outbound and established connections are configured (Manual)
     # Skip due to being a manual test

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -413,7 +413,7 @@ selections:
     ## 3.5 Firewall Configuration ##
     ### 3.5.1 Configure UncomplicatedFirewall ###
     #### 3.5.1.1 Ensure ufw is installed (Automated)
-    - package_ufw_installed
+    - '!package_ufw_installed'
 
     #### 3.5.1.2 Ensure iptables-persistent is not installed with ufw (Automated)
     - package_iptables-persistent_removed
@@ -471,11 +471,11 @@ selections:
     #### 3.5.3.1 Configure iptables software ####
     ##### 3.5.3.1.1 Ensure iptables packages are installed (Automated)
     - package_iptables_installed
-    - package_iptables-persistent_installed
+    - '!package_iptables-persistent_installed'
 
     ###### 3.5.3.1.2 Ensure nftables is not installed with iptables (Automated)
-    - service_nftables_disabled
-    - package_nftables_removed
+    - '!service_nftables_disabled'
+    - '!package_nftables_removed'
 
     ###### 3.5.3.1.3 Ensure ufw is uninstalled or disabled with iptables (Automated)
     - package_ufw_removed

--- a/products/ubuntu2204/profiles/cis_level1_server.profile
+++ b/products/ubuntu2204/profiles/cis_level1_server.profile
@@ -458,7 +458,7 @@ selections:
     # Skip due to being a manual test
 
     #### 3.5.2.8 Ensure nftables default deny firewall policy (Automated)
-    # NEEDS RULE
+    - nftables_ensure_default_deny_policy
 
     #### 3.5.2.9 Ensure nftables service is enabled (Automated)
     - service_nftables_enabled

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -26,6 +26,8 @@ args:
     {{% else %}}
       pkgname: snmp
     {{% endif %}}
+  nftables:
+      pkgname: nftables
   nss-pam-ldapd:
     {{% if pkg_system == "rpm" %}}
       pkgname: nss-pam-ldapd
@@ -69,6 +71,8 @@ args:
     pkgname: tftp-server
   tmux:
     pkgname: tmux
+  ufw:
+    pkgname: ufw
   usbguard:
     pkgname: usbguard
   yum:


### PR DESCRIPTION
#### Description:

- This PR adds the following rules to Ubuntu CIS profiles:
  - nftables_rules_permanent
  - set_nftables_loopback_traffic
  - nftables_ensure_default_deny_policy
  - set_nftables_base_chain
- To make nftables the default firewall, I've added `platform: package[...]` to nftables, ufw and iptables rules, that way rules that are not applicable won't be checked. I appreciate your feedback on that.

#### Rationale:

- This is needed for CIS on Ubuntu 20.04 and 22.04