### PR TITLE
fix: use grep -E instead of deprecated egrep

### DIFF
--- a/.github/workflows/gate.yaml
+++ b/.github/workflows/gate.yaml
@@ -168,7 +168,7 @@ jobs:
         with:
           coverageLocations: build/tests/coverage.xml:coverage.py
       - name: Validate gitmailmap
-        run: egrep "\S" .mailmap | egrep -v '^#' | git check-mailmap --stdin
+        run: grep -E "\S" .mailmap | grep -Ev '^#' | git check-mailmap --stdin
 
   validate-fedora-rawhide:
     name: Build, Test on Fedora Rawhide (Container)

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -850,7 +850,7 @@ shopt -s lastpipe
 
 result=$XCCDF_RESULT_PASS
 
-cat /etc/passwd | egrep -v '^(root|halt|sync|shutdown)' | awk -F: '($7 != "/usr/sbin/nologin" && $7 != "/bin/false") { print $1 " " $6 }'| while read user dir; do
+cat /etc/passwd | grep -Ev '^(root|halt|sync|shutdown)' | awk -F: '($7 != "/usr/sbin/nologin" && $7 != "/bin/false") { print $1 " " $6 }'| while read user dir; do
 	if [ ! -d "$dir" ]; then
 		echo "The home directory ($dir) of user $user does not exist."
 		result=$XCCDF_RESULT_FAIL

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/use_pam_wheel_group_for_su/bash/shared.sh
@@ -8,7 +8,7 @@ if [ -z "$pamstr" ]; then
     sed -Ei '/^auth\b.*\brequired\b.*\bpam_wheel\.so/d' ${PAM_CONF} # remove any remaining uncommented pam_wheel.so line
     sed -Ei "/^auth\s+sufficient\s+pam_rootok\.so.*$/a auth required pam_wheel.so use_uid group=${var_pam_wheel_group_for_su}" ${PAM_CONF}
 else
-    group_val=$(echo -n "$pamstr" | egrep -o '\bgroup=[_a-z][-0-9_a-z]*' | cut -d '=' -f 2)
+    group_val=$(echo -n "$pamstr" | grep -Eo '\bgroup=[_a-z][-0-9_a-z]*' | cut -d '=' -f 2)
     if [ -z "${group_val}" ] || [ ${group_val} != ${var_pam_wheel_group_for_su} ]; then
         sed -Ei "s/(^auth\s+required\s+pam_wheel.so\s+[^#]*group=)[_a-z][-0-9_a-z]*/\1${var_pam_wheel_group_for_su}/" ${PAM_CONF}
     fi

--- a/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/sce/ubuntu2004.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_users_own_home_directories/sce/ubuntu2004.sh
@@ -13,7 +13,7 @@ shopt -s lastpipe
 
 result=$XCCDF_RESULT_PASS
 
-cat /etc/passwd | egrep -v '^(root|halt|sync|shutdown)' | awk -F: '($7 != "/usr/sbin/nologin" && $7 != "/bin/false") { print $1 " " $6 }'| while read user dir; do
+cat /etc/passwd | grep -Ev '^(root|halt|sync|shutdown)' | awk -F: '($7 != "/usr/sbin/nologin" && $7 != "/bin/false") { print $1 " " $6 }'| while read user dir; do
 	if [ ! -d "$dir" ]; then
 		echo "The home directory ($dir) of user $user does not exist."
 		result=$XCCDF_RESULT_FAIL

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_passwd/policy/stig/shared.yml
@@ -13,7 +13,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow" with the following command:
 
-    $ sudo auditctl -l | egrep '(/usr/bin/passwd)'
+    $ sudo auditctl -l | grep -E '(/usr/bin/passwd)'
 
     -a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=unset -k privileged-passwd
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_networkconfig_modification/rule.yml
@@ -67,7 +67,7 @@ ocil_clause: 'the system is not configured to audit changes of the network confi
 ocil: |-
     To determine if the system is configured to audit changes to its network configuration,
     run the following command:
-    <pre>auditctl -l | egrep '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/sysconfig/network)'</pre>
+    <pre>auditctl -l | grep -E '(/etc/issue|/etc/issue.net|/etc/hosts|/etc/sysconfig/network)'</pre>
     If the system is configured to watch for network configuration changes, a line should be returned for
     each file specified (and <tt>perm=wa</tt> should be indicated for each).
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification/rule.yml
@@ -59,7 +59,7 @@ ocil_clause: 'the system is not configured to audit account changes'
 ocil: |-
     To determine if the system is configured to audit account changes,
     run the following command:
