### PR TITLE
Fix Ansible fatal error from `configure_tmux_lock_keybinding`

### DIFF
--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/console_screen_locking/configure_tmux_lock_keybinding/ansible/shared.yml
@@ -3,4 +3,4 @@
 # strategy = configure
 # complexity = low
 # disruption = low
-{{{ ansible_only_lineinfile(None, "/etc/tmux.conf", "\s*bind\s+\w\s+lock-session.*$", "bind X lock-session", create=create, mode="0644") }}}
+{{{ ansible_only_lineinfile(None, "/etc/tmux.conf", "\s*bind\s+\w\s+lock-session.*$", "bind X lock-session", create="true", mode="0644") }}}


### PR DESCRIPTION
#### Description:
Specify `create` value in `configure_tmux_lock_keybinding` instead of using undefined variable.

#### Rationale:
Undefined variable causes fatal error in Ansible 2.15:
```
TASK [Insert correct line into /etc/tmux.conf] *********************************
fatal: [192.168.122.230]: FAILED! => {"changed": false, "msg": "argument 'create' is of type <class 'NoneType'> and we were unable to convert to bool: <class 'NoneType'> cannot be converted to a bool"}
```


#### Review Hints:
Build content and inspect `Insert correct line into /etc/tmux.conf` task in `build/rhel8/fixes/ansible/configure_tmux_lock_keybinding.yml`.
Before:
```
- name: Insert correct line into /etc/tmux.conf
  lineinfile:
    path: /etc/tmux.conf
    create: null
    regexp: \s*bind\s+\w\s+lock-session.*$
    mode: '0644'
    line: bind X lock-session
    state: present
```
After:
```
- name: Insert correct line into /etc/tmux.conf
  lineinfile:
    path: /etc/tmux.conf
    create: true
    regexp: \s*bind\s+\w\s+lock-session.*$
    mode: '0644'
    line: bind X lock-session
    state: present
```