### PR TITLE
OCP: Add CPE for HyperShift Hosted cluster

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_alwaysadmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_alwaysadmit/rule.yml
@@ -34,6 +34,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>AlwaysAdmit</tt> admission control plugin is not set'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_alwayspullimages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_alwayspullimages/rule.yml
@@ -50,6 +50,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>AlwaysPullImages</tt> is included in <tt>admissionConfig</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_namespacelifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_namespacelifecycle/rule.yml
@@ -35,6 +35,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'API server config contains <tt>NamespaceLifecycle</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_noderestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_noderestriction/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>enable-admission-plugins</tt> does not contain <tt>NodeRestriction</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_scc/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the list of enabled admission plugins contains <tt>SecurityContextConstraint</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_admission_control_plugin_securitycontextdeny/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_securitycontextdeny/rule.yml
@@ -42,6 +42,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: |-
     '<tt>enable-admission-plugins</tt>does not contain <tt>SecurityContextDeny</tt>'
 

--- a/applications/openshift/api-server/api_server_admission_control_plugin_service_account/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_service_account/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'API server configuration contains <tt>ServiceAccount</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
@@ -41,6 +41,8 @@ references:
   pcidss: Req-2.2
   srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>.apiServerArguments["feature-gates"]</tt> does not include <tt>APIPriorityAndFairness</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -44,6 +44,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -44,6 +44,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -43,6 +43,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_no_aa/rule.yml
@@ -28,6 +28,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'The Node authorization-mode is configured and enabled'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_node/rule.yml
@@ -30,6 +30,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'The Node authorization-mode is configured and enabled'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -35,6 +35,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'The RBAC authorization mode is enabled'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_basic_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_basic_auth/rule.yml
@@ -48,6 +48,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'basic-auth-file is configured and enabled for the API server'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -33,6 +33,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>bindAddress</tt> allows unsecure connections'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -48,6 +48,8 @@ references:
 identifiers:
     cce@ocp4: CCE-84284-9
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>client-ca-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -64,6 +64,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000429-CTR-001060
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>aescbc</tt> is not configured as the encryption provider'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -48,6 +48,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>etcd-cafile</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -46,6 +46,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>etcd-certfile</tt> does not exist or is not configured to valid certificates'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -46,6 +46,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>keyFile</tt> does not exist or is not configured to valid certificates'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
+++ b/applications/openshift/api-server/api_server_https_for_kubelet_conn/rule.yml
@@ -32,6 +32,8 @@ references:
     pcidss: Req-2.2,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>kubelet-https</tt> is set to false'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -34,7 +34,6 @@ rationale: |-
 identifiers:
   cce@ocp4: CCE-83955-5
 
-
 severity: medium
 
 references:
@@ -43,6 +42,8 @@ references:
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
+
+platform: not ocp4-on-hypershift-hosted
 
 ocil_clause: 'insecure-bind-address is exists and has not been removed</tt>'
 

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -39,7 +39,7 @@ identifiers:
   cce@ocp4: CCE-83813-6
 
 platforms:
-  - ocp4.6 or ocp4.7 or ocp4.8 or ocp4.9 or ocp4.10
+  - (ocp4.6 or ocp4.7 or ocp4.8 or ocp4.9 or ocp4.10) and not ocp4-on-hypershift-hosted
 
 severity: medium
 

--- a/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_certificate_authority/rule.yml
@@ -47,6 +47,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>kubelet-certificate-authority</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert/rule.yml
@@ -35,7 +35,7 @@ identifiers:
   cce@ocp4: CCE-84080-1
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13) and not ocp4-on-hypershift-hosted
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_cert_pre_4_9/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_cert_pre_4_9/rule.yml
@@ -31,7 +31,7 @@ identifiers:
   cce@ocp4: CCE-85890-2
 
 platforms:
-    - ocp4.6 or ocp4.7 or ocp4.8
+    - (ocp4.6 or ocp4.7 or ocp4.8) and not ocp4-on-hypershift-hosted
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key/rule.yml
@@ -35,7 +35,7 @@ identifiers:
   cce@ocp4: CCE-83591-8
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13) and not ocp4-on-hypershift-hosted
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_kubelet_client_key_pre_4_9/rule.yml
+++ b/applications/openshift/api-server/api_server_kubelet_client_key_pre_4_9/rule.yml
@@ -31,7 +31,7 @@ identifiers:
   cce@ocp4: CCE-90794-9
 
 platforms:
