### PR TITLE
ssg_test_suite features

### DIFF
--- a/Dockerfiles/centos8
+++ b/Dockerfiles/centos8
@@ -5,15 +5,15 @@ ENV OSCAP_DIR content
 ENV BUILD_JOBS 4
 
 RUN true \
-  && dnf -y upgrade \
-  && dnf -y install cmake openscap-utils python3-jinja2 \
-    python3-libs python3-pip python3-pyyaml dnf-plugins-core \
-  && dnf -y --enablerepo=powertools install ninja-build \
-  && mkdir -p /home/$OSCAP_USERNAME \
-  && dnf clean all \
-  && rm -rf /usr/share/doc /usr/share/doc-base \
-    /usr/share/man /usr/share/locale /usr/share/zoneinfo \
-  && true
+    && dnf -y upgrade \
+    && dnf -y install cmake openscap-utils python3-jinja2 \
+        python3-libs python3-pip python3-pyyaml dnf-plugins-core \
+    && dnf -y --enablerepo=powertools install ninja-build \
+    && mkdir -p /home/$OSCAP_USERNAME \
+    && dnf clean all \
+    && rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+    && true
 
 WORKDIR /home/$OSCAP_USERNAME
 
@@ -25,7 +25,7 @@ RUN rm -rf $OSCAP_DIR/build/*
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
 CMD true \
-  && cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -G Ninja .. \
-  && ninja -j $BUILD_JOBS \
-  && ctest --output-on-failure -j $BUILD_JOBS \
-  && true
+    && cmake -DPYTHON_EXECUTABLE=/usr/bin/python3 -G Ninja .. \
+    && ninja -j $BUILD_JOBS \
+    && ctest --output-on-failure -j $BUILD_JOBS \
+    && true

--- a/Dockerfiles/fedora
+++ b/Dockerfiles/fedora
@@ -6,13 +6,13 @@ ENV BUILD_JOBS 4
 ENV ANSIBLE_LOCAL_TEMP /home/$OSCAP_USERNAME/.ansible/tmp
 
 RUN true \
-	&& dnf -y upgrade \
-	&& dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible \
-	&& mkdir -p /home/$OSCAP_USERNAME \
-	&& dnf clean all \
-	&& rm -rf /usr/share/doc /usr/share/doc-base \
-		/usr/share/man /usr/share/locale /usr/share/zoneinfo \
-	&& true
+    && dnf -y upgrade \
+    && dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible \
+    && mkdir -p /home/$OSCAP_USERNAME \
+    && dnf clean all \
+    && rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+    && true
 
 WORKDIR /home/$OSCAP_USERNAME
 
@@ -24,7 +24,7 @@ RUN rm -rf $OSCAP_DIR/build/*
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
 CMD true \
-	&& cmake -G Ninja .. \
-	&& ninja -j $BUILD_JOBS \
-	&& ctest --output-on-failure -j $BUILD_JOBS \
-	&& true
+    && cmake -G Ninja .. \
+    && ninja -j $BUILD_JOBS \
+    && ctest --output-on-failure -j $BUILD_JOBS \
+    && true

--- a/Dockerfiles/fedora_linkchecker
+++ b/Dockerfiles/fedora_linkchecker
@@ -5,13 +5,13 @@ ENV OSCAP_DIR content
 ENV BUILD_JOBS 4
 
 RUN true \
-	&& dnf -y upgrade \
-	&& dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible linkchecker \
-	&& mkdir -p /home/$OSCAP_USERNAME \
-	&& dnf clean all \
-	&& rm -rf /usr/share/doc /usr/share/doc-base \
-		/usr/share/man /usr/share/locale /usr/share/zoneinfo \
-	&& true
+    && dnf -y upgrade \
+    && dnf -y install cmake ninja-build openscap-utils python3-jinja2 python3-PyYAML ansible linkchecker \
+    && mkdir -p /home/$OSCAP_USERNAME \
+    && dnf clean all \
+    && rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+    && true
 
 WORKDIR /home/$OSCAP_USERNAME
 
@@ -23,7 +23,7 @@ RUN rm -rf $OSCAP_DIR/build/*
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
 CMD true \
-	&& cmake -G Ninja .. \
-	&& ninja -j $BUILD_JOBS \
-	&& ctest --output-on-failure -R linkcheck \
-	&& true
+    && cmake -G Ninja .. \
+    && ninja -j $BUILD_JOBS \
+    && ctest --output-on-failure -R linkcheck \
+    && true

--- a/Dockerfiles/opensuse_leap_15_2
+++ b/Dockerfiles/opensuse_leap_15_2
@@ -5,13 +5,13 @@ ENV OSCAP_DIR content
 ENV BUILD_JOBS 4
 
 RUN true \
-	&& zypper --non-interactive in cmake ninja openscap-utils libxml2-tools libxslt-tools python3-PyYAML python3-Jinja2 python3-pytest python3-pytest-cov python3-Sphinx python3-sphinx_rtd_theme python3-pip python3-myst-parser \
-        && pip install pip --upgrade \
-        && pip install json2html sphinxcontrib.jinjadomain \
-	&& mkdir -p /home/$OSCAP_USERNAME \
-	&& rm -rf /usr/share/doc /usr/share/doc-base \
-		/usr/share/man /usr/share/locale /usr/share/zoneinfo \
-	&& true
+    && zypper --non-interactive in cmake ninja openscap-utils libxml2-tools libxslt-tools python3-PyYAML python3-Jinja2 python3-pytest python3-pytest-cov python3-Sphinx python3-sphinx_rtd_theme python3-pip python3-myst-parser \
+    && pip install pip --upgrade \
+    && pip install json2html sphinxcontrib.jinjadomain \
+    && mkdir -p /home/$OSCAP_USERNAME \
+    && rm -rf /usr/share/doc /usr/share/doc-base \
+        /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+    && true
 
 WORKDIR /home/$OSCAP_USERNAME
 
@@ -23,7 +23,7 @@ RUN rm -rf $OSCAP_DIR/build/*
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
 CMD true \
-	&& cmake -G Ninja .. \
-	&& ninja -j $BUILD_JOBS \
-	&& ctest --output-on-failure -j $BUILD_JOBS \
-	&& true
+    && cmake -G Ninja .. \
+    && ninja -j $BUILD_JOBS \
+    && ctest --output-on-failure -j $BUILD_JOBS \
+    && true

--- a/Dockerfiles/test_suite-centos
+++ b/Dockerfiles/test_suite-centos
@@ -9,16 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
-		python \
-		$ADDITIONAL_PACKAGES \
-        && true
+    && yum install -y openssh-clients openssh-server openscap-scanner \
+        python \
+        $ADDITIONAL_PACKAGES \
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
-
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-centos
+++ b/Dockerfiles/test_suite-centos
@@ -1,5 +1,5 @@
 # This Dockerfile is a minimal example for a CentOS-based SSG test suite target container.
-FROM centos
+FROM centos:7
 
 ENV AUTH_KEYS=/root/.ssh/authorized_keys
 
@@ -10,8 +10,9 @@ ARG ADDITIONAL_PACKAGES
 # Don't clean all, as the test scenario may require package install.
 RUN true \
     && yum install -y openssh-clients openssh-server openscap-scanner \
-        python \
+        python findutils \
         $ADDITIONAL_PACKAGES \
+    && rm -rf /var/cache/yum \
     && true
 
 RUN true \
@@ -21,3 +22,20 @@ RUN true \
     && chmod og-rw /root/.ssh "$AUTH_KEYS" \
     && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
     && true
+
+RUN set -ex; \
+    sed '\
+s/^EnvironmentFile=.*/PassEnvironment=TEST_SSHD_PORT/;\
+/ExecStart=/ s,=.*,=/usr/sbin/sshd -p $TEST_SSHD_PORT -D,;\
+' /usr/lib/systemd/system/sshd.service > /etc/systemd/system/test-sshd.service; \
+    systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount getty.target console-getty.service systemd-udev-trigger.service systemd-udevd.service systemd-random-seed.service systemd-machine-id-commit.service systemd-resolved.service proc-sys-fs-binfmt_misc.mount systemd-oomd.service systemd-userdbd.service; \
+    systemctl enable test-sshd.service; \
+    :
+
+STOPSIGNAL SIGRTMIN+3
+
+RUN set -ex; \
+    [ -e /sbin/init ] || ln -s ../lib/systemd/systemd /sbin/init; \
+    :
+
+ENTRYPOINT ["/sbin/init"]

