### PR TITLE
Update CIS controls related to nftables table and chains

### DIFF
--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1209,14 +1209,25 @@ controls:
       - var_nftables_family=inet
       - var_nftables_table=filter
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5245
   - id: 3.4.2.6
     title: Ensure nftables base chains exist (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: pending
+    status: supported
+    notes: |-
+      RHEL systems use firewalld for firewall management. Although nftables is the default
+      back-end for firewalld, it is not recommended to use nftables directly when firewalld
+      is in use. When using firewalld the base chains are installed by default.
+    related_rules:
+      - set_nftables_base_chain
+      - var_nftables_table=firewalld
+      - var_nftables_family=inet
+      - var_nftables_base_chain_names=chain_names
+      - var_nftables_base_chain_types=chain_types
+      - var_nftables_base_chain_hooks=chain_hooks
+      - var_nftables_base_chain_priorities=chain_priorities
+      - var_nftables_base_chain_policies=chain_policies
 
   # NEEDS RULE
   # https://github.com/ComplianceAsCode/content/issues/5246

--- a/controls/cis_rhel8.yml
+++ b/controls/cis_rhel8.yml
@@ -1200,14 +1200,16 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: partial
+    status: supported
     notes:
-       The audit (OVAL check) cannot be automated,
-       and should be addressed manually.
+      RHEL systems use firewalld for firewall management. Although nftables is the default
+      back-end for firewalld, it is not recommended to use nftables directly when firewalld
+      is in use. firewalld uses the inet firewalld that is created when firewalld is installed.
+      The OVAL check cannot be automated but an SCE is availble.
     rules:
       - set_nftables_table
       - var_nftables_family=inet
-      - var_nftables_table=filter
+      - var_nftables_table=firewalld
 
   - id: 3.4.2.6
     title: Ensure nftables base chains exist (Automated)

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1103,14 +1103,16 @@ controls:
     levels:
       - l1_server
       - l1_workstation
-    status: partial
+    status: supported
     notes:
-       The audit (OVAL check) cannot be automated,
-       and should be addressed manually.
+      RHEL systems use firewalld for firewall management. Although nftables is the default
+      back-end for firewalld, it is not recommended to use nftables directly when firewalld
+      is in use. firewalld uses the inet firewalld that is created when firewalld is installed.
+      The OVAL check cannot be automated but an SCE is availble.
     rules:
       - set_nftables_table
       - var_nftables_family=inet
-      - var_nftables_table=filter
+      - var_nftables_table=firewalld
 
   - id: 3.4.2.3
     title: Ensure nftables base chains exist (Automated)

--- a/controls/cis_rhel9.yml
+++ b/controls/cis_rhel9.yml
@@ -1112,14 +1112,25 @@ controls:
       - var_nftables_family=inet
       - var_nftables_table=filter
 
-  # NEEDS RULE
-  # https://github.com/ComplianceAsCode/content/issues/5245
   - id: 3.4.2.3
     title: Ensure nftables base chains exist (Automated)
     levels:
       - l1_server
       - l1_workstation
-    status: pending
+    status: supported
+    notes: |-
+      RHEL systems use firewalld for firewall management. Although nftables is the default
+      back-end for firewalld, it is not recommended to use nftables directly when firewalld
+      is in use. When using firewalld the base chains are installed by default.
+    related_rules:
+      - set_nftables_base_chain
+      - var_nftables_table=firewalld
+      - var_nftables_family=inet
+      - var_nftables_base_chain_names=chain_names
+      - var_nftables_base_chain_types=chain_types
+      - var_nftables_base_chain_hooks=chain_hooks
+      - var_nftables_base_chain_priorities=chain_priorities
+      - var_nftables_base_chain_policies=chain_policies
 
   - id: 3.4.2.4
     title: Ensure host based firewall loopback traffic is configured (Automated)

--- a/linux_os/guide/system/network/network-nftables/var_nftables_table.var
+++ b/linux_os/guide/system/network/network-nftables/var_nftables_table.var
@@ -14,4 +14,5 @@ interactive: true
 
 options:
     default: filter
-    filter: filter 
+    filter: filter
+    firewalld: firewalld


### PR DESCRIPTION
#### Description:

Update CIS requirements about nftables table and base chains in RHEL8 and RHEL9.
RHEL systems use firewalld for firewall management. Although nftables is the default back-end for firewalld, it is not recommended to use nftables directly when firewalld is in use. 

- Ensure nftables base chains exist (Automated)
  - When using firewalld the base chains are installed by default.
- Ensure an nftables table exists (Automated)
  - firewalld uses the inet firewalld that is created when firewalld is installed. The OVAL check cannot be automated but an SCE is availble.

#### Rationale:

- More accurate CIS control files for RHEL8 and RHEL9
- Fixes #5245