### PR TITLE
Implement distributed product properties without applying them

### DIFF
--- a/build-scripts/compile_product.py
+++ b/build-scripts/compile_product.py
@@ -12,6 +12,10 @@ def create_parser():
         "needed for autodetection of profile root"
     )
     parser.add_argument(
+        "--product-properties",
+        help="The directory with additional product properties yamls."
+    )
+    parser.add_argument(
         "--compiled-product-yaml", required=True,
         help="Where to save the compiled product yaml."
     )
@@ -23,6 +27,8 @@ def main():
     args = parser.parse_args()
 
     product = ssg.products.Product(args.product_yaml)
+    if args.product_properties:
+        product.read_properties_from_directory(args.product_properties)
     product.write(args.compiled_product_yaml)
 
 

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -96,7 +96,7 @@ macro(ssg_build_compiled_artifacts PRODUCT)
 
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_product.py" --product-yaml "${CMAKE_SOURCE_DIR}/products/${PRODUCT}/product.yml" --compiled-product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_product.py" --product-yaml "${CMAKE_SOURCE_DIR}/products/${PRODUCT}/product.yml" --product-properties "${CMAKE_SOURCE_DIR}/product_properties" --compiled-product-yaml "${CMAKE_CURRENT_BINARY_DIR}/product.yml"
         COMMENT "[${PRODUCT}-content] compiling product yaml"
     )
 

--- a/docs/flowcharts/flowchart_products.md
+++ b/docs/flowcharts/flowchart_products.md
@@ -11,6 +11,7 @@ flowchart TD
     subgraph products
     60[products] --> |identified by| 61[product_name]
         61[product_name] --> |defined at| 62[product.yml]
+        61[product_properties] --> |defined at| 62[product.yml, product_properties/]
         61[product_name] --> |contains| 63[overlays]
         61[product_name] --> |contains| 64[profiles]
             64[profiles] --> |written at| 65[profile_name.profile]

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -68,6 +68,10 @@ build files/configuration, etc.
 <td><p><code>utils</code></p></td>
 <td><p>Miscellaneous scripts used for development but not used by the build system.</p></td>
 </tr>
+<tr class="even">
+<td><p><code>product_properties</code></p></td>
+<td><p>Directory with its own README and with drop-in files that can define product properties across more products at once using jinja macros.</p></td>
+</tr>
 </tbody>
 </table>
 

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -427,6 +427,10 @@ so you can use only product properties in the content.
 In other words, use this functionality to avoid referencing product versions in macros used in checks or remediations.
 Instead, use properties that directly relate to configurations being checked or set, and that help to reveal the intention of the check or remediation code.
 
+As Jinja2 conditionals are prone to errors, products can be protected by product stability tests.
+If a product sample is present in `tests/data/product_stability/`, it is compared to the actual compiled product,
+and if there is a difference that is not only cosmetic, a product stability test will fail.
+
 Rules are unselected by default - even if the scanner reads rule
 definitions, they are effectively ignored during the scan or
 remediation. A rule may be selected by any number of profiles, so when

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -418,15 +418,14 @@ that begin with underscores are not meant to be used in descriptions.
 You can also check documentation for all macros in the `Jinja Macros Reference`
 section accessible from the table of contents.
 
-To parametrize rules and remediations as well as Jinja macros, you can
-use product-specific variables defined in `product.yml` in product root
-directory. Moreover, you can define **implied properties** which are
-variables inferred from them. For example, you can define a condition
-that checks if the system uses `yum` or `dnf` as a package manager and
-based on that populate a variable containing correct path to the
-configuration file. The inferring logic is implemented in
-`_get_implied_properties` in `ssg/yaml.py`. Constants and mappings used
-in implied properties should be defined in `ssg/constants.py`.
+To parametrize rules and remediations as well as Jinja macros,
+use product-specific variables defined either
+in `product.yml` in product root directory,
+or in files in the `product_properties` project directory.
+Use this functionality to associate product properties with product versions,
+so you can use only product properties in the content.
+In other words, use this functionality to avoid referencing product versions in macros used in checks or remediations.
+Instead, use properties that directly relate to configurations being checked or set, and that help to reveal the intention of the check or remediation code.
 
 Rules are unselected by default - even if the scanner reads rule
 definitions, they are effectively ignored during the scan or

