### PR TITLE
Add bash_systemctl_daemon_reload

### DIFF
--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/krb_sec_set.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/krb_sec_set.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 cp $SHARED/fstab /etc/
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_all_krb_sec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_all_krb_sec.fail.sh
@@ -2,3 +2,4 @@
 
 cp $SHARED/fstab /etc/
 sed -i 's/,sec=krb5:krb5i:krb5p//' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_krb_sec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/missing_krb_sec.fail.sh
@@ -3,3 +3,4 @@
 cp $SHARED/fstab /etc/
 # delete sec=.. only from nfs4
 sed -i 's|\(.*nfs4.*\),sec=krb5:krb5i:krb5p\(.*\)|\1\2|' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/no_nfs.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_krb_sec_remote_filesystems/tests/no_nfs.pass.sh
@@ -2,3 +2,4 @@
 
 cp $SHARED/fstab /etc/
 sed -i '/nfs/d' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_all_noexec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_all_noexec.fail.sh
@@ -2,3 +2,4 @@
 
 cp $SHARED/fstab /etc/
 sed -i 's/,noexec//' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_noexec.fail.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/missing_noexec.fail.sh
@@ -2,3 +2,4 @@
 
 cp $SHARED/fstab /etc/
 sed -i 's|\(.*nfs4.*\),noexec\(.*\)|\1\2|' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/no_nfs.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/no_nfs.pass.sh
@@ -2,3 +2,4 @@
 
 cp $SHARED/fstab /etc/
 sed -i '/nfs/d' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/noexec_set.pass.sh
+++ b/linux_os/guide/services/nfs_and_rpc/nfs_configuring_clients/mounting_remote_filesystems/mount_option_noexec_remote_filesystems/tests/noexec_set.pass.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 cp $SHARED/fstab /etc/
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/correct.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/correct.pass.sh
@@ -7,6 +7,7 @@
 cp /etc/fstab /etc/fstab.backup
 sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
 awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 # Remount all partitions. (--all option can't be used because it doesn't
 # mount e.g. /boot partition
 declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
@@ -16,8 +17,10 @@ done
 
 PARTITION="/dev/new_partition1"; create_partition
 make_fstab_given_partition_line "/tmp/partition1" ext2 nodev
+{{{ bash_systemctl_daemon_reload() }}}
 mount_partition "/tmp/partition1"
 
 PARTITION="/dev/new_partition2"; create_partition
 make_fstab_given_partition_line "/tmp/partition2" ext2 nodev
+{{{ bash_systemctl_daemon_reload() }}}
 mount_partition "/tmp/partition2"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/local_mounted_during_runtime.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/local_mounted_during_runtime.fail.sh
@@ -7,6 +7,7 @@
 cp /etc/fstab /etc/fstab.backup
 sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
 awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 # Remount all partitions. (--all option can't be used because it doesn't
 # mount e.g. /boot partition
 declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_multiple_nodev.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_multiple_nodev.fail.sh
@@ -7,6 +7,7 @@
 cp /etc/fstab /etc/fstab.backup
 sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
 awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 # Remount all partitions. (--all option can't be used because it doesn't
 # mount e.g. /boot partition
 declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
@@ -16,8 +17,10 @@ done
 
 PARTITION="/dev/new_partition1"; create_partition
 make_fstab_given_partition_line "/tmp/partition1" ext2
+{{{ bash_systemctl_daemon_reload() }}}
 mount_partition "/tmp/partition1"
 
 PARTITION="/dev/new_partition2"; create_partition
 make_fstab_given_partition_line "/tmp/partition2" ext2
+{{{ bash_systemctl_daemon_reload() }}}
 mount_partition "/tmp/partition2"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_one_nodev.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/missing_one_nodev.fail.sh
@@ -7,6 +7,7 @@
 cp /etc/fstab /etc/fstab.backup
 sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
 awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 # Remount all partitions. (--all option can't be used because it doesn't
 # mount e.g. /boot partition
 declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )
@@ -16,8 +17,10 @@ done
 
 PARTITION="/dev/new_partition1"; create_partition
 make_fstab_given_partition_line "/tmp/partition1" ext2 nodev
