### PR TITLE
fix: ssg_test_suite: warning when rule not in benchmark

### DIFF
--- a/tests/ssg_test_suite/rule.py
+++ b/tests/ssg_test_suite/rule.py
@@ -309,10 +309,10 @@ class RuleChecker(oscap.Checker):
             if not self._rule_matches_rule_spec(short_rule_id):
                 continue
             if full_rule_id not in all_rules_in_benchmark:
-                # This is an error only if the user specified the rules to be
+                # This is a problem only if the user specified the rules to be
                 # tested explicitly using command line arguments
                 if self.target_type == "rule ID":
-                    logging.error(
+                    logging.warning(
                         "Rule '{0}' isn't present in benchmark '{1}' in '{2}'"
                         .format(
                             full_rule_id, self.benchmark_id, self.datastream))


### PR DESCRIPTION

#### Description:

When rule selected to be tested is not in benchmark, issue `WARNING`, not `ERROR`.

#### Rationale:

ERROR message just confuses most of time and the situation is not something that can be fixed. It is lack of configuration. I think warning is better choice.

In many cases Automatus tests fail because it checks `ERROR` string in log.

For example now: #10600 there is the case.

#### Review Hints:

I'm not sure if this is the way to fix the issue. Maybe testing rule selection algorithm should not not select rules not in benchmarks. Warnings are still visible in logs.