--- a/product_properties/README.md
+++ b/product_properties/README.md
@@ -3,6 +3,10 @@ Product properties
 
 YAML files contained here are processed in lexicographic order, and they allow to define product properties in a efficient way.
 Processing of those files can use `jinja2`, and macros or conditionals have access to product properties defined previously and in the `product.yml`.
-Properties read from these yaml files can be overriden by properties from files processed later, while the properties specified in the `product.yml` override all previous definitions.
 
-Conventionally, use the filename prefix `10-` to define defaults, and use subsequent prefixes to override those defaults based on products.
+Properties in a file are expressed in two mappings - obligatory `default` and optional `overrides`.
+Properties defined in a mapping nested below `default` can be overriden in a mapping nested below `overrides`.
+A property can be set only in one file, so the default-override pattern implemented by Jinja macros can be accomplished, but it has to take place in one file.
+Properties specified in the `product.yml` can't be overriden by this mechanism, and attempting to do so will result in an error.
+
+Conventionally, use the filename numerical prefix e.g. `10-` to ensure that some symbols are available before they are used in a definition of other symbols.

--- a/product_properties/README.md
+++ b/product_properties/README.md
@@ -1,0 +1,8 @@
+Product properties
+==================
+
+YAML files contained here are processed in lexicographic order, and they allow to define product properties in a efficient way.
+Processing of those files can use `jinja2`, and macros or conditionals have access to product properties defined previously and in the `product.yml`.
+Properties read from these yaml files can be overriden by properties from files processed later, while the properties specified in the `product.yml` override all previous definitions.
+
+Conventionally, use the filename prefix `10-` to define defaults, and use subsequent prefixes to override those defaults based on products.

--- a/ssg/environment.py
+++ b/ssg/environment.py
@@ -6,7 +6,10 @@ from .products import load_product_yaml
 from .yaml import open_raw
 
 
-def open_environment(build_config_yaml_path, product_yaml_path):
+def open_environment(build_config_yaml_path, product_yaml_path, product_properties_path=None):
     contents = open_raw(build_config_yaml_path)
-    contents.update(load_product_yaml(product_yaml_path))
+    product = load_product_yaml(product_yaml_path)
+    if product_properties_path:
+        product.read_properties_from_directory(product_properties_path)
+    contents.update(product)
     return contents

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -26,7 +26,7 @@ from .constants import (DEFAULT_PRODUCT, product_directories,
                         XCCDF_PLATFORM_TO_PACKAGE,
                         SSG_REF_URIS)
 from .utils import merge_dicts, required_key
-from .yaml import open_raw, ordered_dump
+from .yaml import open_raw, ordered_dump, open_and_expand
 
 
 def _validate_product_oval_feed_url(contents):
@@ -155,6 +155,17 @@ class Product(object):
         self.primary_data["reference_uris"] = merge_dicts(SSG_REF_URIS, reference_uris)
 
         self.primary_data["basic_properties_derived"] = True
+
+    def expand_by(self, property_dict):
+        self.primary_data.update(property_dict)
+
+    def read_properties_from_directory(self, path):
+        filenames = glob(path + "/*.yml")
+        for f in sorted(filenames):
+            substitutions_dict = dict()
+            substitutions_dict.update(self)
+            new_symbols = open_and_expand(f, substitutions_dict)
+            self.expand_by(new_symbols.items())
 
 
 def load_product_yaml(product_yaml_path):

--- a/ssg/products.py
+++ b/ssg/products.py
@@ -111,53 +111,61 @@ def product_yaml_path(ssg_root, product):
 
 class Product(object):
     def __init__(self, filename):