-    <pre>auditctl -l | egrep '(/etc/passwd|/etc/shadow|/etc/group|/etc/gshadow|/etc/security/opasswd)'</pre>
+    <pre>auditctl -l | grep -E '(/etc/passwd|/etc/shadow|/etc/group|/etc/gshadow|/etc/security/opasswd)'</pre>
     If the system is configured to watch for account changes, lines should be returned for
     each file specified (and with <tt>perm=wa</tt> for each).
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/group" with the following command:
 
-    $ sudo auditctl -l | egrep '(/etc/group)'
+    $ sudo auditctl -l | grep -E '(/etc/group)'
 
     -w /etc/group -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_group/rule.yml
@@ -75,7 +75,7 @@ ocil_clause: 'the command does not return a line, or the line is commented out'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/group" with the following command:
 
-    $ sudo auditctl -l | egrep '(/etc/group)'
+    $ sudo auditctl -l | grep -E '(/etc/group)'
 
     -w /etc/group -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow" with the following command:
 
-    $ sudo auditctl -l | egrep '(/etc/gshadow)'
+    $ sudo auditctl -l | grep -E '(/etc/gshadow)'
 
     -w /etc/gshadow -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_gshadow/rule.yml
@@ -75,7 +75,7 @@ ocil_clause: 'the system is not configured to audit account changes'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/gshadow" with the following command:
 
-    $ sudo auditctl -l | egrep '(/etc/gshadow)'
+    $ sudo auditctl -l | grep -E '(/etc/gshadow)'
 
     -w /etc/gshadow -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd" with the following command:
 
-    $ sudo auditctl -l | egrep '(/etc/security/opasswd)'
+    $ sudo auditctl -l | grep -E '(/etc/security/opasswd)'
 
     -w /etc/security/opasswd -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_opasswd/rule.yml
@@ -76,7 +76,7 @@ ocil_clause: 'the command does not return a line, or the line is commented out'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/security/opasswd" with the following command:
 
-    $ sudo auditctl -l | egrep '(/etc/security/opasswd)'
+    $ sudo auditctl -l | grep -E '(/etc/security/opasswd)'
 
     -w /etc/security/opasswd -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd" with the following command:
 
-    $  sudo auditctl -l | egrep '(/etc/passwd)'
+    $  sudo auditctl -l | grep -E '(/etc/passwd)'
 
     -w /etc/passwd -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_passwd/rule.yml
@@ -75,7 +75,7 @@ ocil_clause: 'the command does not return a line, or the line is commented out'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd" with the following command:
 
-    $  sudo auditctl -l | egrep '(/etc/passwd)'
+    $  sudo auditctl -l | grep -E '(/etc/passwd)'
 
     -w /etc/passwd -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/policy/stig/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/policy/stig/shared.yml
@@ -9,7 +9,7 @@ vuldiscussion: |-
 checktext: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd with the following command:
 
-    $  sudo auditctl -l | egrep '(/etc/shadow)'
+    $  sudo auditctl -l | grep -E '(/etc/shadow)'
 
     -w /etc/shadow -p wa -k identity
 

--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_rules_usergroup_modification_shadow/rule.yml
@@ -75,7 +75,7 @@ ocil_clause: 'command does not return a line, or the line is commented out'
 ocil: |-
     Verify {{{ full_name }}} generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/passwd with the following command:
 
-    $  sudo auditctl -l | egrep '(/etc/shadow)'
+    $  sudo auditctl -l | grep -E '(/etc/shadow)'
 
     -w /etc/shadow -p wa -k identity
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_ra/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv6.conf.all.accept_ra | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv6.conf.all.accept_ra | tail -1
 
     net.ipv6.conf.all.accept_ra = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_redirects/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.all.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F net.ipv6.conf.all.accept_redirects | tail -1
 
     net.ipv6.conf.all.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_accept_source_route/policy/stig/shared.yml
@@ -20,7 +20,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.all.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F net.ipv6.conf.all.accept_source_route | tail -1
 
     net.ipv6.conf.all.accept_source_route = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_all_forwarding/policy/stig/shared.yml
@@ -21,7 +21,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv6.conf.all.forwarding | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv6.conf.all.forwarding | tail -1
 
     net.ipv6.conf.all.forwarding = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_ra/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.default.accept_ra | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F net.ipv6.conf.default.accept_ra | tail -1
 
     net.ipv6.conf.default.accept_ra = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_redirects/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.default.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F net.ipv6.conf.default.accept_redirects | tail -1
 
     net.ipv6.conf.default.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-ipv6/configuring_ipv6/sysctl_net_ipv6_conf_default_accept_source_route/policy/stig/shared.yml
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv6.conf.default.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F net.ipv6.conf.default.accept_source_route | tail -1
 
     net.ipv6.conf.default.accept_source_route = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_redirects/policy/stig/shared.yml
