### PR TITLE
Update rule aide_scan_notification for sle 15

### DIFF
--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/rule.yml
@@ -51,6 +51,7 @@ references:
     stigid@rhel7: RHEL-07-020040
     stigid@rhel8: RHEL-08-010360
     stigid@sle12: SLES-12-010510
+    stigid@sle15: SLES-15-010570
 
 ocil_clause: 'AIDE has not been configured or has not been configured to notify personnel of scan details'
 

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -63,6 +63,7 @@ selections:
     - account_temp_expire_date
     - account_unique_id
     - aide_check_audit_tools
+    - aide_scan_notification
     - aide_verify_acls
     - aide_verify_ext_attributes
     - aide_periodic_cron_checking


### PR DESCRIPTION
#### Description:

- _Update rule aide_scan_notification for sle 15_

#### Rationale:

- _Accoring DISA recommendations Version 1, Release 9 from 26 January 2023 about SLE 15 STIG - "SLES-15-010570 - Verify the SUSE operating system notifies the SA when AIDE discovers anomalies in the operation of any security functions"_