-        self.primary_data = dict()
+        self._primary_data = dict()
+        self._acquired_data = dict()
         self._load_from_filename(filename)
-        if "basic_properties_derived" not in self.primary_data:
+        if "basic_properties_derived" not in self._primary_data:
             self._derive_basic_properties(filename)
+
+    @property
+    def _data_as_dict(self):
+        data = dict()
+        data.update(self._acquired_data)
+        data.update(self._primary_data)
+        return data
 
     def write(self, filename):
         with open(filename, "w") as f:
-            ordered_dump(self.primary_data, f)
+            ordered_dump(self._data_as_dict, f)
 
     def __getitem__(self, key):
-        return self.primary_data[key]
+        return self._data_as_dict[key]
 
     def __contains__(self, key):
-        return key in self.primary_data
+        return key in self._data_as_dict
 
     def __iter__(self):
-        return iter(self.primary_data.items())
+        return iter(self._data_as_dict.items())
 
     def __len__(self):
-        return len(self.primary_data)
+        return len(self._data_as_dict)
 
     def get(self, key, default=None):
-        return self.primary_data.get(key, default)
+        return self._data_as_dict.get(key, default)
 
     def _load_from_filename(self, filename):
-        self.primary_data = open_raw(filename)
+        self._primary_data = open_raw(filename)
 
     def _derive_basic_properties(self, filename):
-        _validate_product_oval_feed_url(self.primary_data)
+        _validate_product_oval_feed_url(self._primary_data)
 
         # The product directory is necessary to get absolute paths to benchmark, profile and
         # cpe directories, which are all relative to the product directory
-        self.primary_data["product_dir"] = os.path.dirname(filename)
+        self._primary_data["product_dir"] = os.path.dirname(filename)
 
-        platform_package_overrides = self.primary_data.get("platform_package_overrides", {})
+        platform_package_overrides = self._primary_data.get("platform_package_overrides", {})
         # Merge common platform package mappings, while keeping product specific mappings
-        self.primary_data["platform_package_overrides"] = merge_dicts(
+        self._primary_data["platform_package_overrides"] = merge_dicts(
                 XCCDF_PLATFORM_TO_PACKAGE, platform_package_overrides)
-        self.primary_data.update(_get_implied_properties(self.primary_data))
+        self._primary_data.update(_get_implied_properties(self._primary_data))
 
-        reference_uris = self.primary_data.get("reference_uris", {})
-        self.primary_data["reference_uris"] = merge_dicts(SSG_REF_URIS, reference_uris)
+        reference_uris = self._primary_data.get("reference_uris", {})
+        self._primary_data["reference_uris"] = merge_dicts(SSG_REF_URIS, reference_uris)
 
-        self.primary_data["basic_properties_derived"] = True
+        self._primary_data["basic_properties_derived"] = True
 
-    def expand_by(self, property_dict):
-        self.primary_data.update(property_dict)
+    def expand_by_acquired_data(self, property_dict):
+        self._acquired_data.update(property_dict)
 
     def read_properties_from_directory(self, path):
         filenames = glob(path + "/*.yml")
@@ -165,7 +173,7 @@ class Product(object):
             substitutions_dict = dict()
             substitutions_dict.update(self)
             new_symbols = open_and_expand(f, substitutions_dict)
-            self.expand_by(new_symbols.items())
+            self.expand_by_acquired_data(new_symbols.items())
 
 
 def load_product_yaml(product_yaml_path):

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -15,6 +15,7 @@ import ssg.utils
 import ssg.yaml
 import ssg.build_yaml
 import ssg.rule_yaml
+import ssg.products
 
 
 def main():
@@ -34,16 +35,18 @@ def main():
 
     known_dirs = set()
     for product in ssg.constants.product_directories:
-        product_dir = os.path.join(ssg_root, "products", product)
-        product_yaml_path = os.path.join(product_dir, "product.yml")
-        product_yaml = ssg.yaml.open_raw(product_yaml_path)
+        product_yaml_path = ssg.products.product_yaml_path(ssg_root, product)
+        product = ssg.products.Product(product_yaml_path)
+        product.read_properties_from_directory(os.path.join(ssg_root, "product_properties"))
 
         env_yaml = ssg.environment.open_environment(ssg_build_config_yaml, product_yaml_path)
         ssg.jinja.add_python_functions(env_yaml)
 
-        guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])
-        additional_content_directories = product_yaml.get("additional_content_directories", [])
-        add_content_dirs = [os.path.abspath(os.path.join(product_dir, rd)) for rd in additional_content_directories]
+        guide_dir = os.path.join(product["product_dir"], product['benchmark_root'])
+        additional_content_directories = product.get("additional_content_directories", [])
+        add_content_dirs = [
+                os.path.abspath(os.path.join(product["product_dir"], rd))
+                for rd in additional_content_directories]
 
         for cur_dir in [guide_dir] + add_content_dirs:
             if cur_dir not in known_dirs:

