### PR TITLE
further improvements to bash_replace_or_append

### DIFF
--- a/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/bash/shared.sh
+++ b/linux_os/guide/services/ftp/ftp_configure_vsftpd/ftp_present_banner/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_sle
 
 
-{{{ bash_replace_or_append('/etc/vsftpd.conf', '^banner_file', '/etc/issue', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/vsftpd.conf', 'banner_file', '/etc/issue', '%s=%s') }}}

--- a/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
+++ b/linux_os/guide/services/ldap/openldap_client/ldap_client_start_tls/bash/shared.sh
@@ -2,7 +2,7 @@
 
 
 # Use LDAP for authentication
-{{{ bash_replace_or_append('/etc/sysconfig/authconfig', '^USELDAPAUTH', 'yes', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/sysconfig/authconfig', 'USELDAPAUTH', 'yes', '%s=%s') }}}
 
 # Configure client to use TLS for all authentications
-{{{ bash_replace_or_append('/etc/nslcd.conf', '^ssl', 'start_tls', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/nslcd.conf', 'ssl', 'start_tls', '%s %s') }}}

--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/bash/shared.sh
@@ -2,7 +2,7 @@
 
 {{{ bash_instantiate_variables("var_postfix_root_mail_alias") }}}
 
-{{{ bash_replace_or_append('/etc/aliases', '^root', "$var_postfix_root_mail_alias", '%s: %s') }}}
+{{{ bash_replace_or_append('/etc/aliases', 'root', "$var_postfix_root_mail_alias", '%s: %s') }}}
 
 if [ -f /usr/bin/newaliases ]; then
     newaliases

--- a/linux_os/guide/services/ntp/chronyd_client_only/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_client_only/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 
-{{{ bash_replace_or_append(chrony_conf_path, '^port', '0', '%s %s') }}}
+{{{ bash_replace_or_append(chrony_conf_path, 'port', '0', '%s %s') }}}

--- a/linux_os/guide/services/ntp/chronyd_no_chronyc_network/bash/shared.sh
+++ b/linux_os/guide/services/ntp/chronyd_no_chronyc_network/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol
 
 
-{{{ bash_replace_or_append(chrony_conf_path, '^cmdport', '0', '%s %s') }}}
+{{{ bash_replace_or_append(chrony_conf_path, 'cmdport', '0', '%s %s') }}}

--- a/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/ubuntu.sh
+++ b/linux_os/guide/services/ntp/chronyd_run_as_chrony_user/bash/ubuntu.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_ubuntu
 
-{{{ bash_replace_or_append(chrony_conf_path, '^user', '_chrony', '%s %s') }}}
+{{{ bash_replace_or_append(chrony_conf_path, 'user', '_chrony', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_allow_only_protocol2/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_rhv
 
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Protocol', '2', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'Protocol', '2', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_sshd_disable_compression") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Compression', "$var_sshd_disable_compression", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'Compression', "$var_sshd_disable_compression", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_rhosts_rsa/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
 
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^RhostsRSAAuthentication', 'no', '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'RhostsRSAAuthentication', 'no', '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_ciphers/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("sshd_approved_ciphers") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^Ciphers', "$sshd_approved_ciphers", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'Ciphers', "$sshd_approved_ciphers", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("sshd_approved_macs") }}}
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "$sshd_approved_macs", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'MACs', "$sshd_approved_macs", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/default_correct_value.pass.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_ol,multi_platform_rhel
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'MACs', "hmac-sha2-512,hmac-sha2-256,hmac-sha1,hmac-sha1-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/rhel7_correct_value.pass.sh
@@ -2,4 +2,4 @@
 #
 # profiles = xccdf_org.ssgproject.content_profile_cis
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'MACs', "umac-64-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,hmac-sha1-etm@openssh.com,umac-64@openssh.com,umac-128@openssh.com,hmac-sha2-256,hmac-sha2-512,hmac-sha1,hmac-sha1-etm@openssh.com", '%s %s') }}}

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_macs/tests/wrong_value.fail.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_ol,multi_platform_rhel
 
-{{{ bash_replace_or_append('/etc/ssh/sshd_config', '^MACs', "wrong_value_expected_to_fail.com", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/ssh/sshd_config', 'MACs', "wrong_value_expected_to_fail.com", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/password_quality/password_quality_pwquality/accounts_password_pam_retry/bash/shared.sh
@@ -11,7 +11,7 @@
 
 {{% if product in ['ol8', 'ol9', 'rhel8', 'rhel9'] -%}}
 	{{{ bash_replace_or_append('/etc/security/pwquality.conf',
-							   '^retry',
+							   'retry',
 							   '$var_password_pam_retry',
 							   '%s = %s') }}}
 	{{% for cfile in configuration_files %}}

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
@@ -1,4 +1,4 @@
 # platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
 
 
-{{{ bash_replace_or_append('/etc/systemd/system.conf', '^CtrlAltDelBurstAction=', 'none', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/systemd/system.conf', 'CtrlAltDelBurstAction=', 'none', '%s=%s') }}}

--- a/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/account_expiration/account_disable_post_pw_expiration/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_account_disable_post_pw_expiration") }}}
 
-{{{ bash_replace_or_append('/etc/default/useradd', '^INACTIVE', "$var_account_disable_post_pw_expiration", '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/default/useradd', 'INACTIVE', "$var_account_disable_post_pw_expiration", '%s=%s') }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_logon_fail_delay/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_accounts_fail_delay") }}}
 
-{{{ bash_replace_or_append('/etc/login.defs', '^FAIL_DELAY', "$var_accounts_fail_delay", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/login.defs', 'FAIL_DELAY', "$var_accounts_fail_delay", '%s %s') }}}

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_etc_login_defs/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_accounts_user_umask") }}}
 
-{{{ bash_replace_or_append('/etc/login.defs', '^UMASK', "$var_accounts_user_umask", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/login.defs', 'UMASK', "$var_accounts_user_umask", '%s %s') }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_configure_remote_server/bash/shared.sh
@@ -7,7 +7,7 @@ AUDITCONFIG={{{ audisp_conf_path }}}/audisp-remote.conf
 {{% if 'ubuntu' in product %}}
 AUREMOTECONFIG=/etc/audisp/plugins.d/au-remote.conf
 
-{{{ bash_replace_or_append("$AUREMOTECONFIG", '^active', 'yes') }}}
+{{{ bash_replace_or_append("$AUREMOTECONFIG", 'active', 'yes') }}}
 {{% endif %}}
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^remote_server', "$var_audispd_remote_server") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'remote_server', "$var_audispd_remote_server") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_disk_full_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG={{{ audisp_conf_path }}}/audisp-remote.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^disk_full_action', "$var_audispd_disk_full_action") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'disk_full_action', "$var_audispd_disk_full_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_encrypt_sent_records/bash/shared.sh
@@ -2,10 +2,10 @@
 
 AUDISP_REMOTE_CONFIG="{{{ audisp_conf_path }}}/audisp-remote.conf"
 {{% if product in ["rhel8", "fedora", "ol8", "rhv4"] %}}
-option="^transport"
+option="transport"
 value="KRB5"
 {{% else %}}
-option="^enable_krb5"
+option="enable_krb5"
 value="yes"
 {{% endif %}}
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_network_failure_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG={{{ audisp_conf_path }}}/audisp-remote.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^network_failure_action', "$var_audispd_network_failure_action") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'network_failure_action', "$var_audispd_network_failure_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_audispd_syslog_plugin_activated/bash/shared.sh
@@ -3,4 +3,4 @@ var_syslog_active="yes"
 
 AUDISP_SYSLOGCONFIG={{{ audisp_conf_path }}}/plugins.d/syslog.conf
 
-{{{ bash_replace_or_append("$AUDISP_SYSLOGCONFIG", '^active', "$var_syslog_active") }}}
+{{{ bash_replace_or_append("$AUDISP_SYSLOGCONFIG", 'active', "$var_syslog_active") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action/bash/shared.sh
@@ -9,4 +9,4 @@
 #
 var_auditd_disk_error_action="$(echo $var_auditd_disk_error_action | cut -d \| -f 1)"
 
-{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_error_action', "$var_auditd_disk_error_action") }}}
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", 'disk_error_action', "$var_auditd_disk_error_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action_stig/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_error_action_stig/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_auditd_disk_error_action") }}}
 
-{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_error_action', "$var_auditd_disk_error_action") }}}
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", 'disk_error_action', "$var_auditd_disk_error_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 var_auditd_disk_full_action="$(echo $var_auditd_disk_full_action | cut -d \| -f 1)"
 
-{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_full_action', "$var_auditd_disk_full_action") }}}
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", 'disk_full_action', "$var_auditd_disk_full_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action_stig/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_disk_full_action_stig/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_auditd_disk_full_action") }}}
 
-{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^disk_full_action', "$var_auditd_disk_full_action") }}}
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", 'disk_full_action', "$var_auditd_disk_full_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_action_mail_acct/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^action_mail_acct', "$var_auditd_action_mail_acct") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'action_mail_acct', "$var_auditd_action_mail_acct") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^admin_space_left_action', "$var_auditd_admin_space_left_action") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'admin_space_left_action', "$var_auditd_admin_space_left_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^max_log_file', "$var_auditd_max_log_file") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'max_log_file', "$var_auditd_max_log_file") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^max_log_file_action', "$var_auditd_max_log_file_action") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'max_log_file_action', "$var_auditd_max_log_file_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action_stig/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("var_auditd_max_log_file_action") }}}
 
-{{{ bash_replace_or_append("/etc/audit/auditd.conf", '^max_log_file_action', "$var_auditd_max_log_file_action") }}}
+{{{ bash_replace_or_append("/etc/audit/auditd.conf", 'max_log_file_action', "$var_auditd_max_log_file_action") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_num_logs/bash/shared.sh
@@ -4,4 +4,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^num_logs', "$var_auditd_num_logs") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'num_logs', "$var_auditd_num_logs") }}}

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_space_left_action/bash/shared.sh
@@ -10,4 +10,4 @@
 
 AUDITCONFIG=/etc/audit/auditd.conf
 
-{{{ bash_replace_or_append("$AUDITCONFIG", '^space_left_action', "$var_auditd_space_left_action") }}}
+{{{ bash_replace_or_append("$AUDITCONFIG", 'space_left_action', "$var_auditd_space_left_action") }}}

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
@@ -6,8 +6,9 @@
 {{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
 - name: "Set rsyslog remote loghost"
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/rsyslog.conf
-    regexp: "^\\*\\.\\*"
+    regexp: >-
+      ^\*\.\*[ \\t]+(?:@|\:omrelp\:)
     line: "*.* @@{{ rsyslog_remote_loghost_address }}"
     create: yes

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
@@ -2,4 +2,4 @@
 
 {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
-{{{ bash_replace_or_append('/etc/rsyslog.conf', '^\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}
+{{{ bash_replace_or_append('/etc/rsyslog.conf', '\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
@@ -2,4 +2,11 @@
 
 {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
 
-{{{ bash_replace_or_append('/etc/rsyslog.conf', '\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}
+{{{ bash_replace_or_append(
+    '/etc/rsyslog.conf',
+    '*.*',
+    "@@${rsyslog_remote_loghost_address}",
+    '%s %s',
+    key_regex='^\*\.\*[ \t]\+\(@\|:omrelp:\)',
+    word_boundary='',
+) }}}

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/oval/shared.xml
@@ -1,3 +1,4 @@
+{{%- set remote_rx = "^\*\.\*[ \t]+(?:@|\:omrelp\:)" -%}}
 <def-group>
   <definition class="compliance" id="rsyslog_remote_loghost" version="1">
     {{{ oval_metadata("Syslog logs should be sent to a remote loghost") }}}
@@ -33,14 +34,14 @@
 
   <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_conf" version="1">
     <ind:filepath>/etc/rsyslog.conf</ind:filepath>
-    <ind:pattern operation="pattern match">^\*\.\*[\s]+(?:@|\:omrelp\:)</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ remote_rx }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <ind:textfilecontent54_object id="object_remote_loghost_rsyslog_d" version="1">
     <ind:path>/etc/rsyslog.d</ind:path>
     <ind:filename operation="pattern match">^.+\.conf$</ind:filename>
-    <ind:pattern operation="pattern match">^\*\.\*[\s]+(?:@|\:omrelp\:)</ind:pattern>
+    <ind:pattern operation="pattern match">{{{ remote_rx }}}</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_exec_shield/bash/shared.sh
@@ -16,7 +16,7 @@ if [ "$(getconf LONG_BIT)" = "32" ] ; then
   # If kernel.exec-shield present in /etc/sysctl.conf, change value to "1"
   #	else, add "kernel.exec-shield = 1" to /etc/sysctl.conf
   #
-  {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.exec-shield', '1') }}}
+  {{{ bash_replace_or_append('/etc/sysctl.conf', 'kernel.exec-shield', '1') }}}
 fi
 
 if [ "$(getconf LONG_BIT)" = "64" ] ; then

--- a/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/clean_components_post_updating/bash/shared.sh
@@ -1,7 +1,7 @@
 # platform = multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_rhv,multi_platform_sle
 
 {{% if 'sle' in product %}}
-{{{ bash_replace_or_append('/etc/zypp/zypp.conf', '^solver.upgradeRemoveDroppedPackages', 'true', '%s=%s') }}}
+{{{ bash_replace_or_append('/etc/zypp/zypp.conf', 'solver.upgradeRemoveDroppedPackages', 'true', '%s=%s') }}}
 {{% else %}}
 if grep --silent ^clean_requirements_on_remove {{{ pkg_manager_config_file }}} ; then
         sed -i "s/^clean_requirements_on_remove.*/clean_requirements_on_remove=1/g" {{{ pkg_manager_config_file }}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_globally_activated/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_rhel,multi_platform_ol,multi_platform_fedora,multi_platform_rhv,multi_platform_sle
 
-{{{ bash_replace_or_append( pkg_manager_config_file , '^gpgcheck', '1') }}}
+{{{ bash_replace_or_append( pkg_manager_config_file , 'gpgcheck', '1') }}}

--- a/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/shared.sh
+++ b/linux_os/guide/system/software/updating/ensure_gpgcheck_local_packages/bash/shared.sh
@@ -1,3 +1,3 @@
 # platform = multi_platform_all
 
-{{{ bash_replace_or_append( pkg_manager_config_file , '^localpkg_gpgcheck', '1') }}}
+{{{ bash_replace_or_append( pkg_manager_config_file , 'localpkg_gpgcheck', '1') }}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1571,22 +1571,35 @@ fi
 
 
 {{#
-    Macro to replace configuration setting in config file or add the configuration setting if
-    it does not exist.
+Macro to replace configuration setting in config file or add the configuration setting if
+it does not exist.
 
-    Example Calls:
+All regular expression files accept Basic Regular Expression (BRE) format.
 
-      With default format of 'key = value'::
+Inherent limitations:
+
+* no '"' in jinja level variables, error raised
+* only allowed control character is \t (vertical tab), filtered away at shell level
+* caller is responsible for shell quoting (variables from
+  `bash_instantiate_variables` are quoted automatically)
+
+Example Calls:
+
+    With default format of 'key = value'::
 
         {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.randomize_va_space', '2') }}}
 
-      With custom key/value format::
+    With custom key/value format::
 
         {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', 'disabled', '%s=%s') }}}
 
-      With a variable::
+    With a variable::
 
         {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', "$var_selinux_state", '%s=%s') }}}
+
+    Caller is responsible for shell quoting::
+
+        {{{ bash_replace_or_append(( unsafe_file | quote), 'key', "value") }}}
 
 :param config_file: Configuration file that will be modified
 :type config_file: str

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -16,6 +16,77 @@ Then, assume that variables of that names are defined and contain the correct va
 
 
 {{#
+Escape value to be used in *sed* **s** command as regexp, all but ``\w`` is quoted
+
+All control characters are removed except ``\t`` (horizontal tab).
+
+There is *bash_sed_escape_replacement* for replacement escape.
+
+Example calls:
+
+    Unsafe variable::
+
+        variable=$'q"$(foo^bar)/`rm -rf`'
+        {{{ bash_sed_escape_regexp("variable", "result_variable") }}}
+        sed -Ei "s/${result_variable}/replacement/" file
+
+    Full set::
+
+        {{{ bash_sed_escape_regexp("variable", "variable") }}}
+        {{{ bash_sed_escape_replacement("replacement", "replacement") }}}
+        sed -Ei "s/${variable}/${replacement}/" file
+
+:param variable: Shell variable name with content to be escaped
+:type variable: str
+:param result_variable: Shell variable name where escaped content is placed
+:type result_variable: str
+
+#}}
+{{%- macro bash_sed_escape_regexp(variable, result_variable) -%}}
+{{#-
+    First weed out control characters. See: ascii(7)
+    Then escape other than \w and ^ with [ ]. And then ^ with \^.
+-#}}
+{{%- if (variable is not string) or ((variable | quote) != variable) -%}}
+{{{ raise("variable '" ~ variable ~ "' must be shell variable name, not value.") }}}
+{{%- endif -%}}
+{{%- if (result_variable is not string) or ((result_variable | quote) != result_variable) -%}}
+{{{ raise("result_variable '" ~ result_variable ~ "' must be shell variable name, not value.") }}}
+{{%- endif -%}}
+{{{ result_variable }}}="$(set -o pipefail;LC_ALL=C sed 's/[\x00-\x08\x0a-\x1f\x7f]//g;s/[^^a-zA-Z0-9_]/[&]/g;s/\^/\\^/g' <<< "{{{ "${" ~ variable ~ "}" }}}" | tr -d '\n')"
+{{%- endmacro -%}}
+
+
+{{#
+Escape value to be used in *sed* **s** command as replacement, against ``/`` and ``\`` (like ``\1``)
+
+All control characters are removed except ``\t`` (horizontal tab).
+
+There is *bash_sed_escape_regexp* for regexp escape.
+
+:param variable: Shell variable name with content to be escaped
+:type variable: str
+:param result_variable: Shell variable name where escaped content is placed
+:type result_variable: str
+:param delim: Delimiter character in **s** command
+:type delim: char
+
+#}}
+{{%- macro bash_sed_escape_replacement(variable, result_variable, delim="/") -%}}
+{{%- if (variable is not string) or ((variable | quote) != variable) -%}}
+{{{ raise("variable '" ~ variable ~ "' must be shell variable name, not value.") }}}
+{{%- endif -%}}
+{{%- if (result_variable is not string) or ((result_variable | quote) != result_variable) -%}}
+{{{ raise("result_variable '" ~ result_variable ~ "' must be shell variable name, not value.") }}}
+{{%- endif -%}}
+{{%- if (delim is not string) or ((delim | length) != 1) -%}}
+{{{ raise("delim '" ~ delim ~ "' must be char aka string with legth of one.") }}}
+{{%- endif -%}}
+{{{ result_variable }}}="$(LC_ALL=C sed 's/[\x00-\x08\x0a-\x1f\x7f]//g;s/\\/\\\\/g{{% if delim == '^' %}};s/\^/\\^/g{{% else %}};s^{{{ delim }}}^\\{{{ delim }}}^g{{% endif %}};s/[&]/\\&/g' <<< "{{{ "${" ~ variable ~ "}" }}}" | tr -d '\n')"
+{{%- endmacro -%}}
+
+
+{{#
     Make sure that we have a line like this in pamFile (additional options are left as-is):
     type control module option=valueRegexArg
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1716,7 +1716,7 @@ Example Calls:
 {{%- endif -%}}
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.
-stripped_key="$(sed 's/[\^=\$,;+]*//g' <<< "{{{ key }}}")"
+stripped_key="$(LC_ALL=C sed 's/[\^=$,;+]*//g' <<< "{{{ key }}}")"
 
 # shellcheck disable=SC2059
 printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
@@ -1725,8 +1725,8 @@ printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
 # We search for the key string followed by a word boundary (matched by \>),
 # so if we search for 'setting', 'setting2' won't match.
 if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
-    escaped_formatted_output="$(sed -e 's|/|\\/|g' <<< "${formatted_output}")"
-    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/${escaped_formatted_output}/gi" "{{{ config_file }}}"
+    escaped_formatted_output="$(LC_ALL=C sed 's|/|\\/|g' <<< "${formatted_output}")"
+    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/${escaped_formatted_output}/i" "{{{ config_file }}}"
 else
     {{{ bash_ensure_nl_at_eof(config_file) | indent }}}
     {{%- if cce_identifiers and 'cce' in cce_identifiers %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1689,9 +1689,11 @@ Example Calls:
 :type format: str
 :param insensitive: If true *key* is case insensitive
 :type insensitive: bool
+:param word_boundary: Regex to separate *key* in case of common prefix
+:type word_boundary: str
 
 #}}
-{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s', insensitive=true) -%}}
+{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s', insensitive=true, word_boundary="\\>") -%}}
 {{%- if key is not string -%}}
 {{{ raise("key '" ~ key ~ "' is not string") }}}
 {{%- endif -%}}
@@ -1703,6 +1705,9 @@ Example Calls:
 {{%- endif -%}}
 {{%- if insensitive is not boolean -%}}
 {{{ raise("insensitive '" ~ insensitive ~ "' is not boolean") }}}
+{{%- endif -%}}
+{{%- if word_boundary is not string -%}}
+{{{ raise("word_boundary '" ~ word_boundary ~ "' is not string") }}}
 {{%- endif -%}}
 {{%- if key.startswith('^') -%}}
 {{{ raise("key is not partially regex any more, use key_regex") }}}
@@ -1719,18 +1724,25 @@ Example Calls:
 {{%- if '"' in format -%}}
 {{{ raise("format contains '\"' character, must not. You can put value of format in shell variable.") }}}
 {{%- endif -%}}
+{{%- if '"' in word_boundary -%}}
+{{{ raise("word_boundary contains '\"' character, must not. You can put value of word_boundary in shell variable.") }}}
+{{%- endif -%}}
 
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.
 stripped_key="$(LC_ALL=C sed 's/[\^=$,;+]*//g' <<< "{{{ key }}}")"
-key_regex="{{{ key }}}\\>"
+key_regex="{{{ key ~ word_boundary }}}"
 
 # shellcheck disable=SC2059
 printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
 
 # If the key exists, change it. Otherwise, add it to the config_file.
-# We search for the key string followed by a word boundary (matched by \>),
+{{%- if word_boundary == "" %}}
+# We search for the key string followed by a word boundary (matched by {{{ word_boundary }}}),
 # so if we search for 'setting', 'setting2' won't match.
+{{%- else %}}
+# We search for the key string, but care should be take not to match common prefix.
+{{%- endif %}}
 if LC_ALL=C grep -q -m 1{{%- if insensitive %}} -i{{%- endif %}} -e "${key_regex}" "{{{ config_file }}}"; then
     {{{ bash_sed_escape_replacement("formatted_output", "escaped_formatted_output") }}}
     LC_ALL=C sed -i --follow-symlinks "s/${key_regex}.*/${escaped_formatted_output}/{{%- if insensitive -%}}i{{%- endif -%}}" "{{{ config_file }}}"

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1716,24 +1716,24 @@ Example Calls:
 {{%- endif -%}}
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.
-stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "{{{ key }}}")
+stripped_key="$(sed 's/[\^=\$,;+]*//g' <<< "{{{ key }}}")"
 
 # shellcheck disable=SC2059
-printf -v formatted_output "{{{ format }}}" "$stripped_key" "{{{ value }}}"
+printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
 
 # If the key exists, change it. Otherwise, add it to the config_file.
 # We search for the key string followed by a word boundary (matched by \>),
 # so if we search for 'setting', 'setting2' won't match.
 if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
-    escaped_formatted_output=$(sed -e 's|/|\\/|g' <<< "$formatted_output")
-    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/$escaped_formatted_output/gi" "{{{ config_file }}}"
+    escaped_formatted_output="$(sed -e 's|/|\\/|g' <<< "${formatted_output}")"
+    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/${escaped_formatted_output}/gi" "{{{ config_file }}}"
 else
     {{{ bash_ensure_nl_at_eof(config_file) | indent }}}
     {{%- if cce_identifiers and 'cce' in cce_identifiers %}}
     {{{ set_cce_value() }}}
     printf '# Per %s: Set %s in %s\n' "${cce}" "${formatted_output}" "{{{ config_file }}}" >> "{{{ config_file }}}"
     {{%- endif %}}
-    printf '%s\n' "$formatted_output" >> "{{{ config_file }}}"
+    printf '%s\n' "${formatted_output}" >> "{{{ config_file }}}"
 fi
 {{%- endmacro -%}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1714,9 +1714,11 @@ Example Calls:
 {{%- if '"' in format -%}}
 {{{ raise("format contains '\"' character, must not. You can put value of format in shell variable.") }}}
 {{%- endif -%}}
+
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.
 stripped_key="$(LC_ALL=C sed 's/[\^=$,;+]*//g' <<< "{{{ key }}}")"
+key_regex="{{{ key }}}\\>"
 
 # shellcheck disable=SC2059
 printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
@@ -1724,9 +1726,9 @@ printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
 # If the key exists, change it. Otherwise, add it to the config_file.
 # We search for the key string followed by a word boundary (matched by \>),
 # so if we search for 'setting', 'setting2' won't match.
-if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
+if LC_ALL=C grep -q -m 1 -i -e "${key_regex}" "{{{ config_file }}}"; then
     escaped_formatted_output="$(LC_ALL=C sed 's|/|\\/|g' <<< "${formatted_output}")"
-    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/${escaped_formatted_output}/i" "{{{ config_file }}}"
+    LC_ALL=C sed -i --follow-symlinks "s/${key_regex}.*/${escaped_formatted_output}/i" "{{{ config_file }}}"
 else
     {{{ bash_ensure_nl_at_eof(config_file) | indent }}}
     {{%- if cce_identifiers and 'cce' in cce_identifiers %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1687,9 +1687,11 @@ Example Calls:
 :type value: str
 :param format: Optional argument, The printf-like format string that will be given stripped key and value as arguments, so e.g. ``%s=%s` will result in key=value substitution (i.e. without spaces around =)
 :type format: str
+:param insensitive: If true *key* is case insensitive
+:type insensitive: bool
 
 #}}
-{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s') -%}}
+{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s', insensitive=true) -%}}
 {{%- if key is not string -%}}
 {{{ raise("key '" ~ key ~ "' is not string") }}}
 {{%- endif -%}}
@@ -1698,6 +1700,9 @@ Example Calls:
 {{%- endif -%}}
 {{%- if format is not string -%}}
 {{{ raise("format '" ~ format ~ "' is not string") }}}
+{{%- endif -%}}
+{{%- if insensitive is not boolean -%}}
+{{{ raise("insensitive '" ~ insensitive ~ "' is not boolean") }}}
 {{%- endif -%}}
 {{%- if key.startswith('^') -%}}
 {{{ raise("key is not partially regex any more, use key_regex") }}}
@@ -1726,9 +1731,9 @@ printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
 # If the key exists, change it. Otherwise, add it to the config_file.
 # We search for the key string followed by a word boundary (matched by \>),
 # so if we search for 'setting', 'setting2' won't match.
-if LC_ALL=C grep -q -m 1 -i -e "${key_regex}" "{{{ config_file }}}"; then
+if LC_ALL=C grep -q -m 1{{%- if insensitive %}} -i{{%- endif %}} -e "${key_regex}" "{{{ config_file }}}"; then
     {{{ bash_sed_escape_replacement("formatted_output", "escaped_formatted_output") }}}
-    LC_ALL=C sed -i --follow-symlinks "s/${key_regex}.*/${escaped_formatted_output}/i" "{{{ config_file }}}"
+    LC_ALL=C sed -i --follow-symlinks "s/${key_regex}.*/${escaped_formatted_output}/{{%- if insensitive -%}}i{{%- endif -%}}" "{{{ config_file }}}"
 else
     {{{ bash_ensure_nl_at_eof(config_file) | indent }}}
     {{%- if cce_identifiers and 'cce' in cce_identifiers %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1658,15 +1658,15 @@ Example Calls:
 
     With default format of 'key = value'::
 
-        {{{ bash_replace_or_append('/etc/sysctl.conf', '^kernel.randomize_va_space', '2') }}}
+        {{{ bash_replace_or_append('/etc/sysctl.conf', 'kernel.randomize_va_space', '2') }}}
 
     With custom key/value format::
 
-        {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', 'disabled', '%s=%s') }}}
+        {{{ bash_replace_or_append('/etc/sysconfig/selinux', 'SELINUX=', 'disabled', '%s=%s') }}}
 
     With a variable::
 
-        {{{ bash_replace_or_append('/etc/sysconfig/selinux', '^SELINUX=', "$var_selinux_state", '%s=%s') }}}
+        {{{ bash_replace_or_append('/etc/sysconfig/selinux', 'SELINUX=', "$var_selinux_state", '%s=%s') }}}
 
     Caller is responsible for shell quoting::
 
@@ -1687,13 +1687,17 @@ Example Calls:
 :type value: str
 :param format: Optional argument, The printf-like format string that will be given stripped key and value as arguments, so e.g. ``%s=%s` will result in key=value substitution (i.e. without spaces around =)
 :type format: str
-:param insensitive: If true *key* is case insensitive
+:param insensitive: If true *key*, or *key_regex* are case insensitive
 :type insensitive: bool
 :param word_boundary: Regex to separate *key* in case of common prefix
 :type word_boundary: str
+:param key_regex: Regex to match the key line
+:type key_regex: str
+:param key_starts_with: If true, line must start with *key*. Only enabled if *key_regex* is not set
+:type key_starts_with: bool
 
 #}}
-{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s', insensitive=true, word_boundary="\\>") -%}}
+{{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s', insensitive=true, word_boundary="\\>", key_regex=none, key_starts_with=true) -%}}
 {{%- if key is not string -%}}
 {{{ raise("key '" ~ key ~ "' is not string") }}}
 {{%- endif -%}}
@@ -1709,7 +1713,13 @@ Example Calls:
 {{%- if word_boundary is not string -%}}
 {{{ raise("word_boundary '" ~ word_boundary ~ "' is not string") }}}
 {{%- endif -%}}
-{{%- if key.startswith('^') -%}}
+{{%- if (key_regex is not none) and (key_regex is not string) -%}}
+{{{ raise("key_regex '" ~ key_regex ~ "' is not string") }}}
+{{%- endif -%}}
+{{%- if key_starts_with is not boolean -%}}
+{{{ raise("key_starts_with '" ~ key_starts_with ~ "' is not boolean") }}}
+{{%- endif -%}}
+{{%- if (key_regex is none) and key.startswith('^') -%}}
 {{{ raise("key is not partially regex any more, use key_regex") }}}
 {{%- endif -%}}
 {{%- if '"' in config_file -%}}
@@ -1727,14 +1737,24 @@ Example Calls:
 {{%- if '"' in word_boundary -%}}
 {{{ raise("word_boundary contains '\"' character, must not. You can put value of word_boundary in shell variable.") }}}
 {{%- endif -%}}
+{{%- if key_regex is not none and '"' in key_regex -%}}
+{{{ raise("key_regex contains '\"' character, must not. You can put value of key_regex in shell variable.") }}}
+{{%- endif -%}}
 
-# Strip any search characters in the key arg so that the key can be replaced without
-# adding any search characters to the config file.
-stripped_key="$(LC_ALL=C sed 's/[\^=$,;+]*//g' <<< "{{{ key }}}")"
-key_regex="{{{ key ~ word_boundary }}}"
+{{%- if key_regex is none -%}}
+key_regex="{{{ key }}}"
+{{{ bash_sed_escape_regexp("key_regex", "key_regex") }}}
+{{%- if key_starts_with %}}
+key_regex="^${key_regex}{{{ word_boundary }}}"
+{{%- else %}}
+key_regex+="{{{ word_boundary }}}"
+{{%- endif -%}}
+{{%- else %}}
+key_regex="{{{ key_regex ~ word_boundary }}}"
+{{%- endif %}}
 
 # shellcheck disable=SC2059
-printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
+printf -v formatted_output "{{{ format }}}" "{{{ key }}}" "{{{ value }}}"
 
 # If the key exists, change it. Otherwise, add it to the config_file.
 {{%- if word_boundary == "" %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1601,6 +1601,13 @@ Example Calls:
 
         {{{ bash_replace_or_append(( unsafe_file | quote), 'key', "value") }}}
 
+    There is sometimes need to submit '"' in str fields. Because of shell
+    scripting limitations, this is not allowed as jinja variable and error is
+    raised, but you can do it like this::
+
+        format='"%s" = "%s"'
+        {{{ bash_replace_or_append('/etc/config', 'key parts', "value parts", "${format}") }}}
+
 :param config_file: Configuration file that will be modified
 :type config_file: str
 :param key: Configuration option to change
@@ -1612,6 +1619,30 @@ Example Calls:
 
 #}}
 {{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s') -%}}
+{{%- if key is not string -%}}
+{{{ raise("key '" ~ key ~ "' is not string") }}}
+{{%- endif -%}}
+{{%- if value is not string -%}}
+{{{ raise("value '" ~ value ~ "' is not string") }}}
+{{%- endif -%}}
+{{%- if format is not string -%}}
+{{{ raise("format '" ~ format ~ "' is not string") }}}
+{{%- endif -%}}
+{{%- if key.startswith('^') -%}}
+{{{ raise("key is not partially regex any more, use key_regex") }}}
+{{%- endif -%}}
+{{%- if '"' in config_file -%}}
+{{{ raise("config_file contains '\"' character, must not. You can put value of config_file in shell variable.") }}}
+{{%- endif -%}}
+{{%- if '"' in key -%}}
+{{{ raise("key contains '\"' character, must not. You can put value of key in shell variable.") }}}
+{{%- endif -%}}
+{{%- if '"' in value -%}}
+{{{ raise("value contains '\"' character, must not. You can put value of value in shell variable.") }}}
+{{%- endif -%}}
+{{%- if '"' in format -%}}
+{{{ raise("format contains '\"' character, must not. You can put value of format in shell variable.") }}}
+{{%- endif -%}}
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.
 stripped_key=$(sed 's/[\^=\$,;+]*//g' <<< "{{{ key }}}")

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1754,7 +1754,7 @@ key_regex="{{{ key_regex ~ word_boundary }}}"
 {{%- endif %}}
 
 # shellcheck disable=SC2059
-printf -v formatted_output "{{{ format }}}" "{{{ key }}}" "{{{ value }}}"
+printf -v formatted_output "{{{ format }}}" "{{{ key }}}" "$(tr -d '\n' <<< "{{{ value }}}")"
 
 # If the key exists, change it. Otherwise, add it to the config_file.
 {{%- if word_boundary == "" %}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1727,7 +1727,7 @@ printf -v formatted_output "{{{ format }}}" "${stripped_key}" "{{{ value }}}"
 # We search for the key string followed by a word boundary (matched by \>),
 # so if we search for 'setting', 'setting2' won't match.
 if LC_ALL=C grep -q -m 1 -i -e "${key_regex}" "{{{ config_file }}}"; then
-    escaped_formatted_output="$(LC_ALL=C sed 's|/|\\/|g' <<< "${formatted_output}")"
+    {{{ bash_sed_escape_replacement("formatted_output", "escaped_formatted_output") }}}
     LC_ALL=C sed -i --follow-symlinks "s/${key_regex}.*/${escaped_formatted_output}/i" "{{{ config_file }}}"
 else
     {{{ bash_ensure_nl_at_eof(config_file) | indent }}}

--- a/shared/templates/accounts_password/bash.template
+++ b/shared/templates/accounts_password/bash.template
@@ -21,4 +21,4 @@ fi
 }}}
 {{% endif %}}
 
-{{{ bash_replace_or_append('/etc/security/pwquality.conf', '^' ~ VARIABLE , '$var_password_pam_' ~ VARIABLE , '%s = %s') }}}
+{{{ bash_replace_or_append('/etc/security/pwquality.conf', VARIABLE, '$var_password_pam_' ~ VARIABLE , '%s = %s') }}}

--- a/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_directory.pass.sh
@@ -5,7 +5,7 @@
 source common.sh
 
 {{% if product in ["ol8", "ol9"] %}}
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 {{% endif %}}
 
 {{{ bash_sshd_remediation(parameter=PARAMETER, value=VALUE, config_is_distributed=sshd_distributed_config) -}}}

--- a/shared/templates/sshd_lineinfile/tests/correct_value_including_relative_path.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_including_relative_path.pass.sh
@@ -4,6 +4,6 @@
 
 source common.sh
 
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 
 echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/ssh/sshd_config.d/other.conf

--- a/shared/templates/sshd_lineinfile/tests/correct_value_multiple_includes.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/correct_value_multiple_includes.pass.sh
@@ -4,7 +4,7 @@
 
 source common.sh
 
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 echo "Include /etc/dummy" >> "/etc/ssh/sshd_config"
 
 echo "{{{ PARAMETER }}} {{{ VALUE }}}" >> /etc/dummy

--- a/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
+++ b/shared/templates/sshd_lineinfile/tests/duplicated_param_directory.pass.sh
@@ -6,7 +6,7 @@ mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
 {{% if product in ["ol8", "ol9"] %}}
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 {{% endif %}}
 
 if grep -q "^\s*{{{ PARAMETER }}}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_directory.fail.sh
@@ -9,7 +9,7 @@ mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
 {{% if product in ["ol8", "ol9"] %}}
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 {{% endif %}}
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_file_with_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_file_with_directory.fail.sh
@@ -9,7 +9,7 @@ mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
 {{% if product in ["ol8", "ol9"] %}}
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 {{% endif %}}
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_including_relative_path.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_including_relative_path.fail.sh
@@ -8,7 +8,7 @@ SSHD_VAL={{{ VALUE }}}
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
 	sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*

--- a/shared/templates/sshd_lineinfile/tests/param_conflict_multiple_includes.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/param_conflict_multiple_includes.fail.sh
@@ -8,7 +8,7 @@ SSHD_VAL={{{ VALUE }}}
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 echo "Include /etc/bad_config.conf" >> "/etc/ssh/sshd_config"
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then

--- a/shared/templates/sshd_lineinfile/tests/wrong_value_directory.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/wrong_value_directory.fail.sh
@@ -9,7 +9,7 @@ mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
 {{% if product in ["ol8", "ol9"] %}}
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "/etc/ssh/sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 {{% endif %}}
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then

--- a/shared/templates/sshd_lineinfile/tests/wrong_value_including_relative_path.fail.sh
+++ b/shared/templates/sshd_lineinfile/tests/wrong_value_including_relative_path.fail.sh
@@ -8,7 +8,7 @@ SSHD_VAL="bad_val"
 mkdir -p /etc/ssh/sshd_config.d
 touch /etc/ssh/sshd_config.d/nothing
 
-{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s") }}}
+{{{ bash_replace_or_append("/etc/ssh/sshd_config", "Include", "sshd_config.d/*.conf", "%s %s", key_starts_with=false) }}}
 
 if grep -q "^\s*${SSHD_PARAM}" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/* ; then
 	sed -i "/^\s*${SSHD_PARAM}.*/Id" /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*

--- a/shared/templates/sysctl/bash.template
+++ b/shared/templates/sysctl/bash.template
@@ -46,7 +46,7 @@ SYSCONFIG_FILE="/etc/sysctl.conf"
 {{% if sysctl_remediate_drop_in_file == "true" %}}
 sed -i "/^$SYSCONFIG_VAR/d" /etc/sysctl.conf
 {{% endif %}}
-{{{ bash_replace_or_append('${SYSCONFIG_FILE}', '^' ~ SYSCTLVAR , '$sysctl_' ~ SYSCTLID ~ '_value') }}}
+{{{ bash_replace_or_append('${SYSCONFIG_FILE}', SYSCTLVAR, '$sysctl_' ~ SYSCTLID ~ '_value') }}}
 
 {{%- else %}}
 
@@ -62,5 +62,5 @@ sed -i "/^$SYSCONFIG_VAR/d" /etc/sysctl.conf
 {{% if sysctl_remediate_drop_in_file == "true" %}}
 sed -i "/^$SYSCONFIG_VAR/d" /etc/sysctl.conf
 {{% endif %}}
-{{{ bash_replace_or_append('${SYSCONFIG_FILE}', '^' ~ SYSCTLVAR , SYSCTLVAL ) }}}
+{{{ bash_replace_or_append('${SYSCONFIG_FILE}', SYSCTLVAR, SYSCTLVAL ) }}}
 {{%- endif %}}

--- a/tests/unit/bash/test_bash_ensure_ini_config.bats.jinja
+++ b/tests/unit/bash/test_bash_ensure_ini_config.bats.jinja
@@ -50,7 +50,7 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -61,10 +61,10 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf pam_cert_auth.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 
-    run diff "pam_cert_auth.conf" <(printf "$expected_output")
+    run diff -u "pam_cert_auth.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -74,7 +74,7 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -84,7 +84,7 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -93,7 +93,7 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -103,7 +103,7 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -114,7 +114,7 @@ teardown() {
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_verbosity" "1"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -125,10 +125,10 @@ teardown() {
 
     call_bash_ensure_ini_config "pam_cert_auth.conf sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 
-     run diff "pam_cert_auth.conf" <(printf "$expected_output")
+     run diff -u "pam_cert_auth.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -138,6 +138,6 @@ teardown() {
 
     call_bash_ensure_ini_config "sssd_test/sssd.conf" "pam" "pam_cert_auth" "true"
 
-    run diff "sssd_test/sssd.conf" <(printf "$expected_output")
+    run diff -u "sssd_test/sssd.conf" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -160,18 +160,16 @@ teardown() {
 }
 
 @test "bash_replace_or_append - Key ending with . remediation" {
-    skip "Implementation needs to have word_boundary"
-    printf "kernel.randomize_va_space. = 5\n" > "${tmp_file}"
+    printf "kernel.randomize_va_space.=5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space. = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space.' '2'
+    {{{ bash_replace_or_append("${tmp_file}", 'kernel.randomize_va_space.', '2', word_boundary="[ \t=]") | indent(4) }}}
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Key contains * with remediation" {
-    skip "Implementation does not quote regexps properly despite skipped_key functionality"
     printf "kernel.randomize_va_space. = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space. = 5\nkernel.* = 2\n"
 
@@ -481,7 +479,6 @@ teardown() {
 }
 
 @test "bash_replace_or_append - Remediate value containing newline prefix" {
-    skip "Value newline trim not implemented."
     before="foo"
     key="kernel.randomize_va_fake"
     value="6"
@@ -503,7 +500,6 @@ teardown() {
 }
 
 @test "bash_replace_or_append - Remediate value containing newline suffix" {
-    skip "Value newline trim not implemented."
     before="foo"
     key="kernel.randomize_va_fake"
     value="6"
@@ -525,7 +521,6 @@ teardown() {
 }
 
 @test "bash_replace_or_append - Remediate value containing multiple newlines prefix and suffix" {
-    skip "Value newline trim not implemented."
     before="foo"
     key="kernel.randomize_va_fake"
     value="6"
@@ -1006,4 +1001,109 @@ teardown() {
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
+}
+
+@test "bash_replace_or_append - Value is same as delim in format" {
+    before="foo"
+    key="kernel.randomize_va_fake"
+    value="$(printf "\t")"
+
+    format='%s\t%s'
+    before_fmt="%s\n"
+    key_fmt="%s"
+    value_fmt="%s"
+    expected_output="${before}\n${key}\t${value}\n"
+
+    IFS='' read -d '' -r key_param < <(printf "${key_fmt}" "${key}") || :
+    IFS='' read -d '' -r value_param < <(printf "${value_fmt}" "${value}") || :
+    printf "${before_fmt}" "${before}" > "${tmp_file}"
+
+    call_bash_replace_or_append_w_format "${tmp_file}" "${key_param}" "${value_param}" "${format}"
+
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
+}
+
+@test "bash_replace_or_append - Key has all ASCII 0x20-0x7e" {
+    # z at end handles word_boundary
+    key=' !"#$%&'"'"'()*+,-./01234567890:;<=>?@ABCEDFGHIJKLMNOPQRSTUVWXYZ[\\]^_\`abcedfghijklmnopqrstuvwxyz{|}~z'
+    value1="1"
+    value2="2"
+
+    call_bash_replace_or_append "${tmp_file}" "${key}" "${value1}"
+
+    run diff -u "${tmp_file}" <(echo -E "${key} = ${value1}")
+    [ "${status}" -eq 0 ]
+
+    call_bash_replace_or_append "${tmp_file}" "${key}" "${value2}"
+
+    run diff -u "${tmp_file}" <(echo -E "${key} = ${value2}")
+    [ "${status}" -eq 0 ]
+}
+
+@test "bash_replace_or_append - *.* and key_regex" {
+    printf "*.* /var/log/messages\n*.*\t@@syloghost\n" > "${tmp_file}"
+    expected_output="*.* /var/log/messages\n*.*\t@@127.0.0.1\n"
+
+    rsyslog_remote_loghost_address="127.0.0.1"
+    {{{ bash_replace_or_append("${tmp_file}", "*.*", "@@${rsyslog_remote_loghost_address}", '%s\t%s', key_regex='^\*\.\*[ \t]\+\(@\|:omrelp:\)', word_boundary='') | indent(4) }}}
+
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
+}
+
+@test "bash_replace_or_append - Check 2 char keys, empty" {
+    skip "takes long time"
+    nums=(9 $(seq 32 50) $(seq 58 66) $(seq 91 98) $(seq 123 126))
+    for a in "${nums[@]}"; do
+        for b in "${nums[@]}"; do
+            rm "${tmp_file}"
+            IFS='' read -d '' -r key < <(printf "\\x$(printf "%x" "$a")\\x$(printf "%x" "$b")") || :
+            {{{ bash_replace_or_append("${tmp_file}", "${key}", "a", '%s\t%s', word_boundary='') | indent(12) }}}
+            run diff -u "${tmp_file}" <(printf "%s\ta\n" "${key}")
+            [ "${status}" -eq 0 ]
+        done
+    done
+}
+
+@test "bash_replace_or_append - Check 2 char keys, wrong value" {
+    skip "takes long time"
+    nums=(9 $(seq 32 50) $(seq 58 66) $(seq 91 98) $(seq 123 126))
+    for a in "${nums[@]}"; do
+        for b in "${nums[@]}"; do
+            IFS='' read -d '' -r key < <(printf "\\x$(printf "%x" "$a")\\x$(printf "%x" "$b")") || :
+            printf "%s\tb\n" "${key}" > "${tmp_file}"
+            {{{ bash_replace_or_append("${tmp_file}", "${key}", "a", '%s\t%s', word_boundary='') | indent(12) }}}
+            run diff -u "${tmp_file}" <(printf "%s\ta\n" "${key}")
+            [ "${status}" -eq 0 ]
+        done
+    done
+}
+
+@test "bash_replace_or_append - Check 2 char keys, wrong value and right value" {
+    skip "takes long time"
+    nums=(9 $(seq 32 50) $(seq 58 66) $(seq 91 98) $(seq 123 126))
+    for a in "${nums[@]}"; do
+        for b in "${nums[@]}"; do
+            IFS='' read -d '' -r key < <(printf "\\x$(printf "%x" "$a")\\x$(printf "%x" "$b")") || :
+            printf "%s\tb\n%s\ta\n" "${key}" "${key}" > "${tmp_file}"
+            {{{ bash_replace_or_append("${tmp_file}", "${key}", "a", '%s\t%s', word_boundary='') | indent(12) }}}
+            run diff -u "${tmp_file}" <(printf "%s\ta\n%s\ta\n" "${key}" "${key}")
+            [ "${status}" -eq 0 ]
+        done
+    done
+}
+
+@test "bash_replace_or_append - Check 2 char keys, right and wrong value" {
+    skip "takes long time"
+    nums=(9 $(seq 32 50) $(seq 58 66) $(seq 91 98) $(seq 123 126))
+    for a in "${nums[@]}"; do
+        for b in "${nums[@]}"; do
+            IFS='' read -d '' -r key < <(printf "\\x$(printf "%x" "$a")\\x$(printf "%x" "$b")") || :
+            printf "%s\ta\n%s\tb\n" "${key}" "${key}" > "${tmp_file}"
+            {{{ bash_replace_or_append("${tmp_file}", "${key}", "a", '%s\t%s', word_boundary='') | indent(12) }}}
+            run diff -u "${tmp_file}" <(printf "%s\ta\n%s\ta\n" "${key}" "${key}")
+            [ "${status}" -eq 0 ]
+        done
+    done
 }

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -53,7 +53,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 5" > "$tmp_file"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -63,7 +63,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 2" > "$tmp_file"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -73,7 +73,7 @@ teardown() {
     printf "" > "$tmp_file"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -83,7 +83,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_fake = 5" > "$tmp_file"
     expected_output="kernel.randomize_va_fake = 5\nkernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -93,7 +93,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space=5" > "$tmp_file"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -103,7 +103,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space=2" > "$tmp_file"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -113,7 +113,7 @@ teardown() {
     printf "" > "$tmp_file"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -123,7 +123,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_fake=5" > "$tmp_file"
     expected_output="kernel.randomize_va_fake=5\nkernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -133,7 +133,7 @@ teardown() {
     printf "%s\n" "kernel.core_pattern=|/bin/true" > "$tmp_file"
     expected_output="kernel.core_pattern=|/bin/false\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" '^kernel.core_pattern' '|/bin/false' '%s=%s'
+    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.core_pattern' '|/bin/false' '%s=%s'
 
     run diff "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
@@ -143,7 +143,7 @@ teardown() {
     printf "kernel.randomize_va_space = 5\nakernel.randomize_va_space = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\nakernel.randomize_va_space = 5\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -153,7 +153,7 @@ teardown() {
     printf "kernel.randomize_va_space = 5\nkernel.randomize_va_space2 = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\nkernel.randomize_va_space2 = 5\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -164,7 +164,7 @@ teardown() {
     printf "kernel.randomize_va_space. = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space. = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space.' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space.' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -175,7 +175,7 @@ teardown() {
     printf "kernel.randomize_va_space. = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space. = 5\nkernel.* = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.*' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.*' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -185,7 +185,7 @@ teardown() {
     printf "kernel.randomize_va_space = 5\n# kernel.randomize_va_space = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n# kernel.randomize_va_space = 5\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -195,7 +195,7 @@ teardown() {
     printf "KERNEL.RANDOMIZE_VA_SPACE = 5\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -205,7 +205,7 @@ teardown() {
     printf "kernel.randomize_va_space = FOO\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = foo\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' 'foo'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' 'foo'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -215,7 +215,7 @@ teardown() {
     printf "kernel.randomize_va_space = foo\nKERNEL.RANDOMIZE_VA_SPACE = 2\nkernel.randomize_va_space = foo\n" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\nkernel.randomize_va_space = 2\nkernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -225,7 +225,7 @@ teardown() {
     rm "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -236,7 +236,7 @@ teardown() {
     rm "${tmp_file}"
     mkdir -p "${tmp_file}"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
     [ "${status}" -eq 0 ]
 }
 
@@ -245,7 +245,7 @@ teardown() {
     rm "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "symlink.sh" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "symlink.sh" 'kernel.randomize_va_space' '2'
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
     [ -L symlink.sh ]
@@ -256,7 +256,7 @@ teardown() {
     ln -s "${tmp_file}" symlink.sh
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "symlink.sh" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "symlink.sh" 'kernel.randomize_va_space' '2'
     [ -L symlink.sh ]
     [ -f "${tmp_file}" ]
     run diff -u "${tmp_file}" <(printf "${expected_output}")
@@ -268,7 +268,7 @@ teardown() {
     ln -s "${tmp_file}" symlink.sh
     expected_output="foo\nkernel.randomize_va_space = 2\nbar\n"
 
-    call_bash_replace_or_append "symlink.sh" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "symlink.sh" 'kernel.randomize_va_space' '2'
     [ -L symlink.sh ]
     [ -f "${tmp_file}" ]
     run diff -u "${tmp_file}" <(printf "${expected_output}")
@@ -280,7 +280,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -291,7 +291,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -302,7 +302,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -313,7 +313,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [[ ${tmp_file} =~ foo ]]
@@ -326,7 +326,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "${tmp_file}" '^kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [[ ${tmp_file} =~ foo ]]
@@ -338,7 +338,7 @@ teardown() {
     printf "%s\n" "kernel.core_pattern=|/bin/true" > "${tmp_file}"
     expected_output="kernel.core_pattern=\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.core_pattern' '' '%s=%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.core_pattern' '' '%s=%s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -348,7 +348,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space 2\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.randomize_va_space' '2' '%s %s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s %s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -358,7 +358,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_space 2" > "${tmp_file}"
     expected_output="kernel.randomize_va_space 2\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.randomize_va_space' '2' '%s %s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s %s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -368,7 +368,7 @@ teardown() {
     printf "" > "${tmp_file}"
     expected_output="kernel.randomize_va_space 2\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.randomize_va_space' '2' '%s %s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s %s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -378,7 +378,7 @@ teardown() {
     printf "%s\n" "kernel.randomize_va_fake 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_fake 5\nkernel.randomize_va_space 2\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.randomize_va_space' '2' '%s %s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s %s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -388,7 +388,7 @@ teardown() {
     printf "%s\n" "kernel.core_pattern |/bin/true" > "${tmp_file}"
     expected_output="kernel.core_pattern |/bin/false\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.core_pattern' '|/bin/false' '%s %s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.core_pattern' '|/bin/false' '%s %s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -398,7 +398,7 @@ teardown() {
     printf "%s\n" "kernel.core_pattern |/bin/true" > "${tmp_file}"
     expected_output="kernel.core_pattern \n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.core_pattern' '' '%s %s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.core_pattern' '' '%s %s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
@@ -408,7 +408,7 @@ teardown() {
     printf "kernel.core_pattern\t|/bin/true\n" > "${tmp_file}"
     expected_output="kernel.core_pattern\t\n"
 
-    call_bash_replace_or_append_w_format "${tmp_file}" '^kernel.core_pattern' '' '%s\t%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.core_pattern' '' '%s\t%s'
 
     run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -55,7 +55,7 @@ teardown() {
 
     call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -65,7 +65,7 @@ teardown() {
 
     call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -75,7 +75,7 @@ teardown() {
 
     call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -85,7 +85,7 @@ teardown() {
 
     call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -95,7 +95,7 @@ teardown() {
 
     call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -105,7 +105,7 @@ teardown() {
 
     call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -115,7 +115,7 @@ teardown() {
 
     call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -125,7 +125,7 @@ teardown() {
 
     call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 
@@ -135,7 +135,7 @@ teardown() {
 
     call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.core_pattern' '|/bin/false' '%s=%s'
 
-    run diff "${tmp_file}" <(printf "${expected_output}")
+    run diff -u "${tmp_file}" <(printf "${expected_output}")
     [ "${status}" -eq 0 ]
 }
 

--- a/tests/unit/bash/test_bash_replace_or_append.bats.jinja
+++ b/tests/unit/bash/test_bash_replace_or_append.bats.jinja
@@ -23,7 +23,7 @@ setup() {
     fi
     pushd "${BATS_TEST_TMPDIR}" || exit 1
     tmp_file=test.sh
-    touch "$tmp_file"
+    touch "${tmp_file}"
 }
 
 teardown() {
@@ -50,93 +50,93 @@ teardown() {
 }
 
 @test "bash_replace_or_append - Basic value remediation" {
-    printf "%s\n" "kernel.randomize_va_space = 5" > "$tmp_file"
+    printf "%s\n" "kernel.randomize_va_space = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - No remediation happened" {
-    printf "%s\n" "kernel.randomize_va_space = 2" > "$tmp_file"
+    printf "%s\n" "kernel.randomize_va_space = 2" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Append key to empty file" {
-    printf "" > "$tmp_file"
+    printf "" > "${tmp_file}"
     expected_output="kernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Append key to non-empty file" {
-    printf "%s\n" "kernel.randomize_va_fake = 5" > "$tmp_file"
+    printf "%s\n" "kernel.randomize_va_fake = 5" > "${tmp_file}"
     expected_output="kernel.randomize_va_fake = 5\nkernel.randomize_va_space = 2\n"
 
-    call_bash_replace_or_append "$tmp_file" 'kernel.randomize_va_space' '2'
+    call_bash_replace_or_append "${tmp_file}" 'kernel.randomize_va_space' '2'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Remediation with format" {
-    printf "%s\n" "kernel.randomize_va_space=5" > "$tmp_file"
+    printf "%s\n" "kernel.randomize_va_space=5" > "${tmp_file}"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - No remediation with format" {
-    printf "%s\n" "kernel.randomize_va_space=2" > "$tmp_file"
+    printf "%s\n" "kernel.randomize_va_space=2" > "${tmp_file}"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Append key with format to empty file" {
-    printf "" > "$tmp_file"
+    printf "" > "${tmp_file}"
     expected_output="kernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Append key with format to non-empty file" {
-    printf "%s\n" "kernel.randomize_va_fake=5" > "$tmp_file"
+    printf "%s\n" "kernel.randomize_va_fake=5" > "${tmp_file}"
     expected_output="kernel.randomize_va_fake=5\nkernel.randomize_va_space=2\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.randomize_va_space' '2' '%s=%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.randomize_va_space' '2' '%s=%s'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Remediate value containing forward slash" {
-    printf "%s\n" "kernel.core_pattern=|/bin/true" > "$tmp_file"
+    printf "%s\n" "kernel.core_pattern=|/bin/true" > "${tmp_file}"
     expected_output="kernel.core_pattern=|/bin/false\n"
 
-    call_bash_replace_or_append_w_format "$tmp_file" 'kernel.core_pattern' '|/bin/false' '%s=%s'
+    call_bash_replace_or_append_w_format "${tmp_file}" 'kernel.core_pattern' '|/bin/false' '%s=%s'
 
-    run diff "$tmp_file" <(printf "$expected_output")
-    [ "$status" -eq 0 ]
+    run diff "${tmp_file}" <(printf "${expected_output}")
+    [ "${status}" -eq 0 ]
 }
 
 @test "bash_replace_or_append - Key prefix remediation" {
@@ -421,7 +421,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key}=${value}\n"
 
@@ -443,7 +443,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s "
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before} \n${key}=${value}\n"
 
@@ -465,7 +465,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\t"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\t\n${key}=${value}\n"
 
@@ -488,7 +488,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="\n%s"
     expected_output="${before}\n${key}=${value}\n"
 
@@ -510,7 +510,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s\n"
     expected_output="${before}\n${key}=${value}\n"
 
@@ -532,7 +532,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="\n\n%s\n\n"
     expected_output="${before}\n${key}=${value}\n"
 
@@ -553,7 +553,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt=" %s"
     expected_output="${before}\n${key}= ${value}\n"
 
@@ -574,7 +574,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s "
     expected_output="${before}\n${key}=${value} \n"
 
@@ -595,7 +595,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="  %s  "
     expected_output="${before}\n${key}=  ${value}  \n"
 
@@ -616,7 +616,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="\t%s"
     expected_output="${before}\n${key}=\t${value}\n"
 
@@ -637,7 +637,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s\t"
     expected_output="${before}\n${key}=${value}\t\n"
 
@@ -658,7 +658,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="\t\t%s\t\t"
     expected_output="${before}\n${key}=\t\t${value}\t\t\n"
 
@@ -679,7 +679,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^ %s"
+    key_fmt=" %s"
     value_fmt="%s"
     expected_output="${before}\n ${key}=${value}\n"
 
@@ -700,7 +700,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s "
+    key_fmt="%s "
     value_fmt="%s"
     expected_output="${before}\n${key} =${value}\n"
 
@@ -721,7 +721,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^  %s  "
+    key_fmt="  %s  "
     value_fmt="%s"
     expected_output="${before}\n  ${key}  =${value}\n"
 
@@ -742,7 +742,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^\t%s"
+    key_fmt="\t%s"
     value_fmt="%s"
     expected_output="${before}\n\t${key}=${value}\n"
 
@@ -763,7 +763,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s\t"
+    key_fmt="%s\t"
     value_fmt="%s"
     expected_output="${before}\n${key}\t=${value}\n"
 
@@ -784,7 +784,7 @@ teardown() {
 
     format='%s=%s'
     before_fmt="%s\n"
-    key_fmt="^\t\t%s\t\t"
+    key_fmt="\t\t%s\t\t"
     value_fmt="%s"
     expected_output="${before}\n\t\t${key}\t\t=${value}\n"
 
@@ -805,7 +805,7 @@ teardown() {
 
     format=' %s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n ${key}=${value}\n"
 
@@ -826,7 +826,7 @@ teardown() {
 
     format='%s =%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key} =${value}\n"
 
@@ -847,7 +847,7 @@ teardown() {
 
     format='%s= %s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key}= ${value}\n"
 
@@ -868,7 +868,7 @@ teardown() {
 
     format='%s=%s '
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key}=${value} \n"
 
@@ -889,7 +889,7 @@ teardown() {
 
     format='  %s  =  %s  '
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n  ${key}  =  ${value}  \n"
 
@@ -910,7 +910,7 @@ teardown() {
 
     format='\t%s=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n\t${key}=${value}\n"
 
@@ -931,7 +931,7 @@ teardown() {
 
     format='%s\t=%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key}\t=${value}\n"
 
@@ -952,7 +952,7 @@ teardown() {
 
     format='%s=\t%s'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key}=\t${value}\n"
 
@@ -973,7 +973,7 @@ teardown() {
 
     format='%s=%s\t'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n${key}=${value}\t\n"
 
@@ -994,7 +994,7 @@ teardown() {
 
     format='\t\t%s\t\t=\t\t%s\t\t'
     before_fmt="%s\n"
-    key_fmt="^%s"
+    key_fmt="%s"
     value_fmt="%s"
     expected_output="${before}\n\t\t${key}\t\t=\t\t${value}\t\t\n"
 

--- a/tests/unit/bash/test_set_config_file.bats.jinja
+++ b/tests/unit/bash/test_set_config_file.bats.jinja
@@ -62,7 +62,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -72,7 +72,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -82,7 +82,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -92,7 +92,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -102,7 +102,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -112,7 +112,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 
@@ -132,7 +132,7 @@ teardown() {
 
     call_set_config_file "$tmp_file"
 
-    run diff "$tmp_file" <(printf "$expected_output")
+    run diff -u "$tmp_file" <(printf "$expected_output")
     [ "$status" -eq 0 ]
 }
 


### PR DESCRIPTION
#### Description:

Get rid of `stripped_key` functionality. It is easily forgotten, now it is explicit.

Expand `test_bash_replace_or_append.bats.jinja`

I guess `bash_replace_or_append`` should add space definition and then handle space at start of line.

I'm not sure about control char / newline cleanup now. Maybe it should just `exit 1`. I had a bug in other code and this was needed. But in any case those should not be allowed in `bash` remediation code. `bash_replace_or_append` can only handle line at a time, so newlines break it. Maybe some other macros can handle multiline and newlines are fine. Now I added `LC_ALL=C` to each `sed/grep` call and maybe chars with 8th bit should be cleaned up too. But I wonder for example legit use cases, like UTF-8 directory names in `kernel.core_pattern`.

#### Rationale:

Try to implement `bash_replace_or_append` and document so that it does what is documented expected and is tested.

Usage should be based on case, read manual, and then place what manual says into macro call. Like how white space is handled. Is there case sensitivity . What is word boundary. Can key be expressed in multiple ways. What is delim between key and value.

#### Review Hints:

Kind of wip atm.