--- a/Dockerfiles/test_suite-cs8
+++ b/Dockerfiles/test_suite-cs8
@@ -9,16 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
-		python39 \
-		$ADDITIONAL_PACKAGES \
-        && true
+    && yum install -y openssh-clients openssh-server openscap-scanner \
+        python39 \
+        $ADDITIONAL_PACKAGES \
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
-
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-cs9
+++ b/Dockerfiles/test_suite-cs9
@@ -9,16 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
-		python \
-		$ADDITIONAL_PACKAGES \
-        && true
+    && yum install -y openssh-clients openssh-server openscap-scanner \
+        python \
+        $ADDITIONAL_PACKAGES \
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
-
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -23,3 +23,19 @@ RUN true \
         && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
 && true
 
+RUN set -ex; \
+    sed '\
+s/^EnvironmentFile=.*/PassEnvironment=TEST_SSHD_PORT/;\
+/ExecStart=/ s,=.*,=/usr/sbin/sshd -p $TEST_SSHD_PORT -D,;\
+' /usr/lib/systemd/system/sshd.service > /etc/systemd/system/test-sshd.service; \
+    systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount getty.target console-getty.service systemd-udev-trigger.service systemd-udevd.service systemd-random-seed.service systemd-machine-id-commit.service systemd-resolved.service proc-sys-fs-binfmt_misc.mount systemd-oomd.service systemd-userdbd.service; \
+    systemctl enable test-sshd.service; \
+    :
+
+STOPSIGNAL SIGRTMIN+3
+
+RUN set -ex; \
+    [ -e /sbin/init ] || ln -s ../lib/systemd/systemd /sbin/init; \
+    :
+
+ENTRYPOINT ["/sbin/init"]

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -10,6 +10,7 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
+        && printf "install_weak_deps=False\n"  >> /etc/dnf/dnf.conf \
         && yum install -y openssh-clients openssh-server openscap-scanner \
                 python3 findutils \
                 $ADDITIONAL_PACKAGES \

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -11,8 +11,8 @@ ARG ADDITIONAL_PACKAGES
 # Don't clean all, as the test scenario may require package install.
 RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
-		python3 findutils \
-		$ADDITIONAL_PACKAGES \
+                python3 findutils \
+                $ADDITIONAL_PACKAGES \
         && true
 
 RUN true \

--- a/Dockerfiles/test_suite-fedora
+++ b/Dockerfiles/test_suite-fedora
@@ -14,6 +14,7 @@ RUN true \
         && yum install -y openssh-clients openssh-server openscap-scanner \
                 python3 findutils \
                 $ADDITIONAL_PACKAGES \
+        && rm -rf /var/cache/dnf \
         && true
 
 RUN true \
@@ -31,6 +32,7 @@ s/^EnvironmentFile=.*/PassEnvironment=TEST_SSHD_PORT/;\
 ' /usr/lib/systemd/system/sshd.service > /etc/systemd/system/test-sshd.service; \
     systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount getty.target console-getty.service systemd-udev-trigger.service systemd-udevd.service systemd-random-seed.service systemd-machine-id-commit.service systemd-resolved.service proc-sys-fs-binfmt_misc.mount systemd-oomd.service systemd-userdbd.service; \
     systemctl enable test-sshd.service; \
+    printf "keepcache=True\n"  >> /etc/dnf/dnf.conf; \
     :
 
 STOPSIGNAL SIGRTMIN+3

--- a/Dockerfiles/test_suite-ol7
+++ b/Dockerfiles/test_suite-ol7
@@ -9,15 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
+    && yum install -y openssh-clients openssh-server openscap-scanner \
         python tar \
         $ADDITIONAL_PACKAGES \
-        && true
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-ol8
+++ b/Dockerfiles/test_suite-ol8
@@ -9,15 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
+    && yum install -y openssh-clients openssh-server openscap-scanner \
         python3 tar \
         $ADDITIONAL_PACKAGES \
-        && true
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-ol9
+++ b/Dockerfiles/test_suite-ol9
@@ -9,15 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && dnf install -y openssh-clients openssh-server openscap-scanner \
+    && dnf install -y openssh-clients openssh-server openscap-scanner \
         python3 tar \
         $ADDITIONAL_PACKAGES \
-        && true
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-rhel
+++ b/Dockerfiles/test_suite-rhel
@@ -9,15 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
-		python \
-		$ADDITIONAL_PACKAGES \
-        && true
+    && yum install -y openssh-clients openssh-server openscap-scanner \
+        python \
+        $ADDITIONAL_PACKAGES \
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-rhel8
+++ b/Dockerfiles/test_suite-rhel8
@@ -9,15 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
-		python3 \
-		$ADDITIONAL_PACKAGES \
-        && true
+    && yum install -y openssh-clients openssh-server openscap-scanner \
+         python3 \
+         $ADDITIONAL_PACKAGES \
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/test_suite-rhel9
+++ b/Dockerfiles/test_suite-rhel9
@@ -9,15 +9,15 @@ ARG ADDITIONAL_PACKAGES
 # Install Python so Ansible remediations can work
 # Don't clean all, as the test scenario may require package install.
 RUN true \