--- a/tests/test_parse_affected.py
+++ b/tests/test_parse_affected.py
@@ -37,9 +37,11 @@ def main():
     for product in ssg.constants.product_directories:
         product_yaml_path = ssg.products.product_yaml_path(ssg_root, product)
         product = ssg.products.Product(product_yaml_path)
-        product.read_properties_from_directory(os.path.join(ssg_root, "product_properties"))
 
-        env_yaml = ssg.environment.open_environment(ssg_build_config_yaml, product_yaml_path)
+        product_properties_path = os.path.join(ssg_root, "product_properties")
+        env_yaml = ssg.environment.open_environment(
+                ssg_build_config_yaml, product_yaml_path, product_properties_path)
+        env_yaml.update(product)
         ssg.jinja.add_python_functions(env_yaml)
 
         guide_dir = os.path.join(product["product_dir"], product['benchmark_root'])

--- a/tests/unit/ssg-module/data/properties/00-default.yml
+++ b/tests/unit/ssg-module/data/properties/00-default.yml
@@ -1,10 +1,8 @@
 
-property_one: one
-property_two: one
-grub2_uefi_boot_path: "garbage"
+- property_one: one
 
 {{% if product == "rhel7" %}}
-rhel_version: "seven"
+- rhel_version: "seven"
 {{% else %}}
-rhel_version: "not_seven"
+- rhel_version: "not_seven"
 {{% endif %}}

--- a/tests/unit/ssg-module/data/properties/00-default.yml
+++ b/tests/unit/ssg-module/data/properties/00-default.yml
@@ -1,6 +1,7 @@
 
 property_one: one
 property_two: one
+grub2_uefi_boot_path: "garbage"
 
 {{% if product == "rhel7" %}}
 rhel_version: "seven"

--- a/tests/unit/ssg-module/data/properties/00-default.yml
+++ b/tests/unit/ssg-module/data/properties/00-default.yml
@@ -1,8 +1,9 @@
 
-- property_one: one
+default:
+  property_one: one
 
-{{% if product == "rhel7" %}}
-- rhel_version: "seven"
-{{% else %}}
-- rhel_version: "not_seven"
+{{%- if product == "rhel7" %}}
+  rhel_version: "seven"
+{{%- else %}}
+  rhel_version: "not_seven"
 {{% endif %}}

--- a/tests/unit/ssg-module/data/properties/00-default.yml
+++ b/tests/unit/ssg-module/data/properties/00-default.yml
@@ -1,0 +1,9 @@
+
+property_one: one
+property_two: one
+
+{{% if product == "rhel7" %}}
+rhel_version: "seven"
+{{% else %}}
+rhel_version: "not_seven"
+{{% endif %}}

--- a/tests/unit/ssg-module/data/properties/10-property_two.yml
+++ b/tests/unit/ssg-module/data/properties/10-property_two.yml
@@ -1,2 +1,6 @@
-property_two: two
+{{% if property_one == "one" %}}
+- property_two: two
+{{% else %}}
+- property_two: one
+{{% endif %}}
 