@@ -24,7 +24,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.all.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.all.accept_redirects | tail -1
 
     net.ipv4.conf.all.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_accept_source_route/policy/stig/shared.yml
@@ -26,7 +26,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.all.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.all.accept_source_route | tail -1
 
     net.ipv4.conf.all.accept_source_route = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_log_martians/policy/stig/shared.yml
@@ -20,7 +20,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.all.log_martians | tail -1
+    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | grep -Ev '^(#|$)' | grep -F net.ipv4.conf.all.log_martians | tail -1
 
     net.ipv4.conf.all.log_martians = 1
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_rp_filter/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.all.rp_filter | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.all.rp_filter | tail -1
 
     net.ipv4.conf.all.rp_filter = 1
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_redirects/policy/stig/shared.yml
@@ -23,7 +23,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.accept_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.default.accept_redirects | tail -1
 
     net.ipv4.conf.default.accept_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_accept_source_route/policy/stig/shared.yml
@@ -25,7 +25,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.accept_source_route | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.default.accept_source_route | tail -1
 
     net.ipv4.conf.default.accept_source_route = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_default_rp_filter/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.rp_filter | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.default.rp_filter | tail -1
 
     net.ipv4.conf.default.rp_filter = 1
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_echo_ignore_broadcasts/policy/stig/shared.yml
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|$)' | grep -F net.ipv4.icmp_echo_ignore_broadcasts | tail -1
+    $ /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|$)' | grep -F net.ipv4.icmp_echo_ignore_broadcasts | tail -1
 
     net.ipv4.icmp_echo_ignore_broadcasts = 1
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_icmp_ignore_bogus_error_responses/policy/stig/shared.yml
@@ -16,7 +16,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.icmp_ignore_bogus_error_response | tail -1
+    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | grep -Ev '^(#|$)' | grep -F net.ipv4.icmp_ignore_bogus_error_response | tail -1
 
     net.ipv4.icmp_ignore_bogus_error_response = 1
 

--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_tcp_syncookies/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.tcp_syncookies | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.tcp_syncookies | tail -1
     net.ipv4.tcp_syncookies = 1
 
     If the network parameter "ipv4.tcp_syncookies" is not equal to "1" or nothing is returned, this is a finding.

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_all_send_redirects/policy/stig/shared.yml
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F net.ipv4.conf.all.send_redirects | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F net.ipv4.conf.all.send_redirects | tail -1
 
     net.ipv4.conf.all.send_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_conf_default_send_redirects/policy/stig/shared.yml
@@ -22,7 +22,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.ipv4.conf.default.send_redirects | tail -1
+    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.ipv4.conf.default.send_redirects | tail -1
 
     net.ipv4.conf.default.send_redirects = 0
 

--- a/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/policy/stig/shared.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_parameters/sysctl_net_ipv4_ip_forward/policy/stig/shared.yml
@@ -20,7 +20,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this network parameter.
 
-    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | egrep -v '^(#|$)' | grep -F net.ipv4.conf.all.forwarding | tail -1
+    $ { /usr/lib/systemd/systemd-sysctl --cat-config; cat /etc/sysctl.conf; } | grep -Ev '^(#|$)' | grep -F net.ipv4.conf.all.forwarding | tail -1
 
     net.ipv4.conf.all.forwarding = 0
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_hardlinks/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F fs.protected_hardlinks | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F fs.protected_hardlinks | tail -1
 
     fs.protected_hardlinks = 1
 

--- a/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/files/sysctl_fs_protected_symlinks/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F fs.protected_symlinks | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F fs.protected_symlinks | tail -1
 
     fs.protected_symlinks = 1
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_kptr_restrict/policy/stig/shared.yml
@@ -12,7 +12,7 @@ checktext: |-
 
     Verify the configuration of the kernel.kptr_restrict kernel parameter with the following command:
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F kernel.kptr_restrict | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F kernel.kptr_restrict | tail -1
 
     kernel.kptr_restrict =1
 

--- a/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/enable_execshield_settings/sysctl_kernel_randomize_va_space/policy/stig/shared.yml
@@ -16,7 +16,7 @@ checktext: |-
     Check that the configuration files are present to enable this kernel parameter.
     Verify the configuration of the kernel.kptr_restrict kernel parameter with the following command:
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' |  grep -F kernel.randomize_va_space | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' |  grep -F kernel.randomize_va_space | tail -1
 
     kernel.randomize_va_space = 2
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_core_pattern/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to disable core dump storage.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.core_pattern | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F kernel.core_pattern | tail -1
 
     kernel.core_pattern = |/bin/false
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_dmesg_restrict/policy/stig/shared.yml
@@ -23,7 +23,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.dmesg_restrict | tail -1
+    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F kernel.dmesg_restrict | tail -1
     kernel.dmesg_restrict = 1
 
     If "kernel.dmesg_restrict" is not set to "1" or is missing this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_kexec_load_disabled/policy/stig/shared.yml
