### PR TITLE
Sync rules that contain a stig ID to those in stig profiles for ol products

### DIFF
--- a/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/rule.yml
+++ b/linux_os/guide/services/mail/postfix_client/postfix_client_configure_mail_alias/rule.yml
@@ -31,7 +31,6 @@ references:
     nist: CM-6(a)
     nist@sle12: AU-5(a),AU-5.1(ii)
     srg: SRG-OS-000046-GPOS-00022
-    stigid@ol8: OL08-00-030030
     stigid@sle12: SLES-12-020050
     stigid@sle15: SLES-15-030580
 

--- a/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_set_keepalive/rule.yml
@@ -57,7 +57,6 @@ references:
     pcidss: Req-8.1.8
     pcidss4: "8.2.8"
     srg: SRG-OS-000163-GPOS-00072,SRG-OS-000279-GPOS-00109
-    stigid@ol7: OL07-00-040340
     stigid@rhel8: RHEL-08-010200
     stigid@sle12: SLES-12-030191
     stigid@ubuntu2004: UBTU-20-010036

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -40,7 +40,6 @@ references:
     anssi: BP28(R32)
     disa: CCI-000196
     srg: SRG-OS-000073-GPOS-00041
-    stigid@ol8: OL08-00-010130
 
 ocil_clause: 'rounds is not set to {{{ xccdf_value("var_password_pam_unix_rounds") }}} or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -34,7 +34,6 @@ references:
   anssi: BP28(R32)
   disa: CCI-000196
   srg: SRG-OS-000073-GPOS-00041
-  stigid@ol8: OL08-00-010130
 
 ocil_clause: 'rounds is not set to {{{ xccdf_value("var_password_pam_unix_rounds") }}} or is commented out'
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
@@ -29,7 +29,6 @@ identifiers:
 references:
     disa: CCI-000366
     srg: SRG-OS-000480-GPOS-00227
-    stigid@ol7: OL07-00-020600
     stigid@ol8: OL08-00-010720
     stigid@rhel7: RHEL-07-020600
     stigid@rhel8: RHEL-08-010720

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_admin_space_left_action/rule.yml
@@ -54,7 +54,6 @@ references:
     pcidss: Req-10.7
     pcidss4: "10.5.1"
     srg: SRG-OS-000343-GPOS-00134
-    stigid@ol7: OL07-00-030340
 
 ocil_clause: 'there is no evidence that real-time alerts are configured on the system'
 

--- a/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
+++ b/linux_os/guide/system/auditing/configure_auditd_data_retention/auditd_data_retention_max_log_file_action/rule.yml
@@ -59,7 +59,6 @@ references:
     pcidss: Req-10.7
     pcidss4: "10.5.1"
     srg: SRG-OS-000047-GPOS-00023
-    stigid@ol8: OL08-00-030050
 
 ocil_clause: 'the value of the "max_log_file_action" option is set to "ignore", "rotate", or "suspend", or the line is commented out'
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configured_firewalld_default_deny/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/configured_firewalld_default_deny/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: alinux2,ol9,rhel8,rhel9
+prodtype: alinux2,ol8,ol9,rhel8,rhel9
 
 title: 'Firewalld Must Employ a Deny-all, Allow-by-exception Policy for Allowing Connections to Other Systems'
 

--- a/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
+++ b/linux_os/guide/system/permissions/restrictions/kernel_module_uvcvideo_disabled/rule.yml
@@ -19,7 +19,7 @@ references:
     disa: CCI-000381
     nist: CM-7 (a),CM-7 (5) (b)
     srg: SRG-OS-000095-GPOS-00049,SRG-OS-000370-GPOS-00155
-    stigid@l8: OL08-00-040020
+    stigid@ol8: OL08-00-040020
     stigid@rhel8: RHEL-08-040020
 
 platform: machine

--- a/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
+++ b/linux_os/guide/system/software/integrity/endpoint_security_software/mcafee_security_software/install_mcafee_antivirus/rule.yml
@@ -28,7 +28,6 @@ references:
     nist: CM-6(a),SC-28,SI-3(a)
     nist-csf: DE.CM-4,DE.DP-3,PR.DS-1
     srg: SRG-OS-000480-GPOS-00227
-    stigid@ol7: OL07-00-032000
     stigid@rhel7: RHEL-07-032000
 
 ocil_clause: 'virus scanning software is not installed or running'

--- a/linux_os/guide/system/software/system-tools/package_libreport-plugin-rhtsupport_removed/rule.yml
+++ b/linux_os/guide/system/software/system-tools/package_libreport-plugin-rhtsupport_removed/rule.yml
@@ -19,7 +19,6 @@ identifiers:
 references:
     disa: CCI-000381
     srg: SRG-OS-000095-GPOS-00049
-    stigid@ol8: OL08-00-040001
     stigid@rhel8: RHEL-08-040001
 
 {{{ complete_ocil_entry_package(package="libreport-plugin-rhtsupport") }}}

--- a/products/ol7/profiles/stig.profile
+++ b/products/ol7/profiles/stig.profile
@@ -334,7 +334,7 @@ selections:
     - auditd_audispd_remote_daemon_type
     - account_temp_expire_date
     - package_screen_installed
-    - sysctl_kernel_dmesg_restric
+    - sysctl_kernel_dmesg_restrict
     - authconfig_config_files_symlinks
     - ensure_oracle_gpgkey_installed
     - dconf_gnome_disable_user_list

--- a/products/ol8/profiles/stig.profile
+++ b/products/ol8/profiles/stig.profile
@@ -126,7 +126,6 @@ selections:
 
     # OL08-00-010130
     - set_password_hashing_min_rounds_logindefs
-    - accounts_password_pam_unix_rounds_system_auth
 
     # OL08-00-010140
     - grub2_uefi_password
@@ -965,6 +964,7 @@ selections:
     - package_abrt_removed
     - package_abrt-libs_removed
     - package_abrt-server-info-page_removed
+    - package_libreport-plugin-logger_removed
 
     # OL08-00-040002
     - package_sendmail_removed


### PR DESCRIPTION
#### Description:

- Added/removed Stig Id from rules
- Added/removed rules from stig profiles

#### Rationale:

- This ensures there are no rules with a STIG ID assigned but not used in STIG profile. At least in OL products

#### Review Hints:

- This is entirely about OL, no behavior change