### PR TITLE
Set platform all for rules that are selected in RHEL9 STIG profile

### DIFF
--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_host_based_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_sle,multi_platform_ol
+# platform = multi_platform_all
 
 # Identify local mounts
 MOUNT_LIST=$(df --local | awk '{ print $6 }')

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/r_services/no_user_host_based_files/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_sle,multi_platform_ol
+# platform = multi_platform_all
 
 # Identify local mounts
 MOUNT_LIST=$(df --local | awk '{ print $6 }')

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/ansible/shared.yml
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
+# platform = multi_platform_all
 # reboot = false
 # complexity = low
 # strategy = configure

--- a/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/bash/shared.sh
+++ b/linux_os/guide/services/obsolete/tftp/tftpd_uses_secure_mode/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 7,Oracle Linux 8,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables ("var_tftpd_secure_directory") }}}
 

--- a/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/ansible/shared.yml
+++ b/linux_os/guide/services/xwindows/disabling_xwindows/xwindows_runlevel_target/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,multi_platform_rhv,multi_platform_fedora,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_ol
+# platform = multi_platform_all
 # reboot = true
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_ol,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/disallow_bypass_password_sudo/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_ol,multi_platform_sle
+# platform = multi_platform_all
 
 sed -i '/pam_succeed_if/d' /etc/pam.d/sudo

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_all
 
 {{{ set_config_file(path="/etc/login.defs",
                     parameter="SHA_CRYPT_MIN_ROUNDS",

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,Oracle Linux 7,Oracle Linux 8,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_burstaction/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 
 
 {{{ bash_replace_or_append('/etc/systemd/system.conf', '^CtrlAltDelBurstAction=', 'none', '%s=%s') }}}

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,multi_platform_fedora,Oracle Linux 7,Oracle Linux 8,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = disable
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-physical/disable_ctrlaltdel_reboot/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 systemctl disable --now ctrl-alt-del.target
 systemctl mask --now ctrl-alt-del.target

--- a/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-physical/screen_locking/smart_card_login/configure_opensc_card_drivers/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,multi_platform_fedora,multi_platform_rhv,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = configure
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_sle
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_all
+# platform = multi_platform_sle
 
 {{{ bash_instantiate_variables("var_accounts_authorized_local_users_regex") }}}
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/accounts_authorized_local_users/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 
 {{{ bash_instantiate_variables("var_accounts_authorized_local_users_regex") }}}
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_expiration/accounts_password_set_min_life_existing/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/no_empty_passwords_etc_shadow/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_ol,multi_platform_sle,multi_platform_ubuntu
+# platform = multi_platform_all
 
 readarray -t users_with_empty_pass < <(sudo awk -F: '!$2 {print $1}' /etc/shadow)
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/root_logins/accounts_no_uid_except_zero/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle,Red Hat Enterprise Linux 7
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,Oracle Linux 7,Oracle Linux 8,multi_platform_sle,multi_platform_fedora
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/bash/shared.sh
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_have_homedir_login_defs/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,Oracle Linux 7,Oracle Linux 8,multi_platform_sle,multi_platform_fedora
+# platform = multi_platform_all
 
 {{{ set_config_file("/etc/login.defs", "CREATE_HOME", "yes", create=true, insert_after="", insert_before="^\s*CREATE_HOME", insensitive=true) }}}

--- a/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
+++ b/linux_os/guide/system/accounts/accounts-session/accounts_tmout/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_ol,multi_platform_rhel,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
+++ b/linux_os/guide/system/permissions/files/dir_perms_world_writable_root_owned/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Fedora,Oracle Linux 7,Oracle Linux 8
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = unknown
 # complexity = low

--- a/linux_os/guide/system/software/gnome/dconf_db_up_to_date/bash/shared.sh
+++ b/linux_os/guide/system/software/gnome/dconf_db_up_to_date/bash/shared.sh
@@ -1,3 +1,3 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_all
 
 dconf update

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/ansible/shared.yml
@@ -8,6 +8,7 @@
 - name: Check to see the current status of FIPS mode
   command: /usr/bin/fips-mode-setup --check
   register: is_fips_enabled
+  ignore_errors: yes
   changed_when: false
 
 - name: Enable FIPS mode

--- a/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/fips/enable_fips_mode/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,Red Hat Virtualization 4
+# platform = multi_platform_all
 {{{ bash_instantiate_variables("var_system_crypto_policy") }}}
 
 fips-mode-setup --enable

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_scan_notification/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Red Hat Enterprise Linux 8,Red Hat Virtualization 4,Oracle Linux 7,Oracle Linux 8,multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_acls/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_all
 
 {{{ bash_package_install("aide") }}}
 

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_sle
+# platform = multi_platform_all
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
+++ b/linux_os/guide/system/software/integrity/software-integrity/aide/aide_verify_ext_attributes/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_sle
+# platform = multi_platform_all
 
 {{{ bash_package_install("aide") }}}
 

--- a/tests/fmf-plans/ansible-stig.fmf
+++ b/tests/fmf-plans/ansible-stig.fmf
@@ -1,0 +1,16 @@
+summary:
+  Destructive STIG profile test (Ansible)
+discover:
+  how: fmf
+  url: https://src.fedoraproject.org/tests/scap-security-guide.git
+  test:
+  - /Sanity/ansible-machine-hardening/stig
+execute:
+  how: tmt
+adjust:
+- enabled: false
+  when: distro == fedora
+  continue: false
+- enabled: false
+  when: distro <= centos-8
+  continue: false


### PR DESCRIPTION
#### Description:
- Set platform all for rules that are selected in RHEL9 STIG profile

#### Rationale:

- Let's see what happens when we enable remediation for rules in RHEL9 STIG that didn't have the remediation enabled before.
- Prefer `multi_platform_all` and let `prodtype` decide which product that remediation will be applicable to.