### PR TITLE
Remove ids from dedicated_ssh_keyowner in the product stability

### DIFF
--- a/tests/data/product_stability/rhel7.yml
+++ b/tests/data/product_stability/rhel7.yml
@@ -40,7 +40,6 @@ full_name: Red Hat Enterprise Linux 7
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '997'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat

--- a/tests/data/product_stability/rhel8.yml
+++ b/tests/data/product_stability/rhel8.yml
@@ -68,7 +68,6 @@ full_name: Red Hat Enterprise Linux 8
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '995'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/efi/EFI/redhat

--- a/tests/data/product_stability/rhel9.yml
+++ b/tests/data/product_stability/rhel9.yml
@@ -24,7 +24,6 @@ full_name: Red Hat Enterprise Linux 9
 gid_min: 1000
 groups:
   dedicated_ssh_keyowner:
-    id: '996'
     name: ssh_keys
 grub2_boot_path: /boot/grub2
 grub2_uefi_boot_path: /boot/grub2


### PR DESCRIPTION
#### Description:

Update the product stability tests by removing  the `dedicated_ssh_keyowner` ids.

Due to the ordering of the PRs this was not caught until both PRs were merged.

#### Rationale:

Ensure master is green.