### PR TITLE
Add rules SLES-15-010375 and SLES-12-010375

### DIFF
--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/rule.yml
@@ -31,6 +31,8 @@ references:
     stigid@ol8: OL08-00-010375
     stigid@rhel7: RHEL-07-010375
     stigid@rhel8: RHEL-08-010375
+    stigid@sle12: SLES-12-010375
+    stigid@sle15: SLES-15-010375
 
 {{{ complete_ocil_entry_sysctl_option_value(sysctl="kernel.dmesg_restrict", value="1") }}}
 

--- a/products/sle12/profiles/stig.profile
+++ b/products/sle12/profiles/stig.profile
@@ -273,6 +273,7 @@ selections:
     - sudoers_validate_passwd
     - susefirewall2_ddos_protection
     - susefirewall2_only_required_services
+    - sysctl_kernel_dmesg_restrict
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_randomize_va_space
     - sysctl_net_ipv4_conf_all_accept_redirects

--- a/products/sle15/profiles/stig.profile
+++ b/products/sle15/profiles/stig.profile
@@ -269,6 +269,7 @@ selections:
     - sudo_require_reauthentication
     - sudoers_default_includedir
     - sudoers_validate_passwd
+    - sysctl_kernel_dmesg_restrict
     - sysctl_kernel_kptr_restrict
     - sysctl_kernel_randomize_va_space
     - sysctl_net_ipv4_conf_all_accept_redirects


### PR DESCRIPTION
#### Description:

- _Update rule sysctl_kernel_dmesg_restrict_

#### Rationale:

- _Accoring DISA recommendations Version 1, Release 9 from 26 January 2023 about SLE 15/12 STIG - "SLES-15-010375/SLES-12-010375 - Verify the operating system is configured to restrict access to the kernel message buffer."_