### PR TITLE
Update pass aging rules to not ignore empty pass

### DIFF
--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/oval/shared.xml
@@ -33,7 +33,7 @@
   </unix:shadow_object>
 
   <unix:shadow_state id="filter_no_passwords_or_locked_accounts_max_life" version="1">
-      <unix:password operation="pattern match">^[^\!\*]+$</unix:password>
+      <unix:password operation="pattern match">^[^\!\*]*$</unix:password>
   </unix:shadow_state>
 
   <unix:shadow_state id="min_max_password_change_interval" version="1"

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/tests/incorrect_max_pass_age_empty_pass.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_max_life_existing/tests/incorrect_max_pass_age_empty_pass.fail.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# variables = var_accounts_minimum_age_login_defs=1,var_accounts_maximum_age_login_defs=60
+# make existing entries pass
+for acct in $(awk -F: '(/^[^:]+:[^!*]/ && ($5 > var || $5 == "")) {print $1}' /etc/shadow ); do
+    chage -M 60 -d $(date +%Y-%m-%d) $acct
+done
+# Add a failing test.
+# 9000 is picked as an arbitrarily large number.
+echo 'max-test-user::18648:1:9000::::' >> /etc/shadow
+echo "max-test-user:x:50000:1000::/:/usr/bin/bash" >> /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/oval/shared.xml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/oval/shared.xml
@@ -30,7 +30,7 @@
   </unix:shadow_object>
 
   <unix:shadow_state id="filter_no_passwords_or_locked_accounts_min_life" version="1">
-      <unix:password operation="pattern match">^[^\!\*]+$</unix:password>
+      <unix:password operation="pattern match">^[^\!\*]*$</unix:password>
   </unix:shadow_state>
 
   <unix:shadow_state id="max_min_password_change_interval" version="1" comment="change passwords every maximum interval or less">

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_min_pass_age_empty_pass.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/tests/incorrect_min_pass_age_empty_pass.fail.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# variables = var_accounts_minimum_age_login_defs=1
+# packages = passwd
+
+# make existing entries pass
+for acct in $(awk -F: '(/^[^:]+:[^!*]/ && ($4 < 1 || $4 == "")) {print $1}' /etc/shadow ); do
+    chage -m 1 -d $(date +%Y-%m-%d) $acct
+done
+# add a failing entry
+echo 'max-test-user::18648:0:60::::' >> /etc/shadow
+echo "max-test-user:x:50000:1000::/:/usr/bin/bash" >> /etc/passwd


### PR DESCRIPTION
#### Description:

- Update regex in `accounts_password_set_max_life_existing` & `accounts_password_set_min_life_existing` so empty passwords are not ignored

#### Rationale:

- Empty string can be a password and should be  treated the same as any other

#### Review Hints:

- The introduced tests should cover this new behavior