+{{{ bash_systemctl_daemon_reload() }}}
 mount_partition "/tmp/partition1"
 
 PARTITION="/dev/new_partition2"; create_partition
 make_fstab_given_partition_line "/tmp/partition2" ext2
+{{{ bash_systemctl_daemon_reload() }}}
 mount_partition "/tmp/partition2"

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/remote_without_nodev.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_nonroot_local_partitions/tests/remote_without_nodev.pass.sh
@@ -8,6 +8,7 @@
 cp /etc/fstab /etc/fstab.backup
 sed -e 's/\bnodev\b/,/g' -e 's/,,//g' -e 's/\s,\s/defaults/g' /etc/fstab.backup
 awk '{$4 = $4",nodev"; print}' /etc/fstab.backup > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 # Remount all partitions. (--all option can't be used because it doesn't
 # mount e.g. /boot partition
 declare -a partitions=( $(awk '{print $2}' /etc/fstab | grep "^/\w") )

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_bad_opts.fail.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /var/cdrom iso9660 ro 0 0" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_good_opts.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /var/cdrom iso9660 nodev 0 0" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.fail.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,noexec,nosuid,defaults 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,nodev,noexec 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_first.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_first.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 nodev,ro,noauto,nosuid,noexec 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_last.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/cd_multiple_opts_last.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,noexec,nodev 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/no_partitions.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nodev_removable_partitions/tests/no_partitions.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_bad_opts.fail.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /var/cdrom iso9660 ro 0 0" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_good_opts.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /var/cdrom iso9660 noexec 0 0" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.fail.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,nodev,defaults 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,noexec,nodev 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_first.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_first.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 noexec,ro,noauto,nosuid,nodev 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_last.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/cd_multiple_opts_last.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,nodev,noexec 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/no_partitions.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_noexec_removable_partitions/tests/no_partitions.pass.sh
@@ -5,3 +5,4 @@
 
 touch /dev/cdrom
 echo "" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_bad_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_bad_opts.fail.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /var/cdrom iso9660 ro 0 0" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_good_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_good_opts.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /var/cdrom iso9660 nosuid 0 0" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.fail.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,noexec,nodev,defaults 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,nosuid,noexec,nodev 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_first.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_first.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 nosuid,ro,noauto,noexec,nodev 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_last.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/cd_multiple_opts_last.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "/dev/cdrom /media/cdrom iso9660 ro,noauto,noexec,nodev,nosuid 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/no_partitions.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_nosuid_removable_partitions/tests/no_partitions.pass.sh
@@ -2,3 +2,4 @@
 
 touch /dev/cdrom
 echo "" > /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/fstab_and_runtime.pass.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/fstab_and_runtime.pass.sh
@@ -9,4 +9,5 @@ hidepid=2
 
 sed -i '/^proc/d' /etc/fstab
 echo "proc  /proc   proc    defaults,hidepid=${hidepid}" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 mount -oremount /proc

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/fstab_only.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/fstab_only.fail.sh
@@ -9,3 +9,4 @@ hidepid=2
 
 sed -i '/^proc/d' /etc/fstab
 echo "proc  /proc   proc    defaults,hidepid=${hidepid}" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/missing_option.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/missing_option.fail.sh
@@ -7,4 +7,5 @@
 
 sed -i '/^proc/d' /etc/fstab
 echo "proc  /proc   proc    defaults" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 mount -oremount /proc

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/runtime_only.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/runtime_only.fail.sh
@@ -8,4 +8,5 @@ hidepid=2
 {{% endif %}}
 
 sed -i '/^proc/d' /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 mount -oremount,hidepid=${hidepid} /proc

--- a/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/wrong_value.fail.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_proc_hidepid/tests/wrong_value.fail.sh
@@ -7,4 +7,5 @@
 
 sed -i '/^proc/d' /etc/fstab
 echo "proc  /proc   proc    defaults,hidepid=0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 mount -oremount /proc

