### PR TITLE
Products have uid_min, use it

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_authconfig.fail.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/smartcard_auth/tests/installed_with_authconfig.fail.sh
@@ -11,12 +11,12 @@ cat << EOF > "/etc/pam.d/system-auth"
 auth        required      pam_env.so
 auth        required      pam_faildelay.so delay=2000000
 auth        sufficient    pam_unix.so nullok try_first_pass
-auth        requisite     pam_succeed_if.so uid >= 1000 quiet_success
+auth        requisite     pam_succeed_if.so uid >= {{{ uid_min }}} quiet_success
 auth        required      pam_deny.so
 
 account     required      pam_unix.so
 account     sufficient    pam_localuser.so
-account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     sufficient    pam_succeed_if.so uid < {{{ uid_min }}} quiet
 account     required      pam_permit.so
 
 password    requisite     pam_pwquality.so try_first_pass local_users_only retry=3 authtok_type=
@@ -40,7 +40,7 @@ auth        required      pam_deny.so
 
 account     required      pam_unix.so
 account     sufficient    pam_localuser.so
-account     sufficient    pam_succeed_if.so uid < 1000 quiet
+account     sufficient    pam_succeed_if.so uid < {{{ uid_min }}} quiet
 account     required      pam_permit.so
 
 password    required      pam_pkcs11.so

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
     smithk:x:1000:1000:smithk:/home/smithk:/bin/bash
     throckw:x:1001:1001:throckw:/home/throckw:/bin/bash
 
-    Interactive user account, generally will have a UID of 1000 or greater, a home directory in a specific partition, and an interactive shell.
+    Interactive user account, generally will have a UID of {{{ uid_min }}} or greater, a home directory in a specific partition, and an interactive shell.
 
     Obtain the list of interactive user accounts authorized to be on the system from the System Administrator or Information System Security Officer (ISSO) and compare it to the list of local interactive user accounts on the system.
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/policy/stig/shared.yml
@@ -20,4 +20,4 @@ checktext: |-
 fixtext: |-
     Change the UID of any account on the system, other than root, that has a UID of "0".
 
-    If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "1000". Otherwise, assign a UID of greater than "1000" that has not already been assigned.
+    If the account is associated with system commands or applications, the UID should be changed to one greater than "0" but less than "{{{ uid_min }}}". Otherwise, assign a UID of greater than "{{{ uid_min }}}" that has not already been assigned.

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/rule.yml
@@ -8,8 +8,8 @@ description: |-
     their UID changed.
     <br />
     If the account is associated with system commands or applications the UID
-    should be changed to one greater than "0" but less than "1000."
-    Otherwise assign a UID greater than "1000" that has not already been
+    should be changed to one greater than "0" but less than "{{{ uid_min }}}."
+    Otherwise assign a UID greater than "{{{ uid_min }}}" that has not already been
     assigned.
 
 rationale: |-
@@ -72,7 +72,7 @@ ocil: |-
 fixtext: |-
     Change the UID of any account on the system, other than root, that has a UID of "0".
     If the account is associated with system commands or applications, the UID
-    should be changed to one greater than "0" but less than "1000". Otherwise,
-    assign a UID of greater than "1000" that has not already been assigned.
+    should be changed to one greater than "0" but less than "{{{ uid_min }}}". Otherwise,
+    assign a UID of greater than "{{{ uid_min }}}" that has not already been assigned.
 
 srg_requirement: 'The root account must be the only account having unrestricted access to the {{{ full_name }}} system.'

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_password_auth_for_systemaccounts/tests/sysaccounts_without_password.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_password_auth_for_systemaccounts/tests/sysaccounts_without_password.pass.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# lock all system accounts (ID < 1000) from /etc/passwd
+# lock all system accounts (ID < {{{ uid_min }}}) from /etc/passwd
 readarray -t systemaccounts < <(awk -F: \
   '($3 < {{{ uid_min }}} && $3 != root && $3 != halt && $3 != sync && $3 != shutdown \
   && $3 != nfsnobody) { print $1 }' /etc/passwd)

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/policy/stig/shared.yml
@@ -8,7 +8,7 @@ vuldiscussion: |-
 checktext: |-
     Verify that system accounts must not have an interactive login shell with the following command:
 
-    $ awk -F: '($3&lt;1000){print $1 ":" $3 ":" $7}' /etc/passwd
+    $ awk -F: '($3&lt;{{{ uid_min }}}){print $1 ":" $3 ":" $7}' /etc/passwd
 
     root:0:/bin/bash
     bin:1:/sbin/nologin

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_max.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_max.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=SYS_UID_MAX
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_sys_uid_min.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=SYS_UID_MIN
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/first_uid_min.pass.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=UID_MIN
 
 # Add key as 1st line, drop others
 sed -Ei '
 1{i\
-'"$key"' 1000
+'"$key"' {{{ uid_min }}}
 }
 /^(SYS_)?UID_(MIN|MAX)/d;
 ' /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_max.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_max.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=SYS_UID_MAX
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_sys_uid_min.pass.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=SYS_UID_MIN
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/last_uid_min.pass.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=UID_MIN
 
 # Add bogus key as 2nd last and valid last line w/o nl
 # drop SYS_UID so it does not mess
 sed -Ei '/^SYS_UID_(MIN|MAX)/d;' /etc/login.defs
-printf "%s 2000\n%s 1000" "$key" "$key" >> /etc/login.defs
+printf "%s 2000\n%s {{{ uid_min }}}" "$key" "$key" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/space_uid_min.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/no_shelllogin_for_systemaccounts/tests/space_uid_min.pass.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 useradd --system --shell /sbin/nologin -u 999 sysuser
-useradd -u 1000 testuser
+useradd -u {{{ uid_min }}} testuser
 
 key=UID_MIN
 
 # Add bogus key as 2nd last and valid last line w/o nl
 # drop SYS_UID so it does not mess
 sed -Ei '/^SYS_UID_(MIN|MAX)/d;' /etc/login.defs
-printf "%s 2000\n\t%s 1000\n" "$key" "$key" >> /etc/login.defs
+printf "%s 2000\n\t%s {{{ uid_min }}}\n" "$key" "$key" >> /etc/login.defs

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_group_ownership/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/bash/shared.sh
@@ -5,7 +5,7 @@
 # disruption = low
 
 readarray -t world_writable_files < <(find / -xdev -type f -perm -0002 2> /dev/null)
-readarray -t interactive_home_dirs < <(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6 }' /etc/passwd)
+readarray -t interactive_home_dirs < <(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $6 }' /etc/passwd)
 
 for world_writable in "${world_writable_files[@]}"; do
     for homedir in "${interactive_home_dirs[@]}"; do

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/bash/shared.sh
@@ -5,7 +5,7 @@
 # disruption = low
 
 readarray -t world_writable_files < <(find / -xdev -type f -perm -0002 2> /dev/null)
-readarray -t interactive_home_dirs < <(awk -F':' '{ if ($3 >= 1000 && $3 != 65534) print $6 }' /etc/passwd)
+readarray -t interactive_home_dirs < <(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6 }' /etc/passwd)
 
 for world_writable in "${world_writable_files[@]}"; do
     for homedir in "${interactive_home_dirs[@]}"; do

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_no_world_writable_programs/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/ansible/shared.yml
@@ -7,4 +7,4 @@
 - name: Ensure interactive local users are the owners of their respective initialization files
   ansible.builtin.command:
     cmd: |
-      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd
+      awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/bash/shared.sh
@@ -4,4 +4,4 @@
 # complexity = low
 # disruption = low
 
-awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd
+awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) system("chown -f " $3" "$6"/.[^\.]?*") }' /etc/passwd

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_dot_user_ownership/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/ansible/shared.yml
@@ -21,5 +21,5 @@
   loop: '{{ local_users }}'
   when:
     - item.value[2]|int >= {{{ uid_min }}}
-    - item.value[2]|int != 65534
+    - item.value[2]|int != {{{ nobody_uid }}}
     - not item.value[4] | regex_search('^\/\w*\/\w{1,}')

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($4 >= {{{ uid_min }}} && $4 != 65534) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != 65534) print $1 }' /etc/passwd); do
     # This follows the same logic of evaluation of home directories as used in OVAL.
     if ! grep -q $user /etc/passwd | cut -d: -f6 | grep '^\/\w*\/\w\{1,\}'; then
         sed -i "s/\($user:x:[0-9]*:[0-9]*:.*:\).*\(:.*\)$/\1\/home\/$user\2/g" /etc/passwd;

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != 65534) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $1 }' /etc/passwd); do
     # This follows the same logic of evaluation of home directories as used in OVAL.
     if ! grep -q $user /etc/passwd | cut -d: -f6 | grep '^\/\w*\/\w\{1,\}'; then
         sed -i "s/\($user:x:[0-9]*:[0-9]*:.*:\).*\(:.*\)$/\1\/home\/$user\2/g" /etc/passwd;

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($4 >= {{{ gid_min }}} && $4 != {{{ nobody_gid }}}) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1 }' /etc/passwd); do
     # This follows the same logic of evaluation of home directories as used in OVAL.
     if ! grep -q $user /etc/passwd | cut -d: -f6 | grep '^\/\w*\/\w\{1,\}'; then
         sed -i "s/\($user:x:[0-9]*:[0-9]*:.*:\).*\(:.*\)$/\1\/home\/$user\2/g" /etc/passwd;

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/policy/stig/shared.yml
@@ -13,7 +13,7 @@ checktext: |-
     smithk:x:1000:1000:smithk:/home/smithk:/bin/bash
     throckw:x:1001:1001:throckw:/home/throckw:/bin/bash
 
-    Inspect the output and verify that all interactive users (normally users with a UID greater that 1000) have a home directory defined.
+    Inspect the output and verify that all interactive users (normally users with a UID greater than 1000) have a home directory defined.
 
     If users home directory is not defined, this is a finding.
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/policy/stig/shared.yml
@@ -8,12 +8,12 @@ vuldiscussion: |-
 checktext: |-
     Verify that interactive users on the system have a home directory assigned with the following command:
 
-    $ sudo awk -F: '($3&gt;=1000)&&($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd
+    $ sudo awk -F: '($3&gt;={{{ uid_min }}})&&($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd
 
     smithk:x:1000:1000:smithk:/home/smithk:/bin/bash
     throckw:x:1001:1001:throckw:/home/throckw:/bin/bash
 
-    Inspect the output and verify that all interactive users (normally users with a UID greater than 1000) have a home directory defined.
+    Inspect the output and verify that all interactive users (normally users with a UID greater than {{{ uid_min }}}) have a home directory defined.
 
     If users home directory is not defined, this is a finding.
 

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
@@ -40,9 +40,9 @@ ocil_clause: 'users home directory is not defined'
 ocil: |-
     Verify that interactive users on the system have a home directory assigned with the following command:
 
-    <pre>$ sudo awk -F: '($3&gt;=1000)&amp;&amp;($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd</pre>
+    <pre>$ sudo awk -F: '($3&gt;={{{ uid_min }}})&amp;&amp;($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd</pre>
 
-    Inspect the output and verify that all interactive users (normally users with a UID greater than 1000) have a home directory defined.
+    Inspect the output and verify that all interactive users (normally users with a UID greater than {{{ uid_min }}}) have a home directory defined.
 
 fixtext: |-
     Assign home directories to all local interactive users on {{{ full_name }}} that currently do not have a home directory assigned.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/rule.yml
@@ -42,7 +42,7 @@ ocil: |-
 
     <pre>$ sudo awk -F: '($3&gt;=1000)&amp;&amp;($7 !~ /nologin/){print $1, $3, $6}' /etc/passwd</pre>
 
-    Inspect the output and verify that all interactive users (normally users with a UID greater that 1000) have a home directory defined.
+    Inspect the output and verify that all interactive users (normally users with a UID greater than 1000) have a home directory defined.
 
 fixtext: |-
     Assign home directories to all local interactive users on {{{ full_name }}} that currently do not have a home directory assigned.

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_defined/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/ansible/shared.yml
@@ -20,4 +20,4 @@
   loop: '{{ local_users }}'
   when:
     - item.value[2]|int >= {{{ uid_min }}}