-        && yum install -y openssh-clients openssh-server openscap-scanner \
-		python3 \
-		$ADDITIONAL_PACKAGES \
-        && true
+    && yum install -y openssh-clients openssh-server openscap-scanner \
+         python3 \
+         $ADDITIONAL_PACKAGES \
+    && true
 
 RUN true \
-        && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
-        && mkdir -p /root/.ssh \
-        && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
-        && chmod og-rw /root/.ssh "$AUTH_KEYS" \
-        && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
-&& true
+    && for key_type in rsa ecdsa; do ssh-keygen -N '' -t $key_type -f /etc/ssh/ssh_host_${key_type}_key; done \
+    && mkdir -p /root/.ssh \
+    && printf "%s\n" "$CLIENT_PUBLIC_KEY" >> "$AUTH_KEYS" \
+    && chmod og-rw /root/.ssh "$AUTH_KEYS" \
+    && sed -i '/session\s\+required\s\+pam_loginuid.so/d' /etc/pam.d/sshd \
+    && true

--- a/Dockerfiles/ubuntu
+++ b/Dockerfiles/ubuntu
@@ -5,12 +5,12 @@ ENV OSCAP_DIR content
 ENV BUILD_JOBS 4
 
 RUN true \
-	&& apt-get -qq update \
-	&& apt-get -qq install cmake ninja-build libopenscap8 libxml2-utils xsltproc python3-jinja2 python3-yaml \
-	&& mkdir -p /home/$OSCAP_USERNAME \
-	&& rm -rf /usr/share/doc /usr/share/doc-base \
-		/usr/share/man /usr/share/locale /usr/share/zoneinfo \
-	&& true
+     && apt-get -qq update \
+     && apt-get -qq install cmake ninja-build libopenscap8 libxml2-utils xsltproc python3-jinja2 python3-yaml \
+     && mkdir -p /home/$OSCAP_USERNAME \
+     && rm -rf /usr/share/doc /usr/share/doc-base \
+          /usr/share/man /usr/share/locale /usr/share/zoneinfo \
+     && true
 
 WORKDIR /home/$OSCAP_USERNAME
 
