### PR TITLE
Add git to dependencies of the stabilize workflow

### DIFF
--- a/.github/workflows/stabilize.yaml
+++ b/.github/workflows/stabilize.yaml
@@ -17,7 +17,7 @@ jobs:
       image: fedora:latest
     steps:
       - name: Install Deps
-        run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible libxslt python3-ansible-lint linkchecker java-1.8.0-openjdk unar wget python-unversioned-command
+        run: dnf install -y cmake ninja-build openscap-utils python3-pyyaml python3-jinja2 python3-pytest ansible libxslt python3-ansible-lint linkchecker java-1.8.0-openjdk unar wget python-unversioned-command git
       - name: Checkout
         uses: actions/checkout@v2
       - name: Configure


### PR DESCRIPTION
Addressing:
Failed to find runtime dependency 'git' in PATH.
