### PR TITLE
Fix install_vm.py on older versions of Python

### DIFF
--- a/tests/install_vm.py
+++ b/tests/install_vm.py
@@ -280,7 +280,7 @@ def join_extented_opt(opt_name, delim, opts):
     return []
 
 
-def get_virt_install_command(data) -> list[str]:
+def get_virt_install_command(data):
     command = [
         "virt-install",
         "--connect={0}".format(data.libvirt),
@@ -335,7 +335,7 @@ def get_virt_install_command(data) -> list[str]:
     return command
 
 
-def run_virt_install(data, command) -> None:
+def run_virt_install(data, command):
     if data.dry:
         print("\nThe following command would be used for the VM installation:")
         print(shlex.join(command))


### PR DESCRIPTION
We will remove the type hints that use collections. According to https://peps.python.org/pep-0585/, the "Type Hinting Generics In Standard Collections" were introduced in Python 3.9, but RHEL 8 and 7 use Python 3.6.

Fixes: https://github.com/ComplianceAsCode/content/issues/10650


This is a backport of https://github.com/ComplianceAsCode/content/pull/10651 to the stabilization branch.