### PR TITLE
fixes in file_groupownership template

### DIFF
--- a/applications/openshift/master/file_groupowner_cni_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_cni_conf/rule.yml
@@ -34,5 +34,5 @@ template:
     name: file_groupowner
     vars:
         filepath: ^/etc/cni/net.d/.*$
-        filegid: '0'
+        gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_controller_manager_kubeconfig/rule.yml
@@ -42,5 +42,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_dir/rule.yml
@@ -41,4 +41,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /var/lib/etcd/member/
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_data_files/rule.yml
@@ -41,5 +41,5 @@ template:
     name: file_groupowner
     vars:
         filepath: ^/var/lib/etcd/member/wal/.*$
-        filegid: '0'
+        gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_member/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_member/rule.yml
@@ -43,5 +43,5 @@ template:
     name: file_groupowner
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
-        filegid: '0'
+        gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_etcd_pki_cert_files/rule.yml
@@ -56,5 +56,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.crt$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
+++ b/applications/openshift/master/file_groupowner_ip_allocations/rule.yml
@@ -35,5 +35,5 @@ template:
     name: file_groupowner
     vars:
         filepath: ^/var/lib/cni/networks/openshift-sdn/.*$
-        filegid: '0'
+        gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_apiserver/rule.yml
@@ -41,4 +41,4 @@ template:
     vars:
         filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
         filepath_is_regex: "true"
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_controller_manager/rule.yml
@@ -41,4 +41,4 @@ template:
     vars:
         filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
         filepath_is_regex: 'true'
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_groupowner_kube_scheduler/rule.yml
@@ -40,5 +40,5 @@ template:
     name: file_groupowner
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/kube-scheduler-pod.yaml$
-        filegid: '0'
+        gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_kubeconfig/rule.yml
@@ -28,4 +28,4 @@ ocil: |-
 #    name: file_groupowner
 #    vars:
 #        filepath: /etc/kubernetes/kubeconfig
-#        filegid: '0'
+#        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
+++ b/applications/openshift/master/file_groupowner_master_admin_kubeconfigs/rule.yml
@@ -46,5 +46,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/.*\.kubeconfig$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_multus_conf/rule.yml
+++ b/applications/openshift/master/file_groupowner_multus_conf/rule.yml
@@ -34,5 +34,5 @@ template:
     name: file_groupowner
     vars:
         filepath: ^/var/run/multus/cni/net.d/.*$
