### PR TITLE
Sort some python imports

### DIFF
--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -2,16 +2,16 @@
 from __future__ import print_function
 
 import argparse
-import textwrap
+import contextlib
 import logging
 import os
 import os.path
-import time
-import sys
-from glob import glob
 import re
-import contextlib
+import sys
 import tempfile
+import textwrap
+import time
+from glob import glob
 
 ssg_dir = os.path.join(os.path.dirname(__file__), "..")
 sys.path.append(ssg_dir)

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -2,8 +2,8 @@
 
 import argparse
 import os
-import sys
 import subprocess
+import sys
 import time
 
 

--- a/tests/ssg_test_suite/__init__.py
+++ b/tests/ssg_test_suite/__init__.py
@@ -1,2 +1,3 @@
 import logging
+
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -1,15 +1,15 @@
 from __future__ import print_function
 
-import os
-import logging
-import subprocess
-from collections import namedtuple
 import functools
-import tarfile
-import tempfile
+import logging
+import os
 import re
 import shutil
+import subprocess
+import tarfile
+import tempfile
 import time
+from collections import namedtuple
 
 import ssg.yaml
 from ssg.build_cpe import ProductCPEs

--- a/tests/ssg_test_suite/log.py
+++ b/tests/ssg_test_suite/log.py
@@ -1,11 +1,11 @@
 from __future__ import print_function
+
 import logging
 import os
 import os.path
 import sys
 
 from ssg.utils import mkdir_p
-
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -1,17 +1,17 @@
 #!/usr/bin/python3
 from __future__ import print_function
 
+import collections
+import datetime
+import json
 import logging
 import os.path
 import re
-import collections
-import xml.etree.ElementTree
-import json
-import datetime
 import socket
+import subprocess
 import sys
 import time
-import subprocess
+import xml.etree.ElementTree
 
 from ssg.constants import OSCAP_PROFILE_ALL_ID
 

--- a/tests/ssg_test_suite/profile.py
+++ b/tests/ssg_test_suite/profile.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import logging
 
-
 import ssg_test_suite.oscap
 from ssg_test_suite.rule import get_viable_profiles
 

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -1,18 +1,18 @@
 from __future__ import print_function
 
+import collections
+import contextlib
+import fnmatch
+import itertools
+import json
 import logging
+import math
 import os
-import shutil
 import os.path
 import re
+import shutil
 import subprocess
-import collections
-import json
-import fnmatch
 import tempfile
-import contextlib
-import itertools
-import math
 
 from ssg.constants import OSCAP_PROFILE, OSCAP_PROFILE_ALL_ID, OSCAP_RULE
 from ssg_test_suite import oscap

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -1,13 +1,13 @@
 from __future__ import print_function
 
 import contextlib
-import sys
-import os
-import re
-import time
-import subprocess
 import json
 import logging
+import os
+import re
+import subprocess
+import sys
+import time
 
 import ssg_test_suite
 from ssg_test_suite import common

--- a/tests/ssg_test_suite/virt.py
+++ b/tests/ssg_test_suite/virt.py
@@ -1,12 +1,13 @@
 #!/usr/bin/python3
 from __future__ import print_function
 
-import libvirt
 import logging
+import socket
+import sys
 import time
 import xml.etree.ElementTree as ET
-import sys
-import socket
+
+import libvirt
 
 # Needed for compatibility as there is no TimeoutError in python2.
 if sys.version_info[0] < 3:

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -1,10 +1,9 @@
 #!/usr/bin/python3
-import xml.etree.cElementTree as ET
-
-import logging
 import contextlib
+import logging
 import re
 import subprocess
+import xml.etree.cElementTree as ET
 
 from ssg.constants import OSCAP_RULE
 from ssg.constants import PREFIX_TO_NS


### PR DESCRIPTION
#### Description:

Sort `ssg_test_suite`, `automatus` and `install_vm` other imports.

Order here is:
- import from python stdlib
- `from ...` from python stdlib
- same from other external libs

Kept `ssg` / `ssg_test_suite` imports as is.

Used `ruff check --select I --fix` to sort imports and then selected the one I wanted.

There is some empty lines added / removed to conform nice style.

#### Rationale:

This makes it easier to avoid / handle conflicts when adding new imports in order.

#### Review Hints:

Should not change anything.