### PR TITLE
Use specific name in private key groups instead of gid.

### DIFF
--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/rule.yml
@@ -3,7 +3,6 @@ documentation_complete: true
 title: 'Verify Group Ownership on SSH Server Private *_key Key Files'
 
 {{% set dedicated_ssh_groupname = groups.get("dedicated_ssh_keyowner", {}).get("name") %}}
-{{% set dedicated_ssh_groupid = groups.get("dedicated_ssh_keyowner", {}).get("id") %}}
 
 description: |-
     SSH server private keys, files that match the <code>/etc/ssh/*_key</code> glob, must be
@@ -36,4 +35,4 @@ template:
             - /etc/ssh/
         file_regex:
             - ^.*_key$
-        filegid: '{{{ dedicated_ssh_groupid if dedicated_ssh_groupid else '0' }}}'
+        filegid: '{{{ dedicated_ssh_groupname if dedicated_ssh_groupname else '0' }}}'

--- a/products/rhel7/product.yml
+++ b/products/rhel7/product.yml
@@ -27,7 +27,6 @@ audisp_conf_path: "/etc/audisp"
 groups:
   dedicated_ssh_keyowner:
     name: ssh_keys
-    id: "997"
 
 cpes_root: "../../shared/applicability"
 cpes:

--- a/products/rhel8/product.yml
+++ b/products/rhel8/product.yml
@@ -27,7 +27,6 @@ grub2_uefi_boot_path: "/boot/efi/EFI/redhat"
 groups:
   dedicated_ssh_keyowner:
     name: ssh_keys
-    id: "995"
 
 faillock_path: "/var/log/faillock"
 

--- a/products/rhel9/product.yml
+++ b/products/rhel9/product.yml
@@ -18,7 +18,6 @@ grub2_uefi_boot_path: "/boot/grub2"
 groups:
   dedicated_ssh_keyowner:
     name: ssh_keys
-    id: "996"
 
 sshd_distributed_config: "true"
 

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -38,11 +38,34 @@
   </unix:file_object>
 
   <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" version="1">
+    {{%- if FILEGID == '0' %}}
     <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
+    {{%- else %}}
+    <unix:group_id datatype="int" var_ref="var_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}"></unix:group_id>
+    {{%- endif %}}
   </unix:file_state>
   {{% endfor %}}
 
   <unix:file_state id="symlink_file_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>
+
+  {{%- if FILEGID != '0' %}}
+  <ind:textfilecontent54_object id="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" version="1" comment="gid of the dedicated {{{ FILEGID }}} group">
+  {{%- if product != 'rhcos4' -%}}
+    <ind:filepath>/etc/group</ind:filepath>
+  {{%- else %}}
+    {{# CoreOS doesn't list all groups in /etc/group - that's probably related to the FS immutability #}}
+    <ind:filepath>/usr/lib/group</ind:filepath>
+  {{%- endif %}}
+    <ind:pattern operation="pattern match">^{{{ FILEGID }}}:\w+:(\w+):.*</ind:pattern>
+    <ind:instance datatype="int" operation="equals">1</ind:instance>
+  </ind:textfilecontent54_object>
+
+  <!-- variable storing count of all group names - including duplicates -->
+  <local_variable id="var_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" datatype="int" version="1"
+                  comment="Count of all group names (including duplicates if any)">
+          <object_component item_field="subexpression" object_ref="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}"/>
+  </local_variable>
+  {{%- endif %}}
 </def-group>


### PR DESCRIPTION
#### Description:

- Use specific name in private key groups instead of gid.

#### Rationale:

- This is an attempt to fix the following three issues:

https://github.com/ComplianceAsCode/content/issues/10594
https://github.com/ComplianceAsCode/content/issues/10593
https://github.com/ComplianceAsCode/content/issues/10592

There is a upstream test ongoing that will help us to identify if the problem was really solved since this looks like some rules are affecting others and unit tests won't help in this case.