### PR TITLE
Add eks platforms to some ocp shared OVAL

### DIFF
--- a/shared/applicability/oval/installed_app_is_ocp4.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4.xml
@@ -4,7 +4,8 @@
     <metadata>
       <title>Red Hat OpenShift Container Platform</title>
       <affected family="unix">
-        <platform>Red Hat OpenShift Container Platform 4</platform>
+        <platform>multi_platform_eks</platform>
+        <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/a:redhat:openshift_container_platform:4.1" source="CPE" />
       <description>The application installed installed on the system is OpenShift 4.</description>

--- a/shared/applicability/oval/installed_app_is_ocp4_node.xml
+++ b/shared/applicability/oval/installed_app_is_ocp4_node.xml
@@ -3,7 +3,8 @@
     <metadata>
       <title>Red Hat OpenShift Container Platform Node</title>
       <affected family="unix">
-        <platform>Red Hat OpenShift Container Platform 4 Node</platform>
+        <platform>multi_platform_eks</platform>
+        <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/o:redhat:openshift_container_platform_node:4" source="CPE" />
       <description>The application installed installed on the system is OpenShift 4.</description>

--- a/shared/applicability/oval/node_is_ocp4_master_node.xml
+++ b/shared/applicability/oval/node_is_ocp4_master_node.xml
@@ -3,7 +3,8 @@
     <metadata>
       <title>Node is Red Hat OpenShift Container Platform 4 Master Node</title>
       <affected family="unix">
-        <platform>Red Hat OpenShift Container Platform 4 Node</platform>
+        <platform>multi_platform_eks</platform>
+        <platform>multi_platform_ocp</platform>
       </affected>
       <reference ref_id="cpe:/a:ocp4-master-node" source="CPE" />
       <description>The current node is an OpenShift 4 master node.</description>


### PR DESCRIPTION
Shared OVALs may get into content of a wider range of products, and it is better to preventatively include those checks, as the project can't do that on-demand at this time.

- Fixes: #10446

#### Review Hints:

- Check the linked issue, the fix ensures that the platform definition is present both on OCP4 and EKS products, and forward-compatibility has been established by using the platform classes rather than platforms.