--- a/tests/unit/ssg-module/data/properties/10-property_two.yml
+++ b/tests/unit/ssg-module/data/properties/10-property_two.yml
@@ -1,0 +1,2 @@
+property_two: two
+

--- a/tests/unit/ssg-module/data/properties/10-property_two.yml
+++ b/tests/unit/ssg-module/data/properties/10-property_two.yml
@@ -1,6 +1,8 @@
+default:
+  property_two: one
+
+overrides:
 {{% if property_one == "one" %}}
-- property_two: two
-{{% else %}}
-- property_two: one
+  property_two: two
 {{% endif %}}
 

--- a/tests/unit/ssg-module/test_products.py
+++ b/tests/unit/ssg-module/test_products.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 import ssg.products
+import ssg.yaml
 
 
 @pytest.fixture
@@ -11,8 +12,18 @@ def ssg_root():
 
 
 @pytest.fixture
-def testing_product_yaml_path():
-    return os.path.abspath(os.path.join(os.path.dirname(__file__), "data", "product.yml"))
+def testing_datadir():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "data"))
+
+
+@pytest.fixture
+def testing_product_yaml_path(testing_datadir):
+    return os.path.abspath(os.path.join(testing_datadir, "product.yml"))
+
+
+@pytest.fixture
+def testing_product(testing_product_yaml_path):
+    return ssg.products.Product(testing_product_yaml_path)
 
 
 def test_get_all(ssg_root):
@@ -28,16 +39,14 @@ def test_get_all(ssg_root):
     assert "firefox" not in products.linux
 
 
-def test_product_yaml(testing_product_yaml_path):
-    product = ssg.products.Product(testing_product_yaml_path)
-    assert "product" in product
-    assert product["product"] == "rhel7"
-    assert product["pkg_system"] == "rpm"
-    assert product["product_dir"].endswith("data")
-    assert product.get("X", "x") == "x"
+def test_product_yaml(testing_product):
+    assert "product" in testing_product
+    assert testing_product["pkg_system"] == "rpm"
+    assert testing_product["product_dir"].endswith("data")
+    assert testing_product.get("X", "x") == "x"
 
     copied_product = dict()
-    copied_product.update(product)
+    copied_product.update(testing_product)
     assert copied_product["pkg_system"] == "rpm"
 
 
@@ -51,8 +60,26 @@ def product_filename_py3(tmp_path):
     return tmp_path / "tmp_product.yml"
 
 
-def test_product_yaml_write(testing_product_yaml_path, product_filename_py2):
-    product = ssg.products.Product(testing_product_yaml_path)
-    product.write(product_filename_py2)
+def test_product_yaml_write(testing_product, product_filename_py2):
+    testing_product.write(product_filename_py2)
     second_product = ssg.products.Product(product_filename_py2)
-    assert product["product_dir"] == second_product["product_dir"]
+    assert testing_product["product_dir"] == second_product["product_dir"]
+
+
+def test_product_updates_with_dict(testing_product):
+    assert "property_one" not in testing_product
+    properties = dict(property_one="one")
+    testing_product.expand_by(properties)
+    assert testing_product["property_one"] == "one"
+    overriding_property = dict(property_one="two")
+    testing_product.expand_by(overriding_property)
+    assert testing_product["property_one"] == "two"
+
+
+def test_product_updates_with_files(testing_product, testing_datadir):
+    properties_dir = os.path.join(testing_datadir, "properties")
+    testing_product.read_properties_from_directory(properties_dir)
+    assert testing_product["property_one"] == "one"
+    assert testing_product["product"] == "rhel7"
+    assert testing_product["rhel_version"] == "seven"
+    assert testing_product["property_two"] == "two"

--- a/tests/unit/ssg-module/test_products.py
+++ b/tests/unit/ssg-module/test_products.py
@@ -33,13 +33,15 @@ def product_with_updated_properties(testing_product, testing_datadir):
     return testing_product
 
 
