### PR TITLE
Store rendered control files

### DIFF
--- a/build-scripts/compile_all.py
+++ b/build-scripts/compile_all.py
@@ -85,10 +85,11 @@ def dump_compiled_profile(base_dir, profile):
     profile.dump_yaml(dest)
 
 
-def get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, controls_manager, controls_dir=None):
-
+def get_all_resolved_profiles_by_id(
+        env_yaml, product_yaml, loader, product_cpes, controls_manager, controls_dir=None):
     profile_files = ssg.products.get_profile_files_from_root(env_yaml, product_yaml)
-    profiles_by_id = load_resolve_and_validate_profiles(env_yaml, profile_files, loader, controls_manager, product_cpes)
+    profiles_by_id = load_resolve_and_validate_profiles(
+        env_yaml, profile_files, loader, controls_manager, product_cpes)
     return profiles_by_id
 
 
@@ -134,7 +135,8 @@ def main():
     controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)
     controls_manager.load()
 
-    profiles_by_id = get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, controls_manager, args.controls_dir)
+    profiles_by_id = get_all_resolved_profiles_by_id(
+        env_yaml, product_yaml, loader, product_cpes, controls_manager, args.controls_dir)
 
     save_everything(args.resolved_base, loader, profiles_by_id.values())
     controls_manager.save_everything(os.path.join(args.resolved_base, "controls"))

--- a/build-scripts/compile_all.py
+++ b/build-scripts/compile_all.py
@@ -85,11 +85,7 @@ def dump_compiled_profile(base_dir, profile):
     profile.dump_yaml(dest)
 
 
-def get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, controls_dir=None):
-    controls_manager = None
-    if controls_dir:
-        controls_manager = ssg.controls.ControlsManager(controls_dir, env_yaml)
-        controls_manager.load()
+def get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, controls_manager, controls_dir=None):
 
     profile_files = ssg.products.get_profile_files_from_root(env_yaml, product_yaml)
     profiles_by_id = load_resolve_and_validate_profiles(env_yaml, profile_files, loader, controls_manager, product_cpes)
@@ -135,9 +131,13 @@ def main():
         None, env_yaml, product_cpes, args.sce_metadata, args.stig_references)
     load_benchmark_source_data_from_directory_tree(loader, env_yaml, product_yaml)
 
-    profiles_by_id = get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, args.controls_dir)
+    controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)
+    controls_manager.load()
+
+    profiles_by_id = get_all_resolved_profiles_by_id(env_yaml, product_yaml, loader, product_cpes, controls_manager, args.controls_dir)
 
     save_everything(args.resolved_base, loader, profiles_by_id.values())
+    controls_manager.save_everything(os.path.join(args.resolved_base, "controls"))
 
 
 if __name__ == "__main__":

--- a/docs/manual/developer/03_creating_content.md
+++ b/docs/manual/developer/03_creating_content.md
@@ -708,6 +708,14 @@ In the real world, controls (requirements) can be nested. For example, PCI-DSS
 has a tree-like structure, within requirement 2.3, we can find 2.3.a, 2.3.b,
 etc. Therefore, each item in `controls` list can contain a `controls` list.
 
+Nesting can be accomplished both by
+
+* nesting whole control definitions, or by
+* nesting references to existing controls in the `policy:control` format, where the `policy:` part can be skipped
+if the reference points to a control in that policy.
+
+Nesting using references allows reuse of controls across multiple policies.
+
 Once we have the initial file, we can read through the policy requirements and
 assess each requirement. For each control, we will have to identify whether it
 can be automated by SCAP. If so, we should look if we already have existing
@@ -989,7 +997,7 @@ controls: a list of controls (required key)
     notes: a short paragraph of text
     rules: a list of rule IDs that cover this control
     related_rules: a list of related rules