--- a/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/bash/shared.sh
+++ b/linux_os/guide/system/permissions/partitions/mount_option_var_tmp_bind/bash/shared.sh
@@ -5,11 +5,13 @@
 if grep -q -P '.*\/var\/tmp.*' /etc/fstab
 then
   sed -i '/.*\/var\/tmp.*/d' /etc/fstab
+  {{{ bash_systemctl_daemon_reload() }}}
 fi
 umount /var/tmp
 
 # Bind-mount /var/tmp to /tmp via /etc/fstab (preserving the /etc/fstab form)
 printf "%-24s%-24s%-8s%-32s%-3s\n" "/tmp" "/var/tmp" "none" "rw,nodev,noexec,nosuid,bind" "0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}
 
 mkdir -p /var/tmp
 mount -B /tmp /var/tmp

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1708,10 +1708,12 @@ if ! grep "$mount_point_match_regexp" /etc/fstab; then
                 | sed -E "s/(rw|defaults|seclabel|{{{ mount_opt }}})(,|$)//g;s/,$//")
     [ "$previous_mount_opts" ] && previous_mount_opts+=","
     echo "{{{ fs_spec }}} {{{ mount_point }}} {{{ type }}} defaults,${previous_mount_opts}{{{ mount_opt }}} 0 0" >> /etc/fstab
+    {{{ bash_systemctl_daemon_reload() }}}
 # If the mount_opt option is not already in the mount point's /etc/fstab entry, add it
 elif ! grep "$mount_point_match_regexp" /etc/fstab | grep "{{{ mount_opt }}}"; then
     previous_mount_opts=$(grep "$mount_point_match_regexp" /etc/fstab | awk '{print $4}')
     sed -i "s|\(${mount_point_match_regexp}.*${previous_mount_opts}\)|\1,{{{ mount_opt }}}|" /etc/fstab