-    - ocp4.6 or ocp4.7 or ocp4.8
+    - (ocp4.6 or ocp4.7 or ocp4.8) and not ocp4-on-hypershift-hosted
 
 severity: high
 

--- a/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
+++ b/applications/openshift/api-server/api_server_no_adm_ctrl_plugins_disabled/rule.yml
@@ -37,6 +37,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'No admission plugins are disabled'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -44,6 +44,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>min-request-timeout</tt> is not set or is not set to an appropriate value'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -35,6 +35,8 @@ references:
   pcidss: Req-2.2
   srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'API server argument <tt>--service-account-lookup</tt> contains <tt>true</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -46,6 +46,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'serviceAccountPublicKeyFiles is not configured correctly'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -46,6 +46,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>tls-cert-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -44,6 +44,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>cipherSuites</tt> is not configured, or contains ciphers (possibly insecure) other than TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256, or TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 in servingInfo'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -46,6 +46,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>tls-private-key-file</tt> is not set as appropriate for <tt>apiServerArguments</tt>'
 
 ocil: |-

--- a/applications/openshift/api-server/api_server_token_auth/rule.yml
+++ b/applications/openshift/api-server/api_server_token_auth/rule.yml
@@ -46,6 +46,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>token-auth-file</tt> argument is configured'
 
 ocil: |-

--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -27,7 +27,8 @@ references:
   pcidss: Req-2.2,Req-10.5.3,Req-10.5.4
   srg: SRG-APP-000092-CTR-000165,SRG-APP-000111-CTR-000220,SRG-APP-000358-CTR-000805
 
-platform: not ocp4-on-hypershift
+platform: not ocp4-on-hypershift and not ocp4-on-hypershift-hosted
+
 
 ocil_clause: 'Logs are not forwarded outside the cluster'
 

--- a/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
+++ b/applications/openshift/controller/controller_insecure_port_disabled/rule.yml
@@ -43,6 +43,8 @@ severity: low
 identifiers:
     cce@ocp4: CCE-83578-5
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: |-
     <tt>port</tt> is not disabled
 

--- a/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
+++ b/applications/openshift/controller/controller_rotate_kubelet_server_certs/rule.yml
@@ -38,6 +38,8 @@ rationale: |-
 
 severity: medium
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: |-
     <tt>RotateKubeletServerCertificate</tt> argument is set to <tt>false</tt> in the
     <tt>controllerArguments</tt> options

--- a/applications/openshift/controller/controller_secure_port/rule.yml
+++ b/applications/openshift/controller/controller_secure_port/rule.yml
@@ -37,6 +37,8 @@ severity: low
 identifiers:
     cce@ocp4: CCE-83861-5
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: |-
     <tt>secure-port</tt> is not configured to use a secure port
 

--- a/applications/openshift/controller/controller_service_account_ca/rule.yml
+++ b/applications/openshift/controller/controller_service_account_ca/rule.yml
@@ -45,6 +45,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>root-ca-file</tt> is not configured</tt>'
 
 ocil: |-

--- a/applications/openshift/controller/controller_service_account_private_key/rule.yml
+++ b/applications/openshift/controller/controller_service_account_private_key/rule.yml
@@ -47,6 +47,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>service-account-private-key-file</tt> does not exist or is configured properly'
 
 ocil: |-