-        filegid: '0'
+        gid_or_name: '0'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_cert_files/rule.yml
@@ -56,5 +56,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/tls\.crt$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_pki_key_files/rule.yml
@@ -56,5 +56,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/.*/.*/.*/.*\.key$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
+++ b/applications/openshift/master/file_groupowner_openshift_sdn_cniserver_config/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /var/run/openshift-sdn/cniserver/config.json
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_openvswitch/rule.yml
+++ b/applications/openshift/master/file_groupowner_openvswitch/rule.yml
@@ -30,4 +30,4 @@ template:
     vars:
         filepath: /etc/openvswitch/
         file_regex: ^.*$
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_ovn_cni_server_sock/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovn_cni_server_sock/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /run/ovn-kubernetes/cni/ovn-cni-server.sock
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/master/file_groupowner_ovn_db_files/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovn_db_files/rule.yml
@@ -35,5 +35,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/var/lib/ovn/etc/*.db$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
-        filegid: 'hugetlbfs'
+        gid_or_name: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
-        filegid: 'hugetlbfs'
+        gid_or_name: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/conf.db
-        filegid: 'hugetlbfs'
+        gid_or_name: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/conf.db
-        filegid: openvswitch
+        gid_or_name: openvswitch

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/system-id.conf
-        filegid: 'hugetlbfs'
+        gid_or_name: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/system-id.conf
-        filegid: 'hugetlbfs'
+        gid_or_name: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_groupowner_scheduler_kubeconfig/rule.yml
@@ -42,5 +42,5 @@ template:
   name: file_groupowner
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
-    filegid: '0'
+    gid_or_name: '0'
     filepath_is_regex: "true"

--- a/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
+++ b/applications/openshift/worker/file_groupowner_kubelet_conf/rule.yml
@@ -39,4 +39,4 @@ template:
     name: file_groupowner
     vars:
         filepath: {{{ kubeletconf_path }}}
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_ca/rule.yml
@@ -33,4 +33,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/kubernetes/kubelet-ca.crt
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_kubeconfig/rule.yml
@@ -33,4 +33,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /var/lib/kubelet/kubeconfig
-        filegid: '0'
+        gid_or_name: '0'

--- a/applications/openshift/worker/file_groupowner_worker_service/rule.yml
+++ b/applications/openshift/worker/file_groupowner_worker_service/rule.yml
@@ -36,4 +36,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/systemd/system/kubelet.service
-        filegid: '0'
+        gid_or_name: '0'

--- a/docs/templates/template_reference.md
+++ b/docs/templates/template_reference.md
@@ -279,7 +279,10 @@
         subdirectories under the directory specified by **filepath**. Default
         value is `"false"`.
 
-    -   **filegid** - group ID (GID)
+    -   **gid_or_name** - group ID (GID) or a group name.
+        If the parameter is an integer, it is treated as group ID. If the
+        parameter is not an integer, it is treated as a group name and it is
+        converted to GID by reading /etc/group.
 
 -   Languages: Ansible, Bash, OVAL
 

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_d/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/cron.d/
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_daily/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/cron.daily/
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_hourly/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/cron.hourly/
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_monthly/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/cron.monthly/
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_cron_weekly/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/cron.weekly/
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
+++ b/linux_os/guide/services/cron_and_at/file_groupowner_crontab/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/crontab
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_at_allow/rule.yml
@@ -43,4 +43,4 @@ template:
     vars:
         filepath: /etc/at.allow
         missing_file_pass: 'true'
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
+++ b/linux_os/guide/services/cron_and_at/restrict_at_cron_users/file_groupowner_cron_allow/rule.yml
@@ -54,4 +54,4 @@ template:
     vars:
         filepath: /etc/cron.allow
         missing_file_pass: 'true'
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/file_groupowner_etc_hosts_allow/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/file_groupowner_etc_hosts_allow/rule.yml
@@ -29,5 +29,5 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/hosts.allow
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/services/obsolete/inetd_and_xinetd/file_groupowner_etc_hosts_deny/rule.yml
+++ b/linux_os/guide/services/obsolete/inetd_and_xinetd/file_groupowner_etc_hosts_deny/rule.yml
@@ -29,5 +29,5 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/hosts.deny
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupowner_sshd_config/rule.yml
@@ -55,4 +55,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/ssh/sshd_config
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/rule.yml
@@ -35,4 +35,4 @@ template:
             - /etc/ssh/
         file_regex:
             - ^.*_key$
-        filegid: '{{{ dedicated_ssh_groupname if dedicated_ssh_groupname else '0' }}}'
+        gid_or_name: '{{{ dedicated_ssh_groupname if dedicated_ssh_groupname else '0' }}}'

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/correct_groupowner.pass.sh
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/correct_groupowner.pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # platform = multi_platform_ol,multi_platform_rhel
 
+if ! grep -q ssh_keys /etc/group; then
+    groupadd ssh_keys
+fi
+
 FAKE_KEY=$(mktemp -p /etc/ssh/ XXXX_key)
 chgrp ssh_keys "$FAKE_KEY"

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/test_config.yml
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_private_key/tests/test_config.yml
@@ -1,0 +1,2 @@
+deny_templated_scenarios:
+    - missing_file_test.pass.sh

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_pub_key/rule.yml
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_pub_key/rule.yml
@@ -34,5 +34,5 @@ template:
             - /etc/ssh/
         file_regex:
             - ^.*\.pub$
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/services/ssh/file_groupownership_sshd_pub_key/tests/missing_file_test.pass.sh
+++ b/linux_os/guide/services/ssh/file_groupownership_sshd_pub_key/tests/missing_file_test.pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# platform = multi_platform_ol,multi_platform_rhel
+
+rm -f /etc/ssh/*.pub

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue/rule.yml
@@ -43,4 +43,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/issue
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue_net/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_issue_net/rule.yml
@@ -41,5 +41,5 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/issue.net
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-banners/file_groupowner_etc_motd/rule.yml
@@ -43,5 +43,5 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/motd
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/accounts/accounts-session/file_groupownership_lastlog/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-session/file_groupownership_lastlog/rule.yml
@@ -32,4 +32,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /usr/bin/lastlog
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/file_groupownership_audit_configuration/rule.yml
@@ -40,4 +40,4 @@ template:
         file_regex:
             - ^audit(\.rules|d\.conf)$
             - ^.*\.rules$
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_grub2_cfg/rule.yml
@@ -61,4 +61,4 @@ template:
     name: file_groupowner
     vars:
         filepath: {{{ grub2_boot_path }}}/grub.cfg
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/file_groupowner_user_cfg/rule.yml
@@ -54,4 +54,4 @@ template:
     name: file_groupowner
     vars:
         filepath: {{{ grub2_boot_path }}}/user.cfg
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_grub2_cfg/rule.yml
@@ -50,4 +50,4 @@ template:
     name: file_groupowner
     vars:
         filepath: {{{ grub2_uefi_boot_path }}}/grub.cfg
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_user_cfg/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/uefi/file_groupowner_efi_user_cfg/rule.yml
@@ -48,4 +48,4 @@ template:
     name: file_groupowner
     vars:
         filepath: {{{ grub2_uefi_boot_path }}}/user.cfg
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_group/rule.yml
@@ -47,5 +47,5 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/group-
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_gshadow/rule.yml
@@ -52,11 +52,11 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/gshadow-
-        filegid: '0'
-        filegid@debian10: '42'
-        filegid@debian11: '42'
-        filegid@ubuntu1604: '42'
-        filegid@ubuntu1804: '42'
-        filegid@ubuntu2004: '42'
-        filegid@ubuntu2204: '42'
+        gid_or_name: '0'
+        gid_or_name@debian10: '42'
+        gid_or_name@debian11: '42'
+        gid_or_name@ubuntu1604: '42'
+        gid_or_name@ubuntu1804: '42'
+        gid_or_name@ubuntu2004: '42'
+        gid_or_name@ubuntu2204: '42'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_passwd/rule.yml
@@ -47,5 +47,5 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/passwd-
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_backup_etc_shadow/rule.yml
@@ -52,10 +52,10 @@ template:
     vars:
         filepath: /etc/shadow-
 {{% if "sle" in product %}}
-        filegid: '15'
+        gid_or_name: '15'
 {{% elif "ubuntu" in product or "debian" in product %}}
-        filegid: '42'
+        gid_or_name: '42'
 {{% else %}}
-        filegid: '0'
+        gid_or_name: '0'
 {{% endif %}}
         missing_file_pass: 'true'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_group/rule.yml
@@ -53,4 +53,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/group
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_gshadow/rule.yml
@@ -56,10 +56,10 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/gshadow
-        filegid: '0'
-        filegid@debian10: '42'
-        filegid@debian11: '42'
-        filegid@ubuntu1604: '42'
-        filegid@ubuntu1804: '42'
-        filegid@ubuntu2004: '42'
-        filegid@ubuntu2204: '42'
+        gid_or_name: '0'
+        gid_or_name@debian10: '42'
+        gid_or_name@debian11: '42'
+        gid_or_name@ubuntu1604: '42'
+        gid_or_name@ubuntu1804: '42'
+        gid_or_name@ubuntu2004: '42'
+        gid_or_name@ubuntu2204: '42'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_passwd/rule.yml
@@ -52,4 +52,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/passwd
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_important_account_files/file_groupowner_etc_shadow/rule.yml
@@ -60,9 +60,9 @@ template:
     vars:
         filepath: /etc/shadow
 {{% if "sle" in product %}}
-        filegid: '15'
+        gid_or_name: '15'
 {{% elif "ubuntu" in product or "debian" in product %}}
-        filegid: '42'
+        gid_or_name: '42'
 {{% else %}}
-        filegid: '0'
+        gid_or_name: '0'
 {{% endif %}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log/rule.yml
@@ -38,10 +38,10 @@ template:
     name: file_groupowner
     vars:
         filepath: /var/log/
-        filegid: '0'
-        filegid@ubuntu1604: '110'
-        filegid@ubuntu1804: '110'
-        filegid@ubuntu2004: '110'
+        gid_or_name: '0'
+        gid_or_name@ubuntu1604: '110'
+        gid_or_name@ubuntu1804: '110'
+        gid_or_name@ubuntu2004: '110'
 
 fixtext: |-
     {{{ describe_file_group_owner(file="/var/log", group=gid) }}}

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_messages/rule.yml
@@ -29,7 +29,7 @@ template:
     name: file_groupowner
     vars:
         filepath: /var/log/messages
-        filegid: '0'
+        gid_or_name: '0'
 fixtext: |-
     {{{ describe_file_group_owner(file="/var/log/messages", group="root") }}}
 

--- a/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_var_log_dir/file_groupowner_var_log_syslog/rule.yml
@@ -24,4 +24,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /var/log/syslog
-        filegid: '4'
+        gid_or_name: '4'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_group_ownership_library_dirs/rule.yml
@@ -62,7 +62,7 @@ template:
             - /usr/lib/
             - /usr/lib64/
         recursive: 'true'
-        filegid: '0'
+        gid_or_name: '0'
 
 fixtext: |-
     Configure the system-wide shared library directories (/lib, /lib64, /usr/lib and /usr/lib64) to be protected from unauthorized access.

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_groupownership_binary_dirs/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/dir_groupownership_binary_dirs/rule.yml
@@ -62,4 +62,4 @@ template:
             - /usr/local/bin/
             - /usr/local/sbin/
         recursive: 'true'
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_audit_binaries/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/file_groupownership_audit_binaries/rule.yml
@@ -80,4 +80,4 @@ template:
             - /sbin/auditd
             - /sbin/audispd
             - /sbin/augenrules
-        filegid: '0'
+        gid_or_name: '0'

--- a/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
+++ b/linux_os/guide/system/permissions/files/permissions_within_important_dirs/root_permissions_syslibrary_files/rule.yml
@@ -65,7 +65,7 @@ template:
             - /usr/lib64/
         file_regex: ^.*$
         recursive: 'true'
-        filegid: '0'
+        gid_or_name: '0'
 
 fixtext: |-
     Configure the system-wide shared library files (/lib, /lib64, /usr/lib and /usr/lib64) to be protected from unauthorized access.

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/file_audit_tools_group_ownership/rule.yml
@@ -66,6 +66,6 @@ template:
             - /sbin/auditd
             - /sbin/rsyslogd
             - /sbin/augenrules
-        filegid: '0'
+        gid_or_name: '0'
         missing_file_pass: 'true'
 

--- a/shared/templates/file_groupowner/ansible.template
+++ b/shared/templates/file_groupowner/ansible.template
@@ -15,7 +15,7 @@
 {{%- endif %}}
 
 - name: Find {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}{{% if RECURSIVE %}} recursively{{% endif %}}
-  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
+  command: 'find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regex "{{{ FILE_REGEX[loop.index0] }}}"'
   register: files_found
   changed_when: False
   failed_when: False
@@ -24,7 +24,7 @@
 - name: Ensure group owner on {{{ path }}} file(s) matching {{{ FILE_REGEX[loop.index0] }}}
   file:
     path: "{{ item }}"
-    group: "{{{ FILEGID }}}"
+    group: "{{{ GID_OR_NAME }}}"
     state: file
   with_items:
     - "{{ files_found.stdout_lines }}"
@@ -38,7 +38,7 @@
 {{% if RECURSIVE %}}
     recurse: yes
 {{% endif %}}
-    group: "{{{ FILEGID }}}"
+    group: "{{{ GID_OR_NAME }}}"
 
 {{% endif %}}
 {{% else %}}
@@ -48,10 +48,10 @@
     path: "{{{ path }}}"
   register: file_exists
 
-- name: Ensure group owner {{{ FILEGID }}} on {{{ path }}}
+- name: Ensure group owner {{{ GID_OR_NAME }}} on {{{ path }}}
   file:
     path: "{{{ path }}}"
-    group: "{{{ FILEGID }}}"
+    group: "{{{ GID_OR_NAME }}}"
   when: file_exists.stat is defined and file_exists.stat.exists
 
 {{% endif %}}

--- a/shared/templates/file_groupowner/bash.template
+++ b/shared/templates/file_groupowner/bash.template
@@ -14,11 +14,11 @@
 {{%- if IS_DIRECTORY %}}
 {{%- if FILE_REGEX %}}
 
-find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -gid {{{ FILEGID }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ FILEGID }}} {} \;
+find {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type f ! -group {{{ GID_OR_NAME }}} -regex '{{{ FILE_REGEX[loop.index0] }}}' -exec chgrp {{{ GID_OR_NAME }}} {} \;
 {{%- else %}}
-find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
+find -H {{{ path }}} {{{ FIND_RECURSE_ARGS }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
 {{%- endif %}}
 {{%- else %}}
-chgrp {{{ FILEGID }}} {{{ path }}}
+chgrp {{{ GID_OR_NAME }}} {{{ path }}}
 {{%- endif %}}
 {{%- endfor %}}

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -1,13 +1,13 @@
 <def-group>
   <definition class="compliance" id="{{{ _RULE_ID }}}" version="1">
    {{% if FILEPATH is not string %}}
-      {{{ oval_metadata("This test makes sure that " + FILEPATH|join(", ") + " is group owned by " + FILEGID + ".") }}}
+      {{{ oval_metadata("This test makes sure that " + FILEPATH|join(", ") + " is group owned by " + GID_OR_NAME + ".") }}}
       <criteria>
     {{% for filepath in FILEPATH %}}
       <criterion comment="Check file group ownership of {{{ filepath }}}" test_ref="test_file_groupowner{{{ FILEID }}}_{{{ loop.index0 }}}" />
     {{% endfor %}}
    {{% else %}}
-    {{{ oval_metadata("This test makes sure that " + FILEPATH + " is group owned by " + FILEGID + ".") }}}
+    {{{ oval_metadata("This test makes sure that " + FILEPATH + " is group owned by " + GID_OR_NAME + ".") }}}
     <criteria>
       <criterion comment="Check file group ownership of {{{ FILEPATH }}}" test_ref="test_file_groupowner{{{ FILEID }}}" />
    {{% endif %}}
@@ -33,39 +33,39 @@
     {{%- else %}}
       <unix:filepath{{% if FILEPATH_IS_REGEX %}} operation="pattern match"{{% endif %}}>{{{ filepath }}}</unix:filepath>
     {{%- endif %}}
-    <filter action="exclude">symlink_file_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}</filter>
-    <filter action="exclude">state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}</filter>
+    <filter action="exclude">symlink_file_groupowner{{{ FILEID }}}_uid_{{{ GID_OR_NAME }}}</filter>
+    <filter action="exclude">state_file_groupowner{{{ FILEID }}}_gid_{{{ GID_OR_NAME }}}_{{{ loop.index0 }}}</filter>
   </unix:file_object>
 
-  <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ FILEGID }}}_{{{ loop.index0 }}}" version="1">
-    {{%- if FILEGID == '0' %}}
-    <unix:group_id datatype="int">{{{ FILEGID }}}</unix:group_id>
+  <unix:file_state id="state_file_groupowner{{{ FILEID }}}_gid_{{{ GID_OR_NAME }}}_{{{ loop.index0 }}}" version="1">
+    {{%- if GROUP_REPRESENTED_WITH_GID %}}
+    <unix:group_id datatype="int">{{{ GID_OR_NAME }}}</unix:group_id>
     {{%- else %}}
-    <unix:group_id datatype="int" var_ref="var_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}"></unix:group_id>
+    <unix:group_id datatype="int" var_ref="var_dedicated_groupowner{{{ FILEID }}}_uid_{{{ GID_OR_NAME }}}"></unix:group_id>
     {{%- endif %}}
   </unix:file_state>
   {{% endfor %}}
 
-  <unix:file_state id="symlink_file_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" version="1">
+  <unix:file_state id="symlink_file_groupowner{{{ FILEID }}}_uid_{{{ GID_OR_NAME }}}" version="1">
     <unix:type operation="equals">symbolic link</unix:type>
   </unix:file_state>
 
-  {{%- if FILEGID != '0' %}}
-  <ind:textfilecontent54_object id="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" version="1" comment="gid of the dedicated {{{ FILEGID }}} group">
+  {{%- if not GROUP_REPRESENTED_WITH_GID %}}
+  <ind:textfilecontent54_object id="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ GID_OR_NAME }}}" version="1" comment="gid of the dedicated {{{ GID_OR_NAME }}} group">
   {{%- if product in ["rhcos4","ocp4"] %}}
     {{# CoreOS doesn't list all groups in /etc/group - that's probably related to the FS immutability #}}
     <ind:filepath>/usr/lib/group</ind:filepath>
   {{%- else %}}
     <ind:filepath>/etc/group</ind:filepath>
   {{%- endif %}}
-    <ind:pattern operation="pattern match">^{{{ FILEGID }}}:\w+:(\w+):.*</ind:pattern>
+    <ind:pattern operation="pattern match">^{{{ GID_OR_NAME }}}:\w+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>
   </ind:textfilecontent54_object>
 
   <!-- variable storing count of all group names - including duplicates -->
-  <local_variable id="var_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" datatype="int" version="1"
+  <local_variable id="var_dedicated_groupowner{{{ FILEID }}}_uid_{{{ GID_OR_NAME }}}" datatype="int" version="1"
                   comment="Count of all group names (including duplicates if any)">
-          <object_component item_field="subexpression" object_ref="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}"/>
+          <object_component item_field="subexpression" object_ref="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ GID_OR_NAME }}}"/>
   </local_variable>
   {{%- endif %}}
 </def-group>

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -1,36 +1,15 @@
-from ssg.utils import parse_template_boolean_value, check_conflict_regex_directory
-
-def _file_owner_groupowner_permissions_regex(data):
-    # this avoids code duplicates
-    if isinstance(data["filepath"], str):
-        data["filepath"] = [data["filepath"]]
-
-    if "file_regex" in data:
-        # we can have a list of filepaths, but only one regex
-        # instead of declaring the same regex multiple times
-        if isinstance(data["file_regex"], str):
-            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
-
-        # if the length of filepaths and file_regex are not the same, then error.
-        # in case we have multiple regexes for just one filepath, than we need
-        # to declare that filepath multiple times
-        if len(data["filepath"]) != len(data["file_regex"]):
-            raise ValueError(
-                "You should have one file_path per file_regex. Please check "
-                "rule '{0}'".format(data["_rule_id"]))
-
-    check_conflict_regex_directory(data)
+from ssg.utils import parse_template_boolean_value
+from ssg.utils import ensure_file_paths_and_file_regexes_are_correctly_defined
 
 
 def preprocess(data, lang):
-    _file_owner_groupowner_permissions_regex(data)
+    ensure_file_paths_and_file_regexes_are_correctly_defined(data)
 
     data["missing_file_pass"] = parse_template_boolean_value(data, parameter="missing_file_pass", default_value=False)
 
     data["recursive"] = parse_template_boolean_value(data,
                                                      parameter="recursive",
                                                      default_value=False)
-
 
     try:
         int(data["gid_or_name"])

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -5,7 +5,8 @@ from ssg.utils import ensure_file_paths_and_file_regexes_are_correctly_defined
 def preprocess(data, lang):
     ensure_file_paths_and_file_regexes_are_correctly_defined(data)
 
-    data["missing_file_pass"] = parse_template_boolean_value(data, parameter="missing_file_pass", default_value=False)
+    data["missing_file_pass"] = parse_template_boolean_value(
+        data, parameter="missing_file_pass", default_value=False)
 
     data["recursive"] = parse_template_boolean_value(data,
                                                      parameter="recursive",

--- a/shared/templates/file_groupowner/template.py
+++ b/shared/templates/file_groupowner/template.py
@@ -31,6 +31,13 @@ def preprocess(data, lang):
                                                      parameter="recursive",
                                                      default_value=False)
 
+
+    try:
+        int(data["gid_or_name"])
+        data["group_represented_with_gid"] = True
+    except ValueError:
+        data["group_represented_with_gid"] = False
+
     if lang == "oval":
         data["fileid"] = data["_rule_id"].replace("file_groupowner", "")
     return data

--- a/shared/templates/file_groupowner/tests/correct_groupowner.pass.sh
+++ b/shared/templates/file_groupowner/tests/correct_groupowner.pass.sh
@@ -4,12 +4,12 @@
 {{% if IS_DIRECTORY and FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
 {{% elif IS_DIRECTORY and RECURSIVE %}}
-find -L {{{ path }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
+find -L {{{ path }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"
     touch {{{ path }}}
 fi
-chgrp {{{ FILEGID }}} {{{ path }}}
+chgrp {{{ GID_OR_NAME }}} {{{ path }}}
 {{% endif %}}
 {{% endfor %}}

--- a/shared/templates/file_groupowner/tests/correct_groupowner.pass.sh
+++ b/shared/templates/file_groupowner/tests/correct_groupowner.pass.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
+{{% else %}}
+chgrp {{{ GID_OR_NAME }}} {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_groupowner/tests/incorrect_groupowner.fail.sh
+++ b/shared/templates/file_groupowner/tests/incorrect_groupowner.fail.sh
@@ -3,10 +3,17 @@
 groupadd group_test
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -exec chgrp group_test {} \;
+{{% else %}}
+chgrp group_test {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
@@ -7,13 +7,13 @@
         {{% if IS_DIRECTORY and FILE_REGEX %}}
         echo "Create specific tests for this rule because of regex"
         {{% elif IS_DIRECTORY and RECURSIVE %}}
-        find -L {{{ path }}} -type d -exec chgrp {{{ FILEGID }}} {} \;
+        find -L {{{ path }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
         {{% else %}}
         if [ ! -f {{{ path }}} ]; then
             mkdir -p "$(dirname '{{{ path }}}')"
             touch {{{ path }}}
         fi
-        chgrp {{{ FILEGID }}} {{{ path }}}
+        chgrp {{{ GID_OR_NAME }}} {{{ path }}}
         {{% endif %}}
     {{% endif %}}
 {{% endfor %}}

--- a/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
@@ -4,10 +4,17 @@
     {{% if MISSING_FILE_PASS %}}
         rm -f {{{ path }}}
     {{% else %}}
-        {{% if IS_DIRECTORY and FILE_REGEX %}}
+        {{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
         echo "Create specific tests for this rule because of regex"
-        {{% elif IS_DIRECTORY and RECURSIVE %}}
+        {{% elif RECURSIVE %}}
         find -L {{{ path }}} -type d -exec chgrp {{{ GID_OR_NAME }}} {} \;
+{{% else %}}
+        chgrp {{{ GID_OR_NAME }}} {{{ path }}}
+{{% endif %}}
         {{% else %}}
         if [ ! -f {{{ path }}} ]; then
             mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_groupowner/tests/missing_file_test.pass.sh
@@ -2,7 +2,15 @@
 
 {{% for path in FILEPATH %}}
     {{% if MISSING_FILE_PASS %}}
+{{% if path.endswith("/") %}}
+{{% if FILE_REGEX %}}
+        echo "Create specific tests for this rule because of regex"
+{{% else %}}
+rm -rf {{{ path }}}
+{{% endif %}}
+{{% else %}}
         rm -f {{{ path }}}
+{{% endif %}}
     {{% else %}}
         {{% if path.endswith("/") %}}
 if [ ! -d {{{ path }}} ]; then

--- a/shared/templates/file_owner/template.py
+++ b/shared/templates/file_owner/template.py
@@ -1,29 +1,9 @@
-from ssg.utils import parse_template_boolean_value, check_conflict_regex_directory
-
-def _file_owner_groupowner_permissions_regex(data):
-    # this avoids code duplicates
-    if isinstance(data["filepath"], str):
-        data["filepath"] = [data["filepath"]]
-
-    if "file_regex" in data:
-        # we can have a list of filepaths, but only one regex
-        # instead of declaring the same regex multiple times
-        if isinstance(data["file_regex"], str):
-            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
-
-        # if the length of filepaths and file_regex are not the same, then error.
-        # in case we have multiple regexes for just one filepath, than we need
-        # to declare that filepath multiple times
-        if len(data["filepath"]) != len(data["file_regex"]):
-            raise ValueError(
-                "You should have one file_path per file_regex. Please check "
-                "rule '{0}'".format(data["_rule_id"]))
-
-    check_conflict_regex_directory(data)
+from ssg.utils import parse_template_boolean_value
+from ssg.utils import ensure_file_paths_and_file_regexes_are_correctly_defined
 
 
 def preprocess(data, lang):
-    _file_owner_groupowner_permissions_regex(data)
+    ensure_file_paths_and_file_regexes_are_correctly_defined(data)
 
     data["missing_file_pass"] = parse_template_boolean_value(data, parameter="missing_file_pass", default_value=False)
 

--- a/shared/templates/file_owner/template.py
+++ b/shared/templates/file_owner/template.py
@@ -5,7 +5,8 @@ from ssg.utils import ensure_file_paths_and_file_regexes_are_correctly_defined
 def preprocess(data, lang):
     ensure_file_paths_and_file_regexes_are_correctly_defined(data)
 
-    data["missing_file_pass"] = parse_template_boolean_value(data, parameter="missing_file_pass", default_value=False)
+    data["missing_file_pass"] = parse_template_boolean_value(
+        data, parameter="missing_file_pass", default_value=False)
 
     data["recursive"] = parse_template_boolean_value(data,
                                                      parameter="recursive",

--- a/shared/templates/file_owner/tests/correct_owner.pass.sh
+++ b/shared/templates/file_owner/tests/correct_owner.pass.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -exec chown {{{ FILEUID }}} {} \;
+{{% else %}}
+chown {{{ FILEUID }}} {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_owner/tests/incorrect_owner.fail.sh
+++ b/shared/templates/file_owner/tests/incorrect_owner.fail.sh
@@ -3,10 +3,17 @@
 useradd testuser_123
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -exec chown testuser_123 {} \;
+{{% else %}}
+chown testuser_123 {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_owner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_owner/tests/missing_file_test.pass.sh
@@ -4,8 +4,15 @@
     {{% if MISSING_FILE_PASS %}}
         rm -f {{{ path }}}
     {{% else %}}
-        {{% if IS_DIRECTORY and RECURSIVE %}}
+        {{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if RECURSIVE %}}
         find -L {{{ path }}} -type d -exec chown {{{ FILEUID }}} {} \;
+{{% else %}}
+        chown {{{ FILEUID }}} {{{ path }}}
+{{%endif %}}
         {{% else %}}
         if [ ! -f {{{ path }}} ]; then
             mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_owner/tests/missing_file_test.pass.sh
+++ b/shared/templates/file_owner/tests/missing_file_test.pass.sh
@@ -2,8 +2,16 @@
 
 {{% for path in FILEPATH %}}
     {{% if MISSING_FILE_PASS %}}
+{{% if path.endswith("/") %}}
+{{% if FILE_REGEX %}}
+        echo "Create specific tests for this rule because of regex"
+{{% else %}}
+rm -rf {{{ path }}}
+{{% endif %}}
+{{% else %}}
         rm -f {{{ path }}}
-    {{% else %}}
+    {{% endif %}}
+{{% else %}}
         {{% if path.endswith("/") %}}
 if [ ! -d {{{ path }}} ]; then
     mkdir -p {{{ path }}}

--- a/shared/templates/file_permissions/template.py
+++ b/shared/templates/file_permissions/template.py
@@ -1,26 +1,5 @@
-from ssg.utils import parse_template_boolean_value, check_conflict_regex_directory
-
-def _file_owner_groupowner_permissions_regex(data):
-    # this avoids code duplicates
-    if isinstance(data["filepath"], str):
-        data["filepath"] = [data["filepath"]]
-
-    if "file_regex" in data:
-        # we can have a list of filepaths, but only one regex
-        # instead of declaring the same regex multiple times
-        if isinstance(data["file_regex"], str):
-            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
-
-        # if the length of filepaths and file_regex are not the same, then error.
-        # in case we have multiple regexes for just one filepath, than we need
-        # to declare that filepath multiple times
-        if len(data["filepath"]) != len(data["file_regex"]):
-            raise ValueError(
-                "You should have one file_path per file_regex. Please check "
-                "rule '{0}'".format(data["_rule_id"]))
-
-    check_conflict_regex_directory(data)
-
+from ssg.utils import parse_template_boolean_value
+from ssg.utils import ensure_file_paths_and_file_regexes_are_correctly_defined
 
 def map_symbolic_permissions(filemode, allow_stricter_permissions):
     mode_int = int(filemode, 8)
@@ -58,7 +37,7 @@ def group_symbolic_permissions(mode_dict):
 
 
 def preprocess(data, lang):
-    _file_owner_groupowner_permissions_regex(data)
+    ensure_file_paths_and_file_regexes_are_correctly_defined(data)
 
     data["allow_stricter_permissions"] = parse_template_boolean_value(data, parameter="allow_stricter_permissions", default_value=True)
 

--- a/shared/templates/file_permissions/tests/correct_permissions.pass.sh
+++ b/shared/templates/file_permissions/tests/correct_permissions.pass.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
+{{% else %}}
+chmod {{{ FILEMODE }}} {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_permissions/tests/lenient_permissions.fail.sh
+++ b/shared/templates/file_permissions/tests/lenient_permissions.fail.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -maxdepth 1 -exec chmod 777 {} \;
+{{% else %}}
+chmod 777 {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/shared/templates/file_permissions/tests/stricter_permisions.pass.sh
+++ b/shared/templates/file_permissions/tests/stricter_permisions.pass.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
 {{% for path in FILEPATH %}}
-{{% if IS_DIRECTORY and FILE_REGEX %}}
+{{% if path.endswith("/") %}}
+if [ ! -d {{{ path }}} ]; then
+    mkdir -p {{{ path }}}
+fi
+{{% if FILE_REGEX %}}
 echo "Create specific tests for this rule because of regex"
-{{% elif IS_DIRECTORY and RECURSIVE %}}
+{{% elif RECURSIVE %}}
 find -L {{{ path }}} -type d -exec chmod {{{ FILEMODE }}} {} \;
+{{% else %}}
+chmod 000 {{{ path }}}
+{{% endif %}}
 {{% else %}}
 if [ ! -f {{{ path }}} ]; then
     mkdir -p "$(dirname '{{{ path }}}')"

--- a/ssg/utils.py
+++ b/ssg/utils.py
@@ -470,3 +470,32 @@ def apply_formatting_on_dict_values(source_dict, string_dict, ignored_keys=froze
         else:
             new_dict[k] = v
     return new_dict
+
+
+def ensure_file_paths_and_file_regexes_are_correctly_defined(data):
+    """
+    This function is common for the file_owner, file_groupowner
+    and file_permissions templates.
+    It ensures that the data structure meets certain rules, e.g. the file_path
+    item is a list and number of list items in file_regex
+    equals to number of items in file_path.
+    """
+    # this avoids code duplicates
+    if isinstance(data["filepath"], str):
+        data["filepath"] = [data["filepath"]]
+
+    if "file_regex" in data:
+        # we can have a list of filepaths, but only one regex
+        # instead of declaring the same regex multiple times
+        if isinstance(data["file_regex"], str):
+            data["file_regex"] = [data["file_regex"]] * len(data["filepath"])
+
+        # if the length of filepaths and file_regex are not the same, then error.
+        # in case we have multiple regexes for just one filepath, than we need
+        # to declare that filepath multiple times
+        if len(data["filepath"]) != len(data["file_regex"]):
+            raise ValueError(
+                "You should have one file_path per file_regex. Please check "
+                "rule '{0}'".format(data["_rule_id"]))
+
+    check_conflict_regex_directory(data)


### PR DESCRIPTION
#### Description:

Please see commit messages.

#### Rationale:

Recent changes to the template made the OVAL check consider both GIDs and group names. But the parameter `filegid` was considered to be a numeric GID only in case it was equal to 0. This created a problem in case a content author tried to use a gid different than 0 - the result was incorrect, it tried to search for a group name instead of using the gid.
This PR tries to fix the behavior - if the parameter is an integer, it is considered to be a gid. If it is a string, it is considered to be a group name.
This should not be a problem since group names can't be numeric.

Also as Automatus tests have been run on many rules, I have discovered two problems in test scenarios for file_groupownership, file_owner and file_permissions templates.
The first problem is that scenarios try to use the is_directory template variable, but this variable is never stored. It is created only at runtime when templates are used to render checks and remediations. This made test scenarios not working correctly in case the the filepath parameter was a directory.
Also I found out that test scenarios did not account for the case when the filepath parameter was a directory and it did not exist on the system prior the test run.

- Fixes #10655 

#### Review Hints:

You can run automatus on the file_groupownership template in template mode:

```
python automatus.py template --libvirt qemu:///system ssgts_vm file_groupownership
python automatus.py template --libvirt qemu:///system ssgts_vm --remediate-using ansible file_groupownership
```

Or you can try for example these rules:

- file_groupowner_var_log_syslog
- file_groupownership_sshd_private_key
- file_groupowner_etc_shadow