### PR TITLE
SLE PCIDSS Fix problem with sshd_strong_kex default selector

### DIFF
--- a/linux_os/guide/services/ssh/sshd_strong_kex.var
+++ b/linux_os/guide/services/ssh/sshd_strong_kex.var
@@ -12,6 +12,7 @@ interactive: false
 
 options:
     default: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
+    pcidss: ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group14-sha256
     cis_rhel7: curve25519-sha256,curve25519-sha256@libssh.org,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
     cis_sle12: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256
     cis_sle15: curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group14-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -77,6 +77,6 @@ selections:
     -  sshd_use_approved_ciphers
     -  sshd_approved_ciphers=cis_sle12
     -  sshd_use_approved_macs
-    -  sshd_strong_kex=default
+    -  sshd_strong_kex=pcidss
     -  sshd_approved_macs=cis_sle12
     -  sysctl_fs_suid_dumpable

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -13,7 +13,7 @@ description: |-
 
 selections:
     -  pcidss_4:all:base
-    -  sshd_strong_kex=default
+    -  sshd_strong_kex=pcidss
     -  sshd_approved_macs=cis_sle15
     -  sshd_approved_ciphers=cis_sle15 
     -  '!service_ntp_enabled'


### PR DESCRIPTION
#### Description:

- Replace usage of default variable selector for sshd_strong_kex variable in PCIDSS4 SLE profiles.

#### Rationale:

- Usage of `default` selector causes side effect oscap not being able to extract value, see #7222 , #7233

Current issue with the `sshd_strong_kex` variable on SLE15 build complains:
```
OpenSCAP Error: Invalid selector 'default' for xccdf:value/@id='xccdf_org.ssgproject.content_value_sshd_strong_kex'. Using null value instead. [/home/abuild/rpmbuild/BUILD/openscap-1.3.4/src/XCCDF_POLICY/xccdf_policy.c:2124]
Could not resolve xccdf:sub/@idref='xccdf_org.ssgproject.content_value_sshd_strong_kex'! [/home/abuild/rpmbuild/BUILD/openscap-1.3.4/src/XCCDF_POLICY/xccdf_policy_substitute.c:106]
A fix for Rule/@id="xccdf_org.ssgproject.content_rule_sshd_use_strong_kex" was skipped: Text substitution failed. [/home/abuild/rpmbuild/BUILD/openscap-1.3.4/src/XCCDF_POLICY/xccdf_policy_remediate.c:761]

```