--- a/applications/openshift/controller/controller_use_service_account/rule.yml
+++ b/applications/openshift/controller/controller_use_service_account/rule.yml
@@ -49,6 +49,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>use-service-account-credentials</tt> is set to <tt>false</tt>'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_auto_tls/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd is using self-signed certificates'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_cert_file/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd client certificate is not configured'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_check_cipher_suite/rule.yml
+++ b/applications/openshift/etcd/etcd_check_cipher_suite/rule.yml
@@ -18,6 +18,8 @@ identifiers:
 references:
   pcidss: Req-4.1
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'ETCD cipher suite does not meet requirements'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_client_cert_auth/rule.yml
@@ -36,6 +36,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd client certificate authentication is not configured'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_key_file/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd client key file is not configured'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_auto_tls/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd is using peer self-signed certificates'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_cert_file/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd peer client certificate is not configured'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_client_cert_auth/rule.yml
@@ -36,6 +36,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd peer client certificate authentication is not configured'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_peer_key_file/rule.yml
+++ b/applications/openshift/etcd/etcd_peer_key_file/rule.yml
@@ -38,6 +38,8 @@ references:
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000441-CTR-001090,SRG-APP-000442-CTR-001095
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'the etcd peer client key file is not configured'
 
 ocil: |-

--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -26,7 +26,7 @@ references:
   srg: SRG-APP-000516-CTR-001325
 
 platforms:
-  - ocp4-master-node
+  - ocp4-master-node and not ocp4-on-hypershift-hosted
 
 warnings:
   - dependency: |-

--- a/applications/openshift/general/oauth_login_template_set/rule.yml
+++ b/applications/openshift/general/oauth_login_template_set/rule.yml
@@ -33,6 +33,8 @@ references:
   nist: AC-8
   srg: SRG-APP-000068-CTR-000120
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'login template is not set'
 
 ocil: |-

--- a/applications/openshift/general/oauth_provider_selection_set/rule.yml
+++ b/applications/openshift/general/oauth_provider_selection_set/rule.yml
@@ -33,6 +33,8 @@ references:
   nist: AC-8
   srg: SRG-APP-000068-CTR-000120
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'provider selection is not set'
 
 ocil: |-

--- a/applications/openshift/general/tls_version_check_apiserver/rule.yml
+++ b/applications/openshift/general/tls_version_check_apiserver/rule.yml
@@ -26,6 +26,8 @@ identifiers:
 references:
   pcidss: Req-4.1
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: 'Ensure TLS version is equal to 1.2 or greater for the openshift api server'
 
 ocil: |-

--- a/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_cert/rule.yml
@@ -28,7 +28,7 @@ identifiers:
     cce@ocp4: CCE-83396-2
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13) and not ocp4-on-hypershift-hosted
 
 references:
     cis@ocp4: 4.2.10

--- a/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
+++ b/applications/openshift/kubelet/kubelet_configure_tls_key/rule.yml
@@ -28,7 +28,7 @@ identifiers:
     cce@ocp4: CCE-90614-9
 
 platforms:
-  - ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13
+  - (ocp4.9 or ocp4.10 or ocp4.11 or ocp4.12 or ocp4.13) and not ocp4-on-hypershift-hosted
 
 references:
     cis@ocp4: 4.2.10

--- a/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -44,6 +44,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>audit-log-maxbackup</tt> is set to <tt>10</tt> or as appropriate'
 
 ocil: |-

--- a/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -44,6 +44,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>audit-log-maxsize</tt> is set to <tt>100</tt> or as appropriate'
 
 ocil: |-

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
@@ -43,6 +43,8 @@ references:
     pcidss: Req-2.2
     srg: SRG-APP-000516-CTR-001325
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>audit-log-path</tt> does not contain a valid audit file path'
 
 ocil: |-

--- a/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
+++ b/applications/openshift/scheduler/scheduler_no_bind_address/rule.yml
@@ -41,6 +41,8 @@ platforms:
 
 severity: medium
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>kube-scheduler-pod</tt> sets --bind-address'
 
 ocil: |-

--- a/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
+++ b/applications/openshift/scheduler/scheduler_port_is_zero/rule.yml
@@ -31,6 +31,8 @@ references:
 
 severity: medium
 
+platform: not ocp4-on-hypershift-hosted
+
 ocil_clause: '<tt>kube-scheduler-pod</tt> port parameter is zero'
 
 ocil: |-

--- a/shared/applicability/ocp4-on-hypershift-hosted.yml
+++ b/shared/applicability/ocp4-on-hypershift-hosted.yml
@@ -1,0 +1,3 @@
+name: "cpe:/a:redhat:openshift_container_platform_on_hypershift_hosted:4"
+title: "Red Hat OpenShift Container Platform 4 on HyperShift Hosted Cluster"
+check_id: installed_app_is_ocp4_on_hypershift_hosted