@@ -22,7 +22,7 @@ RUN rm -rf $OSCAP_DIR/build/*
 WORKDIR /home/$OSCAP_USERNAME/$OSCAP_DIR/build
 
 CMD true \
-	&& cmake -G Ninja .. \
-	&& ninja -j $BUILD_JOBS \
-	&& ctest --output-on-failure -j $BUILD_JOBS \
-	&& true
+     && cmake -G Ninja .. \
+     && ninja -j $BUILD_JOBS \
+     && ctest --output-on-failure -j $BUILD_JOBS \
+     && true

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -709,6 +709,9 @@ class Rule(XCCDFEntity, Templatable):
                 setattr(result, k, v)
         return result
 
+    def __repr__(self):
+        return '<Rule:' + '|'.join(map(repr, self.__dict__.items())) + '>'
+
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None, product_cpes=None, sce_metadata=None):
         rule = super(Rule, cls).from_yaml(yaml_file, env_yaml, product_cpes)

--- a/ssg/shims.py
+++ b/ssg/shims.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import subprocess
+import time
 
 try:
     import queue as Queue
@@ -39,7 +40,10 @@ def input_func(prompt=None):
     try:
         return str(raw_input(prompt))
     except NameError:
-        return input(prompt)
+        try:
+            return input(prompt)
+        except EOFError:
+            time.sleep(3600)
 
 
 unicode_func = str

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -470,3 +470,7 @@ def apply_formatting_on_dict_values(source_dict, string_dict, ignored_keys=froze
         else:
             new_dict[k] = v
     return new_dict
+
+
+def file_known_as_useless(file_name):
+    return file_name.endswith(".swp")

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -48,6 +48,10 @@ def parse_args():
         "Example of a hypervisor domain name tuple: system ssg-test-suite")
 
     common_parser.add_argument(
+        "--container-ssh-port", dest="container_ssh_port", type=int, default=0,
+        help="SSH port used in container test environment.")
+
+    common_parser.add_argument(
         "--datastream", dest="datastream", metavar="DATASTREAM",
         help="Path to the Source DataStream on this machine which is going to be tested. "
         "If not supplied, autodetection is attempted by looking into the build directory.")
@@ -429,12 +433,16 @@ def normalize_passed_arguments(options):
     if options.docker:
         options.test_env = ssg_test_suite.test_env.DockerTestEnv(
             options.scanning_mode, options.docker)
+        if options.container_ssh_port != 0:
+            options.test_env.container_ssh_port = options.container_ssh_port
         logging.info(
             "The base image option has been specified, "
             "choosing Docker-based test environment.")
     elif options.container:
         options.test_env = ssg_test_suite.test_env.PodmanTestEnv(
             options.scanning_mode, options.container)
+        if options.container_ssh_port != 0:
+            options.test_env.container_ssh_port = options.container_ssh_port
         logging.info(
             "The base image option has been specified, "
             "choosing Podman-based test environment.")

--- a/tests/automatus.py
+++ b/tests/automatus.py
@@ -433,19 +433,9 @@ def normalize_passed_arguments(options):
     if options.docker:
         options.test_env = ssg_test_suite.test_env.DockerTestEnv(
             options.scanning_mode, options.docker)
-        if options.container_ssh_port != 0:
-            options.test_env.container_ssh_port = options.container_ssh_port
-        logging.info(
-            "The base image option has been specified, "
-            "choosing Docker-based test environment.")
     elif options.container:
         options.test_env = ssg_test_suite.test_env.PodmanTestEnv(
             options.scanning_mode, options.container)
-        if options.container_ssh_port != 0:
-            options.test_env.container_ssh_port = options.container_ssh_port
-        logging.info(
-            "The base image option has been specified, "
-            "choosing Podman-based test environment.")
     else:
         hypervisor, domain_name = options.libvirt
         # Possible hypervisor spec we have to catch: qemu+unix:///session
@@ -456,6 +446,14 @@ def normalize_passed_arguments(options):
         logging.info(
             "The base image option has not been specified, "
             "choosing libvirt-based test environment.")
+
+    if options.docker or options.container:
+        if options.container_ssh_port != 0:
+            options.test_env.container_ssh_port = options.container_ssh_port
+        logging.info(
+            "The base image option has been specified, "
+            "choosing {} test environment."
+            .format(options.test_env.name))
 
     # Add in product to the test environment. This is independent of actual
     # test environment type so we do it after creation.

--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -367,7 +367,7 @@ To determine the IP address of the {domain} VM use:
   {ip_cmd}
 
 To connect to the {domain} VM use:
-  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@IP
+  ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null admin@IP
 
 To connect to the VM serial console, use:
   virsh console {domain}""".format(** data.__dict__, ip_cmd=ip_cmd))

--- a/tests/kickstarts/test_suite.cfg
+++ b/tests/kickstarts/test_suite.cfg
@@ -111,9 +111,21 @@ openssh-server
 # initialize guest agent for SSG Test Suite
 systemctl enable qemu-guest-agent.service
 
-mkdir -p /root/.ssh
-printf "%s\n" "&&HOST_PUBLIC_KEY&&" >> /root/.ssh/authorized_keys
-chmod og-rw /root/.ssh /root/.ssh/authorized_keys
+(
+    set -epux
+    umask 077
+    for a in /root /home/admin; do
+        mkdir -p "$a"/.ssh
+        printf "%s\n" "&&HOST_PUBLIC_KEY&&" >> "$a"/.ssh/authorized_keys
+    done
+    for a in admin; do
+        chown -R "$a": /home/"$a"/.ssh
+    done
+    # For now this survives sudo_remove_nopasswd
+    printf '# From kickstart
+admin ALL=(root) NOPASSWD: ALL
+' > /etc/sudoers.d/50_admin
+)
 systemctl enable sshd
 
 # This is needed to add entries about password change into /etc/shadow

--- a/tests/oval_tester.py
+++ b/tests/oval_tester.py
@@ -56,7 +56,10 @@ class OVALTester(object):
     def _evaluate_oval(self, oval_path):
         results_path = oval_path + ".results.xml"
         oscap_command = [
-            "oscap", "oval", "eval", "--results", results_path, oval_path]
+            "oscap", "oval", "eval",
+            "--results", results_path,
+            oval_path,
+        ]
         oscap_process = subprocess.Popen(
             oscap_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         oscap_stdout, oscap_stderr = oscap_process.communicate()

--- a/tests/ssg_test_suite/combined.py
+++ b/tests/ssg_test_suite/combined.py
@@ -88,8 +88,8 @@ class CombinedChecker(rule.RuleChecker):
         if len(self.rules_not_tested_yet) != 0:
             not_tested = sorted(list(self.rules_not_tested_yet))
             logging.info("The following rule(s) were not tested:")
-            for rule in not_tested:
-                logging.info("{0}".format(rule))
+            for rule_ in not_tested:
+                logging.info("{0}".format(rule_))
 
     def test_rule(self, state, rule, scenarios):
         super(CombinedChecker, self).test_rule(state, rule, scenarios)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -234,10 +234,10 @@ def matches_platform(scenario_platforms, benchmark_cpes):
 
 
 def run_with_stdout_logging(command, args, log_file):
-    log_file.write("{0} {1}\n".format(command, " ".join(args)))
-    result = subprocess.run(
-            (command,) + args, encoding="utf-8", stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE, check=False)
+    cmd_args = (command,) + args
+    log_file.write("{0}\n".format(shlex.join(cmd_args)))
+    result = subprocess.run(cmd_args, encoding="utf-8", stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE, check=False)
     if result.stdout:
         log_file.write("STDOUT: ")
         log_file.write(result.stdout)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 import functools
 import logging
 import os
+import pprint
 import re
 import shlex
 import shutil
@@ -170,6 +171,7 @@ def run_cmd_local(command, verbose_path, env=None):
     with open(verbose_path, 'w') as verbose_file:
         output = subprocess.run(
             command, stdout=subprocess.PIPE, stderr=verbose_file, env=env)
+    logging.debug('Result local command: {}'.format(pprint.pformat(output)))
     return output.returncode, output.stdout.decode('utf-8')
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -391,15 +391,14 @@ def send_scripts(test_env, test_content_by_rule_id):
         print("Setting up test setup scripts", file=log_file)
 
         test_env.execute_ssh_command(
-            "mkdir -p {remote_dir}".format(remote_dir=remote_dir),
+            ["mkdir", "-p",  remote_dir],
             log_file, "Cannot create directory {0}".format(remote_dir))
         test_env.scp_upload_file(
             archive_file, remote_dir,
             log_file, "Cannot copy archive {0} to the target machine's directory {1}"
             .format(archive_file, remote_dir))
         test_env.execute_ssh_command(
-            "tar xf {remote_archive_file} -C {remote_dir}"
-            .format(remote_dir=remote_dir, remote_archive_file=remote_archive_file),
+            ["tar", "xf", remote_archive_file, "-C", remote_dir],
             log_file, "Cannot extract data tarball {0}".format(remote_archive_file))
     os.unlink(archive_file)
     return remote_dir
@@ -552,7 +551,7 @@ def load_local_tests(local_tests_paths, local_env_yaml):
 def get_cpe_of_tested_os(test_env, log_file):
     os_release_file = "/etc/os-release"
     cpe_line = test_env.execute_ssh_command(
-        "grep CPE_NAME {os_release_file}".format(os_release_file=os_release_file),
+        ["grep", "CPE_NAME", os_release_file],
         log_file)
     # We are parsing an assignment that is possibly quoted
     cpe = re.match(r'''CPE_NAME=(["']?)(.*)\1''', cpe_line)
@@ -589,13 +588,14 @@ def install_packages(test_env, packages):
         platform_cpe = get_cpe_of_tested_os(test_env, log_file)
     platform = cpes_to_platform([platform_cpe])
 
-    command_str = " ".join(INSTALL_COMMANDS[platform] + tuple(packages))
+    command_components = []
+    command_components.extend(INSTALL_COMMANDS[platform] + tuple(packages))
 
     with open(log_file_name, 'a') as log_file:
         print("Installing packages", file=log_file)
         log_file.flush()
         test_env.execute_ssh_command(
-            command_str, log_file,
+            command_components, log_file,
             "Couldn't install required packages: {packages}".format(packages=",".join(packages)))
 
 

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -22,7 +22,7 @@ from ssg.jinja import process_file_with_macros
 from ssg.products import product_yaml_path, load_product_yaml
 from ssg.rules import get_rule_dir_yaml, is_rule_dir
 from ssg.rule_yaml import parse_prodtype
-from ssg.utils import mkdir_p
+from ssg.utils import file_known_as_useless, mkdir_p
 from ssg_test_suite.log import LogHelper
 
 import ssg.templates
@@ -237,7 +237,7 @@ def _exclude_garbage(tarinfo):
     file_name = tarinfo.name
     if file_name.endswith('pyc'):
         return None
-    if file_name.endswith('swp'):
+    if file_known_as_useless(file_name):
         return None
     return tarinfo
 
@@ -466,7 +466,7 @@ def fetch_all_templated_tests_paths(rule_template):
             continue
 
         for filename in filenames:
-            if filename.endswith(".swp"):
+            if file_known_as_useless(filename):
                 continue
 
             # Relative path to the file becomes our results key.
@@ -502,10 +502,6 @@ def load_test(absolute_path, rule_template, local_env_yaml):
     filled_template = ssg.jinja.process_file_with_macros(
         absolute_path, jinja_dict)
     return filled_template
-
-
-def file_known_as_useless(file_name):
-    return file_name.endswith(".swp")
 
 
 def fetch_local_tests_paths(tests_dir):

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import tarfile
@@ -168,23 +169,11 @@ class RuleResult(object):
 
 
 def run_cmd_local(command, verbose_path, env=None):
-    command_string = ' '.join(command)
-    logging.debug('Running {}'.format(command_string))
-    returncode, output = _run_cmd(command, verbose_path, env)
-    return returncode, output
-
-
-def _run_cmd(command_list, verbose_path, env=None):
-    returncode = 0
-    output = b""
-    try:
-        with open(verbose_path, 'w') as verbose_file:
-            output = subprocess.check_output(
-                command_list, stderr=verbose_file, env=env)
-    except subprocess.CalledProcessError as e:
-        returncode = e.returncode
-        output = e.output
-    return returncode, output.decode('utf-8')
+    logging.debug('Running local command: {}'.format(shlex.join(command)))
+    with open(verbose_path, 'w') as verbose_file:
+        output = subprocess.run(
+            command, stdout=subprocess.PIPE, stderr=verbose_file, env=env)
+    return output.returncode, output.stdout.decode('utf-8')
 
 
 def _get_platform_cpes(platform):

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -508,12 +508,11 @@ def load_test(absolute_path, rule_template, local_env_yaml):
     template_vars = rule_template['vars']
     # Load template parameters and apply it to the test case.
     maybe_template = ssg.templates.Template.load_template(_SHARED_TEMPLATES, template_name)
-    if maybe_template is not None:
-        template_parameters = maybe_template.preprocess(template_vars, "tests")
-    else:
+    if maybe_template is None:
         raise ValueError("Rule uses template '{}' "
                          "which doesn't exist in '{}".format(template_name, _SHARED_TEMPLATES))
 
+    template_parameters = maybe_template.preprocess(template_vars, "tests")
     jinja_dict = ssg.utils.merge_dicts(local_env_yaml, template_parameters)
     filled_template = ssg.jinja.process_file_with_macros(
         absolute_path, jinja_dict)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -225,7 +225,7 @@ def run_with_stdout_logging(command, args, log_file):
     cmd_args = (command,) + args
     log_file.write("{0}\n".format(shlex.join(cmd_args)))
     result = subprocess.run(cmd_args, encoding="utf-8", stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, check=False)
+                            stderr=subprocess.PIPE, check=False)
     if result.stdout:
         log_file.write("STDOUT: ")
         log_file.write(result.stdout)

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -48,9 +48,6 @@ _SHARED_TEMPLATES = os.path.abspath(os.path.join(SSG_ROOT, 'shared/templates'))
 
 TEST_SUITE_NAME="ssgts"
 TEST_SUITE_PREFIX = "_{}".format(TEST_SUITE_NAME)
-REMOTE_USER = "root"
-REMOTE_USER_HOME_DIRECTORY = "/root"
-REMOTE_TEST_SCENARIOS_DIRECTORY = os.path.join(REMOTE_USER_HOME_DIRECTORY, TEST_SUITE_NAME)
 
 try:
     SSH_ADDITIONAL_OPTS = tuple(os.environ.get('SSH_ADDITIONAL_OPTIONS').split())
@@ -369,7 +366,7 @@ def create_tarball(test_content_by_rule_id):
 
 
 def send_scripts(test_env, test_content_by_rule_id):
-    remote_dir = REMOTE_TEST_SCENARIOS_DIRECTORY
+    remote_dir = test_env.remote_test_scenarios_directory
     archive_file = create_tarball(test_content_by_rule_id)
     archive_file_basename = os.path.basename(archive_file)
     remote_archive_file = os.path.join(remote_dir, archive_file_basename)
@@ -578,6 +575,8 @@ def install_packages(test_env, packages):
     platform = cpes_to_platform([platform_cpe])
 
     command_components = []
+    if not test_env.is_root:
+        command_components.append('sudo')
     command_components.extend(INSTALL_COMMANDS[platform] + tuple(packages))
 
     with open(log_file_name, 'a') as log_file:

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -58,6 +58,7 @@ except AttributeError:
     SSH_ADDITIONAL_OPTS = tuple()
 
 SSH_ADDITIONAL_OPTS = (
+    "-o", "BatchMode=yes",
     "-o", "StrictHostKeyChecking=no",
     "-o", "UserKnownHostsFile=/dev/null",
 ) + SSH_ADDITIONAL_OPTS

--- a/tests/ssg_test_suite/common.py
+++ b/tests/ssg_test_suite/common.py
@@ -308,6 +308,9 @@ def load_rule_and_env(rule_dir_path, env_yaml, product=None):
     local_env_yaml['rule_title'] = rule.title
     local_env_yaml['products'] = prodtypes
 
+    logging.debug('Rule {}'.format(pprint.pformat(rule)))
+    logging.debug('Env {}'.format(pprint.pformat(local_env_yaml)))
+
     return rule, local_env_yaml
 
 

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -610,9 +610,10 @@ class RuleRunner(GenericRunner):
                     .format(self.rule_id))
             else:
                 msg = (
-                    'Rule evaluation resulted in {0}, '
-                    'instead of expected {1} during {2} stage '
-                    .format(rule_result, self.context, self.stage)
+                    'Rule {4} evaluation resulted in {0}, '
+                    'instead of expected {1} during {2} stage after {3}'
+                    .format(rule_result, self.context, self.stage,
+                            self.script_name, self.rule_id)
                 )
             LogHelper.preload_log(logging.ERROR, msg, 'fail')
         return local_success

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -152,10 +152,12 @@ def run_stage_remediation_ansible(run_type, test_env, formatting, verbose_path):
         'ansible-playbook',
         '-vvv',
         '--inventory={domain_ip},'.format(** formatting),
-        '--user=root',
+        '--user={remote_user}'.format(** test_env),
         '--ssh-common-args={0}'.format(' '.join(test_env.ssh_additional_options)),
-        formatting['playbook'],
     ]
+    if not test_env.is_root:
+        command.append('--become')
+    command.append(formatting['playbook'])
     returncode, output = common.run_cmd_local(command, verbose_path)
     # Appends output of ansible-playbook to the verbose_path file.
     with open(verbose_path, 'ab') as f:

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -142,10 +142,14 @@ def run_stage_remediation_ansible(run_type, test_env, formatting, verbose_path):
     if not get_file_remote(test_env, verbose_path, LogHelper.LOG_DIR,
                            '/' + formatting['output_file']):
         return False
-    command = (
-        'ansible-playbook', '-vvv', '-i', '{0},'.format(formatting['domain_ip']),
-        '-u' 'root', '--ssh-common-args={0}'.format(' '.join(test_env.ssh_additional_options)),
-        formatting['playbook'])
+    command = [
+        'ansible-playbook',
+        '-vvv',
+        '--inventory={domain_ip},'.format(** formatting),
+        '--user=root',
+        '--ssh-common-args={0}'.format(' '.join(test_env.ssh_additional_options)),
+        formatting['playbook'],
+    ]
     command_string = ' '.join(command)
     returncode, output = common.run_cmd_local(command, verbose_path)
     # Appends output of ansible-playbook to the verbose_path file.

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -7,6 +7,7 @@ import json
 import logging
 import os.path
 import re
+import shlex
 import socket
 import subprocess
 import sys
@@ -95,11 +96,10 @@ def find_result_id_in_output(output):
 
 def get_result_id_from_arf(arf_path, verbose_path):
     command = ['oscap', 'info', arf_path]
-    command_string = ' '.join(command)
     returncode, output = common.run_cmd_local(command, verbose_path)
     if returncode != 0:
         raise RuntimeError('{0} returned {1} exit code'.
-                           format(command_string, returncode))
+                           format(shlex.join(command), returncode))
     res_id = find_result_id_in_output(output)
     if res_id is None:
         raise RuntimeError('Failed to find result ID in {0}'
@@ -150,11 +150,10 @@ def run_stage_remediation_ansible(run_type, test_env, formatting, verbose_path):
         '--ssh-common-args={0}'.format(' '.join(test_env.ssh_additional_options)),
         formatting['playbook'],
     ]
-    command_string = ' '.join(command)
     returncode, output = common.run_cmd_local(command, verbose_path)
     # Appends output of ansible-playbook to the verbose_path file.
     with open(verbose_path, 'ab') as f:
-        f.write('Stdout of "{}":'.format(command_string).encode("utf-8"))
+        f.write('Stdout of "{}":'.format(shlex.join(command)).encode("utf-8"))
         f.write(output.encode("utf-8"))
     if returncode != 0:
         msg = (

--- a/tests/ssg_test_suite/oscap.py
+++ b/tests/ssg_test_suite/oscap.py
@@ -617,10 +617,6 @@ class OscapProfileRunner(ProfileRunner):
 
 
 class AnsibleProfileRunner(ProfileRunner):
-    def initial(self):
-        self.command_options += ['--results-arf', self.arf_path]
-        return super(AnsibleProfileRunner, self).initial()
-
     def remediation(self):
         formatting = self._get_formatting_dict_for_remediation()
         formatting['output_file'] = '{0}.yml'.format(self.profile)
@@ -633,10 +629,6 @@ class AnsibleProfileRunner(ProfileRunner):
 
 
 class BashProfileRunner(ProfileRunner):
-    def initial(self):
-        self.command_options += ['--results-arf', self.arf_path]
-        return super(BashProfileRunner, self).initial()
-
     def remediation(self):
         formatting = self._get_formatting_dict_for_remediation()
         formatting['output_file'] = '{0}.sh'.format(self.profile)
@@ -657,12 +649,7 @@ class OscapRuleRunner(RuleRunner):
 
 
 class BashRuleRunner(RuleRunner):
-    def initial(self):
-        self.command_options += ['--results-arf', self.arf_path]
-        return super(BashRuleRunner, self).initial()
-
     def remediation(self):
-
         formatting = self._get_formatting_dict_for_remediation()
         formatting['output_file'] = '{0}.sh'.format(self.rule_id)
 
@@ -671,10 +658,6 @@ class BashRuleRunner(RuleRunner):
 
 
 class AnsibleRuleRunner(RuleRunner):
-    def initial(self):
-        self.command_options += ['--results-arf', self.arf_path]
-        return super(AnsibleRuleRunner, self).initial()
-
     def remediation(self):
         formatting = self._get_formatting_dict_for_remediation()
         formatting['output_file'] = '{0}.yml'.format(self.rule_id)

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -86,7 +86,7 @@ def _apply_script(rule_dir, test_env, script):
     with open(log_file_name, 'a') as log_file:
         log_file.write('##### {0} / {1} #####\n'.format(rule_name, script))
         shared_dir = os.path.join(test_env.remote_test_scenarios_directory, "shared")
-        command = "cd {0}; SHARED={1} bash -x {2}".format(rule_dir, shared_dir, script)
+        command = "cd {0} || exit 1; SHARED={1} bash -x {2}".format(rule_dir, shared_dir, script)
 
         try:
             error_msg_template = (

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -9,6 +9,7 @@ import logging
 import math
 import os
 import os.path
+import pprint
 import re
 import shutil
 import subprocess
@@ -400,6 +401,10 @@ class RuleChecker(oscap.Checker):
 
         templated_tests_paths, local_tests_paths = self._find_tests_paths(
             rule, product_yaml)
+        logging.debug("_load_all_tests rule={} templated_tests_paths={}".format(
+            rule.id, pprint.pformat(templated_tests_paths)))
+        logging.debug("_load_all_tests rule={} local_tests_paths={}".format(
+            rule.id, pprint.pformat(local_tests_paths)))
 
         # All tests is a mapping from path (in the tarball) to contents
         # of the test case. This is necessary because later code (which
@@ -408,11 +413,18 @@ class RuleChecker(oscap.Checker):
         # here, we can save later code from having to understand the
         # templating system.
         all_tests = dict()
+
         templated_tests = common.load_templated_tests(
             templated_tests_paths, rule.rule.template,
             rule.local_env_yaml)
+        logging.debug("_load_all_tests rule={} templated_tests={}".format(
+            rule.id, pprint.pformat(templated_tests)))
+
         local_tests = common.load_local_tests(
             local_tests_paths, rule.local_env_yaml)
+        logging.debug("_load_all_tests rule={} local_tests={}".format(
+            rule.id, pprint.pformat(local_tests)))
+
         all_tests.update(templated_tests)
         all_tests.update(local_tests)
         return all_tests

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -85,7 +85,7 @@ def _apply_script(rule_dir, test_env, script):
 
     with open(log_file_name, 'a') as log_file:
         log_file.write('##### {0} / {1} #####\n'.format(rule_name, script))
-        shared_dir = os.path.join(common.REMOTE_TEST_SCENARIOS_DIRECTORY, "shared")
+        shared_dir = os.path.join(test_env.remote_test_scenarios_directory, "shared")
         command = "cd {0}; SHARED={1} bash -x {2}".format(rule_dir, shared_dir, script)
 
         try:

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -437,6 +437,10 @@ class RuleChecker(oscap.Checker):
         for rule in rules_to_test:
             rule_test_content = self._get_rule_test_content(rule)
             test_content_by_rule_id[rule.id] = rule_test_content
+
+        if self.slice_total == 1:
+            return test_content_by_rule_id
+
         sliced_test_content_by_rule_id = self._slice_sbr(
             test_content_by_rule_id, self.slice_current, self.slice_total)
         return sliced_test_content_by_rule_id

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -312,7 +312,7 @@ class RuleChecker(oscap.Checker):
                 # This is an error only if the user specified the rules to be
                 # tested explicitly using command line arguments
                 if self.target_type == "rule ID":
-                    logging.error(
+                    logging.warning(
                         "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
                         .format(
                             full_rule_id, self.benchmark_id, self.datastream))

--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -255,10 +255,11 @@ class RuleChecker(oscap.Checker):
     def _ensure_package_present_for_all_scenarios(
             self, test_content_by_rule_id):
         packages_required = set()
-
-        for rule_test_content in test_content_by_rule_id.values():
+        for rule_id, rule_test_content in test_content_by_rule_id.items():
             for s in rule_test_content.scenarios:
                 scenario_packages = s.script_params["packages"]
+                logging.debug("Scenario packages {0} {1} {2}".format(
+                    rule_id, s.script, scenario_packages))
                 packages_required.update(scenario_packages)
         if packages_required:
             packages_to_install = self._replace_platform_specific_packages(packages_required)

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -4,6 +4,7 @@ import contextlib
 import json
 import logging
 import os
+import pprint
 import re
 import shlex
 import subprocess
@@ -148,6 +149,7 @@ class TestEnv(object):
         command_str = command if isinstance(command, str) else shlex.join(command)
         result = common.retry_with_stdout_logging(
             "ssh", tuple(self.ssh_additional_options) + (remote_dest, command_str), log_file)
+        logging.debug('Result {}'.format(pprint.pformat(result)))
         if result.returncode:
             error_msg = error_msg_template.format(
                 command=command_str, remote_dest=remote_dest,

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -489,7 +489,7 @@ class DockerTestEnv(ContainerTestEnv):
         img = self.client.images.get(image_name)
         result = self.client.containers.run(
             img, "/usr/sbin/sshd -p {} -D".format(self.internal_ssh_port),
-            name="{0}_{1}".format(self._name_stem, container_name),
+            name="{0}_{1}_{2}".format(self._name_stem, image_name, container_name),
             ports={"{container_ssh_port}:{internal_ssh_port}".format(** self.__dict__): None},
             detach=True)
         return result
@@ -551,7 +551,7 @@ class PodmanTestEnv(ContainerTestEnv):
         self.run_podman_cmd(podman_cmd)
 
     def _new_container_from_image(self, image_name, container_name):
-        long_name = "{0}_{1}".format(self._name_stem, container_name)
+        long_name = "{0}_{1}_{2}".format(self._name_stem, image_name, container_name)
         cache_name = "var-cache"
         self._ensure_cache_volume(cache_name)
         # Podman drops cap_audit_write which causes that it is not possible

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -556,7 +556,7 @@ class PodmanTestEnv(ContainerTestEnv):
             "--publish={internal_ssh_port}".format(** self.__dict__),
             "--detach",
             image_name,
-            "/usr/sbin/sshd", "-p", "{internal_ssh_port}".format(** self.__dict__), "-D",
+            "systemd.setenv=TEST_SSHD_PORT={internal_ssh_port}".format(** self.__dict__),
         ]
         podman_output = self.run_podman_cmd(podman_cmd)
         container_id = podman_output.stdout.decode("utf-8").strip()

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -73,11 +73,15 @@ class TestEnv(object):
 
         self.have_local_oval_graph = False
 
-        self.is_root = True
+        self.is_root = False
 
     def init(self):
-        self.remote_user = "root"
-        self.remote_user_home_directory = "/root"
+        if self.is_root:
+            self.remote_user = "root"
+            self.remote_user_home_directory = "/root"
+        else:
+            self.remote_user = "admin"
+            self.remote_user_home_directory = "/home/admin"
         self.remote_test_scenarios_directory = \
             os.path.join(self.remote_user_home_directory, common.TEST_SUITE_NAME)
         try:

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -133,11 +133,12 @@ class TestEnv(object):
         if not error_msg_template:
             error_msg_template = "Return code of '{command}' on {remote_dest} is {rc}: {stderr}"
         remote_dest = "root@{ip}".format(ip=self.domain_ip)
+        command_str = command if isinstance(command, str) else shlex.join(command)
         result = common.retry_with_stdout_logging(
-            "ssh", tuple(self.ssh_additional_options) + (remote_dest, command), log_file)
+            "ssh", tuple(self.ssh_additional_options) + (remote_dest, command_str), log_file)
         if result.returncode:
             error_msg = error_msg_template.format(
-                command=command, remote_dest=remote_dest,
+                command=command_str, remote_dest=remote_dest,
                 rc=result.returncode, stderr=result.stderr)
             raise RuntimeError(error_msg)
         return result.stdout

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -521,13 +521,18 @@ class PodmanTestEnv(ContainerTestEnv):
         # Podman drops cap_audit_write which causes that it is not possible
         # run sshd by default. Therefore, we need to add the capability.
         # We also need cap_sys_admin so it can perform mount/umount.
-        podman_cmd = ["podman", "run", "--name", long_name,
-                      "--cap-add=cap_audit_write",
-                      "--cap-add=cap_sys_admin",
-                      "--cap-add=cap_sys_chroot",
-                    #   "--privileged",
-                      "--publish", "{}".format(self.internal_ssh_port), "--detach", image_name,
-                      "/usr/sbin/sshd", "-p", "{}".format(self.internal_ssh_port), "-D"]
+        podman_cmd = [
+            "podman", "run",
+            "--name={}".format(long_name),
+            "--cap-add=cap_audit_write",
+            "--cap-add=cap_sys_admin",
+            "--cap-add=cap_sys_chroot",
+            # "--privileged",
+            "--publish={internal_ssh_port}".format(** self.__dict__),
+            "--detach",
+            image_name,
+            "/usr/sbin/sshd", "-p", "{internal_ssh_port}".format(** self.__dict__), "-D",
+        ]
         try:
             podman_output = subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
@@ -539,8 +544,9 @@ class PodmanTestEnv(ContainerTestEnv):
 
     def get_ip_address(self):
         podman_cmd = [
-                "podman", "inspect", self.current_container,
-                "--format", "{{.NetworkSettings.IPAddress}}",
+            "podman", "inspect",
+            "--format={{.NetworkSettings.IPAddress}}",
+            self.current_container,
         ]
         try:
             podman_output = subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
@@ -554,8 +560,11 @@ class PodmanTestEnv(ContainerTestEnv):
         return ip_address
 
     def _get_container_ports(self, container):
-        podman_cmd = ["podman", "inspect", container, "--format",
-                      "{{json .NetworkSettings.Ports}}"]
+        podman_cmd = [
+            "podman", "inspect",
+            "--format={{json .NetworkSettings.Ports}}",
+            container,
+        ]
         try:
             podman_output = subprocess.check_output(podman_cmd, stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -157,12 +157,16 @@ class TestEnv(object):
             raise RuntimeError(error_msg)
         return result.stdout
 
+    def _scp_remote(self, file):
+        return "{user}@{ip}:{file}".format(
+            user=self.remote_user, ip=self.domain_ip, file=file)
+
     def scp_download_file(self, source, destination, log_file, error_msg=None):
-        scp_src = "{user}@{ip}:{source}".format(user=self.remote_user, ip=self.domain_ip, source=source)
+        scp_src = self._scp_remote(source)
         return self.scp_transfer_file(scp_src, destination, log_file, error_msg)
 
     def scp_upload_file(self, source, destination, log_file, error_msg=None):
-        scp_dest = "{user}@{ip}:{dest}".format(user=self.remote_user, ip=self.domain_ip, dest=destination)
+        scp_dest = self._scp_remote(destination)
         return self.scp_transfer_file(source, scp_dest, log_file, error_msg)
 
     def scp_transfer_file(self, source, destination, log_file, error_msg=None):

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -332,6 +332,7 @@ class ContainerTestEnv(TestEnv):
         self.containers = []
         self.domain_ip = None
         self.internal_ssh_port = 22222
+        self.container_ssh_port = 22222
         self.is_root = True
 
     def start(self):
@@ -489,7 +490,7 @@ class DockerTestEnv(ContainerTestEnv):
         result = self.client.containers.run(
             img, "/usr/sbin/sshd -p {} -D".format(self.internal_ssh_port),
             name="{0}_{1}".format(self._name_stem, container_name),
-            ports={"{}".format(self.internal_ssh_port): None},
+            ports={"{container_ssh_port}:{internal_ssh_port}".format(** self.__dict__): None},
             detach=True)
         return result
 
@@ -563,7 +564,7 @@ class PodmanTestEnv(ContainerTestEnv):
             "--cap-add=cap_sys_admin",
             "--cap-add=cap_sys_chroot",
             # "--privileged",
-            "--publish={internal_ssh_port}".format(** self.__dict__),
+            "--publish={container_ssh_port}:{internal_ssh_port}".format(** self.__dict__),
             "--detach",
             "--volume", "{}:/var/cache:rw,nodev,noexec,nosuid".format(cache_name),
             image_name,

--- a/tests/ssg_test_suite/test_env.py
+++ b/tests/ssg_test_suite/test_env.py
@@ -72,8 +72,8 @@ class TestEnv(object):
 
         self.have_local_oval_graph = False
         try:
-            p = subprocess.run(['arf-to-graph', '--version'],
-                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            cmd = ['arf-to-graph', '--version']
+            p = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             if p.returncode == 0:
                 self.have_local_oval_graph = True
         except FileNotFoundError:
@@ -88,7 +88,12 @@ class TestEnv(object):
         html_filename = re.sub(r"\barf\b", "graph", arf_filename)
         html_filename = re.sub(r".xml", ".html", html_filename)
 
-        cmd = ['arf-to-graph', '--all-in-one', '--output', html_filename, arf_filename, '.']
+        cmd = [
+            'arf-to-graph',
+            '--all-in-one',
+            '--output', html_filename,
+            arf_filename, '.',
+        ]
         p = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
         if p.returncode != 0:
             print("Error generating OVAL check summaries: {stderr}".format(stderr=p.stderr),

--- a/tests/ssg_test_suite/xml_operations.py
+++ b/tests/ssg_test_suite/xml_operations.py
@@ -165,11 +165,9 @@ def get_oscap_supported_cpes():
     Obtain a list of CPEs that the scanner supports
     """
     result = []
-    proc = subprocess.Popen(
-            ("oscap", "--version"),
-            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    cmd = ("oscap", "--version"),
     try:
-        outs, errs = proc.communicate(timeout=3)
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, timeout=3)
     except subprocess.TimeoutExpired:
         logging.warn("Scanner timeouted when asked about supported CPEs")
         proc.kill()


### PR DESCRIPTION
#### Description:

- More debugging, maybe excessively so
- allow to run parallel podman containers
- allow to use other user than root in testing (might require `oscap-ssh` modifications), I guess you normally do not use root user as main ssh target user, you go via other user and then sudo
- some simplifications
- use list to run command
- use shlex to join commands
- use persistent container cache to speed up package installs (has risks)
- change containers to use systemd
- add ssh keys to `admin` user

You just need to ensure automatus jobs do not clash:
- own `--container-ssh-port`
- own `--logdir`
- own `--datastream`
- own `--container`
- and you might need to create cache volume before

#### Rationale:

Modern hw can have multiple CPU and this allows to run multiple podman jobs parallel using automatus slice functionality. Containers can share cache volume and subsequent runs are much faster as there is no need to download packages and related data every time.

Using lists / shlex to manage commands means it is more secure and no need to implement parts.

Adding some more logging helps to diagnose problems easier and understand what is going on. Especially logging Env is very nice, to see what ever is available and what are their values. It could be optimized to log base env w/ macros only once and then per rule additions per test. It seems `Rule` needs to have `__repr__`.

Try to change setup to match actual environments more closely.

#### Review Hints:

This is still WIP I guess. I have no idea how to test this and I don't want to break all the other testing.

At least:
- functionality needs to be added behind proper options in automatus
- I'm not sure about `--debug` implementation, functionality is much needed, but when running parallel, it does not work so easily
- logging should not be excessive
- commit flow is not really flowing

At least at this time there was not anything too great at `codeclimate` issues to specially fix.