-def test_list_of_mappings_to_mapping():
-    converter = ssg.products.Product.transform_list_of_mappings_to_mapping
-    assert converter([]) == dict()
-    assert converter([dict(one=1)]) == dict(one=1)
-    assert converter([dict(one=2), dict(one=1)]) == dict(one=1)
+def test_default_and_overrides_mappings_to_mapping():
+    converter = ssg.products.Product.transform_default_and_overrides_mappings_to_mapping
+    assert converter(dict(default=[])) == dict()
+    assert converter(dict(default=dict(one=1))) == dict(one=1)
+    assert converter(dict(default=dict(one=2), overrides=dict(one=1))) == dict(one=1)
     with pytest.raises(ValueError):
-        assert converter([dict(one=2), 5])
+        converter([dict(one=2), 5])
+    with pytest.raises(KeyError):
+        converter(dict(deflaut=dict(one=2)))
 
 
 def test_get_all(ssg_root):

--- a/tests/unit/ssg-module/test_templates.py
+++ b/tests/unit/ssg-module/test_templates.py
@@ -18,7 +18,7 @@ cpe_items_dir = os.path.join(DATADIR, "applicability")
 
 build_config_yaml = os.path.join(ssg_root, "build", "build_config.yml")
 product_yaml = os.path.join(ssg_root, "products", "rhel8", "product.yml")
-env_yaml = open_environment(build_config_yaml, product_yaml)
+env_yaml = open_environment(build_config_yaml, product_yaml, os.path.join(ssg_root, "product_properties"))
 
 
 def test_render_extra_ovals():

--- a/utils/autoprodtyper.py
+++ b/utils/autoprodtyper.py
@@ -64,7 +64,8 @@ def main():
 
     product_base = os.path.join(SSG_ROOT, "products", args.product)
     product_yaml = os.path.join(product_base, "product.yml")
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
+    env_yaml = ssg.environment.open_environment(
+            args.build_config_yaml, product_yaml, os.path.join(SSG_ROOT, "product_properties"))
 
     profiles_root = os.path.join(product_base, "profiles")
     if args.profiles_root:

--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -85,7 +85,8 @@ def get_implemented_stigs(args):
 
     product_dir = os.path.join(args.root, "products", args.product)
     product_yaml_path = os.path.join(product_dir, "product.yml")
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, str(product_yaml_path))
+    env_yaml = ssg.environment.open_environment(
+        args.build_config_yaml, product_yaml_path, os.path.join(args._root, "product_properties"))
 
     known_rules = dict()
     for rule in platform_rules:

--- a/utils/controlrefcheck.py
+++ b/utils/controlrefcheck.py
@@ -73,7 +73,8 @@ def get_rule_object(all_rules, args, control_rule, env_yaml) -> ssg.build_yaml.R
 def get_controls_env(args):
     product_base = os.path.join(SSG_ROOT, "products", args.product)
     product_yaml = os.path.join(product_base, "product.yml")
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml)
+    env_yaml = ssg.environment.open_environment(
+        args.build_config_yaml, product_yaml, os.path.join(SSG_ROOT, "product_properties"))
     controls_manager = ssg.controls.ControlsManager(args.controls, env_yaml)
     controls_manager.load()
     return controls_manager, env_yaml