--- a/shared/applicability/oval/installed_app_is_ocp4.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4.xml
@@ -29,6 +29,10 @@
       <literal_component>/kubernetes-api-resources/hypershift/version</literal_component>
   </local_variable>
 
+  <local_variable id="ocp4_operator_deployment_dump_location" datatype="string" comment="The actual filepath of the file to scan." version="1">
+      <literal_component>/kubernetes-api-resources/api/v1/namespaces/openshift-compliance/pods/api-checks-pod</literal_component>
+  </local_variable>
+
   <unix:file_test id="test_file_for_ocp4" check="only one" comment="Find the actual file to be scanned." version="1">
       <unix:object object_ref="object_file_for_ocp4"/>
   </unix:file_test>
@@ -77,6 +81,23 @@
   <ind:yamlfilecontent_state id="state_hypershift_version" version="1">
       <ind:value datatype="record">
           <field name="#" datatype="string" operation="pattern match">4\..*</field>
+      </ind:value>
+  </ind:yamlfilecontent_state>
+
+  <ind:yamlfilecontent_test id="test_hypershift_hosted" check="at least one" comment="Find one match" version="1">
+      <ind:object object_ref="object_hypershift_hosted"/>
+      <ind:state state_ref="state_hypershift_hosted"/>
+  </ind:yamlfilecontent_test>
+
+
+  <ind:yamlfilecontent_object id="object_hypershift_hosted" version="1">
+      <ind:filepath var_ref="ocp4_operator_deployment_dump_location"/>
+      <ind:yamlpath>.spec.containers[:].command[:]</ind:yamlpath>
+  </ind:yamlfilecontent_object>
+
+  <ind:yamlfilecontent_state id="state_hypershift_hosted" version="1">
+      <ind:value datatype="record" entity_check="at least one">
+          <field name="#" datatype="string" operation="pattern match" entity_check="at least one">^--platform=HyperShift$</field>
       </ind:value>
   </ind:yamlfilecontent_state>
 
@@ -223,7 +244,7 @@
   </ind:yamlfilecontent_state>
 {{% endfor %}}
 
-  <!-- Check for OpenShift Container Platform 4 on HyperShift -->
+  <!-- Check for OpenShift Container Platform 4 on HyperShift Management Cluster -->
   <definition class="inventory" id="installed_app_is_ocp4_on_hypershift" version="1">
     <metadata>
       <title>Red Hat OpenShift Container Platform</title>
@@ -231,10 +252,25 @@
         <platform>Red Hat OpenShift Container Platform 4 on HyperShift</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform_on_hypershift:4" source="CPE" />
-      <description>The application installed installed on the system is OpenShift 4 on HyperShift.</description>
+      <description>The application installed installed on the system is OpenShift 4 on HyperShift Management Cluster.</description>
     </metadata>
     <criteria operator="AND">
       <criterion comment="Make sure there is version for HyperShift HostedCluster" test_ref="test_hypershift_version"/>
+    </criteria>
+  </definition>
+
+    <!-- Check for OpenShift Container Platform 4 on HyperShift Hosted Cluster -->
+  <definition class="inventory" id="installed_app_is_ocp4_on_hypershift_hosted" version="1">
+    <metadata>
+      <title>Red Hat OpenShift Container Platform</title>
+      <affected family="unix">
+        <platform>Red Hat OpenShift Container Platform 4 on HyperShift</platform>
+      </affected>
+      <reference ref_id="cpe:/a:redhat:openshift_container_platform_on_hypershift_hosted:4" source="CPE" />
+      <description>The application installed installed on the system is OpenShift 4 on HyperShift Hosted Cluster.</description>
+    </metadata>
+    <criteria operator="AND">
+      <criterion comment="Make sure there is HyperShift in the Compliance Operator Command flag" test_ref="test_hypershift_hosted"/>
     </criteria>
   </definition>
 


### PR DESCRIPTION
Added ocp4-on-hypershift-hosted CPE for HyperShift Hosted Cluster, excluding rules that will not be checked on HyperShift Hosted Cluster

This works in conjunction with https://github.com/ComplianceAsCode/compliance-operator/pull/331