-    - item.value[2]|int != 65534
+    - item.value[2]|int != {{{ nobody_uid }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/bash/shared.sh
@@ -4,6 +4,6 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $1}' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1}' /etc/passwd); do
     mkhomedir_helper $user 0077;
 done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/home_dir_present.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/home_dir_present.pass.sh
@@ -5,6 +5,6 @@ useradd -m $USER
 
 # This is to make sure that any possible user create in the test environment has also
 # a home dir created on the system.
-for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $1}' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1}' /etc/passwd); do
     mkhomedir_helper $user 0077;
 done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_user_interactive_home_directory_exists/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_groupownership/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1 }' /etc/passwd); do
     home_dir=$(getent passwd $user | cut -d: -f6)
     # Only update the ownership when necessary. This will avoid changing the inode timestamp
     # when the owner is already defined as expected, therefore not impacting in possible integrity

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_ownership/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_home_files_permissions/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_netrc_file_permissions/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_netrc_file_permissions/ansible/shared.yml
@@ -20,7 +20,7 @@
   loop: '{{ local_users }}'
   when:
     - item.value[1]|int >= {{{ uid_min }}}
-    - item.value[1]|int != 65534
+    - item.value[1]|int != {{{ nobody_uid }}}
 
 - name: Ensure group and world cannot access respective .netrc files
   ansible.builtin.file:

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_netrc_file_permissions/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_netrc_file_permissions/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $1 }' /etc/passwd); do
+for user in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $1 }' /etc/passwd); do
     home_dir=$(getent passwd "$user" | cut -d: -f6)
     find "${home_dir}/.netrc" -exec chmod 0600 {} \;
 done

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_netrc_file_permissions/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_netrc_file_permissions/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/policy/stig/shared.yml
@@ -12,7 +12,7 @@ checktext: |-
 
     Note: This may miss local interactive users that have been assigned a privileged UID. Evidence of interactive use may be obtained from a number of log files containing system logon information. The returned directory "/home/smithj" is used as an example.
 
-    $ sudo ls -ld $(awk -F: '($3>=1000)&&($7 !~ /nologin/){print $6}' /etc/passwd)
+    $ sudo ls -ld $(awk -F: '($3>={{{ uid_min }}})&&($7 !~ /nologin/){print $6}' /etc/passwd)
 
     drwxr-x--- 2 smithj admin 4096 Jun 5 12:41 smithj
 

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/rule.yml
@@ -52,7 +52,7 @@ ocil_clause: 'the group ownership is incorrect'
 ocil: |-
     To verify the assigned home directory of all interactive users is group-
     owned by that users primary GID, run the following command:
-    <pre># ls -ld $(awk -F: '($3&gt;=1000)&amp;&amp;($7 !~ /nologin/){print $6}' /etc/passwd)</pre>
+    <pre># ls -ld $(awk -F: '($3&gt;={{{ uid_min }}})&amp;&amp;($7 !~ /nologin/){print $6}' /etc/passwd)</pre>
 
 fixtext: |-
     Change the group owner of a local interactive user’s home directory to the group found in "/etc/passwd". To change the group owner of a local interactive user’s home directory, use the following command:

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_home_directories/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/rule.yml
@@ -46,7 +46,7 @@ ocil_clause: 'the user ownership is incorrect'
 
 ocil: |-
     To verify the home directory ownership, run the following command:
-    <pre># ls -ld $(awk -F: '($3&gt;=1000)&amp;&amp;($7 !~ /nologin/){print $6}' /etc/passwd)</pre>
+    <pre># ls -ld $(awk -F: '($3&gt;={{{ uid_min }}})&amp;&amp;($7 !~ /nologin/){print $6}' /etc/passwd)</pre>
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_ownership_home_directories/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/policy/stig/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/policy/stig/shared.yml
@@ -10,7 +10,7 @@ checktext: |-
 
     Note: This may miss interactive users that have been assigned a privileged User Identifier (UID). Evidence of interactive use may be obtained from a number of log files containing system logon information.
 
-    $ sudo ls -ld $(awk -F: '($3&gt;=1000)&&($7 !~ /nologin/){print $6}' /etc/passwd)
+    $ sudo ls -ld $(awk -F: '($3&gt;={{{ uid_min }}})&&($7 !~ /nologin/){print $6}' /etc/passwd)
 
     drwxr-x--- 2 smithj admin 4096 Jun 5 12:41 smithj
 

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_directories/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/file_permissions_home_dirs/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/ansible/shared.yml
@@ -7,7 +7,7 @@
 - name: Ensure interactive local users are the owners of their respective initialization files
   ansible.builtin.shell:
     cmd: |
-      for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != 65534) print $6}' /etc/passwd); do
+      for dir in $(awk -F':' '{ if ($3 >= {{{ uid_min }}} && $3 != {{{ nobody_uid }}}) print $6}' /etc/passwd); do
         for file in $(find $dir -maxdepth 1 -type f -name ".*"); do
           if [ "$(basename $file)" != ".bash_history" ]; then
             sed -i 's/^\([\s]*umask\s*\)/#\1/g' $file

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/bash/shared.sh
@@ -4,7 +4,7 @@
 # complexity = low
 # disruption = low
 
-{{% call iterate_over_command_output("dir", "awk -F':' '{ if ($3 >= " ~ uid_min ~ " && $3 != 65534) print $6}' /etc/passwd") -%}}
+{{% call iterate_over_command_output("dir", "awk -F':' '{ if ($3 >= " ~ uid_min ~ " && $3 != " ~ nobody_uid ~ ") print $6}' /etc/passwd") -%}}
 {{% call iterate_over_find_output("file", '$dir -maxdepth 1 -type f -name ".*"') -%}}
 if [ "$(basename $file)" != ".bash_history" ]; then
     sed -i 's/^\([\s]*umask\s*\)/#\1/g' "$file"