+    {{{ bash_systemctl_daemon_reload() }}}
 fi
 {{%- endmacro %}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -846,6 +846,16 @@ sed -i "s/disable.*/disable         = yes/gI" "/etc/xinetd.d/$xinetd"
 {{%- endmacro -%}}
 
 
+{{#
+    Macro to run systemctl daemon-reload if possible
+#}}
+{{%- macro bash_systemctl_daemon_reload() -%}}
+{{%- if init_system == "systemd" -%}}
+/usr/bin/systemctl daemon-reload
+{{%- endif -%}}
+{{%- endmacro -%}}
+
+
 {{%- macro _put_into_firefox_cfg(config_item, key, value_varname, where, sed_separator) -%}}
 # If the key exists, change it. Otherwise, add it to the config_file.
 if LC_ALL=C grep -m 1 -q '^{{{ config_item }}}("{{{ key }}}", ' "{{{ where }}}"; then

--- a/shared/templates/mount_option/tests/fstab.fail.sh
+++ b/shared/templates/mount_option/tests/fstab.fail.sh
@@ -12,5 +12,6 @@ make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 nodev
 {{% else %}}
 make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 noexec
 {{% endif %}}
+{{{ bash_systemctl_daemon_reload() }}}
 
 mount_partition {{{ MOUNTPOINT }}} || true

--- a/shared/templates/mount_option/tests/fstab_comment.pass.sh
+++ b/shared/templates/mount_option/tests/fstab_comment.pass.sh
@@ -12,5 +12,6 @@ make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 defaults
 sed -Ei '${s/^/#/}' /etc/fstab
 
 make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 {{{ MOUNTOPTION }}}
+{{{ bash_systemctl_daemon_reload() }}}
 
 mount_partition {{{ MOUNTPOINT }}} || true

--- a/shared/templates/mount_option/tests/runtime.pass.sh
+++ b/shared/templates/mount_option/tests/runtime.pass.sh
@@ -8,5 +8,6 @@ clean_up_partition {{{ MOUNTPOINT }}}
 create_partition
 
 make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 {{{ MOUNTOPTION }}}
+{{{ bash_systemctl_daemon_reload() }}}
 
 mount_partition {{{ MOUNTPOINT }}} || true

--- a/shared/templates/mount_option/tests/separate.pass.sh
+++ b/shared/templates/mount_option/tests/separate.pass.sh
@@ -8,5 +8,6 @@ clean_up_partition {{{ MOUNTPOINT }}}
 create_partition
 
 make_fstab_given_partition_line {{{ MOUNTPOINT }}} ext2 {{{ MOUNTOPTION }}}
+{{{ bash_systemctl_daemon_reload() }}}
 
 # $SHARED/fstab is correct, but we are not mounted.

--- a/shared/templates/mount_option_home/tests/fstab_template.fail.sh
+++ b/shared/templates/mount_option_home/tests/fstab_template.fail.sh
@@ -18,6 +18,7 @@ make_fstab_given_partition_line /srv ext2 nodev
 {{% else %}}
 make_fstab_given_partition_line /srv ext2 noexec
 {{% endif %}}
+{{{ bash_systemctl_daemon_reload() }}}
 
 mount_partition /srv
 

--- a/shared/templates/mount_option_home/tests/separate_template.pass.sh
+++ b/shared/templates/mount_option_home/tests/separate_template.pass.sh
@@ -17,6 +17,7 @@ make_fstab_given_partition_line /srv ext2 nodev
 {{% else %}}
 make_fstab_given_partition_line /srv ext2 noexec
 {{% endif %}}
+{{{ bash_systemctl_daemon_reload() }}}
 
 mount_partition /srv
 

--- a/shared/templates/mount_option_remote_filesystems/tests/correct_option.pass.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/correct_option.pass.sh
@@ -7,3 +7,4 @@ fi
 echo "UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d /mount/point nfs {{{ MOUNTOPTION }}} 0 0" >> /etc/fstab
 echo "label=remote /store\040mount\011point nfs {{{ MOUNTOPTION }}} 0 0" >> /etc/fstab
 echo "host:/dir /host\040dir nfs {{{ MOUNTOPTION }}} 0 0" >> /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/shared/templates/mount_option_remote_filesystems/tests/wrong_option.fail.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/wrong_option.fail.sh
@@ -8,3 +8,4 @@ echo "UUID=e06097bb-cfcd-437b-9e4d-a691f5662a7d /mount/point nfs rw,nosuid,nodev
 echo "host:/dir /host\040dir nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
 
 sed -i -E "s/(^\s*\S+\s+\S+\s+nfs.*)(,{{{ MOUNTOPTION }}}|{{{ MOUNTOPTION }}},)(.*)/\1\3/g" /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/shared/templates/mount_option_remote_filesystems/tests/wrong_option_with_tab.fail.sh
+++ b/shared/templates/mount_option_remote_filesystems/tests/wrong_option_with_tab.fail.sh
@@ -9,3 +9,4 @@ fi
 echo "label=remote /store\040mount\011point nfs rw,nosuid,nodev,noexec 0 0" >> /etc/fstab
 
 sed -i -E "s/(^\s*\S+\s+\S+\s+nfs.*)(,{{{ MOUNTOPTION }}}|{{{ MOUNTOPTION }}},)(.*)/\1\3/g" /etc/fstab
+{{{ bash_systemctl_daemon_reload() }}}

--- a/shared/templates/mount_option_removable_partitions/bash.template
+++ b/shared/templates/mount_option_removable_partitions/bash.template
@@ -9,6 +9,7 @@ mount_option="{{{ MOUNTOPTION }}}"
 if grep -q $device_regex /etc/fstab ; then
     previous_opts=$(grep $device_regex /etc/fstab | awk '{print $4}')
     sed -i "s|\($device_regex.*$previous_opts\)|\1,$mount_option|" /etc/fstab
+    {{{ bash_systemctl_daemon_reload() }}}
 else
     echo "Not remediating, because there is no record of $var_removable_partition in /etc/fstab" >&2
     return 1


### PR DESCRIPTION
#### Description:

In newer systems after changing `/etc/fstab` `systemctl daemon-reload` needs to be run.

#### Rationale:

```
mount: (hint) your fstab has been modified, but systemd still uses
       the old version; use 'systemctl daemon-reload' to reload.
```

#### Review Hints:

If `systemd` is not used, this should be NOP.

If `systemd` is not supported in test env, this probably causes tests to fail.