### PR TITLE
Update OVAL, ansible an tests in audit_rules_suid_privilege_function rule

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -4,6 +4,25 @@
 # complexity = low
 # disruption = low
 
+{{% if product != "ol8" %}}
+{{% set egid_arg = " -F egid=0" %}}
+{{% set euid_arg = " -F euid=0" %}}
+{{% endif %}}
+
+{{% set rx_beg = "^[\s]*-a[\s]+always,exit[\s]+" %}}
+{{% set rx_b32 = "-F[\s]+arch=b32[\s]+" %}}
+{{% set rx_b64 = "-F[\s]+arch=b64[\s]+" %}}
+
+{{% if product == "ol8" %}}
+{{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+" %}}
+{{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+" %}}
+{{% else %}}
+{{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+euid=0[\s]+" %}}
+{{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+egid=0[\s]+" %}}
+{{% endif %}}
+
+{{% set rx_end = "(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" %}}
+
 - name: Service facts
   service_facts:
 
@@ -17,15 +36,20 @@
 - name: Set suid_audit_rules fact
   set_fact:
     suid_audit_rules:
-      - '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid'
-      - '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid'
-      - '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid'
-      - '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid'
+      - rule: '-a always,exit -F arch=b32 -S execve -C gid!=egid{{{ egid_arg }}} -k setgid'
+        regex: {{{ rx_beg + rx_b32 + rx_gid + rx_end }}}
+      - rule: '-a always,exit -F arch=b64 -S execve -C gid!=egid{{{ egid_arg }}} -k setgid'
+        regex: {{{ rx_beg + rx_b64 + rx_gid + rx_end }}}
+      - rule: '-a always,exit -F arch=b32 -S execve -C uid!=euid{{{ euid_arg }}} -k setuid'
+        regex: {{{ rx_beg + rx_b32 + rx_uid + rx_end }}}
+      - rule: '-a always,exit -F arch=b64 -S execve -C uid!=euid{{{ euid_arg }}} -k setuid'
+        regex: {{{ rx_beg + rx_b64 + rx_uid + rx_end }}}
 
 - name: Update /etc/audit/rules.d/privileged.rules to audit privileged functions
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/audit/rules.d/privileged.rules
-    line: "{{  item  }}"
+    line: "{{  item.rule  }}"
+    regexp: "{{ item.regex }}"
     create: yes
   when:
     - '"auditd.service" in ansible_facts.services'
@@ -34,9 +58,10 @@
   with_items: "{{ suid_audit_rules }}"
 
 - name: Update Update /etc/audit/audit.rules to audit privileged functions
-  lineinfile:
+  ansible.builtin.lineinfile:
     path: /etc/audit/audit.rules
-    line: "{{  item  }}"
+    line: "{{  item.rule  }}"
+    regexp: "{{ item.regex }}"
     create: yes
   when:
     - '"auditd.service" in ansible_facts.services'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/ansible/shared.yml
@@ -24,17 +24,17 @@
 {{% set rx_end = "(?:-k[\s]+|-F[\s]+key=)[\S]+[\s]*$" %}}
 
 - name: Service facts
-  service_facts:
+  ansible.builtin.service_facts:
 
 - name: Check the rules script being used
-  command:
+  ansible.builtin.command:
     grep '^ExecStartPost' /usr/lib/systemd/system/auditd.service
   register: check_rules_scripts_result
   changed_when: false
   failed_when: false
 
 - name: Set suid_audit_rules fact
-  set_fact:
+  ansible.builtin.set_fact:
     suid_audit_rules:
       - rule: '-a always,exit -F arch=b32 -S execve -C gid!=egid{{{ egid_arg }}} -k setgid'
         regex: {{{ rx_beg + rx_b32 + rx_gid + rx_end }}}
@@ -70,12 +70,12 @@
   with_items: "{{ suid_audit_rules }}"
 {{%- if product in ['sle12', 'sle15'] %}}
 - name: Restart auditd.service
-  systemd:
+  ansible.builtin.systemd:
     name: auditd.service
     state: restarted
 {{%- else %}} # restarting auditd through systemd doesn't work, see: https://access.redhat.com/solutions/5515011
 - name: Restart Auditd
-  command: /usr/sbin/service auditd restart
+  ansible.builtin.command: /usr/sbin/service auditd restart
 {{%- endif %}}
   when:
     - (augenrules_audit_rules_privilege_function_update_result.changed or

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/oval/shared.xml
@@ -3,7 +3,7 @@
 {{% set rx_b64 = "-F[\s]+arch=b64[\s]+" %}}
 {{% if product == "ol8" %}}
 {{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+" %}}
-{{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=guid[\s]+" %}}
+{{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+" %}}
 {{% else %}}
 {{% set rx_uid = "-S[\s]+execve[\s]+-C[\s]+uid!=euid[\s]+-F[\s]+euid=0[\s]+" %}}
 {{% set rx_gid = "-S[\s]+execve[\s]+-C[\s]+gid!=egid[\s]+-F[\s]+egid=0[\s]+" %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/correct_value.pass.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C uid!=euid"
+OTHER_FILTERS_EGID=" -C gid!=egid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C uid!=euid -F euid=0"
+OTHER_FILTERS_EGID=" -C gid!=egid -F egid=0"
+{{% endif %}}
+
+echo "-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -k setgid" > /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setgid" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_arch.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_arch.fail.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C uid!=euid"
+OTHER_FILTERS_EGID=" -C gid!=egid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C uid!=euid -F euid=0"
+OTHER_FILTERS_EGID=" -C gid!=egid -F egid=0"
+{{% endif %}}
+
+echo "-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setgid" > /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_c.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/miss_c.fail.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a always,exit -F arch=b32 -S execve -C gid!=guid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
+{{% if product != "ol8" %}}
+OTHER_FILTERS_EUID=" -F euid=0"
+OTHER_FILTERS_EGID=" -F egid=0"
+{{% endif %}}
+
+echo "-a always,exit -F arch=b32 -S execve -C gid!=guid${OTHER_FILTERS_EGID} -k setgid" > /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setgid" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve -C uid!=euid${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/other_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/other_key.pass.sh
@@ -3,7 +3,15 @@
 
 # This tests situation where key value is not std. And also situation where there is extra spaces in rules.
 
-echo '  -a   always,exit   -F   arch=b32   -S   execve   -C   gid!=egid   -F   egid=0   -F   key=my_setgid-audit-rule  ' > /etc/audit/rules.d/privileged.rules
-echo '  -a   always,exit   -F   arch=b64   -S   execve   -C   gid!=egid   -F   egid=0   -k   my_setgid-audit-rule  ' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k my_setuid-audit-rule' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=my_setuid-audit-rule' >> /etc/audit/rules.d/privileged.rules
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C     uid!=euid"
+OTHER_FILTERS_EGID=" -C     gid!=egid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C    uid!=euid    -F euid=0"
+OTHER_FILTERS_EGID=" -C    gid!=egid    -F egid=0"
+{{% endif %}}
+
+echo "  -a   always,exit   -F   arch=b32   -S   execve   ${OTHER_FILTERS_EGID}   -F   key=my_setgid-audit-rule  " > /etc/audit/rules.d/privileged.rules
+echo "  -a   always,exit   -F   arch=b64   -S   execve   ${OTHER_FILTERS_EGID}   -k   my_setgid-audit-rule  " >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b32 -S execve ${OTHER_FILTERS_EUID} -k my_setuid-audit-rule" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve ${OTHER_FILTERS_EUID} -F key=my_setuid-audit-rule" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/use_f_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/use_f_key.pass.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=setgid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=setuid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=setuid' >> /etc/audit/rules.d/privileged.rules
+
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C uid!=euid"
+OTHER_FILTERS_EGID=" -C gid!=egid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C uid!=euid -F euid=0"
+OTHER_FILTERS_EGID=" -C gid!=egid -F egid=0"
+{{% endif %}}
+
+echo "-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -F key=setgid" > /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -F key=setgid" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EUID} -F key=setuid" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EUID} -F key=setuid" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_a.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_a.fail.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a never,exit -F arch=b32 -S execve -C gid!=euid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a never,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules
-echo '-a never,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
-echo '-a never,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C uid!=euid"
+OTHER_FILTERS_EGID=" -C gid!=egid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C uid!=euid -F euid=0"
+OTHER_FILTERS_EGID=" -C gid!=egid -F egid=0"
+{{% endif %}}
+
+echo "-a never,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -k setgid" > /etc/audit/rules.d/privileged.rules
+echo "-a never,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setgid" >> /etc/audit/rules.d/privileged.rules
+echo "-a never,exit -F arch=b32 -S execve${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules
+echo "-a never,exit -F arch=b64 -S execve${OTHER_FILTERS_EUID} -k setuid" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_egid.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_egid.fail.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -C uid!=egid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C uid!=egid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C uid!=egid"
+OTHER_FILTERS_EGID=" -C gid!=egid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C uid!=egid -F euid=0"
+OTHER_FILTERS_EGID=" -C gid!=egid -F egid=0"
+{{% endif %}}
+
+echo '-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -k setgid' > /etc/audit/rules.d/privileged.rules
+echo '-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setgid' >> /etc/audit/rules.d/privileged.rules
+echo '-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -k setuid' >> /etc/audit/rules.d/privileged.rules
+echo '-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setuid' >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_euid.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_c_euid.fail.sh
@@ -1,7 +1,15 @@
 #!/bin/bash
 # packages = audit
 
-echo '-a always,exit -F arch=b32 -S execve -C gid!=euid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C gid!=euid -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
-echo '-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -k setuid' >> /etc/audit/rules.d/privileged.rules
+{{% if product == "ol8" %}}
+OTHER_FILTERS_EUID=" -C uid!=euid"
+OTHER_FILTERS_EGID=" -C gid!=euid"
+{{% else %}}
+OTHER_FILTERS_EUID=" -C uid!=euid -F euid=0"
+OTHER_FILTERS_EGID=" -C gid!=euid -F egid=0"
+{{% endif %}}
+
+echo '-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -k setgid' > /etc/audit/rules.d/privileged.rules
+echo '-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setgid' >> /etc/audit/rules.d/privileged.rules
+echo '-a always,exit -F arch=b32 -S execve${OTHER_FILTERS_EGID} -k setuid' >> /etc/audit/rules.d/privileged.rules
+echo '-a always,exit -F arch=b64 -S execve${OTHER_FILTERS_EGID} -k setuid' >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_egid.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_egid.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # packages = audit
+{{% if product == "ol8" %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '-a always,exit -F arch=b32 -S execve -C gid!=egid -F euid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
 echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F euid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_euid.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_suid_privilege_function/tests/wrong_f_euid.fail.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # packages = audit
+{{% if product == "ol8" %}}
+# platform = Not Applicable
+{{% endif %}}
 
 echo '-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -k setgid' > /etc/audit/rules.d/privileged.rules
 echo '-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -k setgid' >> /etc/audit/rules.d/privileged.rules


### PR DESCRIPTION
#### Description:

- Change `audit_rules_suid_privilege_function` rule to not check if `euid=0` or `egid=0` in OL8
- Update ansible for this rule

#### Rationale:

- This is to be better aligned with OL8 DISA STIG
- Ansible update objective is to avoid adding extra lines when the audit rules are in place but not written exactly equal 

#### Review Hints:

- Automatus tests should cover these changes