@@ -19,7 +19,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter with the following command:
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.kexec_load_disabled | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F kernel.kexec_load_disabled | tail -1
 
     kernel.kexec_load_disabled = 1
 

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_perf_event_paranoid/policy/stig/shared.yml
@@ -22,7 +22,7 @@ checktext: |-
     If "kernel.perf_event_paranoid" is not set to "2" or is missing, this is a finding.
     Check that the configuration files are present to enable this kernel parameter.
 
-    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config  | egrep -v '^(#|;)' | grep -F kernel.perf_event_paranoid | tail -1
+    $  sudo /usr/lib/systemd/systemd-sysctl --cat-config  | grep -Ev '^(#|;)' | grep -F kernel.perf_event_paranoid | tail -1
     kernel.perf_event_paranoid = 2
 
     If "kernel.perf_event_paranoid" is not set to "2" or is missing this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_unprivileged_bpf_disabled/policy/stig/shared.yml
@@ -16,7 +16,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.unprivileged_bpf_disabled | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F kernel.unprivileged_bpf_disabled | tail -1
     kernel.unprivileged_bpf_disabled = 1
 
     If the network parameter "ipv4.tcp_syncookies" is not equal to "1" or nothing is returned, this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_kernel_yama_ptrace_scope/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F kernel.yama.ptrace_scope| tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F kernel.yama.ptrace_scope| tail -1
     kernel.yama.ptrace_scope = 1
 
     If the network parameter "kernel.yama.ptrace_scope" is not equal to "1" or nothing is returned, this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_net_core_bpf_jit_harden/policy/stig/shared.yml
@@ -17,7 +17,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F net.core.bpf_jit_harden | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F net.core.bpf_jit_harden | tail -1
     net.core.bpf_jit_harden = 2
 
     If the network parameter "net.core.bpf_jit_harden" is not equal to "2" or nothing is returned, this is a finding.

--- a/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/policy/stig/shared.yml
+++ b/linux_os/guide/system/permissions/restrictions/sysctl_user_max_user_namespaces/policy/stig/shared.yml
@@ -18,7 +18,7 @@ checktext: |-
 
     Check that the configuration files are present to enable this kernel parameter.
 
-    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | egrep -v '^(#|;)' | grep -F user.max_user_namespaces | tail -1
+    $ sudo /usr/lib/systemd/systemd-sysctl --cat-config | grep -Ev '^(#|;)' | grep -F user.max_user_namespaces | tail -1
     user.max_user_namespaces = 0
 
     If the network parameter "user.max_user_namespaces" is not equal to "0" or nothing is returned, this is a finding.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/ubuntu.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_periodic_cron_checking/bash/ubuntu.sh
@@ -5,6 +5,6 @@
 
 # AiDE usually adds its own cron jobs to /etc/cron.daily. If script is there, this rule is
 # compliant. Otherwise, we copy the script to the /etc/cron.weekly
-if ! egrep -q '^(\/usr\/bin\/)?aide(\.wrapper)?\s+' /etc/cron.*/*; then
+if ! grep -Eq '^(\/usr\/bin\/)?aide(\.wrapper)?\s+' /etc/cron.*/*; then
     cp -f /usr/share/aide/config/cron.daily/aide /etc/cron.weekly/
 fi

--- a/linux_os/guide/system/software/sudo/sudoers_validate_passwd/policy/stig/shared.yml
+++ b/linux_os/guide/system/software/sudo/sudoers_validate_passwd/policy/stig/shared.yml
@@ -8,7 +8,7 @@ vuldiscussion: |-
 checktext: |-
     Verify that the sudoers security policy is configured to use the invoking user's password for privilege escalation with the following command:
 
-    $ sudo egrep -i '(!rootpw|!targetpw|!runaspw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#'
+    $ sudo grep -Ei '(!rootpw|!targetpw|!runaspw)' /etc/sudoers /etc/sudoers.d/* | grep -v '#'
 
     /etc/sudoers:Defaults !targetpw
     /etc/sudoers:Defaults !rootpw


### PR DESCRIPTION
#### Description:

Use `grep -E` instead of `egrep`.

#### Rationale:

From grep(1):

       In addition, the variant programs egrep and fgrep are the same as
       grep -E and grep -F, respectively. These variants are deprecated,
       but are provided for backward compatibility.

More context: https://www.phoronix.com/news/GNU-Grep-3.8-Stop-egrep-fgrep

#### Review Hints:

Changes are all over unfortunately.