-    controls: a nested list of controls
+    controls: a (nested) list of either control definitions, or of control references in the policy:id format
     status: a keyword that reflects the current status of the implementation of this control
     tickets: a list of URLs reflecting the work that still needs to be done to address this control
 ```
@@ -1064,6 +1072,7 @@ controls:
           - accounts_password_pam_minlen
           - accounts_password_pam_ocredit
           - var_password_pam_ocredit=1
+      - other-policy:other-control
 ```
 
 ### Using controls in profiles

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -157,6 +157,7 @@ class Control(ssg.entities.common.SelectionHandler, ssg.entities.common.XCCDFEnt
     def represent_as_dict(self):
         data = super(Control, self).represent_as_dict()
         data["rules"] = self.selections
+        data["controls"] = self.controls
         return data
 
 

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -213,6 +213,17 @@ class Policy():
             self.controls.append(c)
             self.controls_by_id[c.id] = c
 
+
+    def dump(self, file):
+        dump = {}
+        dump["id"] = id
+        dump["title"] = self.title
+        dump["source"] = self.source
+        dump["controls"] = self.controls_by_id
+        dump["levels"] = self.levels
+        ssg.yaml.ordered_dump(dump, file)
+
+
     def get_control(self, control_id):
         try:
             c = self.controls_by_id[control_id]
@@ -315,3 +326,10 @@ class ControlsManager():
     def get_all_controls(self, policy_id):
         policy = self._get_policy(policy_id)
         return policy.controls_by_id.values()
+
+    def save_everything(self, output_dir):
+        # Create output directory if it doesn't yet exist.
+        ssg.utils.mkdir_p(output_dir)
+        for policy_id, policy in self.policies.items():
+            with open(os.path.join(output_dir, "{}.{}".format(policy_id, "yml")), "w+") as f:
+                policy.dump(f)

--- a/ssg/entities/common.py
+++ b/ssg/entities/common.py
@@ -284,7 +284,8 @@ class XCCDFEntity(object):
             value = getattr(self, key)
             if value or True:
                 data[key] = getattr(self, key)
-        del data["id_"]
+        if "id_" in data:
+            del data["id_"]
         return data
 
     def dump_yaml(self, file_name, documentation_complete=True):

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -43,6 +43,8 @@ def assert_control_confirms_to_standard(controls_manager, profile):
     assert "accounts_password_pam_ocredit" in c_r4_rules
     assert "var_password_pam_ocredit" in c_r4.variables
     assert c_r4.variables["var_password_pam_ocredit"] == "1"
+    assert "R4.a" in c_r4.controls
+    assert "R4.b" in c_r4.controls
     c_r5 = controls_manager.get_control(profile, "R5")
     assert c_r5.id == "R5"
     assert c_r5.status == "does not meet"

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -72,6 +72,24 @@ def controls_manager(env_yaml):
     return controls_manager
 
 
+@pytest.fixture
+def compiled_controls_dir_py2(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def compiled_controls_dir_py3(tmp_path):
+    return tmp_path
+
+
+@pytest.fixture
+def compiled_controls_manager(env_yaml, controls_manager,compiled_controls_dir_py2):
+    controls_manager.save_everything(compiled_controls_dir_py2)
+    controls_manager = ssg.controls.ControlsManager(compiled_controls_dir_py2, env_yaml)
+    controls_manager.load()
+    return controls_manager
+
+
 def _load_test(controls_manager, profile):
     assert_control_confirms_to_standard(controls_manager, profile)
 
@@ -326,6 +344,10 @@ def test_load_control_from_folder(controls_manager):
 
 def test_load_control_from_folder_and_file(controls_manager):
     _load_test(controls_manager, "jklm")
+
+
+def test_load_compiled_control_from_folder_and_file(compiled_controls_dir_py2, compiled_controls_manager):
+    _load_test(compiled_controls_manager, "jklm")
 
 
 def test_load_control_from_specific_folder_and_file(controls_manager):


### PR DESCRIPTION
#### Description:

- Store rendered (resolved) control files when building the content.
- The files are stored under `build/$product/controls/`
- This PR also adds support for reusing controls across different policies.

#### Rationale:

- Files can be used to display a policy and the relationship of controls with rules in the project.

Note: Seeking feedback and help on how to implement this properly.