--- a/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_users_absent.pass.sh
+++ b/linux_os/guide/system/accounts/accounts-session/user_umask/accounts_umask_interactive_users/tests/interactive_users_absent.pass.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
-# remove all interactive users (ID >= 1000) from /etc/passwd
-sed -i '/.*:[0-9]\{4,\}:/d' /etc/passwd
+{{{ bash_remove_interactive_users_from_passwd_by_uid() }}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chmod/policy/stig/shared.yml
@@ -15,8 +15,8 @@ checktext: |-
 
     $ sudo auditctl -l | grep chmod
 
-    -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     If both the "b32" and "b64" audit rules are not defined for the "chmod", "fchmod", and "fchmodat" syscalls, this is a finding.
 
@@ -25,8 +25,8 @@ fixtext: |-
 
     Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S chmod,fchmod,fchmodat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
-    -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S chmod,fchmod,fchmodat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_chown/policy/stig/shared.yml
@@ -15,8 +15,8 @@ checktext: |-
 
     $ sudo auditctl -l | grep chown
 
-    -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     If both the "b32" and "b64" audit rules are not defined for the "chown", "fchown", "fchownat", and "lchown" syscalls, this is a finding.
 
@@ -25,7 +25,7 @@ fixtext: |-
 
     Add or update the following rules in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S chown,fchown,fchownat,lchown -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmod/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchmod" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S fchmod -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S fchmod -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S fchmod -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S fchmod -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "chmod", "fchmod" and "fchmodat".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchmodat/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchmodat" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S fchmodat -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S fchmodat -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S fchmodat -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S fchmodat -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "chmod", "fchmod" and "fchmodat".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchown/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchown" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S fchown -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S fchown -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S fchown -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S fchown -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "chown", "fchown", "fchownat" and "lchown".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fchownat/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchownat" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S fchownat -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S fchownat -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S fchownat -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S fchownat -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "chown", "fchown", "fchownat" and "lchown".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fremovexattr/policy/stig/shared.yml
@@ -15,8 +15,8 @@ checktext: |-
 
     $ sudo auditctl -l | grep xattr
 
-    -a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     -a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod
     -a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod
@@ -26,8 +26,8 @@ checktext: |-
 fixtext: |-
     Configure {{{ full_name }}} to audit the execution of the "setxattr", "fsetxattr", "lsetxattr", "removexattr", "fremovexattr", and "lremovexattr" system calls by adding or updating the following lines to "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     -a always,exit -F arch=b32 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod
     -a always,exit -F arch=b64 -S setxattr,fsetxattr,lsetxattr,removexattr,fremovexattr,lremovexattr -F auid=0 -k perm_mod

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_fsetxattr/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fsetxattr" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S fsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S fsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S fsetxattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S fsetxattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "fremovexattr", "lremovexattr", "removexattr", "fsetxattr", "lsetxattr" and "setxattr".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lchown/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "lchown" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S lchown -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S lchown -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S lchown -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S lchown -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "chown", "fchown", "fchownat" and "lchown".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lremovexattr/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "lremovexattr" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S lremovexattr -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S lremovexattr -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S lremovexattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S lremovexattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "fremovexattr", "lremovexattr", "removexattr", "fsetxattr", "lsetxattr" and "setxattr".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_lsetxattr/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "lsetxattr" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S lsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S lsetxattr -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S lsetxattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S lsetxattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "fremovexattr", "lremovexattr", "removexattr", "fsetxattr", "lsetxattr" and "setxattr".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_removexattr/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "removexattr" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S removexattr -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S removexattr -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S removexattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S removexattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "fremovexattr", "lremovexattr", "removexattr", "fsetxattr", "lsetxattr" and "setxattr".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_setxattr/policy/stig/shared.yml
@@ -18,8 +18,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "setxattr" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S setxattr -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S setxattr -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S setxattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S setxattr -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     It's allowed to group this system call within the same line as "fremovexattr", "lremovexattr", "removexattr", "fsetxattr", "lsetxattr" and "setxattr".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/policy/stig/shared.yml
@@ -13,12 +13,12 @@ checktext: |-
     "umount" system call, run the following command:
      $ sudo grep "umount" /etc/audit/audit.*
     If the system is configured to audit this activity, it will return a line like the following.
-    -a always,exit -F arch=b32 -S umount -F auid>=1000 -F auid!=unset -k privileged-umount
+    -a always,exit -F arch=b32 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -k privileged-umount
 
     If the command does not return a line, or the line is commented out, then this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "umount" system call by adding or updating the following rules in "/etc/audit/audit.rules" and adding the following rules to "/etc/audit/rules.d/perm_mod.rules" or updating the existing rules in files in the "/etc/audit/rules.d/" directory:
 
-    -a always,exit -F arch=b32 -S umount -F auid>=1000 -F auid!=unset -k perm_mod -a always,exit -F arch=b64 -S umount -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod -a always,exit -F arch=b64 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount/rule.yml
@@ -42,7 +42,7 @@ ocil: |-
     "umount" system call, run the following command:
     <pre space="preserve">$ sudo grep "umount" /etc/audit/audit.*</pre>
     If the system is configured to audit this activity, it will return a line like the following.
-    -a always,exit -F arch=b32 -S umount -F auid>=1000 -F auid!=unset -k privileged-umount
+    -a always,exit -F arch=b32 -S umount -F auid>={{{ uid_min }}} -F auid!=unset -k privileged-umount
 
 warnings:
     - general: |-

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_dac_actions/audit_rules_dac_modification_umount2/policy/stig/shared.yml
@@ -20,7 +20,7 @@ fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "umount2" system call by adding or updating the following rules in "/etc/audit/audit.rules" and adding the following rules to "/etc/audit/rules.d/perm_mod.rules" or updating the existing rules in files in the "/etc/audit/rules.d/" directory:
 
 
-    -a always,exit -F arch=b32 -S umount2 -F auid>=1000 -F auid!=unset -k perm_mod
-    -a always,exit -F arch=b64 -S umount2 -F auid>=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b32 -S umount2 -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
+    -a always,exit -F arch=b64 -S umount2 -F auid>={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_chacl/policy/stig/shared.yml
@@ -15,7 +15,7 @@ checktext: |-
 
     $ sudo auditctl -l | grep chacl
 
-    -a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     If the command does not return a line, or the line is commented out, this is a finding.
     If , this is a finding.
@@ -23,6 +23,6 @@ checktext: |-
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "chacl" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_acl_commands/audit_rules_execution_setfacl/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep setfacl
 
-    -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "setfacl" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_chcon/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep chcon
 
-    -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "chcon" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=unset -k perm_mod
+    -a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_mod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_semanage/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep semanage
 
-    -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "semanage" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/semanage -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setfiles/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep setfiles
 
-    -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "setfiles" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/setfiles -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_execution_selinux_commands/audit_rules_execution_setsebool/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep setsebool
 
-     -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=privileged
+     -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -F key=privileged
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate an audit event for any successful/unsuccessful use of the "setsebool " command by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=privileged
+    -a always,exit -F path=/usr/sbin/setsebool -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -F key=privileged
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rename/policy/stig/shared.yml
@@ -15,15 +15,15 @@ checktext: |-
 
     $ sudo auditctl -l | grep 'rename\|unlink\|rmdir'
 
-    -a always,exit -F arch=b32 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;=1000 -F auid!=unset -k delete
-    -a always,exit -F arch=b64 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;=1000 -F auid!=unset -k delete
+    -a always,exit -F arch=b32 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k delete
+    -a always,exit -F arch=b64 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k delete
 
     If the command does not return an audit rule for "rename", "unlink", "rmdir", "renameat", and "unlinkat" or any of the lines returned are commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate an audit event for any successful/unsuccessful use of the "rename", "unlink", "rmdir", "renameat", and "unlinkat" system calls by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F arch=b32 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;=1000 -F auid!=unset -k delete
-    -a always,exit -F arch=b64 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;=1000 -F auid!=unset -k delete
+    -a always,exit -F arch=b32 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k delete
+    -a always,exit -F arch=b64 -S rename,unlink,rmdir,renameat,unlinkat -F auid&gt;={{{ uid_min }}} -F auid!=unset -k delete
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_renameat/policy/stig/shared.yml
@@ -17,8 +17,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "renameat" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S renameat -F auid>=1000 -F auid!=unset -k delete
-    -a always,exit -F arch=b64 -S renameat -F auid>=1000 -F auid!=unset -k delete
+    -a always,exit -F arch=b32 -S renameat -F auid>={{{ uid_min }}} -F auid!=unset -k delete
+    -a always,exit -F arch=b64 -S renameat -F auid>={{{ uid_min }}} -F auid!=unset -k delete
 
     It's allowed to group this system call within the same line as "rename", "unlink", "rmdir", "renameat", and "unlinkat".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_rmdir/policy/stig/shared.yml
@@ -17,8 +17,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "rmdir" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S rmdir -F auid>=1000 -F auid!=unset -k delete
-    -a always,exit -F arch=b64 -S rmdir -F auid>=1000 -F auid!=unset -k delete
+    -a always,exit -F arch=b32 -S rmdir -F auid>={{{ uid_min }}} -F auid!=unset -k delete
+    -a always,exit -F arch=b64 -S rmdir -F auid>={{{ uid_min }}} -F auid!=unset -k delete
 
     It's allowed to group this system call within the same line as "rename", "unlink", "rmdir", "renameat", and "unlinkat".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlink/policy/stig/shared.yml
@@ -17,8 +17,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "unlink" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S unlink -F auid>=1000 -F auid!=unset -k delete
-    -a always,exit -F arch=b64 -S unlink -F auid>=1000 -F auid!=unset -k delete
+    -a always,exit -F arch=b32 -S unlink -F auid>={{{ uid_min }}} -F auid!=unset -k delete
+    -a always,exit -F arch=b64 -S unlink -F auid>={{{ uid_min }}} -F auid!=unset -k delete
 
     It's allowed to group this system call within the same line as "rename", "unlink", "rmdir", "renameat", and "unlinkat".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_deletion_events/audit_rules_file_deletion_events_unlinkat/policy/stig/shared.yml
@@ -17,8 +17,8 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "unlinkat" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S unlinkat -F auid>=1000 -F auid!=unset -k delete
-    -a always,exit -F arch=b64 -S unlinkat -F auid>=1000 -F auid!=unset -k delete
+    -a always,exit -F arch=b32 -S unlinkat -F auid>={{{ uid_min }}} -F auid!=unset -k delete
+    -a always,exit -F arch=b64 -S unlinkat -F auid>={{{ uid_min }}} -F auid!=unset -k delete
 
     It's allowed to group this system call within the same line as "rename", "unlink", "rmdir", "renameat", and "unlinkat".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/test_audit.rules
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification/tests/test_audit.rules
@@ -1,39 +1,39 @@
 # WARNING: Do not remove the comments in this file
 # one per line
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
 
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
 
 # multiple per arg
--a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat,open,openat,open_by_handle_at,truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
 
 # one per arg
--a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
--a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b32 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access
+-a always,exit -F arch=b64 -S creat -S open -S openat -S open_by_handle_at -S truncate -S ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_creat/policy/stig/shared.yml
@@ -15,11 +15,11 @@ checktext: |-
 
     $ sudo auditctl -l | grep'open\|truncate\|creat'
 
-    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
 
     If the output does not produce rules containing "-F exit=-EPERM", this is a finding.
     If the output does not produce rules containing "-F exit=-EACCES", this is a finding.
@@ -28,10 +28,10 @@ checktext: |-
 fixtext: |-
     Configure {{{ full_name }}} to generate an audit event for any successful/unsuccessful use of the "truncate", "ftruncate", "creat", "open", "openat", and "open_by_handle_at" system calls by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EPERM -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate,ftruncate,creat,open,openat,open_by_handle_at -F exit=-EACCES -F auid&gt;={{{ uid_min }}} -F auid!=unset -k perm_access
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_ftruncate/policy/stig/shared.yml
@@ -16,11 +16,11 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "ftruncate" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
     It's allowed to group this system call within the same line as "creat", "ftruncate", "truncate", "open", "openat" and "open_by_handle_at".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open/policy/stig/shared.yml
@@ -16,11 +16,11 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "open" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
     It's allowed to group this system call within the same line as "creat", "ftruncate", "truncate", "open", "openat" and "open_by_handle_at".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at/policy/stig/shared.yml
@@ -16,11 +16,11 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "open_by_handle_at" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
     It's allowed to group this system call within the same line as "creat", "ftruncate", "truncate", "open", "openat" and "open_by_handle_at".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_by_handle_at_o_trunc_write/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_open_o_trunc_write/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat/policy/stig/shared.yml
@@ -16,11 +16,11 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "openat" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
     It's allowed to group this system call within the same line as "creat", "ftruncate", "truncate", "open", "openat" and "open_by_handle_at".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_creat/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_openat_o_trunc_write/ansible/shared.yml
@@ -17,35 +17,35 @@
         ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
         ## Unsuccessful file creation (open with O_CREAT)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
-        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+        -a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
         ## Unsuccessful file modifications (open for write or truncate)
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
-        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+        -a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
         ## Unsuccessful file access (any other opens) This has to go last.
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
-        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+        -a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat/rule.yml
@@ -28,8 +28,8 @@ description: |-
     Add or update the following lines to <tt>/etc/audit/rules.d/audit.rules</tt> to configure the operating system to generate
     an audit record for all uses of the <tt>renameat</tt> system call:
     <pre>
-    -a always,exit -F arch=b32 -S renameat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-    -a always,exit -F arch=b64 -S renameat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+    -a always,exit -F arch=b32 -S renameat -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
+    -a always,exit -F arch=b64 -S renameat -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
     </pre>
     {{% endif %}}
 rationale: |-
@@ -84,8 +84,8 @@ warnings:
         <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
         {{% else %}}
         <pre>
-        -a always,exit -F arch=b32 -S renameat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        -a always,exit -F arch=b64 -S renameat -F auid>=1000 -F auid!=4294967295 -k perm_mod
+        -a always,exit -F arch=b32 -S renameat -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
+        -a always,exit -F arch=b64 -S renameat -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
         </pre>
         {{% endif %}}
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_renameat2/rule.yml
@@ -12,8 +12,8 @@ description: |-
     Add or update the following lines to <tt>/etc/audit/rules.d/audit.rules</tt> to configure the operating system to generate 
     an audit record for all uses of the <tt>renameat2</tt> system call:  
     <pre>
-    -a always,exit -F arch=b32 -S renameat2 -F auid>=1000 -F auid!=-1 -k perm_mod
-    -a always,exit -F arch=b64 -S renameat2 -F auid>=1000 -F auid!=-1 -k perm_mod</pre>
+    -a always,exit -F arch=b32 -S renameat2 -F auid>={{{ uid_min }}} -F auid!=-1 -k perm_mod
+    -a always,exit -F arch=b64 -S renameat2 -F auid>={{{ uid_min }}} -F auid!=-1 -k perm_mod</pre>
 
 rationale: |-
     Unsuccessful attempts to delete files could be an indicator of malicious activity on a system. Auditing
@@ -39,8 +39,8 @@ warnings:
         have been placed independent of other system calls. Grouping system calls related
         to the same event is more efficient. See the following example:
         <pre>
-        -a always,exit -F arch=b32 -S renameat2 -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        -a always,exit -F arch=b64 -S renameat2 -F auid>=1000 -F auid!=4294967295 -k perm_mod</pre>
+        -a always,exit -F arch=b32 -S renameat2 -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
+        -a always,exit -F arch=b64 -S renameat2 -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod</pre>
 
 template:
     name: audit_rules_unsuccessful_file_modification

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_truncate/policy/stig/shared.yml
@@ -16,11 +16,11 @@ checktext: |-
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful use of the "truncate" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
-    -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
-    -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
-    -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -k perm_access
+    -a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
+    -a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k perm_access
 
     It's allowed to group this system call within the same line as "creat", "ftruncate", "truncate", "open", "openat" and "open_by_handle_at".
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlink/rule.yml
@@ -30,8 +30,8 @@ description: |-
     Add or update the following lines to <tt>/etc/audit/rules.d/audit.rules</tt> to configure the operating system to generate
     an audit record for all uses of the <tt>unlink</tt> system call:
     <pre>
-    -a always,exit -F arch=b32 -S unlink -F auid>=1000 -F auid!=-1 -k perm_mod
-    -a always,exit -F arch=b64 -S unlink -F auid>=1000 -F auid!=-1 -k perm_mod </pre>
+    -a always,exit -F arch=b32 -S unlink -F auid>={{{ uid_min }}} -F auid!=-1 -k perm_mod
+    -a always,exit -F arch=b64 -S unlink -F auid>={{{ uid_min }}} -F auid!=-1 -k perm_mod </pre>
     {{% endif %}}
 
 rationale: |-
@@ -87,8 +87,8 @@ warnings:
         <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
         {{% else %}}
         <pre>
-        -a always,exit -F arch=b32 -S unlink -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        -a always,exit -F arch=b64 -S unlink -F auid>=1000 -F auid!=4294967295 -k perm_mod</pre>
+        -a always,exit -F arch=b32 -S unlink -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
+        -a always,exit -F arch=b64 -S unlink -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod</pre>
         {{% endif %}}
 
 template:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_file_modification/audit_rules_unsuccessful_file_modification_unlinkat/rule.yml
@@ -30,8 +30,8 @@ description: |-
     Add or update the following lines to <tt>/etc/audit/rules.d/audit.rules</tt> to configure the operating system to generate
     an audit record for all uses of the <tt>unlinkat</tt> system call:
     <pre>
-    -a always,exit -F arch=b32 -S unlinkat -F auid>=1000 -F auid!=-1 -k perm_mod
-    -a always,exit -F arch=b64 -S unlinkat -F auid>=1000 -F auid!=-1 -k perm_mod</pre>
+    -a always,exit -F arch=b32 -S unlinkat -F auid>={{{ uid_min }}} -F auid!=-1 -k perm_mod
+    -a always,exit -F arch=b64 -S unlinkat -F auid>={{{ uid_min }}} -F auid!=-1 -k perm_mod</pre>
     {{% endif %}}
 
 rationale: |-
@@ -87,8 +87,8 @@ warnings:
         <pre>-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>={{{ auid }}} -F auid!=unset -F key=unsuccesful-delete</pre>
         {{% else %}}
         <pre>
-        -a always,exit -F arch=b32 -S unlinkat -F auid>=1000 -F auid!=4294967295 -k perm_mod
-        -a always,exit -F arch=b64 -S unlinkat -F auid>=1000 -F auid!=4294967295 -k perm_mod</pre>
+        -a always,exit -F arch=b32 -S unlinkat -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod
+        -a always,exit -F arch=b64 -S unlinkat -F auid>={{{ uid_min }}} -F auid!=4294967295 -k perm_mod</pre>
         {{% endif %}}
 
 template:

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_multiple_per_arg.pass.sh
@@ -11,5 +11,5 @@ rm -f /etc/audit/rules.d/*
 sed '1,8d' test_audit.rules > /etc/audit/audit.rules
 sed -i '4,7d' /etc/audit/audit.rules
 {{% if 'ol' in product or 'rhel' in product %}}
-sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
+sed -i 's/-k modules/-F auid>={{{ uid_min }}} -F auid!=unset -k modules/g' /etc/audit/audit.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_arg.pass.sh
@@ -10,5 +10,5 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,12d' test_audit.rules > /etc/audit/audit.rules
 {{% if 'ol' in product or 'rhel' in product %}}
-sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
+sed -i 's/-k modules/-F auid>={{{ uid_min }}} -F auid!=unset -k modules/g' /etc/audit/audit.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/auditctl_syscalls_one_per_line.pass.sh
@@ -10,5 +10,5 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '8,15d' test_audit.rules > /etc/audit/audit.rules
 {{% if 'ol' in product or 'rhel' in product %}}
-sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/audit.rules
+sed -i 's/-k modules/-F auid>={{{ uid_min }}} -F auid!=unset -k modules/g' /etc/audit/audit.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_multiple_per_arg.pass.sh
@@ -8,5 +8,5 @@ rm -f /etc/audit/rules.d/*
 sed '1,8d' test_audit.rules > /etc/audit/rules.d/test.rules
 sed -i '4,7d' /etc/audit/rules.d/test.rules
 {{% if 'ol' in product or 'rhel' in product %}}
-sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
+sed -i 's/-k modules/-F auid>={{{ uid_min }}} -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_arg.pass.sh
@@ -7,5 +7,5 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '1,12d' test_audit.rules > /etc/audit/rules.d/test.rules
 {{% if 'ol' in product or 'rhel' in product %}}
-sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
+sed -i 's/-k modules/-F auid>={{{ uid_min }}} -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/tests/augen_syscalls_one_per_line.pass.sh
@@ -6,5 +6,5 @@ rm -f /etc/audit/rules.d/*
 # cut out irrelevant rules for this test
 sed '8,15d' test_audit.rules > /etc/audit/rules.d/test.rules
 {{% if 'ol' in product or 'rhel' in product %}}
-sed -i 's/-k modules/-F auid>=1000 -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
+sed -i 's/-k modules/-F auid>={{{ uid_min }}} -F auid!=unset -k modules/g' /etc/audit/rules.d/test.rules
 {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/oval/shared.xml
@@ -37,7 +37,7 @@
   <ind:textfilecontent54_object id="object_32bit_ardm_delete_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -50,7 +50,7 @@
   <ind:textfilecontent54_object id="object_64bit_ardm_delete_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -63,7 +63,7 @@
   <ind:textfilecontent54_object id="object_32bit_ardm_delete_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -76,7 +76,7 @@
   <ind:textfilecontent54_object id="object_64bit_ardm_delete_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+delete_module[\s]+|([\s]+|[,])delete_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/policy/stig/shared.yml
@@ -15,15 +15,15 @@ checktext: |-
 
     $ sudo auditctl -l | grep delete_module
 
-    -a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=unset -k module_chng
-    -a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=unset -k module_chng
+    -a always,exit -F arch=b32 -S delete_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
+    -a always,exit -F arch=b64 -S delete_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
 
     If both the "b32" and "b64" audit rules are not defined for the "delete_module" syscall, or any of the lines returned are commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate an audit event for any successful/unsuccessful use of the "delete_module" system call by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=unset -k module_chng
-    -a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=unset -k module_chng
+    -a always,exit -F arch=b32 -S delete_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
+    -a always,exit -F arch=b64 -S delete_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/rule.yml
@@ -8,7 +8,7 @@ description: |-
     To capture kernel module unloading events, use following line, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
     {{% if "ol" in product or 'rhel' in product %}}
-    <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S delete_module -F key=modules</pre>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/correct_rules.pass.sh
@@ -4,8 +4,8 @@
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
 {{% if "ol" in product or 'rhel' in product %}}
-echo "-a always,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
-echo "-a always,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b32 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}
 echo "-a always,exit -F arch=b32 -S delete_module -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S delete_module -F key=modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_list_action.fail.sh
@@ -4,8 +4,8 @@
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules\
 {{% if "ol" in product or 'rhel' in product %}}
-echo "-a never,exit -F arch=b32 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
-echo "-a never,exit -F arch=b64 -S delete_module -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
+echo "-a never,exit -F arch=b32 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
+echo "-a never,exit -F arch=b64 -S delete_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}
 echo "-a never,exit -F arch=b32 -S delete_module -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a never,exit -F arch=b64 -S delete_module -F key=modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_delete/tests/wrong_syscall.fail.sh
@@ -4,8 +4,8 @@
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
 {{% if "ol" in product or 'rhel' in product %}}
-echo "-a always,exit -F arch=b32 -S delete -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
-echo "-a always,exit -F arch=b64 -S delete -F auid>=1000 -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b32 -S delete -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S delete -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}
 echo "-a always,exit -F arch=b32 -S delete -F key=modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S delete -F key=modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/oval/shared.xml
@@ -37,7 +37,7 @@
   <ind:textfilecontent54_object id="object_32bit_ardm_finit_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -50,7 +50,7 @@
   <ind:textfilecontent54_object id="object_64bit_ardm_finit_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -63,7 +63,7 @@
   <ind:textfilecontent54_object id="object_32bit_ardm_finit_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -76,7 +76,7 @@
   <ind:textfilecontent54_object id="object_64bit_ardm_finit_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+finit_module[\s]+|([\s]+|[,])finit_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/policy/stig/shared.yml
@@ -15,15 +15,15 @@ checktext: |-
 
     $ sudo auditctl -l | grep init_module
 
-    -a always,exit -F arch=b32 -S init_module,finit_module -F auid&gt;=1000 -F auid!=unset -k module_chng
-    -a always,exit -F arch=b64 -S init_module,finit_module -F auid&gt;=1000 -F auid!=unset -k module_chng
+    -a always,exit -F arch=b32 -S init_module,finit_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
+    -a always,exit -F arch=b64 -S init_module,finit_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
 
     If both the "b32" and "b64" audit rules are not defined for the "delete_module" syscall, or any of the lines returned are commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate an audit event for any successful/unsuccessful use of the "init_module" and "finit_module" system calls by adding or updating the following rules in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F arch=b32 -S init_module,finit_module -F auid&gt;=1000 -F auid!=unset -k module_chng
-    -a always,exit -F arch=b64 -S init_module,finit_module -F auid&gt;=1000 -F auid!=unset -k module_chng
+    -a always,exit -F arch=b32 -S init_module,finit_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
+    -a always,exit -F arch=b64 -S init_module,finit_module -F auid&gt;={{{ uid_min }}} -F auid!=unset -k module_chng
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/rule.yml
@@ -10,7 +10,7 @@ description: |-
     with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt> to capture kernel module
     loading and unloading events, setting ARCH to either b32 or b64 as appropriate for your system:
     {{% if "ol" in product or 'rhel' in product %}}
-    <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F key=modules</pre>
     {{% endif %}}    If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility to read audit
@@ -18,7 +18,7 @@ description: |-
     in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
     b64 as appropriate for your system:
     {{% if "ol" in product or 'rhel' in product %}}
-    <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S finit_module -F key=modules</pre>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_finit/tests/correct_rules.pass.sh
@@ -2,8 +2,8 @@
 # packages = audit
 
 {{% if "ol" in product or 'rhel' in product %}}
-echo "-a always,exit -F arch=b32 -S finit_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
-echo "-a always,exit -F arch=b64 -S finit_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b32 -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S finit_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}
 echo "-a always,exit -F arch=b32 -S finit_module -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S finit_module -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/oval/shared.xml
@@ -37,7 +37,7 @@
   <ind:textfilecontent54_object id="object_32bit_ardm_init_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -50,7 +50,7 @@
   <ind:textfilecontent54_object id="object_64bit_ardm_init_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -63,7 +63,7 @@
   <ind:textfilecontent54_object id="object_32bit_ardm_init_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}
@@ -76,7 +76,7 @@
   <ind:textfilecontent54_object id="object_64bit_ardm_init_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
     {{% if "ol" in product or 'rhel' in product %}}
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% else %}}
     <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+init_module[\s]+|([\s]+|[,])init_module([\s]+|[,]))).*(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/rule.yml
@@ -8,7 +8,7 @@ description: |-
     To capture kernel module loading events, use following line, setting ARCH to
     either b32 for 32-bit system, or having two lines for both b32 and b64 in case your system is 64-bit:
     {{% if "ol" in product or 'rhel' in product %}}
-    <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     {{% else %}}
     <pre>-a always,exit -F arch=<i>ARCH</i> -S init_module -F key=modules</pre>
     {{% endif %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_init/tests/correct_rules.pass.sh
@@ -2,8 +2,8 @@
 # packages = audit
 
 {{% if "ol" in product or 'rhel' in product %}}
-echo "-a always,exit -F arch=b32 -S init_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
-echo "-a always,exit -F arch=b64 -S init_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b32 -S init_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S init_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
 {{% else %}}
 echo "-a always,exit -F arch=b32 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules
 echo "-a always,exit -F arch=b64 -S init_module -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/oval/shared.xml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/oval/shared.xml
@@ -36,7 +36,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_query_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -45,7 +45,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_query_module_augenrules" version="1">
     <ind:filepath operation="pattern match">^/etc/audit/rules\.d/.*\.rules$</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -54,7 +54,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_32bit_ardm_query_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b32[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 
@@ -63,7 +63,7 @@
   </ind:textfilecontent54_test>
   <ind:textfilecontent54_object id="object_64bit_ardm_query_module_auditctl" version="1">
     <ind:filepath>/etc/audit/audit.rules</ind:filepath>
-    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>=1000[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
+    <ind:pattern operation="pattern match">^[\s]*-a[\s]+always,exit[\s]+(?:.*-F[\s]+arch=b64[\s]+)(?:.*(-S[\s]+query_module[\s]+|([\s]+|[,])query_module([\s]+|[,]))).*(?:-F\s+auid>={{{ uid_min }}}[\s]+)(?:-F\s+auid!=(unset|4294967295))\s+(-k[\s]+|-F[\s]+key=)[\S]+[\s]*$</ind:pattern>
     <ind:instance datatype="int">1</ind:instance>
   </ind:textfilecontent54_object>
 </def-group>

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/rule.yml
@@ -9,12 +9,12 @@ description: |-
     to read audit rules during daemon startup (the default), add the following lines to a file
     with suffix <tt>.rules</tt> in the directory <tt>/etc/audit/rules.d</tt> to capture kernel module
     loading and unloading events, setting ARCH to either b32 or b64 as appropriate for your system:
-    <pre>-a always,exit -F arch=<i>ARCH</i> -S query_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S query_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
     If the <tt>auditd</tt> daemon is configured to use the <tt>auditctl</tt> utility to read audit
     rules during daemon startup, add the following lines to <tt>/etc/audit/audit.rules</tt> file
     in order to capture kernel module loading and unloading events, setting ARCH to either b32 or
     b64 as appropriate for your system:
-    <pre>-a always,exit -F arch=<i>ARCH</i> -S query_module -F auid>=1000 -F auid!=unset -F key=modules</pre>
+    <pre>-a always,exit -F arch=<i>ARCH</i> -S query_module -F auid>={{{ uid_min }}} -F auid!=unset -F key=modules</pre>
 
 rationale: |-
     The addition/removal of kernel modules can be used to alter the behavior of

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading_query/tests/correct_rules.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-a always,exit -F arch=b32 -S query_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
-echo "-a always,exit -F arch=b64 -S query_module -F auid>=1000 -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b32 -S query_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules
+echo "-a always,exit -F arch=b64 -S query_module -F auid>={{{ uid_min }}} -F auid!=unset -k modules" >> /etc/audit/rules.d/modules.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_init/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_init/policy/stig/shared.yml
@@ -9,13 +9,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep init
 
-    -a always,exit -F path=/usr/sbin/init -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-init
+    -a always,exit -F path=/usr/sbin/init -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-init
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "init" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F path=/usr/sbin/init -F perm=x -F auid>=1000 -F auid!=unset -k privileged-init
+    -a always,exit -F path=/usr/sbin/init -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged-init
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_poweroff/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_poweroff/policy/stig/shared.yml
@@ -9,13 +9,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep poweroff
 
-    -a always,exit -F path=/usr/sbin/poweroff -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-poweroff
+    -a always,exit -F path=/usr/sbin/poweroff -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-poweroff
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "poweroff" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F path=/usr/sbin/poweroff -F perm=x -F auid>=1000 -F auid!=unset -k privileged-poweroff
+    -a always,exit -F path=/usr/sbin/poweroff -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged-poweroff
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_reboot/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_reboot/policy/stig/shared.yml
@@ -9,13 +9,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep reboot
 
-    -a always,exit -F path=/usr/sbin/reboot -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-reboot
+    -a always,exit -F path=/usr/sbin/reboot -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-reboot
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "reboot" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F path=/usr/sbin/reboot -F perm=x -F auid>=1000 -F auid!=unset -k privileged-reboot
+    -a always,exit -F path=/usr/sbin/reboot -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged-reboot
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_shutdown/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_privileged_commands_shutdown/policy/stig/shared.yml
@@ -9,13 +9,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep shutdown
 
-    -a always,exit -F path=/usr/sbin/shutdown -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-shutdown
+    -a always,exit -F path=/usr/sbin/shutdown -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-shutdown
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "shutdown" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:
 
-    -a always,exit -F path=/usr/sbin/shutdown -F perm=x -F auid>=1000 -F auid!=unset -k privileged-shutdown
+    -a always,exit -F path=/usr/sbin/shutdown -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged-shutdown
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_missing_rule.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/audit.rules
 sed -i '/newgrp/d' /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_one_rule.fail.sh
@@ -2,5 +2,5 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_configured.pass.sh
@@ -2,5 +2,5 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/auditctl_rules_without_perm_x.pass.sh
@@ -2,6 +2,6 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/audit.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/audit.rules
 sed -i -E 's/^(.*path=[[:graph:]]+) -F perm=x(.*$)/\1\2/' /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_duplicated.fail.sh
@@ -3,7 +3,7 @@
 # remediation = none
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /tmp/privileged.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /tmp/privileged.rules
 
 # Remediation for this rule cannot remove the duplicates
 cp /tmp/privileged.rules /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_missing_rule.fail.sh
@@ -2,5 +2,5 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
  sed -i '/newgrp/d' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_one_rule.fail.sh
@@ -2,4 +2,4 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured.pass.sh
@@ -2,4 +2,4 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_configured_mixed_keys.pass.sh
@@ -2,7 +2,7 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
 # change key of rules for binaries in /usr/sbin
 # A mixed conbination of -k and -F key= should be accepted
 sed -i '/sbin/s/-k /-F key=/g' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_without_perm_x.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_rules_without_perm_x.pass.sh
@@ -2,5 +2,5 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 privileged /etc/audit/rules.d/privileged.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} privileged /etc/audit/rules.d/privileged.rules
 sed -i -E 's/^(.*path=[[:graph:]]+) -F perm=x(.*$)/\1\2/' /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_mixed_keys.fail.sh
@@ -2,5 +2,5 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/augenrules_two_rules_sep_files.fail.sh
@@ -2,6 +2,6 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
-echo "-a always,exit -F path=/usr/bin/notrelevant -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
-echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/notrelevant -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/priv.rules
+echo "-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands/tests/rules_with_own_key.pass.sh
@@ -2,4 +2,4 @@
 # packages = audit
 # platform = multi_platform_fedora,multi_platform_rhel,Oracle Linux 7,Oracle Linux 8
 
-./generate_privileged_commands_rule.sh 1000 own_key /etc/audit/rules.d/privileged.rules
+./generate_privileged_commands_rule.sh {{{ uid_min }}} own_key /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_apparmor_parser/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_apparmor_parser/rule.yml
@@ -36,7 +36,7 @@ ocil: |-
     To verify that execution of the command is being audited, run the following command:
     <pre>sudo auditctl -l | grep apparmor_parser</pre>
     The output should return something similar to:
-    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid>=1000 -F auid!=-1 -F key=privileged</pre>
+    <pre>-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid>={{{ uid_min }}} -F auid!=-1 -F key=privileged</pre>
 
 template:
     name: audit_rules_privileged_commands

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chage/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep chage
 
-    -a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-chage
+    -a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-chage
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "chage" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-chage
+    -a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-chage
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_chsh/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep chsh
 
-    -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "chsh" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_crontab/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep crontab
 
-    -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-crontab
+    -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-crontab
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "crontab" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-crontab
+    -a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-crontab
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_gpasswd/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep gpasswd
 
-    -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-gpasswd
+    -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-gpasswd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "gpasswd" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-gpasswd
+    -a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-gpasswd
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep kmod
 
-    -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid&gt;=1000 -F auid!=unset -k modules
+    -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k modules
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "kmod" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid&gt;=1000 -F auid!=unset -k modules
+    -a always,exit -F path=/usr/bin/kmod -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k modules
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_kmod/rule.yml
@@ -1,5 +1,5 @@
 {{%- if product in ["ol7", "rhel7", "rhel8", "rhel9"] %}}
-    {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" %}}
+    {{%- set kmod_audit="-a always,exit -F path=/usr/bin/kmod -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=privileged" %}}
 {{%- elif product in ["ubuntu2004", "ubuntu2204"] %}}
     {{%- set kmod_audit="-w /bin/kmod -p x -k modules" %}}
 {{%- else %}}

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_mount/policy/stig/shared.yml
@@ -13,13 +13,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep /usr/bin/mount
 
-    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
+    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "mount" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
+    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_newgrp/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep newgrp
 
-    -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "newgrp" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_pam_timestamp_check/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep timestamp
 
-    -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-pam_timestamp_check
+    -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-pam_timestamp_check
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "pam_timestamp_check" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-pam_timestamp_check
+    -a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-pam_timestamp_check
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | egrep '(/usr/bin/passwd)'
 
-    -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
+    -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-passwd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "passwd" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
+    -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-passwd
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postdrop/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep postdrop
 
-    -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "postdrop" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/postdrop -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_postqueue/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep postqueue
 
-    -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "postqueue" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/postqueue -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_agent/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep ssh-agent
 
-    -a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-ssh
+    -a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-ssh
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "ssh-agent" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-ssh
+    -a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-ssh
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_ssh_keysign/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep ssh-keysign
 
-    -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-ssh
+    -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-ssh
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "ssh-keysign" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-ssh
+    -a always,exit -F path=/usr/libexec/openssh/ssh-keysign -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-ssh
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_su/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep /usr/bin/su
 
-    -a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
+    -a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-priv_change
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "su" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-priv_change
+    -a always,exit -F path=/usr/bin/su -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-priv_change
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep /usr/bin/sudo
 
-    -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "sudo" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_4294967295_configured.pass.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=4294967295 -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_auditctl_unset_configured.pass.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/audit.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=unset -k privileged" >> /etc/audit/audit.rules
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_4294967295_configured.pass.sh
@@ -3,4 +3,4 @@
 # remediation = bash
 # platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_duplicated.fail.sh
@@ -3,5 +3,5 @@
 # remediation = bash
 # platform = Red Hat Enterprise Linux 7,Fedora
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_substring_rule.fail.sh
@@ -3,4 +3,4 @@
 # remediation = bash
 # platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/su -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/su -F auid>={{{ uid_min }}} -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_superstring_rule.fail.sh
@@ -3,4 +3,4 @@
 # remediation = bash
 # platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudoedit -F auid>=1000 -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudoedit -F auid>={{{ uid_min }}} -F auid!=4294967295 -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_augenrules_unset_configured.pass.sh
@@ -3,4 +3,4 @@
 # remediation = bash
 # platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=unset -k privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudo/tests/rhel7_rules_with_own_key.pass.sh
@@ -3,4 +3,4 @@
 # remediation = bash
 # platform = Fedora,Oracle Linux 7,Red Hat Enterprise Linux 7
 
-echo "-a always,exit -F path=/usr/bin/sudo -F auid>=1000 -F auid!=4294967295 -k own_key" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/usr/bin/sudo -F auid>={{{ uid_min }}} -F auid!=4294967295 -k own_key" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_sudoedit/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep /usr/bin/sudoedit
 
-    -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "sudoedit" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;=1000 -F auid!=unset -k priv_cmd
+    -a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k priv_cmd
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_umount/policy/stig/shared.yml
@@ -15,14 +15,14 @@ checktext: |-
 
     $ sudo auditctl -l | grep umount
 
-    -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
+    -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
 
     If the command does not return an audit rule for "umount" or any of the lines returned are commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "umount" command by adding or updating the following rules in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
+    -a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
 
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-echo "-a always,exit -F path=/sbin/unix2_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/sbin/unix2_chkpwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep unix_chkpwd
 
-    -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "unix_chkpwd" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_chkpwd/tests/only_chkpwd_rule.fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # packages = audit
 
-echo "-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules
+echo "-a always,exit -F path=/sbin/unix_chkpwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=privileged" >> /etc/audit/rules.d/privileged.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix_update/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep unix_update
 
-    -a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "unix_update" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/unix_update -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_userhelper/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep userhelper
 
-    -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    -a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "userhelper" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-unix-update
+    a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-unix-update
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_usermod/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep usermod
 
-    -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-usermod
+    -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-usermod
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "usermod " command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-usermod
+    -a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-usermod
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_correct_rule.pass.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/auditctl_wrong_dir.fail.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_correct_rule.pass.sh
@@ -2,5 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_open/tests/augenrules_wrong_dir.fail.sh
@@ -2,5 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S open -F a1&03 -F path=/etc/password -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S open -F a1&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_correct_rule.pass.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_multiple_syscalls.pass.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/auditctl_wrong_dir.fail.sh
@@ -5,5 +5,5 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_correct_rule.pass.sh
@@ -2,5 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_escaped_gt.fail.sh
@@ -2,5 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid&gt;={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_etc_passwd_openat/tests/augenrules_wrong_dir.fail.sh
@@ -2,5 +2,5 @@
 # packages = audit
 
 
-echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
-echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b32 -S openat -F a2&03 -F path=/etc/password -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F arch=b64 -S openat -F a2&03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/policy/stig/shared.yml
@@ -15,13 +15,13 @@ checktext: |-
 
     $ sudo auditctl -l | grep /usr/bin/mount
 
-    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
+    -a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
 
     If the command does not return a line, or the line is commented out, this is a finding.
 
 fixtext: |-
     Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "mount" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
-    --a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-mount
+    --a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;={{{ uid_min }}} -F auid!=unset -k privileged-mount
 
     The audit daemon must be restarted for the changes to take effect.

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_media_export/tests/correct_rules.pass.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # packages = audit
 
-echo "-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
-echo "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
+echo "-a always,exit -F arch=b32 -S mount -F auid>={{{ uid_min }}} -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules
+echo "-a always,exit -F arch=b64 -S mount -F auid>={{{ uid_min }}} -F auid!=unset -k mount" >> /etc/audit/rules.d/mount.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_correct_rule.pass.sh
@@ -5,4 +5,4 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/auditctl_wrong_dir.fail.sh
@@ -5,4 +5,4 @@
 # Use auditctl in RHEL7
 sed -i "s%^ExecStartPost=.*%ExecStartPost=-/sbin/auditctl%" /usr/lib/systemd/system/auditd.service
 
-echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules
+echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_correct_rule.pass.sh
@@ -2,4 +2,4 @@
 # packages = audit
 
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_dir.fail.sh
@@ -2,4 +2,4 @@
 # packages = audit
 
 
-echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/auditd/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/directory_access_var_log_audit/tests/augenrules_wrong_perm.fail.sh
@@ -2,4 +2,4 @@
 # packages = audit
 
 
-echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>=1000 -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules
+echo "-a always,exit -F dir=/var/log/audit/ -F perm=w -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail" >> /etc/audit/rules.d/var_log_audit.rules

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful file accesses'
 
 {{% set file_contents_audit_access_failed =
 "## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access" %}}
+-a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access" %}}
 
 description: |-
     Ensure that unsuccessful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed_aarch64/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful file accesses (AArch64)'
 
 {{% set file_contents_audit_access_failed =
 "## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access" %}}
+-a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access" %}}
 
 description: |-
     Ensure that unsuccessful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_failed_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_failed_ppc64le/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of unsuccessful file accesses (ppc64le)'
 
 {{% set file_contents_audit_access_failed =
 "## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-access
--a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-access" %}}
+-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access
+-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-access" %}}
 
 description: |-
     Ensure that unsuccessful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success/rule.yml
@@ -7,8 +7,8 @@ title: 'Configure auditing of successful file accesses'
 {{% set file_contents_audit_access_success =
 "## Successful file access (any other opens) This has to go last.
 ## These next two are likely to result in a whole lot of events
--a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access
--a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access" %}}
+-a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-access
+-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-access" %}}
 
 description: |-
     Ensure that successful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success_aarch64/rule.yml
@@ -7,8 +7,8 @@ title: 'Configure auditing of successful file accesses (AArch64)'
 {{% set file_contents_audit_access_success =
 "## Successful file access (any other opens) This has to go last.
 ## These next two are likely to result in a whole lot of events
--a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access
--a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access" %}}
+-a always,exit -F arch=b32 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-access
+-a always,exit -F arch=b64 -S openat,openat2,open_by_handle_at -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-access" %}}
 
 description: |-
     Ensure that successful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_access_success_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_access_success_ppc64le/rule.yml
@@ -7,7 +7,7 @@ title: 'Configure auditing of successful file accesses (ppc64le)'
 {{% set file_contents_audit_access_success =
 "## Successful file access (any other opens) This has to go last.
 ## These next two are likely to result in a whole lot of events
--a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-access" %}}
+-a always,exit -F arch=b64 -S open,openat,openat2,open_by_handle_at -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-access" %}}
 
 description: |-
     Ensure that successful attempts to access a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed/rule.yml
@@ -6,18 +6,18 @@ title: 'Configure auditing of unsuccessful file creations'
 
 {{% set file_contents_audit_create_failed =
 "## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-create" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create" %}}
 
 description: |-
     Ensure that unsuccessful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed_aarch64/rule.yml
@@ -6,14 +6,14 @@ title: 'Configure auditing of unsuccessful file creations (AArch64)'
 
 {{% set file_contents_audit_create_failed =
 "## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create" %}}
 
 description: |-
     Ensure that unsuccessful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_failed_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_failed_ppc64le/rule.yml
@@ -6,12 +6,12 @@ title: 'Configure auditing of unsuccessful file creations (ppc64le)'
 
 {{% set file_contents_audit_create_failed =
 "## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-create" %}}
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S open -F a1&amp;0100 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-create" %}}
 
 description: |-
     Ensure that unsuccessful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success/rule.yml
@@ -6,12 +6,12 @@ title: 'Configure auditing of successful file creations'
 
 {{% set file_contents_audit_create_success =
 "## Successful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b32 -S open -F a1&amp;0100 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S open -F a1&amp;0100 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-create" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b64 -S open -F a1&amp;0100 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b32 -S creat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b64 -S creat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-create" %}}
 
 description: |-
     Ensure that successful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success_aarch64/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of successful file creations (AArch64)'
 
 {{% set file_contents_audit_create_success =
 "## Successful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b32 -S open -F a1&amp;0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b32 -S creat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b32 -S open -F a1&amp;0100 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b32 -S creat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create" %}}
 
 description: |-
     Ensure that successful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_create_success_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_create_success_ppc64le/rule.yml
@@ -6,9 +6,9 @@ title: 'Configure auditing of successful file creations (ppc64le)'
 
 {{% set file_contents_audit_create_success =
 "## Successful file creation (open with O_CREAT)
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S open -F a1&amp;0100 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create
--a always,exit -F arch=b64 -S creat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-create" %}}
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;0100 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b64 -S open -F a1&amp;0100 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create
+-a always,exit -F arch=b64 -S creat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-create" %}}
 
 description: |-
     Ensure that successful attempts to create a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful file deletions'
 
 {{% set file_contents_audit_delete_failed =
 "## Unsuccessful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-delete" %}}
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete" %}}
 
 description: |-
     Ensure that unsuccessful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed_aarch64/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful file deletions (AArch64)'
 
 {{% set file_contents_audit_delete_failed =
 "## Unsuccessful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlinkat,renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlinkat,renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete" %}}
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlinkat,renameat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlinkat,renameat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete" %}}
 
 description: |-
     Ensure that unsuccessful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_failed_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_failed_ppc64le/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of unsuccessful file deletions (ppc64le)'
 
 {{% set file_contents_audit_delete_failed =
 "## Unsuccessful file delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-delete" %}}
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-delete" %}}
 
 description: |-
     Ensure that unsuccessful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/kubernetes/shared.yml
@@ -2,7 +2,7 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 
 {{% set file_contents = """## Successful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete""" -%}}
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete""" -%}}
 
 {{{- kubernetes_machine_config_file(path='/etc/audit/rules.d/30-ospp-v42-4-delete-success.rules', file_permissions_mode='0600', source=file_contents) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of successful file deletions'
 
 {{% set file_contents_audit_delete_success =
 "## Successful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-delete" %}}
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete" %}}
 
 description: |-
     Ensure that successful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success_aarch64/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success_aarch64/kubernetes/shared.yml
@@ -2,7 +2,7 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 
 {{% set file_contents = """## Successful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete
--a always,exit -F arch=b64 -S unlinkat,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete""" -%}}
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete
+-a always,exit -F arch=b64 -S unlinkat,renameat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete""" -%}}
 
 {{{- kubernetes_machine_config_file(path='/etc/audit/rules.d/30-ospp-v42-4-delete-success.rules', file_permissions_mode='0600', source=file_contents) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success_aarch64/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of successful file deletions (AArch64)'
 
 {{% set file_contents_audit_delete_success =
 "## Successful file delete
--a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete
--a always,exit -F arch=b64 -S unlinkat,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete" %}}
+-a always,exit -F arch=b32 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete
+-a always,exit -F arch=b64 -S unlinkat,renameat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete" %}}
 
 description: |-
     Ensure that successful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success_ppc64le/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success_ppc64le/kubernetes/shared.yml
@@ -2,6 +2,6 @@
 # platform = multi_platform_rhel,multi_platform_fedora,multi_platform_rhcos
 
 {{% set file_contents = """## Successful file delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete""" -%}}
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete""" -%}}
 
 {{{- kubernetes_machine_config_file(path='/etc/audit/rules.d/30-ospp-v42-4-delete-success.rules', file_permissions_mode='0600', source=file_contents) }}}

--- a/linux_os/guide/system/auditing/policy_rules/audit_delete_success_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_delete_success_ppc64le/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure auditing of successful file deletions (ppc64le)'
 
 {{% set file_contents_audit_delete_success =
 "## Successful file delete
--a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-delete" %}}
+-a always,exit -F arch=b64 -S unlink,unlinkat,rename,renameat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-delete" %}}
 
 description: |-
     Ensure that successful attempts to delete a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed/rule.yml
@@ -6,18 +6,18 @@ title: 'Configure auditing of unsuccessful file modifications'
 
 {{% set file_contents_audit_modify_failed =
 "## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-modification" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification" %}}
 
 description: |-
     Ensure that unsuccessful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed_aarch64/rule.yml
@@ -6,16 +6,16 @@ title: 'Configure auditing of unsuccessful file modifications (AARch64)'
 
 {{% set file_contents_audit_modify_failed =
 "## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification" %}}
 
 description: |-
     Ensure that unsuccessful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_failed_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_failed_ppc64le/rule.yml
@@ -6,12 +6,12 @@ title: 'Configure auditing of unsuccessful file modifications (ppc64le)'
 
 {{% set file_contents_audit_modify_failed =
 "## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-modification" %}}
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S open -F a1&amp;01003 -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-modification" %}}
 
 description: |-
     Ensure that unsuccessful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success/rule.yml
@@ -6,12 +6,12 @@ title: 'Configure auditing of successful file modifications'
 
 {{% set file_contents_audit_modify_success =
 "## Successful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b32 -S open -F a1&amp;01003 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S open -F a1&amp;01003 -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-modification" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S open -F a1&amp;01003 -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification" %}}
 
 description: |-
     Ensure that successful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success_aarch64/rule.yml
@@ -6,11 +6,11 @@ title: 'Configure auditing of successful file modifications (AArch64)'
 
 {{% set file_contents_audit_modify_success =
 "## Successful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b32 -S open -F a1&amp;01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification" %}}
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b32 -S open -F a1&amp;01003 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification" %}}
 
 description: |-
     Ensure that successful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_modify_success_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_modify_success_ppc64le/rule.yml
@@ -6,9 +6,9 @@ title: 'Configure auditing of successful file modifications (ppc64le)'
 
 {{% set file_contents_audit_modify_success =
 "## Successful file modifications (open for write or truncate)
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S open -F a1&amp;01003 -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-modification" %}}
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;01003 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S open -F a1&amp;01003 -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-modification" %}}
 
 description: |-
     Ensure that successful attempts to modify a file are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general/rule.yml
@@ -25,42 +25,42 @@ title: 'Perform general configuration of Audit for OSPP'
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and
 ## shadow for writes
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/passwd -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/shadow -F auid&gt;=1000 -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/passwd -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/shadow -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
 
 ## User enable and disable. This is entirely handled by pam.
 
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F path=/etc/passwd -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/shadow -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/group -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=group-modify
--a always,exit -F path=/etc/gshadow -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/passwd -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/shadow -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/group -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/gshadow -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;=1000 -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 
@@ -69,14 +69,14 @@ title: 'Perform general configuration of Audit for OSPP'
 -a always,exit -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 
 ## Audit log access
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid&gt;=1000 -F auid!=unset -F key=access-audit-trail
+-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F path=/var/run/utmp -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/btmp -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/wtmp -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=session
+-a always,exit -F path=/var/run/utmp -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/btmp -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/wtmp -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid&gt;=1000 -F auid!=unset -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general_aarch64/kubernetes/shared.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general_aarch64/kubernetes/shared.yml
@@ -29,40 +29,40 @@ spec:
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and
 ## shadow for writes
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
 
 ## User enable and disable. This is entirely handled by pam.
 
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F path=/etc/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
--a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/passwd -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/shadow -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/group -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/gshadow -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 
@@ -71,14 +71,14 @@ spec:
 -a always,exit -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 
 ## Audit log access
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail
+-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>={{{ uid_min }}} -F auid!=unset -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
+-a always,exit -F path=/var/run/utmp -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/btmp -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=unset -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>={{{ uid_min }}} -F auid!=unset -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general_aarch64/rule.yml
@@ -25,40 +25,40 @@ title: 'Perform general configuration of Audit for OSPP (AArch64)'
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and
 ## shadow for writes
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b32 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
 
 ## User enable and disable. This is entirely handled by pam.
 
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F path=/etc/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
--a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 
@@ -67,14 +67,14 @@ title: 'Perform general configuration of Audit for OSPP (AArch64)'
 -a always,exit -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 
 ## Audit log access
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail
+-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
+-a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=unset -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_ospp_general_ppc64le/rule.yml
@@ -25,38 +25,38 @@ title: 'Perform general configuration of Audit for OSPP (ppc64le)'
 ## User add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch passwd and
 ## shadow for writes
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>=1000 -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/passwd -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/passwd -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&amp;03 -F path=/etc/shadow -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F arch=b64 -S open -F a1&amp;03 -F path=/etc/shadow -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
 
 ## User enable and disable. This is entirely handled by pam.
 
 ## Group add delete modify. This is covered by pam. However, someone could
 ## open a file and directly create or modify a user, so we'll watch group and
 ## gshadow for writes
--a always,exit -F path=/etc/passwd -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/shadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=user-modify
--a always,exit -F path=/etc/group -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
--a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=1000 -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/passwd -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/shadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=user-modify
+-a always,exit -F path=/etc/group -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
+-a always,exit -F path=/etc/gshadow -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=group-modify
 
 
 ## Use of special rights for config changes. This would be use of setuid
 ## programs that relate to user accts. This is not all setuid apps because
 ## requirements are only for ones that affect system configuration.
--a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
--a always,exit -F path=/usr/bin/at -F perm=x -F auid>=1000 -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/unix_chkpwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/usernetctl -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/userhelper -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/sbin/seunshare -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/mount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newuidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/newgidmap -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/umount -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
+-a always,exit -F path=/usr/bin/at -F perm=x -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=special-config-changes
 
 ## Privilege escalation via su or sudo. This is entirely handled by pam.
 
@@ -65,14 +65,14 @@ title: 'Perform general configuration of Audit for OSPP (ppc64le)'
 -a always,exit -F dir=/etc/sudoers.d/ -F perm=wa -F key=special-config-changes
 
 ## Audit log access
--a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=1000 -F auid!=unset -F key=access-audit-trail
+-a always,exit -F dir=/var/log/audit/ -F perm=r -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=access-audit-trail
 ## Attempts to Alter Process and Session Initiation Information
--a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
--a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=1000 -F auid!=unset -F key=session
+-a always,exit -F path=/var/run/utmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/btmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
+-a always,exit -F path=/var/log/wtmp -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=session
 
 ## Attempts to modify MAC controls
--a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=1000 -F auid!=unset -F key=MAC-policy
+-a always,exit -F dir=/etc/selinux/ -F perm=wa -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=MAC-policy
 
 ## Software updates. This is entirely handled by rpm.
 

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful ownership changes'
 
 {{% set file_contents_audit_owner_change_failed =
 "## Unsuccessful ownership change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-owner-change" %}}
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed_aarch64/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful ownership changes (AArch64)'
 
 {{% set file_contents_audit_owner_change_failed =
 "## Unsuccessful ownership change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S fchown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S fchown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change" %}}
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S fchown,fchownat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S fchown,fchownat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_failed_ppc64le/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of unsuccessful ownership changes (ppc64le)'
 
 {{% set file_contents_audit_owner_change_failed =
 "## Unsuccessful ownership change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-owner-change" %}}
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-owner-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of successful ownership changes'
 
 {{% set file_contents_audit_owner_change_success =
 "## Successful ownership change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-owner-change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-owner-change" %}}
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-owner-change
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-owner-change" %}}
 
 description: |-
     Ensure that successful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success_aarch64/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of successful ownership changes (AArch64)'
 
 {{% set file_contents_audit_owner_change_success =
 "## Successful ownership change
--a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change
--a always,exit -F arch=b64 -S fchown,fchownat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change" %}}
+-a always,exit -F arch=b32 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-owner-change
+-a always,exit -F arch=b64 -S fchown,fchownat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-owner-change" %}}
 
 description: |-
     Ensure that successful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_owner_change_success_ppc64le/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure auditing of successful ownership changes (ppc64le)'
 
 {{% set file_contents_audit_owner_change_success =
 "## Successful ownership change
--a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-owner-change" %}}
+-a always,exit -F arch=b64 -S lchown,fchown,chown,fchownat -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-owner-change" %}}
 
 description: |-
     Ensure that successful attempts to change an ownership of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful permission changes'
 
 {{% set file_contents_audit_perm_change_failed =
 "## Unsuccessful permission change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=1000 -F auid!=unset -F key=unsuccessful-perm-change" %}}
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change file or directory permissions are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed_aarch64/rule.yml
@@ -6,10 +6,10 @@ title: 'Configure auditing of unsuccessful permission changes (AArch64)'
 
 {{% set file_contents_audit_perm_change_failed =
 "## Unsuccessful permission change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change" %}}
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change file or directory permissions are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_failed_ppc64le/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of unsuccessful permission changes (ppc64le)'
 
 {{% set file_contents_audit_perm_change_failed =
 "## Unsuccessful permission change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccessful-perm-change" %}}
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EACCES -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F exit=-EPERM -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=unsuccessful-perm-change" %}}
 
 description: |-
     Ensure that unsuccessful attempts to change file or directory permissions are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of successful permission changes'
 
 {{% set file_contents_audit_perm_change_success =
 "## Successful permission change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-perm-change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=1000 -F auid!=unset -F key=successful-perm-change" %}}
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-perm-change
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid&gt;=" ~ uid_min ~ " -F auid!=unset -F key=successful-perm-change" %}}
 
 description: |-
     Ensure that successful attempts to modify permissions of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success_aarch64/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success_aarch64/rule.yml
@@ -6,8 +6,8 @@ title: 'Configure auditing of successful permission changes (AArch64)'
 
 {{% set file_contents_audit_perm_change_success =
 "## Successful permission change
--a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change
--a always,exit -F arch=b64 -S fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change" %}}
+-a always,exit -F arch=b32 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-perm-change
+-a always,exit -F arch=b64 -S fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-perm-change" %}}
 
 description: |-
     Ensure that successful attempts to modify permissions of files or directories are audited.

--- a/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success_ppc64le/rule.yml
+++ b/linux_os/guide/system/auditing/policy_rules/audit_perm_change_success_ppc64le/rule.yml
@@ -6,7 +6,7 @@ title: 'Configure auditing of successful permission changes (ppc64le)'
 
 {{% set file_contents_audit_perm_change_success =
 "## Successful permission change
--a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=1000 -F auid!=unset -F key=successful-perm-change" %}}
+-a always,exit -F arch=b64 -S chmod,fchmod,fchmodat,setxattr,lsetxattr,fsetxattr,removexattr,lremovexattr,fremovexattr -F success=1 -F auid>=" ~ uid_min ~ " -F auid!=unset -F key=successful-perm-change" %}}
 
 description: |-
     Ensure that successful attempts to modify permissions of files or directories are audited.

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/shared.xml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_system_commands_dirs/oval/shared.xml
@@ -15,14 +15,14 @@
 
   <unix:file_object comment="system commands files" id="object_groupownership_system_commands_dirs" version="1">
     <!-- Check that system commands within directories /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin 
-         belong to group with gid 0 (root) or gid < 1000 (system account)-->
+         belong to group with gid 0 (root) or gid < {{{ gid_min }}} (system account)-->
     <unix:path operation="pattern match">^\/s?bin|^\/usr\/s?bin|^\/usr\/local\/s?bin</unix:path>
     <unix:filename operation="pattern match">^.*$</unix:filename>
    <filter action="include">state_groupowner_system_commands_dirs_not_root_or_system_account</filter>
   </unix:file_object>
 
   <unix:file_state id="state_groupowner_system_commands_dirs_not_root_or_system_account" version="1">
-    <unix:group_id datatype="int" operation="greater than or equal">1000</unix:group_id>
+    <unix:group_id datatype="int" operation="greater than or equal">{{{ gid_min }}}</unix:group_id>
   </unix:file_state>
 
 </def-group>

--- a/shared/macros/01-general.jinja
+++ b/shared/macros/01-general.jinja
@@ -1141,38 +1141,38 @@ Part of the grub2_bootloader_argument(_absent) templates.
 ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
 ## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
 {{%- endmacro -%}}
 
 

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -501,7 +501,7 @@ The macro requires following parameters:
 :type action_arch_filters: str
 :param other_filters: Other filters that may characterize the rule. For example, "-F a2&03 -F path=/etc/passwd"
 :type other_filters: str
-:param auid_filters: The auid filters of the rule. For example, "-F auid>=1000 -F auid!=unset"
+:param auid_filters: The auid filters of the rule. For example, "-F auid>=" ~ uid_min ~ " -F auid!=unset"
 :type auid_filters: str
 :param syscalls: List of syscalls to ensure presense among audit rules. For example, "['fchown', 'lchown', 'fchownat']"
 :type syscalls: list[str]
@@ -597,7 +597,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     For example, "-F a2&03 -F path=/etc/passwd"
 :type other_filters: str
 :param auid_filters: The auid filters of the rule.
-    For example, "-F auid>=1000 -F auid!=unset"
+    For example, "-F auid>=" ~ uid_min ~ " -F auid!=unset"
 :type auid_filters: str
 :param syscalls: List of syscalls to ensure presense among audit rules.
     For example, "['fchown', 'lchown', 'fchownat']"

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -2649,3 +2649,16 @@ from /etc/os-release from VERSION_ID variable.
 {{%- macro bash_get_version_os_linux(os_release_path="/etc/os-release") -%}}
 grep -P "^VERSION_ID=[\"']?[\w.]+[\"']?$" {{{ os_release_path }}} | sed "s/^VERSION_ID=[\"']\?\([^\"']\+\)[\"']\?$/\1/"
 {{%- endmacro -%}}
+
+
+{{#
+Remove all interactive users (UID >= uid_min) from /etc/passwd
+#}}
+{{%- macro bash_remove_interactive_users_from_passwd_by_uid() -%}}
+# remove all interactive users (UID >= {{{ uid_min }}}) from /etc/passwd
+del=""
+while read -r user; do
+    del+="/^${user}:/d;"
+done < <(awk -F: '($3 >= {{{ uid_min }}}) { print $1 }' /etc/passwd)
+sed -i "${del}" /etc/passwd
+{{%- endmacro -%}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1765,7 +1765,7 @@ Notes:
 :type action_arch_filters: str
 :param other_filters: Other filters that may characterize the rule. For example, "-F a2&03 -F path=/etc/passwd"
 :type other_filters: str
-:param auid_filters: The auid filters of the rule. For example, "-F auid>=1000 -F auid!=unset"
+:param auid_filters: The auid filters of the rule. For example, "-F auid>=" ~ uid_min ~ " -F auid!=unset"
 :type auid_filters: str
 :param syscall: The syscall to ensure presense among audit rules. For example, "chown"
 :type syscall: str

--- a/shared/macros/10-fixtext.jinja
+++ b/shared/macros/10-fixtext.jinja
@@ -25,21 +25,21 @@ Configure the audit system to generate an audit event for any successful/unsucce
 
 {{% if extra_params -%}}
 {{% if flag -%}}
--a always,exit -F arch=b32 -S {{{ event }}} -F {{{ flag }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -k {{{ key }}}
--a always,exit -F arch=b64 -S {{{ event }}} -F {{{ flag }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b32 -S {{{ event }}} -F {{{ flag }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b64 -S {{{ event }}} -F {{{ flag }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
 
--a always,exit -F arch=b32 -S {{{ event }}} -F {{{ flag }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -k {{{ key }}}
--a always,exit -F arch=b64 -S {{{ event }}} -F {{{ flag }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b32 -S {{{ event }}} -F {{{ flag }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b64 -S {{{ event }}} -F {{{ flag }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
 {{% else -%}}
--a always,exit -F arch=b32 -S {{{ event }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -k {{{ key }}}
--a always,exit -F arch=b64 -S {{{ event }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b32 -S {{{ event }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b64 -S {{{ event }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
 
--a always,exit -F arch=b32 -S {{{ event }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -k {{{ key }}}
--a always,exit -F arch=b64 -S {{{ event }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b32 -S {{{ event }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b64 -S {{{ event }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
 {{% endif %}}
 {{% else %}}
--a always,exit -F arch=b32 -S {{{ event }}} -F auid>=1000 -F auid!=unset -k {{{ key }}}
--a always,exit -F arch=b64 -S {{{ event }}} -F auid>=1000 -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b32 -S {{{ event }}} -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
+-a always,exit -F arch=b64 -S {{{ event }}} -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
 {{%- endif -%}}
 
 {{%- if event_group %}}
@@ -411,7 +411,7 @@ Fixtext macro describing how to audit a command.
 {{% macro fixtext_audit_rules_command(command, filepath, key) -%}}
 Configure the audit system to generate an audit event for any successful/unsuccessful use of the "{{{ command }}}" command by adding or updating the following rule in the "/etc/audit/rules.d/audit.rules" file:
 
--a always,exit -F path={{{ filepath }}} -F perm=x -F auid>=1000 -F auid!=unset -k {{{ key }}}
+-a always,exit -F path={{{ filepath }}} -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k {{{ key }}}
 
 The audit daemon must be restarted for the changes to take effect.
 {{%- endmacro %}}
@@ -429,7 +429,7 @@ Fixtext for ensuring that a privileged command is audited.
 {{% macro fixtext_audit_rules_privileged_commands(cmd, path_prefix, key) -%}}
 Configure {{{ full_name }}} to generate audit records upon successful/unsuccessful attempts to use the "{{{ cmd }}}" command by adding or updating the following rule in "/etc/audit/rules.d/audit.rules":
 
--a always,exit -F path={{{path_prefix}}}{{{ cmd }}} -F perm=x -F auid>=1000 -F auid!=unset -k {{% if key %}}{{{ key }}}{{% else %}}privileged-{{{ cmd }}}{{% endif %}}
+-a always,exit -F path={{{path_prefix}}}{{{ cmd }}} -F perm=x -F auid>={{{ uid_min }}} -F auid!=unset -k {{% if key %}}{{{ key }}}{{% else %}}privileged-{{{ cmd }}}{{% endif %}}
 
 The audit daemon must be restarted for the changes to take effect.
 {{%- endmacro %}}

--- a/shared/macros/10-kubernetes.jinja
+++ b/shared/macros/10-kubernetes.jinja
@@ -502,38 +502,38 @@ AuditBackend=LinuxAudit
 ## 10-base-config.rules, 11-loginuid.rules, and 43-module-load.rules installed.
 
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
 
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S truncate,ftruncate -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
 
 ## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
 {{%- endmacro %}}
 
 

--- a/shared/templates/audit_rules_dac_modification/tests/correct_rules.pass.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/correct_rules.pass.sh
@@ -4,8 +4,8 @@
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
 
-echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
 
 {{% if CHECK_ROOT_USER %}}
     echo "-a always,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/shared/templates/audit_rules_dac_modification/tests/wrong_list_action.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/wrong_list_action.fail.sh
@@ -3,8 +3,8 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a never,exit -F arch=b64 -S {{{ ATTR }}} -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a never,exit -F arch=b64 -S {{{ ATTR }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
 
 {{% if CHECK_ROOT_USER %}}
     echo "-a never,exit -F arch=b32 -S {{{ ATTR }}} -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/shared/templates/audit_rules_dac_modification/tests/wrong_syscall.fail.sh
+++ b/shared/templates/audit_rules_dac_modification/tests/wrong_syscall.fail.sh
@@ -3,8 +3,8 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S pipe -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
-echo "-a always,exit -F arch=b64 -S pipe -F auid>=1000 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b32 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
+echo "-a always,exit -F arch=b64 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules
 
 {{% if CHECK_ROOT_USER %}}
     echo "-a always,exit -F arch=b32 -S pipe -F auid=0 -F auid!=unset -F key=perm_mod" >> /etc/audit/rules.d/perm_mod.rules

--- a/shared/templates/audit_rules_file_deletion_events/tests/correct_rules.pass.sh
+++ b/shared/templates/audit_rules_file_deletion_events/tests/correct_rules.pass.sh
@@ -3,5 +3,5 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
-echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules

--- a/shared/templates/audit_rules_file_deletion_events/tests/wrong_list_action.fail.sh
+++ b/shared/templates/audit_rules_file_deletion_events/tests/wrong_list_action.fail.sh
@@ -3,5 +3,5 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a never,exit -F arch=b32 -S {{{ NAME }}} -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
-echo "-a never,exit -F arch=b64 -S {{{ NAME }}} -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a never,exit -F arch=b32 -S {{{ NAME }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a never,exit -F arch=b64 -S {{{ NAME }}} -F auid>={{{ uid_min }}} -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules

--- a/shared/templates/audit_rules_file_deletion_events/tests/wrong_syscall.fail.sh
+++ b/shared/templates/audit_rules_file_deletion_events/tests/wrong_syscall.fail.sh
@@ -3,5 +3,5 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S pipe -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
-echo "-a always,exit -F arch=b64 -S pipe -F auid>=1000 -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b32 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules
+echo "-a always,exit -F arch=b64 -S pipe -F auid>={{{ uid_min }}} -F auid!=unset -F key=delete" >> /etc/audit/rules.d/delete.rules

--- a/shared/templates/audit_rules_unsuccessful_file_modification/tests/correct_rules.pass.sh
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/tests/correct_rules.pass.sh
@@ -3,7 +3,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules

--- a/shared/templates/audit_rules_unsuccessful_file_modification/tests/one_filter.fail.sh
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/tests/one_filter.fail.sh
@@ -2,7 +2,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccessful-perm-change.rules

--- a/shared/templates/audit_rules_unsuccessful_file_modification/tests/only_eacces.fail.sh
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/tests/only_eacces.fail.sh
@@ -3,5 +3,5 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules

--- a/shared/templates/audit_rules_unsuccessful_file_modification/tests/wrong_list_action.fail.sh
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/tests/wrong_list_action.fail.sh
@@ -3,7 +3,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a never,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a never,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a never,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a never,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a never,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a never,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a never,exit -F arch=b32 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a never,exit -F arch=b64 -S {{{ NAME }}} -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules

--- a/shared/templates/audit_rules_unsuccessful_file_modification/tests/wrong_syscall.fail.sh
+++ b/shared/templates/audit_rules_unsuccessful_file_modification/tests/wrong_syscall.fail.sh
@@ -3,7 +3,7 @@
 
 rm -f /etc/audit/rules.d/*
 > /etc/audit/audit.rules
-echo "-a always,exit -F arch=b32 -S pipe -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S pipe -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b32 -S pipe -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
-echo "-a always,exit -F arch=b64 -S pipe -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S pipe -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S pipe -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b32 -S pipe -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules
+echo "-a always,exit -F arch=b64 -S pipe -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-perm-change" >> /etc/audit/rules.d/unsuccesful-perm-change.rules

--- a/shared/templates/mount_option_home/bash.template
+++ b/shared/templates/mount_option_home/bash.template
@@ -19,7 +19,7 @@ function perform_remediation (){
 }
 
 readarray -t home_directories  < \
-    <(awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $6}' /etc/passwd )
+    <(awk -F':' '{if ($3>={{{ uid_min }}} && $3!= {{{ nobody_uid }}}) print $6}' /etc/passwd )
 
 
 for home_directory in "${home_directories[@]}"

--- a/shared/templates/mount_option_home/bash.template
+++ b/shared/templates/mount_option_home/bash.template
@@ -19,7 +19,7 @@ function perform_remediation (){
 }
 
 readarray -t home_directories  < \
-    <(awk -F':' '{if ($3>=1000 && $3!= 65534) print $6}' /etc/passwd )
+    <(awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $6}' /etc/passwd )
 
 
 for home_directory in "${home_directories[@]}"

--- a/shared/templates/mount_option_home/tests/fstab_template.fail.sh
+++ b/shared/templates/mount_option_home/tests/fstab_template.fail.sh
@@ -4,7 +4,7 @@
 . $SHARED/partition.sh
 
 mkdir -p /srv/home
-awk -F':' '{if ($3>=1000 && $3!= 65534) print $1}' /etc/passwd \
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $1}' /etc/passwd \
         | xargs -I{} userdel -r {}
 
 umount /srv || true  # no problem if not mounted

--- a/shared/templates/mount_option_home/tests/fstab_template.fail.sh
+++ b/shared/templates/mount_option_home/tests/fstab_template.fail.sh
@@ -4,7 +4,7 @@
 . $SHARED/partition.sh
 
 mkdir -p /srv/home
-awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $1}' /etc/passwd \
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= {{{ nobody_uid }}}) print $1}' /etc/passwd \
         | xargs -I{} userdel -r {}
 
 umount /srv || true  # no problem if not mounted

--- a/shared/templates/mount_option_home/tests/runtime_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/runtime_template.pass.sh
@@ -4,7 +4,7 @@
 . $SHARED/partition.sh
 
 mkdir -p /srv/home
-awk -F':' '{if ($3>=1000 && $3!= 65534) print $1}' /etc/passwd \
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $1}' /etc/passwd \
         | xargs -I{} userdel -r {}
 
 umount /srv || true  # no problem if not mounted

--- a/shared/templates/mount_option_home/tests/runtime_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/runtime_template.pass.sh
@@ -4,7 +4,7 @@
 . $SHARED/partition.sh
 
 mkdir -p /srv/home
-awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $1}' /etc/passwd \
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= {{{ nobody_uid }}}) print $1}' /etc/passwd \
         | xargs -I{} userdel -r {}
 
 umount /srv || true  # no problem if not mounted

--- a/shared/templates/mount_option_home/tests/separate_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/separate_template.pass.sh
@@ -3,7 +3,7 @@
 
 . $SHARED/partition.sh
 
-awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $1}' /etc/passwd \
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= {{{ nobody_uid }}}) print $1}' /etc/passwd \
         | xargs -I{} userdel -r {}
 
 umount /srv || true  # no problem if not mounted

--- a/shared/templates/mount_option_home/tests/separate_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/separate_template.pass.sh
@@ -3,7 +3,7 @@
 
 . $SHARED/partition.sh
 
-awk -F':' '{if ($3>=1000 && $3!= 65534) print $1}' /etc/passwd \
+awk -F':' '{if ($3>={{{ uid_min }}} && $3!= 65534) print $1}' /etc/passwd \
         | xargs -I{} userdel -r {}
 
 umount /srv || true  # no problem if not mounted

--- a/tests/shared/audit_open.rules
+++ b/tests/shared/audit_open.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file access (any other opens) This has to go last.
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
--a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b32 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access
+-a always,exit -F arch=b64 -S open,creat,truncate,ftruncate,openat,open_by_handle_at -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-access

--- a/tests/shared/audit_open_o_creat.rules
+++ b/tests/shared/audit_open_o_creat.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S open -F a1&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create

--- a/tests/shared/audit_open_o_trunc_write.rules
+++ b/tests/shared/audit_open_o_trunc_write.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S open -F a1&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification

--- a/tests/shared/audit_openat_o_creat.rules
+++ b/tests/shared/audit_openat_o_creat.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file creation (open with O_CREAT)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&0100 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-create

--- a/tests/shared/audit_openat_o_trunc_write.rules
+++ b/tests/shared/audit_openat_o_trunc_write.rules
@@ -1,5 +1,5 @@
 ## Unsuccessful file modifications (open for write or truncate)
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
--a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>=1000 -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EACCES -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b32 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification
+-a always,exit -F arch=b64 -S openat,open_by_handle_at -F a2&01003 -F exit=-EPERM -F auid>={{{ uid_min }}} -F auid!=unset -F key=unsuccesful-modification


### PR DESCRIPTION
#### Description:

Instead of number 1000, use `uid_min` and `gid_min`.

Instead of number 65534, use `nobody_uid` and `nobody_gid`.

#### Rationale:

Currently all products have `uid_min` as 1000 and son. But there must be reason why it was defined in first place.

#### Review Hints:

Unfortunately changes are all over. Teste ds change and only typo should be visible.

Some tests needed to change as they just assumed any number in `/etc/passwd` > 1000 was mark of interactive user.

Majority of changes were done by scripts. 