### PR TITLE
update rule SLES-12-030250

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/oval/shared.xml
@@ -6,14 +6,24 @@
       <criteria comment="sshd is not installed" operator="AND">
         <extend_definition comment="sshd is not required or requirement is unset"
         definition_ref="sshd_not_required_or_unset" />
+        {{% if product in ['sle12'] %}}
+        <extend_definition comment="rpm package openssh removed"
+          definition_ref="package_openssh_removed" />
+        {{% else %}}
         <extend_definition comment="rpm package openssh-server removed"
-        definition_ref="package_openssh-server_removed" />
+          definition_ref="package_openssh-server_removed" />
+        {{% endif %}}
       </criteria>
       <criteria comment="sshd is installed and configured" operator="AND">
         <extend_definition comment="sshd is required or requirement is unset"
         definition_ref="sshd_required_or_unset" />
+        {{% if product in ['sle12'] %}}
+        <extend_definition comment="rpm package openssh installed"
+          definition_ref="package_openssh_installed" />
+        {{% else %}}
         <extend_definition comment="rpm package openssh-server installed"
-        definition_ref="package_openssh-server_installed" />
+          definition_ref="package_openssh-server_installed" />
+        {{% endif %}}
         <criterion comment="Check Compression in /etc/ssh/sshd_config"
         test_ref="test_sshd_disable_compression" />
       </criteria>

--- a/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_disable_compression/rule.yml
@@ -53,6 +53,8 @@ ocil: |-
 platform: os_linux[rhel]<7.4
 {{% elif product == "ol7" %}}
 platform: os_linux[ol]<7.4
+{{% elif product == "sle12" %}}
+platform: package[openssh]<7.4
 {{% endif %}}
 
 fixtext: '{{{ fixtext_sshd_lineinfile("Compression", xccdf_value("var_sshd_disable_compression"), no) }}}'

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -79,3 +79,5 @@ args:
     pkgname: yum
   zypper:
     pkgname: zypper
+  openssh:
+    pkgname: openssh


### PR DESCRIPTION
#### Description:

- _Update rule sshd_disable_compression_

#### Rationale:

- _Accoring DISA recommendations Version 2, Release: 9 Benchmark Date: 26 Jan 2023 about SLE 12 STIG - "SSLES-12-030250 - Note: If the installed version of OpenSSH is 7.4 or above, this requirement is not applicable."_