### PR TITLE
Fix template not found error in Automatus

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -443,10 +443,13 @@ class RuleChecker(oscap.Checker):
 
     def _test_target(self):
         rules_to_test = self._get_rules_to_test()
+        source = self.rule_spec
+        if not self.rule_spec:
+            source = self.template_spec
         if not rules_to_test:
             logging.error("No tests found matching the {0}(s) '{1}'".format(
                 self.target_type,
-                ", ".join(self.rule_spec)))
+                ", ".join(source)))
             return
 
         test_content_by_rule_id = self._get_test_content_by_rule_id(


### PR DESCRIPTION


#### Description:

This PR adds logic to ensure that user friendly error is given to the user if the user gives an invalid template name to Automatus.

#### Rationale:

So that Automatus returns a nice error vs a traceback.
#### Review Hints:
The following command should reproduce
```
 ./automatus.py template --libvirt qemu:///system automatus_rhel_9_3 --datastream ../build/ssg-rhel9-ds.xml not_valid
```