### PR TITLE
Parameter name mismatch fixes

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1558,7 +1558,7 @@ done
 :param type:        mount type of new mount point (used when adding new entry in fstab)
 
 #}}
-{{% macro bash_ensure_mount_option_for_vfstype(vfstype, mount_opt, filesystem, type) -%}}
+{{% macro bash_ensure_mount_option_for_vfstype(vfstype, mount_opt, fs_spec, type) -%}}
 vfstype_points=()
 readarray -t vfstype_points < <(grep -E "[[:space:]]{{{ vfstype }}}[[:space:]]" /etc/fstab | awk '{print $2}')
 


### PR DESCRIPTION
#### Description:

Jinja macro parameters should match what is used in macro.

#### Rationale:

This seems plain typo, docstring is right for example. Fix should be right as parameter is passed to next macro.

I wonder if this kind of issues could be catched via code analysis tool. Jinja macros allow inheritance and it is used, so many variables are not passed as parameter.

#### Review Hints:

Seems like simple bug. Passed only eyball test.

Why this worked? `filesystem` does not appear to be any jinja variable in `10-bash.jinja`.