### PR TITLE
Fix compare datastream check to correctly treat new line characters.

### DIFF
--- a/.github/workflows/compare-ds.yaml
+++ b/.github/workflows/compare-ds.yaml
@@ -81,14 +81,12 @@ jobs:
       - name: Get diff.log
         if: ${{ steps.compare_ds.outputs.COMPARE_DS_OUTPUT_SIZE != '0'}}
         id: diff
-        run: | # set -f to disable any glob expansion that can be triggered in the echo command
-          set -f
+        run: |
           body=$(cat diff.log)
-          body="${body//'%'/'%25'}"
-          body="${body//$'\n'/'%0A'}"
-          body="${body//$'\r'/'%0D'}"
-          echo "log=${body:0:65000}">> $GITHUB_OUTPUT
-          set +f
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+          echo "log<<$EOF" >> "$GITHUB_OUTPUT"
+          echo "${body:0:65000}" >> "$GITHUB_OUTPUT"
+          echo "$EOF" >> "$GITHUB_OUTPUT"
       - name: Find Comment
         uses: peter-evans/find-comment@v2
         id: fc


### PR DESCRIPTION
Try a fix for the following:


This datastream diff is auto generated by the check `Compare DS/Generate Diff`
<details>
<summary>Click here to see the full diff</summary>

```diff
ansible remediation for rule 'xccdf_org.ssgproject.content_rule_configure_tmux_lock_keybinding' differs.%0A--- xccdf_org.ssgproject.content_rule_configure_tmux_lock_keybinding%0A+++ xccdf_org.ssgproject.content_rule_configure_tmux_lock_keybinding%0A@@ -42,7 +42,7 @@%0A - name: Insert correct line into /etc/tmux.conf%0A   lineinfile:%0A     path: /etc/tmux.conf%0A-    create: null%0A+    create: true%0A     regexp: \s*bind\s+\w\s+lock-session.*$%0A     mode: '0644'%0A     line: bind X lock-session
```

</details>

The break line characters were necessary before: https://github.com/ComplianceAsCode/content/pull/10588


Implementation according: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string