### PR TITLE
Fix var_firewalld_default_zone_filename datatype

### DIFF
--- a/linux_os/guide/system/network/network_implement_access_control/oval/shared.xml
+++ b/linux_os/guide/system/network/network_implement_access_control/oval/shared.xml
@@ -22,7 +22,7 @@
     </criteria>
   </definition>
 
-  <local_variable id="var_firewalld_default_zone_filename" datatype="int" version="1"
+  <local_variable id="var_firewalld_default_zone_filename" datatype="string" version="1"
       comment="Name of the zone definition file">
     <concat>
        <object_component item_field="subexpression" object_ref="obj_firewalld_default_zone"/>


### PR DESCRIPTION


#### Description:

Filepath is not an int

#### Rationale:

Fix nightly builds.
