### PR TITLE
Fix tests in sshd_lineinfile template

### DIFF
--- a/shared/templates/sshd_lineinfile/tests/comment.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/comment.fail.sh
@@ -1,13 +1,3 @@
 #!/bin/bash
 
-SSHD_PARAM={{{ PARAMETER }}}
-SSHD_VAL={{{ VALUE }}}
-
-mkdir -p /etc/ssh/sshd_config.d
-touch /etc/ssh/sshd_config.d/nothing
-
-if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
-	sed -i "s/^${SSHD_PARAM}.*/# ${SSHD_PARAM} ${SSHD_VAL}/g" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
-else
-	echo "# ${SSHD_PARAM} ${SSHD_VAL}" >> /etc/ssh/sshd_config
-fi
+source common.sh

--- a/shared/templates/sshd_lineinfile/tests/common.sh
+++ b/shared/templates/sshd_lineinfile/tests/common.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SSHD_PARAM={{{ PARAMETER }}}
+SSHD_VAL={{{ VALUE }}}
+
+mkdir -p /etc/ssh/sshd_config.d
+touch /etc/ssh/sshd_config.d/nothing
+
+if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
+	sed -i "s/^${SSHD_PARAM}.*/# ${SSHD_PARAM} ${SSHD_VAL}/g" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*
+else
+	echo "# ${SSHD_PARAM} ${SSHD_VAL}" >> /etc/ssh/sshd_config
+fi

--- a/shared/templates/sshd_lineinfile/tests/correct_value.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value.pass.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
 
+source common.sh
+
 {{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=sshd_distributed_config) -}}}

--- a/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
@@ -2,8 +2,7 @@
 
 # platform = multi_platform_fedora,Oracle Linux 8,Oracle Linux 9,Red Hat Enterprise Linux 9
 
-mkdir -p /etc/ssh/sshd_config.d
-touch /etc/ssh/sshd_config.d/nothing
+source common.sh
 
 {{% if product in ["ol8", "ol9"] %}}
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}

--- a/shared/templates/sshd_lineinfile/tests/correct_value_including_relative_path.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_including_relative_path.pass.sh
@@ -2,8 +2,7 @@
 
 # platform = Oracle Linux 8,Oracle Linux 9
 
-mkdir -p /etc/ssh/sshd_config.d
-touch /etc/ssh/sshd_config.d/nothing
+source common.sh
 
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
 

--- a/shared/templates/sshd_lineinfile/tests/correct_value_multiple_includes.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_multiple_includes.pass.sh
@@ -2,8 +2,7 @@
 
 # platform = Oracle Linux 8,Oracle Linux 9
 
-mkdir -p /etc/ssh/sshd_config.d
-touch /etc/ssh/sshd_config.d/nothing
+source common.sh
 
 {{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
 echo "Include /etc/dummy" >> "/etc/ssh/sshd_config"


### PR DESCRIPTION
#### Description:

- Change passing tests so they are based on comment.fail.sh

#### Rationale:

- In some cases the testing environment had existing non compliant configurations which made some test fail when they were expected to pass. This ensures that doesn't happen

#### Review Hints:

- Automatus results should be enough as this adresses only tests results
- Only make sure this change makes sense