--- a/utils/create_scap_delta_tailoring.py
+++ b/utils/create_scap_delta_tailoring.py
@@ -109,7 +109,8 @@ def get_implemented_stigs(product, root_path, build_config_yaml_path,
 
     product_dir = os.path.join(root_path, "products", product)
     product_yaml_path = os.path.join(product_dir, "product.yml")
-    env_yaml = ssg.environment.open_environment(build_config_yaml_path, str(product_yaml_path))
+    env_yaml = ssg.environment.open_environment(
+        build_config_yaml_path, product_yaml_path, os.path.join(root_path, "product_properties"))
 
     known_rules = dict()
     for rule in platform_rules:

--- a/utils/create_srg_export.py
+++ b/utils/create_srg_export.py
@@ -369,10 +369,11 @@ def handle_output(output: str, results: list, format_type: str, product: str) ->
     print(f'Wrote output to {output}')
 
 
-def get_env_yaml(root: str, product: str, build_config_yaml: str) -> dict:
-    product_dir = os.path.join(root, "products", product)
+def get_env_yaml(root: str, product_path: str, build_config_yaml: str) -> dict:
+    product_dir = os.path.join(root, "products", product_path)
     product_yaml_path = os.path.join(product_dir, "product.yml")
-    env_yaml = ssg.environment.open_environment(build_config_yaml, str(product_yaml_path))
+    env_yaml = ssg.environment.open_environment(
+            build_config_yaml, product_yaml_path, os.path.join(root, "product_properties"))
     return env_yaml
 
 
@@ -383,8 +384,8 @@ def main() -> None:
 
     srgs = ssg.build_stig.parse_srgs(args.manual)
     product_dir = os.path.join(args.root, "products", args.product)
-    product_yaml_path = os.path.join(product_dir, "product.yml")
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, str(product_yaml_path))
+    env_yaml = get_env_yaml(
+            args.root, args.product, args.build_config_yaml)
     policy = get_policy(args, env_yaml)
     rule_json = get_rule_json(args.json)
 

--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -153,6 +153,8 @@ def find_rules_generator(args, func):
         if product not in product_yamls:
             product_path = ssg.products.product_yaml_path(args.root, product)
             product_yaml = ssg.products.load_product_yaml(product_path)
+            properties_directory = os.path.join(args.root, "product_properties")
+            product_yaml.read_properties_from_directory(properties_directory)
             product_yamls[product] = product_yaml
 
         local_env_yaml = dict(cmake_build_type='Debug')

--- a/utils/refchecker.py
+++ b/utils/refchecker.py
@@ -111,7 +111,8 @@ def main():
     product_base = os.path.join(SSG_ROOT, "products", args.product)
     product_yaml_path = os.path.join(product_base, "product.yml")
     product_yaml = ssg.products.Product(product_yaml_path)
-    env_yaml = ssg.environment.open_environment(args.build_config_yaml, product_yaml_path)
+    env_yaml = ssg.environment.open_environment(
+        args.build_config_yaml, product_yaml_path, os.path.join(SSG_ROOT, "product_properties"))
 
     controls_manager = None
     if os.path.exists(args.controls):

--- a/utils/rule_dir_json.py
+++ b/utils/rule_dir_json.py
@@ -50,6 +50,7 @@ def walk_products(root, all_products):
         product_dir = os.path.join(root, "products", product)
         product_yaml_path = os.path.join(product_dir, "product.yml")
         product_yaml = ssg.products.load_product_yaml(product_yaml_path)
+        product_yaml.read_properties_from_directory(os.path.join(root, "product_properties"))
         product_yamls[product] = product_yaml
 
         guide_dir = os.path.join(product_dir, product_yaml['benchmark_root'])

--- a/utils/template_renderer.py
+++ b/utils/template_renderer.py
@@ -58,7 +58,7 @@ class Renderer(object):
         self.verbose = verbose
 
     def get_env_yaml(self, build_dir):
-        product_yaml = os.path.join(self.project_directory, "products", self.product, "product.yml")
+        product_yaml = os.path.join(build_dir, self.product, "product.yml")
         build_config_yaml = os.path.join(build_dir, "build_config.yml")
         if not (os.path.exists(product_yaml) and os.path.exists(build_config_yaml)):
             msg = (


### PR DESCRIPTION
#### Description:

The PR  #10554 that went through some review already introduces product properties, and illustrates them on real properties and real products.
However, as touching products is relatively costly due to the need for approvals, I have carved out the functionality from the application, so this PR implements the functionality and tests, but it doesn't change anything.

#### Rationale:

Changes to product definitions can be accomplished more easily when they are not mixed with the build system code, so the split of the original PR into two makes some sense.

#### Review Hints:

See the #10554 to see the feature it in action, and diff the code.