### PR TITLE
SRG-APP-000090-CTR-000155: No longer Does not Meet, but instead covered by setting the OCP audit profile

### DIFF
--- a/applications/openshift/logging/audit_profile_set/rule.yml
+++ b/applications/openshift/logging/audit_profile_set/rule.yml
@@ -59,7 +59,7 @@ references:
   nist: AU-2,AU-3,AU-3(1),AU-6,AU-6(1),AU-7,AU-7(1),AU-8,AU-8(1),AU-9,AU-12,AU-12(1),AU-12(3),CM-5(1),SI-11,SI-12,SI-4(20),SI-4(23)
   pcidss: Req-2.2,Req-12.5.5
   pcidss4: "12.1.4"
-  srg: SRG-APP-000089-CTR-000150,SRG-APP-000101-CTR-000205
+  srg: SRG-APP-000089-CTR-000150,SRG-APP-000090-CTR-000155,SRG-APP-000101-CTR-000205
 
 ocil_clause: 'The proper audit profile is not set'
 

--- a/controls/srg_ctr/SRG-APP-000090-CTR-000155.yml
+++ b/controls/srg_ctr/SRG-APP-000090-CTR-000155.yml
@@ -4,21 +4,7 @@ controls:
   - medium
   title: {{{ full_name }}} must allow only the ISSM (or individuals or roles
     appointed by the ISSM) to select which auditable events are to be audited.
-  related_rules:
+  rules:
   - audit_profile_set
-  status: does not meet
-  status_justification: |-
-    The OpenShift Container Platform records every request/action against the API Server[1]. The platform allows for configuring the verbosity, such as meta-data only, or the entire request body. But, all events are audited, and the ISSM or admins are not able to filter or select only certain event types to be audited.
+  status: automated
 
-    [1] https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html
-  artifact_description: |-
-    Supporting evidence is in the following documentation
-
-    https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html
-  mitigation: |-
-    All requests to the API Server are audited.
-  fixtext: |-
-    This requirement is a permanent finding and cannot be fixed.
-  check: |-
-    {{{ full_name }}} does not support this requirement.
-    This is an applicable-does not meet finding.


### PR DESCRIPTION
#### Description:

- The SRG SRG-APP-000090-CTR-000155 was marked as does not met in the original draft. It's been changed to applicable/configurable
  with the advice to configure the appropriate audit level

#### Rationale:

- OCP4 STIG

#### Review Hints:

- I will post the links to the SRG export later
