### PR TITLE
modify regexp in bash remediation of chronyd_specify_remote_server

### DIFF
--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/bash/shared.sh
@@ -4,6 +4,6 @@
 
 config_file="{{{ chrony_conf_path }}}"
 
-if ! grep -q '^[\s]*(?:server|pool)[\s]+[\w]+' "$config_file" ; then
+if ! grep -q '^[[:space:]]*\(server\|pool\)[[:space:]]\+[[:graph:]]\+' "$config_file" ; then
   {{{ bash_ensure_there_are_servers_in_ntp_compatible_config_file("$config_file", "$var_multiple_time_servers") | indent(2) }}}
 fi


### PR DESCRIPTION
#### Description:

- change the regex so that is correctly matches the line, I think matching the space characters was the problem

#### Rationale:

- previously, new lines were inserted into the file no matter if there were some correct lines before

- I believe it was original intend of this PR: https://github.com/ComplianceAsCode/content/pull/10278 

#### Review Hints:
```
./build_product rhel8
cd tests
python automatus.py rule --libvirt qemu:///system rhel8 chronyd_specify_remote_server
```

