### PR TITLE
Add a product stability test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,12 @@ add_test(
 set_tests_properties("stable-profiles" PROPERTIES LABELS quick)
 
 add_test(
+    NAME "stable-products"
+    COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_product_stability.py" "${CMAKE_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/data/product_stability"
+)
+set_tests_properties("stable-products" PROPERTIES LABELS quick)
+
+add_test(
     NAME "machine-only-rules"
     COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_SOURCE_DIR}/test_machine_only_rules.py" --source_dir "${CMAKE_SOURCE_DIR}" --build_dir "${CMAKE_BINARY_DIR}"
 )

--- a/tests/common/stability.py
+++ b/tests/common/stability.py
@@ -1,0 +1,40 @@
+from __future__ import print_function
+
+import sys
+
+
+class Difference(object):
+    def __init__(self):
+        self.added = []
+        self.removed = []
+        self.modified = dict()
+
+    def remove_item_from_comparison(self, item):
+        if item in self.added:
+            self.added.remove(item)
+        if item in self.removed:
+            self.removed.remove(item)
+        if item in self.modified:
+            self.modified.pop(item)
+
+    @property
+    def empty(self):
+        return not (self.added or self.removed or self.modified)
+
+
+def describe_changeset(intro, changeset):
+    if not changeset:
+        return ""
+
+    msg = intro
+    for item in changeset:
+        msg += " - {item}\n".format(item=item)
+    return msg
+
+
+def report_comparison(name, result, message_generator):
+    if not result.empty:
+        msg = message_generator(result, name)
+        print(msg, file=sys.stderr)
+
+

--- a/tests/data/product_stability/alinux2.yml
+++ b/tests/data/product_stability/alinux2.yml
@@ -2,85 +2,29 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: ALINUX-2
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- alinux2:
+    check_id: installed_OS_is_alinux2
+    name: cpe:/o:alinux:alibaba_cloud_linux:2
+    title: Alibaba Cloud Linux 2
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Alibaba Cloud Linux 2
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +39,12 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: alinux2
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: https://www.cisecurity.org/benchmark/aliyun_linux
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +66,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/alinux3.yml
+++ b/tests/data/product_stability/alinux3.yml
@@ -2,85 +2,29 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: ALINUX-3
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- alinux3:
+    check_id: installed_OS_is_alinux3
+    name: cpe:/o:alinux:alibaba_cloud_linux:3
+    title: Alibaba Cloud Linux 3
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Alibaba Cloud Linux 3
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +39,12 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: alinux3
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: https://www.cisecurity.org/benchmark/aliyun_linux
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +66,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/anolis8.yml
+++ b/tests/data/product_stability/anolis8.yml
@@ -2,85 +2,29 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: ANOLIS-8
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- anolis8:
+    check_id: installed_OS_is_anolis8
+    name: cpe:/o:anolis:anolis_os:8
+    title: Anolis OS 8
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Anolis OS 8
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +39,11 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: anolis8
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +65,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/chromium.yml
+++ b/tests/data/product_stability/chromium.yml
@@ -1,0 +1,67 @@
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: CHROMIUM
+benchmark_root: ./guide
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- chromium:
+    check_id: installed_app_is_chromium
+    name: cpe:/a:google:chromium-browser
+    title: Google Chromium Browser
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Chromium
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/grub2
+nobody_gid: 65534
+nobody_uid: 65534
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: login
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: chromium
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: product
+uid_min: 1000

--- a/tests/data/product_stability/debian10.yml
+++ b/tests/data/product_stability/debian10.yml
@@ -1,0 +1,76 @@
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: DEBIAN-10
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony/chrony.conf
+cpes:
+- debian10:
+    check_id: installed_OS_is_debian10
+    name: cpe:/o:debian:debian_linux:10
+    title: Debian Linux 10
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Debian 10
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub
+grub2_uefi_boot_path: /boot/grub2
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+pkg_manager: apt_get
+pkg_system: dpkg
+platform_package_overrides:
+  aarch64_arch: null
+  gdm: gdm3
+  grub2: grub2-common
+  login_defs: login
+  net-snmp: snmp
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  nss-pam-ldapd: libpam-ldap
+  ovirt: null
+  pam: libpam-runtime
+  s390x_arch: null
+  shadow: login
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: debian10
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/debian11.yml
+++ b/tests/data/product_stability/debian11.yml
@@ -2,105 +2,53 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: DEBIAN-11
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- debian11:
+    check_id: installed_OS_is_debian11
+    name: cpe:/o:debian:debian_linux:11
+    title: Debian Linux 11
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Debian 11
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
-grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+groups: {}
+grub2_boot_path: /boot/grub
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
-pkg_system: rpm
-pkg_version: fd431d51
+pkg_manager: apt_get
+pkg_system: dpkg
 platform_package_overrides:
   aarch64_arch: null
+  gdm: gdm3
   grub2: grub2-common
-  login_defs: shadow-utils
+  login_defs: login
+  net-snmp: snmp
   no_ovirt: null
   non-uefi: null
   not_aarch64_arch: null
   not_s390x_arch: null
+  nss-pam-ldapd: libpam-ldap
   ovirt: null
+  pam: libpam-runtime
   s390x_arch: null
+  shadow: login
   sssd: sssd-common
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: debian11
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: https://benchmarks.cisecurity.org/tools2/linux/CIS_Debian_Benchmark_v1.0.pdf
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +70,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/eks.yml
+++ b/tests/data/product_stability/eks.yml
@@ -2,89 +2,39 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
-benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
+benchmark_id: EKS
+benchmark_root: ../../applications
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- eks:
+    check_id: installed_app_is_eks
+    name: cpe:/a:amazon:elastic_kubernetes_service:1
+    title: Amazon Elastic Kubernetes Service
+- eks-node:
+    check_id: installed_app_is_eks_node
+    name: cpe:/o:amazon:elastic_kubernetes_service_node:1
+    title: Amazon Elastic Kubernetes Service Node
+- eks-1.21:
+    check_id: installed_app_is_eks_1_21
+    name: cpe:/a:amazon:elastic_kubernetes_service_node:1.21
+    title: Amazon Elastic Kubernetes Service 1.21
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Amazon Elastic Kubernetes Service
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
-  login_defs: shadow-utils
+  login_defs: login
   no_ovirt: null
   non-uefi: null
   not_aarch64_arch: null
@@ -95,12 +45,12 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: eks
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: https://www.cisecurity.org/benchmark/kubernetes/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +72,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -2,89 +2,33 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: EXAMPLE
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- example:
+    check_id: installed_OS_is_part_of_Unix_family
+    name: cpe:/o:example
+    title: Example
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Example
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
+pkg_manager: dnf
+pkg_manager_config_file: /etc/dnf/dnf.conf
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
-  login_defs: shadow-utils
+  login_defs: login
   no_ovirt: null
   non-uefi: null
   not_aarch64_arch: null
@@ -95,12 +39,11 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: example
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +65,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/fedora.yml
+++ b/tests/data/product_stability/fedora.yml
@@ -2,85 +2,55 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: FEDORA
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- fedora_40:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:40
+    title: Fedora 40
+- fedora_39:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:39
+    title: Fedora 39
+- fedora_38:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:38
+    title: Fedora 38
+- fedora_37:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:37
+    title: Fedora 37
+- fedora_36:
+    check_id: installed_OS_is_fedora
+    name: cpe:/o:fedoraproject:fedora:36
+    title: Fedora 36
 cpes_root: ../../shared/applicability
-dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+dconf_gdm_dir: distro.d
+faillock_path: /var/run/faillock
+full_name: Fedora
+future_pkg_release: 62f2920f
+future_pkg_version: 18b8e74c
+future_release_fingerprint: E8F23996F23218640CB44CBE75CF5AC418B8E74C
+future_version: 39
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
+latest_pkg_release: 6202d9c6
+latest_pkg_version: eb10b464
+latest_release_fingerprint: 6A51BBABBA3D5467B6171221809A8D7CEB10B464
+latest_version: 38
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
+pkg_manager: dnf
+pkg_manager_config_file: /etc/dnf/dnf.conf
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +65,19 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+previous_pkg_release: 6112bcdc
+previous_pkg_version: 5323552a
+previous_release_fingerprint: ACB5EE4E831C74BB7C168D27F55AD3FB5323552A
+previous_version: 37
+product: fedora
 profiles_root: ./profiles
+rawhide_pkg_release: 63d04c2c
+rawhide_pkg_version: a15b79cc
+rawhide_release_fingerprint: 115DF9AEF857853EE8445D0A0727707EA15B79CC
+rawhide_version: 40
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,8 +99,7 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
-sshd_distributed_config: 'false'
+sshd_distributed_config: 'true'
 sysctl_remediate_drop_in_file: 'false'
 type: platform
 uid_min: 1000

--- a/tests/data/product_stability/firefox.yml
+++ b/tests/data/product_stability/firefox.yml
@@ -1,0 +1,67 @@
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: FIREFOX
+benchmark_root: ./guide
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- firefox:
+    check_id: installed_app_is_firefox
+    name: cpe:/a:mozilla:firefox
+    title: Mozilla Firefox
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Firefox
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/grub2
+nobody_gid: 65534
+nobody_uid: 65534
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: login
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: firefox
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: product
+uid_min: 1000

--- a/tests/data/product_stability/macos1015.yml
+++ b/tests/data/product_stability/macos1015.yml
@@ -1,0 +1,67 @@
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: macOS-1015
+benchmark_root: ../../apple_os/
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- macos15:
+    check_id: installed_OS_is_macos1015
+    name: cpe:/o:apple:macos:10.15
+    title: Apple macOS 10.15
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Apple macOS 10.15
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/grub2
+nobody_gid: 65534
+nobody_uid: 65534
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: login
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: macos1015
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/ocp4.yml
+++ b/tests/data/product_stability/ocp4.yml
@@ -1,0 +1,154 @@
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: OCP-4
+benchmark_root: ../../applications
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- ocp4:
+    check_id: installed_app_is_ocp4
+    name: cpe:/a:redhat:openshift_container_platform:4.1
+    title: Red Hat OpenShift Container Platform 4
+- ocp4-node:
+    check_id: installed_app_is_ocp4_node
+    name: cpe:/o:redhat:openshift_container_platform_node:4
+    title: Red Hat OpenShift Container Platform 4 Node
+- ocp4-node-on-ovn:
+    check_id: installed_app_is_ocp4_node_on_openshift-ovn
+    name: cpe:/a:redhat:openshift_container_platform_node_on_ovn:4
+    title: Red Hat OpenShift Container Platform 4 Node on OVN
+- ocp4-node-on-sdn:
+    check_id: installed_app_is_ocp4_node_on_openshift-sdn
+    name: cpe:/a:redhat:openshift_container_platform_node_on_sdn:4
+    title: Red Hat OpenShift Container Platform 4 Node on SDN
+- ocp4.6:
+    check_id: installed_app_is_ocp4_6
+    name: cpe:/a:redhat:openshift_container_platform:4.6
+    title: Red Hat OpenShift Container Platform 4.6
+- ocp4.7:
+    check_id: installed_app_is_ocp4_7
+    name: cpe:/a:redhat:openshift_container_platform:4.7
+    title: Red Hat OpenShift Container Platform 4.7
+- ocp4.8:
+    check_id: installed_app_is_ocp4_8
+    name: cpe:/a:redhat:openshift_container_platform:4.8
+    title: Red Hat OpenShift Container Platform 4.8
+- ocp4.9:
+    check_id: installed_app_is_ocp4_9
+    name: cpe:/a:redhat:openshift_container_platform:4.9
+    title: Red Hat OpenShift Container Platform 4.9
+- ocp4.10:
+    check_id: installed_app_is_ocp4_10
+    name: cpe:/a:redhat:openshift_container_platform:4.10
+    title: Red Hat OpenShift Container Platform 4.10
+- ocp4.11:
+    check_id: installed_app_is_ocp4_11
+    name: cpe:/a:redhat:openshift_container_platform:4.11
+    title: Red Hat OpenShift Container Platform 4.11
+- ocp4.12:
+    check_id: installed_app_is_ocp4_12
+    name: cpe:/a:redhat:openshift_container_platform:4.12
+    title: Red Hat OpenShift Container Platform 4.12
+- ocp4.13:
+    check_id: installed_app_is_ocp4_13
+    name: cpe:/a:redhat:openshift_container_platform:4.13
+    title: Red Hat OpenShift Container Platform 4.13
+- ocp4.14:
+    check_id: installed_app_is_ocp4_14
+    name: cpe:/a:redhat:openshift_container_platform:4.14
+    title: Red Hat OpenShift Container Platform 4.14
+- ocp4.15:
+    check_id: installed_app_is_ocp4_15
+    name: cpe:/a:redhat:openshift_container_platform:4.15
+    title: Red Hat OpenShift Container Platform 4.15
+- ocp4.16:
+    check_id: installed_app_is_ocp4_16
+    name: cpe:/a:redhat:openshift_container_platform:4.16
+    title: Red Hat OpenShift Container Platform 4.16
+- ocp4.17:
+    check_id: installed_app_is_ocp4_17
+    name: cpe:/a:redhat:openshift_container_platform:4.17
+    title: Red Hat OpenShift Container Platform 4.17
+- ocp4.18:
+    check_id: installed_app_is_ocp4_18
+    name: cpe:/a:redhat:openshift_container_platform:4.18
+    title: Red Hat OpenShift Container Platform 4.18
+- ocp4-on-aws:
+    check_id: installed_app_is_ocp4_on_aws
+    name: cpe:/a:redhat:openshift_container_platform_on_aws:4
+    title: Red Hat OpenShift Container Platform 4 on AWS
+- ocp4-on-azure:
+    check_id: installed_app_is_ocp4_on_azure
+    name: cpe:/a:redhat:openshift_container_platform_on_azure:4
+    title: Red Hat OpenShift Container Platform 4 on Azure
+- ocp4-on-gcp:
+    check_id: installed_app_is_ocp4_on_gcp
+    name: cpe:/a:redhat:openshift_container_platform_on_gcp:4
+    title: Red Hat OpenShift Container Platform 4 on GCP
+- ocp4-on-ovn:
+    check_id: installed_app_is_ocp4_on_openshiftovn
+    name: cpe:/a:redhat:openshift_container_platform_on_ovn:4
+    title: Red Hat OpenShift Container Platform 4 on OVN
+- ocp4-on-sdn:
+    check_id: installed_app_is_ocp4_on_openshiftsdn
+    name: cpe:/a:redhat:openshift_container_platform_on_sdn:4
+    title: Red Hat OpenShift Container Platform 4 on SDN
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Red Hat OpenShift Container Platform 4
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/grub2
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+pkg_system: rpm
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: login
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: ocp4
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/kubernetes/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/ol7.yml
+++ b/tests/data/product_stability/ol7.yml
@@ -1,86 +1,35 @@
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
-audisp_conf_path: /etc/audit
+audisp_conf_path: /etc/audisp
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: OL-7
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- ol7:
+    check_id: installed_OS_is_ol7_family
+    name: cpe:/o:oracle:linux:7
+    title: Oracle Linux 7
 cpes_root: ../../shared/applicability
-dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+dconf_gdm_dir: local.d
+faillock_path: /var/run/faillock
+full_name: Oracle Linux 7
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
+oval_feed_url: https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
+pkg_release: '53619141'
 pkg_system: rpm
-pkg_version: fd431d51
+pkg_version: ec551f03
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -89,18 +38,19 @@ platform_package_overrides:
   non-uefi: null
   not_aarch64_arch: null
   not_s390x_arch: null
+  openssl-pkcs11: pam_pkcs11
   ovirt: null
   s390x_arch: null
   sssd: sssd-common
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: ol7
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: https://www.cisecurity.org/benchmark/oracle_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +72,7 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
+release_key_fingerprint: 42144123FECFC55B9086313D72F97B74EC551F03
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/ol8.yml
+++ b/tests/data/product_stability/ol8.yml
@@ -2,85 +2,34 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: OL-8
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- ol8:
+    check_id: installed_OS_is_ol8_family
+    name: cpe:/o:oracle:linux:8
+    title: Oracle Linux 8
 cpes_root: ../../shared/applicability
-dconf_gdm_dir: gdm.d
+dconf_gdm_dir: local.d
 faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+full_name: Oracle Linux 8
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
+oval_feed_url: https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
+pkg_release: 5cabf60d
 pkg_system: rpm
-pkg_version: fd431d51
+pkg_version: ad986da3
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +44,12 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: ol8
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: https://www.cisecurity.org/benchmark/oracle_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +71,7 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
+release_key_fingerprint: 76FD3DB13AB67410B89DB10E82562EA9AD986DA3
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/ol9.yml
+++ b/tests/data/product_stability/ol9.yml
@@ -2,85 +2,37 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
+aux_pkg_release: 629ec292
+aux_pkg_version: 8b4efbe6
+auxiliary_key_fingerprint: 982231759C7467065D0CE9B2A7DD07088B4EFBE6
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: OL-9
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- ol9:
+    check_id: installed_OS_is_ol9_family
+    name: cpe:/o:oracle:linux:9
+    title: Oracle Linux 9
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
 faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+full_name: Oracle Linux 9
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
+oval_feed_url: https://linux.oracle.com/security/oval/com.oracle.elsa-all.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
+pkg_release: 629e59ec
 pkg_system: rpm
-pkg_version: fd431d51
+pkg_version: 8d8b756f
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +47,12 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: ol9
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis: ''
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +74,7 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
+release_key_fingerprint: 3E6D826D3FBAB389C2F38E34BC4D06A08D8B756F
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/opensuse.yml
+++ b/tests/data/product_stability/opensuse.yml
@@ -2,89 +2,45 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: OPENSUSE
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- opensuse-42.1:
+    check_id: installed_OS_is_opensuse_leap42
+    name: cpe:/o:opensuse:leap:42.1
+    title: openSUSE Leap 42.1
+- opensuse-42.2:
+    check_id: installed_OS_is_opensuse_leap42
+    name: cpe:/o:opensuse:leap:42.2
+    title: openSUSE Leap 42.2
+- opensuse-42.3:
+    check_id: installed_OS_is_opensuse_leap42
+    name: cpe:/o:opensuse:leap:42.3
+    title: openSUSE Leap 42.3
+- opensuse-15:
+    check_id: installed_OS_is_opensuse_leap15
+    name: cpe:/o:opensuse:leap:15.0
+    title: openSUSE Leap 15.0
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: openSUSE
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
+pkg_manager: zypper
+pkg_manager_config_file: /etc/zypp/zypper.conf
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
-  login_defs: shadow-utils
+  login_defs: login
   no_ovirt: null
   non-uefi: null
   not_aarch64_arch: null
@@ -95,12 +51,11 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: opensuse
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +77,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/data/product_stability/rhcos4.yml
+++ b/tests/data/product_stability/rhcos4.yml
@@ -2,82 +2,28 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: RHCOS-4
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- rhcos4:
+    check_id: installed_OS_is_rhcos4
+    name: cpe:/o:redhat:enterprise_linux_coreos:4
+    title: Red Hat Enterprise Linux CoreOS 4
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Red Hat Enterprise Linux CoreOS 4
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b
 pkg_system: rpm
 pkg_version: fd431d51
@@ -95,12 +41,11 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: rhcos4
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf

--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -1,81 +1,53 @@
 aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
-audisp_conf_path: /etc/audit
+audisp_conf_path: /etc/audisp
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
+aux_pkg_release: 45700c69
+aux_pkg_version: 2fa658e0
+auxiliary_key_fingerprint: 43A6E49C4A38F4BE9ABF2A5345689C882FA658E0
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: RHEL-7
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
+centos_major_version: '7'
+centos_pkg_release: 53a7ff4b
+centos_pkg_version: f4a80eb5
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- rhel7:
+    check_id: installed_OS_is_rhel7
+    name: cpe:/o:redhat:enterprise_linux:7
+    title: Red Hat Enterprise Linux 7
+- rhel7-server:
+    check_id: installed_OS_is_rhel7
+    name: cpe:/o:redhat:enterprise_linux:7::server
+    title: Red Hat Enterprise Linux 7 Server
+- rhel7-client:
+    check_id: installed_OS_is_rhel7
+    name: cpe:/o:redhat:enterprise_linux:7::client
+    title: Red Hat Enterprise Linux 7 Client
+- rhel7-computenode:
+    check_id: installed_OS_is_rhel7
+    name: cpe:/o:redhat:enterprise_linux:7::computenode
+    title: Red Hat Enterprise Linux 7 ComputeNode
+- rhel7-workstation:
+    check_id: installed_OS_is_rhel7
+    name: cpe:/o:redhat:enterprise_linux:7::workstation
+    title: red hat enterprise linux 7 workstation
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Red Hat Enterprise Linux 7
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
+    id: '997'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
+oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL7.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b
@@ -89,13 +61,14 @@ platform_package_overrides:
   non-uefi: null
   not_aarch64_arch: null
   not_s390x_arch: null
+  openssl-pkcs11: pam_pkcs11
   ovirt: null
   s390x_arch: null
   sssd: sssd-common
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: rhel7
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -1,0 +1,130 @@
+aide_bin_path: /usr/sbin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+aux_pkg_release: 5b32db75
+aux_pkg_version: d4082792
+auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
+basic_properties_derived: true
+benchmark_id: RHEL-8
+benchmark_root: ../../linux_os/guide
+centos_major_version: '8'
+centos_pkg_release: 5ccc5b19
+centos_pkg_version: 8483c65d
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- rhel8:
+    check_id: installed_OS_is_rhel8
+    name: cpe:/o:redhat:enterprise_linux:8
+    title: Red Hat Enterprise Linux 8
+- rhel8.0:
+    check_id: installed_OS_is_rhel8_0
+    name: cpe:/o:redhat:enterprise_linux:8.0
+    title: Red Hat Enterprise Linux 8.0
+- rhel8.1:
+    check_id: installed_OS_is_rhel8_1
+    name: cpe:/o:redhat:enterprise_linux:8.1
+    title: Red Hat Enterprise Linux 8.1
+- rhel8.2:
+    check_id: installed_OS_is_rhel8_2
+    name: cpe:/o:redhat:enterprise_linux:8.2
+    title: Red Hat Enterprise Linux 8.2
+- rhel8.3:
+    check_id: installed_OS_is_rhel8_3
+    name: cpe:/o:redhat:enterprise_linux:8.3
+    title: Red Hat Enterprise Linux 8.3
+- rhel8.4:
+    check_id: installed_OS_is_rhel8_4
+    name: cpe:/o:redhat:enterprise_linux:8.4
+    title: Red Hat Enterprise Linux 8.4
+- rhel8.5:
+    check_id: installed_OS_is_rhel8_5
+    name: cpe:/o:redhat:enterprise_linux:8.5
+    title: Red Hat Enterprise Linux 8.5
+- rhel8.6:
+    check_id: installed_OS_is_rhel8_6
+    name: cpe:/o:redhat:enterprise_linux:8.6
+    title: Red Hat Enterprise Linux 8.6
+- rhel8.7:
+    check_id: installed_OS_is_rhel8_7
+    name: cpe:/o:redhat:enterprise_linux:8.7
+    title: Red Hat Enterprise Linux 8.7
+- rhel8.8:
+    check_id: installed_OS_is_rhel8_8
+    name: cpe:/o:redhat:enterprise_linux:8.8
+    title: Red Hat Enterprise Linux 8.8
+- rhel8.9:
+    check_id: installed_OS_is_rhel8_9
+    name: cpe:/o:redhat:enterprise_linux:8.9
+    title: Red Hat Enterprise Linux 8.9
+- rhel8.10:
+    check_id: installed_OS_is_rhel8_10
+    name: cpe:/o:redhat:enterprise_linux:8.10
+    title: Red Hat Enterprise Linux 8.10
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/log/faillock
+full_name: Red Hat Enterprise Linux 8
+gid_min: 1000
+groups:
+  dedicated_ssh_keyowner:
+    id: '995'
+    name: ssh_keys
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/efi/EFI/redhat
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
+pkg_manager: yum
+pkg_manager_config_file: /etc/yum.conf
+pkg_release: 4ae0493b
+pkg_system: rpm
+pkg_version: fd431d51
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2-common
+  login_defs: shadow-utils
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: rhel8
+product_dir: /home/matyc/git/scap-security-guide/products/rhel8
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -2,82 +2,38 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
+aux_pkg_release: 6229229e
+aux_pkg_version: 5a6340b3
+auxiliary_key_fingerprint: 7E4624258C406535D56D6F135054E4A45A6340B3
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: RHEL-9
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
+centos_major_version: '9'
 centos_pkg_release: 5ccc5b19
 centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- rhel9:
+    check_id: installed_OS_is_rhel9
+    name: cpe:/o:redhat:enterprise_linux:9
+    title: Red Hat Enterprise Linux 9
 cpes_root: ../../shared/applicability
-dconf_gdm_dir: gdm.d
+dconf_gdm_dir: distro.d
 faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+full_name: Red Hat Enterprise Linux 9
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
+    id: '996'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
-pkg_manager: yum
-pkg_manager_config_file: /etc/yum.conf
+oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL9.xml.bz2
+pkg_manager: dnf
+pkg_manager_config_file: /etc/dnf/dnf.conf
 pkg_release: 4ae0493b
 pkg_system: rpm
 pkg_version: fd431d51
@@ -95,7 +51,7 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: rhel9
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
@@ -123,7 +79,7 @@ reference_uris:
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
 release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
-sshd_distributed_config: 'false'
+sshd_distributed_config: 'true'
 sysctl_remediate_drop_in_file: 'false'
 type: platform
 uid_min: 1000

--- a/tests/data/product_stability/rhv4.yml
+++ b/tests/data/product_stability/rhv4.yml
@@ -6,76 +6,29 @@ aux_pkg_release: 5b32db75
 aux_pkg_version: d4082792
 auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: RHV-4
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- rhel8-host:
+    check_id: installed_OS_is_rhv4
+    name: cpe:/o:redhat:enterprise_linux:8::hypervisor
+    title: Red Hat Virtualization 4 Host
+- rhvm4:
+    check_id: installed_app_is_rhv4
+    name: cpe:/a:redhat:enterprise_virtualization_manager:4
+    title: Red Hat Virtualization 4 Manager
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: Red Hat Virtualization 4
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
 pkg_release: 4ae0493b
@@ -95,12 +48,11 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: rhv4
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf

--- a/tests/data/product_stability/sle12.yml
+++ b/tests/data/product_stability/sle12.yml
@@ -1,0 +1,77 @@
+aide_bin_path: /usr/bin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: SLE-12
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- sle12-server:
+    check_id: installed_OS_is_sle12
+    name: cpe:/o:suse:linux_enterprise_server:12
+    title: SUSE Linux Enterprise Server 12
+- sle12-desktop:
+    check_id: installed_OS_is_sle12
+    name: cpe:/o:suse:linux_enterprise_desktop:12
+    title: SUSE Linux Enterprise Desktop 12
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: SUSE Linux Enterprise 12
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/efi/EFI/sles
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+oval_feed_url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.12.xml
+pkg_manager: zypper
+pkg_manager_config_file: /etc/zypp/zypp.conf
+pkg_system: rpm
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2
+  login_defs: shadow
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: sle12
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/suse_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'true'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/sle15.yml
+++ b/tests/data/product_stability/sle15.yml
@@ -1,0 +1,80 @@
+aide_bin_path: /usr/bin/aide
+aide_conf_path: /etc/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: SLE-15
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony.conf
+cpes:
+- sle15-server:
+    check_id: installed_OS_is_sle15
+    name: cpe:/o:suse:linux_enterprise_server:15
+    title: SUSE Linux Enterprise Server 15
+- sle15-desktop:
+    check_id: installed_OS_is_sle15
+    name: cpe:/o:suse:linux_enterprise_desktop:15
+    title: SUSE Linux Enterprise Desktop 15
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: SUSE Linux Enterprise 15
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub2
+grub2_uefi_boot_path: /boot/grub2
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+oval_feed_url: https://ftp.suse.com/pub/projects/security/oval/suse.linux.enterprise.15.xml
+pkg_manager: zypper
+pkg_manager_config_file: /etc/zypp/zypp.conf
+pkg_release: 5f68629b
+pkg_system: rpm
+pkg_version: 39db7c82
+platform_package_overrides:
+  aarch64_arch: null
+  grub2: grub2
+  login_defs: shadow
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  ovirt: null
+  s390x_arch: null
+  sssd: sssd
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: sle15
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/suse_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+release_key_fingerprint: FEAB502539D846DB2C0961CA70AF9E8139DB7C82
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'true'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/ubuntu1604.yml
+++ b/tests/data/product_stability/ubuntu1604.yml
@@ -1,0 +1,80 @@
+aide_bin_path: /usr/bin/aide.wrapper
+aide_conf_path: /etc/aide/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: UBUNTU-XENIAL
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony/chrony.conf
+cpes:
+- ubuntu1604:
+    check_id: installed_OS_is_ubuntu1604
+    name: cpe:/o:canonical:ubuntu_linux:16.04::~~lts~~~
+    title: Ubuntu release 16.04 (Xenial)
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Ubuntu 16.04
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub
+grub2_uefi_boot_path: /boot/efi/EFI/ubuntu
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.xenial.cve.oval.xml
+pkg_manager: apt_get
+pkg_manager_config_file: /etc/apt/apt.conf
+pkg_system: dpkg
+platform_package_overrides:
+  aarch64_arch: null
+  audit: auditd
+  gdm: gdm3
+  grub2: grub2-common
+  login_defs: login
+  net-snmp: snmp
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  nss-pam-ldapd: libpam-ldap
+  openssl-pkcs11: libpam-pkcs11
+  ovirt: null
+  pam: libpam-runtime
+  s390x_arch: null
+  shadow: login
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: ubuntu1604
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/ubuntu1804.yml
+++ b/tests/data/product_stability/ubuntu1804.yml
@@ -1,0 +1,79 @@
+aide_bin_path: /usr/bin/aide.wrapper
+aide_conf_path: /etc/aide/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: UBUNTU-BIONIC
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony/chrony.conf
+cpes:
+- ubuntu1804:
+    check_id: installed_OS_is_ubuntu1804
+    name: cpe:/o:canonical:ubuntu_linux:18.04::~~lts~~~
+    title: Ubuntu release 18.04 (Bionic Beaver)
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Ubuntu 18.04
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub
+grub2_uefi_boot_path: /boot/efi/EFI/ubuntu
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+pkg_manager: apt_get
+pkg_manager_config_file: /etc/apt/apt.conf
+pkg_system: dpkg
+platform_package_overrides:
+  aarch64_arch: null
+  audit: auditd
+  gdm: gdm3
+  grub2: grub2-common
+  login_defs: login
+  net-snmp: snmp
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  nss-pam-ldapd: libpam-ldap
+  openssl-pkcs11: libpam-pkcs11
+  ovirt: null
+  pam: libpam-runtime
+  s390x_arch: null
+  shadow: login
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: ubuntu1804
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/ubuntu2004.yml
+++ b/tests/data/product_stability/ubuntu2004.yml
@@ -1,0 +1,80 @@
+aide_bin_path: /usr/bin/aide.wrapper
+aide_conf_path: /etc/aide/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: UBUNTU_20-04
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony/chrony.conf
+cpes:
+- ubuntu2004:
+    check_id: installed_OS_is_ubuntu2004
+    name: cpe:/o:canonical:ubuntu_linux:20.04::~~lts~~~
+    title: Ubuntu release 20.04 (Focal Fossa)
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Ubuntu 20.04
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub
+grub2_uefi_boot_path: /boot/grub
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.focal.cve.oval.xml
+pkg_manager: apt_get
+pkg_manager_config_file: /etc/apt/apt.conf
+pkg_system: dpkg
+platform_package_overrides:
+  aarch64_arch: null
+  audit: auditd
+  gdm: gdm3
+  grub2: grub2-common
+  login_defs: login
+  net-snmp: snmp
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  nss-pam-ldapd: libpam-ldap
+  openssl-pkcs11: libpam-pkcs11
+  ovirt: null
+  pam: libpam-runtime
+  s390x_arch: null
+  shadow: login
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: ubuntu2004
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/ubuntu2204.yml
+++ b/tests/data/product_stability/ubuntu2204.yml
@@ -1,0 +1,82 @@
+aide_bin_path: /usr/bin/aide
+aide_conf_path: /etc/aide/aide.conf
+audisp_conf_path: /etc/audit
+auid: 1000
+basic_properties_derived: true
+benchmark_id: UBUNTU_22-04
+benchmark_root: ../../linux_os/guide
+chrony_conf_path: /etc/chrony/chrony.conf
+cpes:
+- ubuntu2204:
+    check_id: installed_OS_is_ubuntu2204
+    name: cpe:/o:canonical:ubuntu_linux:22.04::~~lts~~~
+    title: Ubuntu release 22.04 (Jammy Jellyfish)
+cpes_root: ../../shared/applicability
+dconf_gdm_dir: gdm.d
+faillock_path: /var/run/faillock
+full_name: Ubuntu 22.04
+gid_min: 1000
+groups: {}
+grub2_boot_path: /boot/grub
+grub2_uefi_boot_path: /boot/grub
+init_system: systemd
+nobody_gid: 65534
+nobody_uid: 65534
+oval_feed_url: https://people.canonical.com/~ubuntu-security/oval/com.ubuntu.jammy.cve.oval.xml
+pkg_manager: apt_get
+pkg_manager_config_file: /etc/apt/apt.conf
+pkg_system: dpkg
+platform_package_overrides:
+  NetworkManager: network-manager
+  aarch64_arch: null
+  audit: auditd
+  avahi: avahi-daemon
+  dconf: dconf-editor
+  gdm: gdm3
+  grub2: grub2-common
+  login_defs: login
+  net-snmp: snmp
+  no_ovirt: null
+  non-uefi: null
+  not_aarch64_arch: null
+  not_s390x_arch: null
+  nss-pam-ldapd: libpam-ldap
+  ovirt: null
+  pam: libpam-runtime
+  s390x_arch: null
+  shadow: login
+  sssd: sssd-common
+  sssd-ldap: null
+  uefi: null
+  zipl: s390utils-base
+product: ubuntu2204
+profiles_root: ./profiles
+reference_uris:
+  anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
+  app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
+  cis: https://www.cisecurity.org/benchmark/ubuntu_linux/
+  cis-csc: https://www.cisecurity.org/controls/
+  cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
+  cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
+  cobit5: https://www.isaca.org/resources/cobit
+  cui: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-171.pdf
+  dcid: not_officially_available
+  disa: https://public.cyber.mil/stigs/cci/
+  hipaa: https://www.gpo.gov/fdsys/pkg/CFR-2007-title45-vol1/pdf/CFR-2007-title45-vol1-chapA-subchapC.pdf
+  isa-62443-2009: https://www.isa.org/products/isa-62443-2-1-2009-security-for-industrial-automat
+  isa-62443-2013: https://www.isa.org/products/ansi-isa-62443-3-3-99-03-03-2013-security-for-indu
+  ism: https://www.cyber.gov.au/acsc/view-all-content/ism
+  iso27001-2013: https://www.iso.org/standard/54534.html
+  nerc-cip: https://www.nerc.com/pa/Stand/Standard%20Purpose%20Statement%20DL/US_Standard_One-Stop-Shop.xlsx
+  nist: http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r4.pdf
+  nist-csf: https://nvlpubs.nist.gov/nistpubs/CSWP/NIST.CSWP.04162018.pdf
+  os-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cgeneral-purpose-os
+  ospp: https://www.niap-ccevs.org/Profile/PP.cfm
+  pcidss: https://www.pcisecuritystandards.org/documents/PCI_DSS_v3-2-1.pdf
+  pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
+  stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
+  stigref: https://public.cyber.mil/stigs/srg-stig-tools/
+sshd_distributed_config: 'false'
+sysctl_remediate_drop_in_file: 'false'
+type: platform
+uid_min: 1000

--- a/tests/data/product_stability/uos20.yml
+++ b/tests/data/product_stability/uos20.yml
@@ -2,85 +2,29 @@ aide_bin_path: /usr/sbin/aide
 aide_conf_path: /etc/aide.conf
 audisp_conf_path: /etc/audit
 auid: 1000
-aux_pkg_release: 5b32db75
-aux_pkg_version: d4082792
-auxiliary_key_fingerprint: 6A6AA7C97C8890AEC6AEBFE2F76F66C3D4082792
 basic_properties_derived: true
-benchmark_id: RHEL-8
+benchmark_id: UOS-20
 benchmark_root: ../../linux_os/guide
-centos_major_version: '8'
-centos_pkg_release: 5ccc5b19
-centos_pkg_version: 8483c65d
 chrony_conf_path: /etc/chrony.conf
 cpes:
-- rhel8:
-    check_id: installed_OS_is_rhel8
-    name: cpe:/o:redhat:enterprise_linux:8
-    title: Red Hat Enterprise Linux 8
-- rhel8.0:
-    check_id: installed_OS_is_rhel8_0
-    name: cpe:/o:redhat:enterprise_linux:8.0
-    title: Red Hat Enterprise Linux 8.0
-- rhel8.1:
-    check_id: installed_OS_is_rhel8_1
-    name: cpe:/o:redhat:enterprise_linux:8.1
-    title: Red Hat Enterprise Linux 8.1
-- rhel8.2:
-    check_id: installed_OS_is_rhel8_2
-    name: cpe:/o:redhat:enterprise_linux:8.2
-    title: Red Hat Enterprise Linux 8.2
-- rhel8.3:
-    check_id: installed_OS_is_rhel8_3
-    name: cpe:/o:redhat:enterprise_linux:8.3
-    title: Red Hat Enterprise Linux 8.3
-- rhel8.4:
-    check_id: installed_OS_is_rhel8_4
-    name: cpe:/o:redhat:enterprise_linux:8.4
-    title: Red Hat Enterprise Linux 8.4
-- rhel8.5:
-    check_id: installed_OS_is_rhel8_5
-    name: cpe:/o:redhat:enterprise_linux:8.5
-    title: Red Hat Enterprise Linux 8.5
-- rhel8.6:
-    check_id: installed_OS_is_rhel8_6
-    name: cpe:/o:redhat:enterprise_linux:8.6
-    title: Red Hat Enterprise Linux 8.6
-- rhel8.7:
-    check_id: installed_OS_is_rhel8_7
-    name: cpe:/o:redhat:enterprise_linux:8.7
-    title: Red Hat Enterprise Linux 8.7
-- rhel8.8:
-    check_id: installed_OS_is_rhel8_8
-    name: cpe:/o:redhat:enterprise_linux:8.8
-    title: Red Hat Enterprise Linux 8.8
-- rhel8.9:
-    check_id: installed_OS_is_rhel8_9
-    name: cpe:/o:redhat:enterprise_linux:8.9
-    title: Red Hat Enterprise Linux 8.9
-- rhel8.10:
-    check_id: installed_OS_is_rhel8_10
-    name: cpe:/o:redhat:enterprise_linux:8.10
-    title: Red Hat Enterprise Linux 8.10
+- uos20:
+    check_id: installed_OS_is_uos20
+    name: cpe:/o:uos:uniontech_os_server:20
+    title: UnionTech OS Server 20
 cpes_root: ../../shared/applicability
 dconf_gdm_dir: gdm.d
-faillock_path: /var/log/faillock
-full_name: Red Hat Enterprise Linux 8
+faillock_path: /var/run/faillock
+full_name: UnionTech OS Server 20
 gid_min: 1000
-groups:
-  dedicated_ssh_keyowner:
-    id: '995'
-    name: ssh_keys
+groups: {}
 grub2_boot_path: /boot/grub2
-grub2_uefi_boot_path: /boot/efi/EFI/redhat
+grub2_uefi_boot_path: /boot/grub2
 init_system: systemd
 nobody_gid: 65534
 nobody_uid: 65534
-oval_feed_url: https://access.redhat.com/security/data/oval/com.redhat.rhsa-RHEL8.xml.bz2
 pkg_manager: yum
 pkg_manager_config_file: /etc/yum.conf
-pkg_release: 4ae0493b
 pkg_system: rpm
-pkg_version: fd431d51
 platform_package_overrides:
   aarch64_arch: null
   grub2: grub2-common
@@ -95,12 +39,11 @@ platform_package_overrides:
   sssd-ldap: null
   uefi: null
   zipl: s390utils-base
-product: rhel8
+product: uos20
 profiles_root: ./profiles
 reference_uris:
   anssi: http://www.ssi.gouv.fr/administration/bonnes-pratiques/
   app-srg: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=application-servers
-  cis: https://www.cisecurity.org/benchmark/red_hat_linux/
   cis-csc: https://www.cisecurity.org/controls/
   cjis: https://www.fbi.gov/file-repository/cjis-security-policy-v5_5_20160601-2-1.pdf
   cnss: http://www.cnss.gov/Assets/pdf/CNSSI-1253.pdf
@@ -122,7 +65,6 @@ reference_uris:
   pcidss4: https://docs-prv.pcisecuritystandards.org/PCI%20DSS/Standard/PCI-DSS-v4_0.pdf
   stigid: https://public.cyber.mil/stigs/downloads/?_dl_facet_stigs=operating-systems%2Cunix-linux
   stigref: https://public.cyber.mil/stigs/srg-stig-tools/
-release_key_fingerprint: 567E347AD0044ADE55BA8A5F199E2F91FD431D51
 sshd_distributed_config: 'false'
 sysctl_remediate_drop_in_file: 'false'
 type: platform

--- a/tests/test_product_stability.py
+++ b/tests/test_product_stability.py
@@ -7,7 +7,7 @@ import sys
 
 import ssg.products
 
-import tests.test_profile_stability as stability
+from tests.common import stability
 
 
 IGNORED_PROPERTIES = (
@@ -59,7 +59,7 @@ def compare_dictionaries(reference, sample):
     return result
 
 
-def get_references(ref_root):
+def get_references_filenames(ref_root):
     return glob.glob(os.path.join(ref_root, "*.yml"))
 
 
@@ -91,15 +91,9 @@ def inform_and_append_fix_based_on_reference_compiled_product(ref, build_root, f
 
     compiled_path = os.path.join(build_root, product_id, "product.yml")
     compiled_product = ssg.products.Product(compiled_path)
-    if not compiled_product:
-        msg = ("Unexpectedly unable to find compiled product file corresponding"
-               "to the test file {ref}, although the corresponding product has been built. "
-               "This indicates that a profile we have tests for is missing."
-               .format(ref=ref))
-        raise RuntimeError(msg)
     difference = get_reference_vs_built_difference(ref_product, compiled_product)
     if not difference.empty:
-        stability.report_comparison(product_id, difference)
+        stability.report_comparison(product_id, difference, describe_change)
         fix_commands.append(
             "cp '{compiled}' '{reference}'"
             .format(compiled=compiled_path, reference=ref)
@@ -112,7 +106,7 @@ def main():
     parser.add_argument("test_data_root")
     args = parser.parse_args()
 
-    reference_files = get_references(args.test_data_root)
+    reference_files = get_references_filenames(args.test_data_root)
     if not reference_files:
         raise RuntimeError("Unable to find any reference compiled products in {test_root}"
                            .format(test_root=args.test_data_root))

--- a/tests/test_product_stability.py
+++ b/tests/test_product_stability.py
@@ -7,39 +7,12 @@ import sys
 
 import ssg.products
 
+import tests.test_profile_stability as stability
+
 
 IGNORED_PROPERTIES = (
     "product_dir",
 )
-
-
-class Difference(object):
-    def __init__(self):
-        self.added = []
-        self.removed = []
-        self.modified = dict()
-
-    def remove_item_from_comparison(self, item):
-        if item in self.added:
-            self.added.remove(item)
-        if item in self.removed:
-            self.removed.remove(item)
-        if item in self.modified:
-            self.modified.pop(item)
-
-    @property
-    def empty(self):
-        return not (self.added or self.removed or self.modified)
-
-
-def describe_changeset(intro, changeset):
-    if not changeset:
-        return ""
-
-    msg = intro
-    for rid in changeset:
-        msg += " - {rid}\n".format(rid=rid)
-    return msg
 
 
 def describe_modification(intro, changeset):
@@ -56,11 +29,11 @@ def describe_modification(intro, changeset):
 def describe_change(difference, name):
     msg = ""
 
-    msg += describe_changeset(
+    msg += stability.describe_changeset(
         "Following properties were added to the {name} product:\n".format(name=name),
         difference.added,
     )
-    msg += describe_changeset(
+    msg += stability.describe_changeset(
         "Following properties were removed from the {name} product:\n".format(name=name),
         difference.removed,
     )
@@ -75,7 +48,7 @@ def compare_dictionaries(reference, sample):
     reference_keys = set(reference.keys())
     sample_keys = set(sample.keys())
 
-    result = Difference()
+    result = stability.Difference()
     result.added = list(sample_keys.difference(reference_keys))
     result.removed = list(reference_keys.difference(sample_keys))
     for key, value in reference.items():
@@ -84,13 +57,6 @@ def compare_dictionaries(reference, sample):
     for item in IGNORED_PROPERTIES:
         result.remove_item_from_comparison(item)
     return result
-
-
-def report_comparison(name, result):
-    msg = ""
-    if not result.empty:
-        msg = describe_change(result, name)
-    print(msg, file=sys.stderr)
 
 
 def get_references(ref_root):
@@ -144,7 +110,7 @@ def main():
             raise RuntimeError(msg)
         difference = get_reference_vs_built_difference(ref_product, compiled_product)
         if not difference.empty:
-            report_comparison(product_id, difference)
+            stability.report_comparison(product_id, difference)
             fix_commands.append(
                 "cp '{compiled}' '{reference}'"
                 .format(compiled=compiled_path, reference=ref)

--- a/tests/test_product_stability.py
+++ b/tests/test_product_stability.py
@@ -8,11 +8,24 @@ import sys
 import ssg.products
 
 
+IGNORED_PROPERTIES = (
+    "product_dir",
+)
+
+
 class Difference(object):
     def __init__(self):
         self.added = []
         self.removed = []
         self.modified = dict()
+
+    def remove_item_from_comparison(self, item):
+        if item in self.added:
+            self.added.remove(item)
+        if item in self.removed:
+            self.removed.remove(item)
+        if item in self.modified:
+            self.modified.pop(item)
 
     @property
     def empty(self):
@@ -68,6 +81,8 @@ def compare_dictionaries(reference, sample):
     for key, value in reference.items():
         if sample.get(key, value) != value:
             result.modified[key] = (value, sample[key])
+    for item in IGNORED_PROPERTIES:
+        result.remove_item_from_comparison(item)
     return result
 
 
@@ -148,4 +163,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/tests/test_product_stability.py
+++ b/tests/test_product_stability.py
@@ -1,0 +1,151 @@
+from __future__ import print_function
+
+import argparse
+import glob
+import os.path
+import sys
+
+import ssg.products
+
+
+class Difference(object):
+    def __init__(self):
+        self.added = []
+        self.removed = []
+        self.modified = dict()
+
+    @property
+    def empty(self):
+        return not (self.added or self.removed or self.modified)
+
+
+def describe_changeset(intro, changeset):
+    if not changeset:
+        return ""
+
+    msg = intro
+    for rid in changeset:
+        msg += " - {rid}\n".format(rid=rid)
+    return msg
+
+
+def describe_modification(intro, changeset):
+    if not changeset:
+        return ""
+
+    msg = intro
+    for what, (initial, final) in changeset.items():
+        msg += " - {what} from '{initial}' -> '{final}'\n".format(
+                what=what, initial=initial, final=final)
+    return msg
+
+
+def describe_change(difference, name):
+    msg = ""
+
+    msg += describe_changeset(
+        "Following properties were added to the {name} product:\n".format(name=name),
+        difference.added,
+    )
+    msg += describe_changeset(
+        "Following properties were removed from the {name} product:\n".format(name=name),
+        difference.removed,
+    )
+    msg += describe_modification(
+        "Following properties got different values in the {name} product:\n".format(name=name),
+        difference.modified,
+    )
+    return msg.rstrip()
+
+
+def compare_dictionaries(reference, sample):
+    reference_keys = set(reference.keys())
+    sample_keys = set(sample.keys())
+
+    result = Difference()
+    result.added = list(sample_keys.difference(reference_keys))
+    result.removed = list(reference_keys.difference(sample_keys))
+    for key, value in reference.items():
+        if sample.get(key, value) != value:
+            result.modified[key] = (value, sample[key])
+    return result
+
+
+def report_comparison(name, result):
+    msg = ""
+    if not result.empty:
+        msg = describe_change(result, name)
+    print(msg, file=sys.stderr)
+
+
+def get_references(ref_root):
+    return glob.glob(os.path.join(ref_root, "*.yml"))
+
+
+def corresponding_product_built(build_dir, product_id):
+    return os.path.isdir(os.path.join(build_dir, product_id))
+
+
+def get_matching_compiled_product_filename(build_dir, product_id):
+    ref_path_components = reference_fname.split(os.path.sep)
+    matching_filename = os.path.join(build_dir, product_id, "product.yml")
+    if os.path.isfile(matching_filename):
+        return matching_filename
+
+
+def get_reference_vs_built_difference(ref_product, built_product):
+    ref_dict = dict()
+    ref_dict.update(ref_product)
+    built_dict = dict()
+    built_dict.update(built_product)
+    difference = compare_dictionaries(ref_dict, built_dict)
+    return difference
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build_root")
+    parser.add_argument("test_data_root")
+    args = parser.parse_args()
+
+    reference_files = get_references(args.test_data_root)
+    if not reference_files:
+        raise RuntimeError("Unable to find any reference compiled products in {test_root}"
+                           .format(test_root=args.test_data_root))
+    fix_commands = []
+    for ref in reference_files:
+        ref_product = ssg.products.Product(ref)
+        product_id = ref_product["product"]
+        if not corresponding_product_built(args.build_root, product_id):
+            continue
+
+        compiled_path = os.path.join(args.build_root, product_id, "product.yml")
+        compiled_product = ssg.products.Product(compiled_path)
+        if not compiled_product:
+            msg = ("Unexpectedly unable to find compiled product file corresponding"
+                   "to the test file {ref}, although the corresponding product has been built. "
+                   "This indicates that a profile we have tests for is missing."
+                   .format(ref=ref))
+            raise RuntimeError(msg)
+        difference = get_reference_vs_built_difference(ref_product, compiled_product)
+        if not difference.empty:
+            report_comparison(product_id, difference)
+            fix_commands.append(
+                "cp '{compiled}' '{reference}'"
+                .format(compiled=compiled_path, reference=ref)
+            )
+
+    if fix_commands:
+        msg = (
+            "If changes to mentioned products are intentional, "
+            "copy those compiled files, so they become the new reference:\n{fixes}\n"
+            "If those changes are unwanted, take a look at product properties "
+            "that likely cause these changes."
+            .format(fixes="\n".join(fix_commands)))
+        print(msg, file=sys.stderr)
+    sys.exit(bool(fix_commands))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_profile_stability.py
+++ b/tests/test_profile_stability.py
@@ -12,10 +12,19 @@ class Difference(object):
     def __init__(self):
         self.added = []
         self.removed = []
+        self.modified = dict()
+
+    def remove_item_from_comparison(self, item):
+        if item in self.added:
+            self.added.remove(item)
+        if item in self.removed:
+            self.removed.remove(item)
+        if item in self.modified:
+            self.modified.pop(item)
 
     @property
     def empty(self):
-        return not (self.added or self.removed)
+        return not (self.added or self.removed or self.modified)
 
 
 def describe_changeset(intro, changeset):
@@ -23,8 +32,8 @@ def describe_changeset(intro, changeset):
         return ""
 
     msg = intro
-    for rid in changeset:
-        msg += " - {rid}\n".format(rid=rid)
+    for item in changeset:
+        msg += " - {item}\n".format(item=item)
     return msg
 
 


### PR DESCRIPTION
#### Description:

With the recent introduction of the product class in #10529 and planned introduction of product properties in #10554, a mechanism that can make sure that changes to product properties are under control seems to be needed.
The following test makes sure that if product properties are changed, such changes are confirmed.

It may be that in order to avoid situations s.a. the need to update all test references manually when a new property is introduced, the test script could have this as an option. Automatic update of references would still show in the PR diff, which would preserve the element of confirmation.

#### Rationale:

- Prevention of https://github.com/ComplianceAsCode/content/pull/10554#discussion_r1196624739

#### Review Hints:

- Build a product, modify the compiled product yaml or the test reference, and either run the `stable-products` tests, or the test script directly.