### PR TITLE
SLE Add rsyslog_remote_loghost droping remediations

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_sle,multi_platform_ol
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/sle15.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/sle15.yml
@@ -9,38 +9,29 @@
   ansible.builtin.lineinfile:
     path: /etc/rsyslog.conf
     create: false
-    regexp: "^\\*\\.\\*"
+    regexp: "^\\*\\.\\*\\s+.*$"
     state: absent
-  check_mode: true
   changed_when: false
   register: dupes_master
 
-- name: Deduplicate values from rsyslog master configuration
-  ansible.builtin.lineinfile:
-    path: /etc/rsyslog.conf
-    create: false
-    regexp: "^\\*\\.\\*"
-    state: absent
-  when: dupes_master.found is defined and dupes_master.found > 1
-
-- name: Collect all config rsyslog files which configure Compress
+- name: Collect all config rsyslog files which configure remote logger
   ansible.builtin.find:
     paths: /etc/rsyslog.d/
-    contains: "^\\*\\.\\*"
+    contains: "^\\*\\.\\*\\s+.*$"
     patterns: "*.conf"
   register: rsyslog_dropin_config_files
 
 - name: Deduplicate values from rsyslog dropin configuration
   ansible.builtin.lineinfile:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     create: false
-    regexp: "^\\*\\.\\*"
+    regexp: "^\\*\\.\\*\\s+.*$"
     state: absent
   loop: "{{  rsyslog_dropin_config_files.files }}"
   
 - name: "Set rsyslog remote loghost"
   lineinfile:
     dest: /etc/rsyslog.d/remote.conf
-    regexp: "^\\*\\.\\*"
+    regexp: "^\\*\\.\\*\\s+.*$"
     line: "*.* @@{{ rsyslog_remote_loghost_address }}"
     create: yes

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/sle15.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/ansible/sle15.yml
@@ -1,0 +1,46 @@
+# platform = multi_platform_sle
+# reboot = false
+# strategy = restrict
+# complexity = low
+# disruption = low
+{{{ ansible_instantiate_variables("rsyslog_remote_loghost_address") }}}
+
+- name: Check for duplicate values in master configuration
+  ansible.builtin.lineinfile:
+    path: /etc/rsyslog.conf
+    create: false
+    regexp: "^\\*\\.\\*"
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: dupes_master
+
+- name: Deduplicate values from rsyslog master configuration
+  ansible.builtin.lineinfile:
+    path: /etc/rsyslog.conf
+    create: false
+    regexp: "^\\*\\.\\*"
+    state: absent
+  when: dupes_master.found is defined and dupes_master.found > 1
+
+- name: Collect all config rsyslog files which configure Compress
+  ansible.builtin.find:
+    paths: /etc/rsyslog.d/
+    contains: "^\\*\\.\\*"
+    patterns: "*.conf"
+  register: rsyslog_dropin_config_files
+
+- name: Deduplicate values from rsyslog dropin configuration
+  ansible.builtin.lineinfile:
+    path: "{{ item }}"
+    create: false
+    regexp: "^\\*\\.\\*"
+    state: absent
+  loop: "{{  rsyslog_dropin_config_files.files }}"
+  
+- name: "Set rsyslog remote loghost"
+  lineinfile:
+    dest: /etc/rsyslog.d/remote.conf
+    regexp: "^\\*\\.\\*"
+    line: "*.* @@{{ rsyslog_remote_loghost_address }}"
+    create: yes

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_sle,multi_platform_ol,multi_platform_ubuntu
+# platform = Red Hat Virtualization 4,multi_platform_fedora,multi_platform_rhel,multi_platform_ol,multi_platform_ubuntu
 
 {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
 

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/sle15.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/sle15.sh
@@ -1,0 +1,11 @@
+# platform = multi_platform_sle
+
+{{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
+RSYSLOG_CONF_FILES=$(ls /etc/rsyslog.d/*.conf)
+RSYSLOG_CONF_FILES+=("/etc/rsyslog.conf")
+for f in "${RSYSLOG_CONF_FILES[@]}"; do
+    if grep -q -m 1 -i -e '^\*\.\*' "$f"; then
+        sed -i --follow-symlinks "s/^\*\.\*.*/#&/g"
+    fi
+done
+{{{ bash_replace_or_append('/etc/rsyslog.d/remote.conf', '^\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/sle15.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/sle15.sh
@@ -1,6 +1,6 @@
 # platform = multi_platform_sle
 
 {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
-{{{ bash_comment_config_line("/etc/rsyslog.conf", '^*.*') }}}
-{{{ bash_comment_config_line("/etc/rsyslog.d/*.conf", '^*.*') }}}
+{{{ bash_comment_config_line("/etc/rsyslog.conf", '^\*\.\*') }}}
+{{{ bash_comment_config_line("/etc/rsyslog.d/*.conf", '^\*\.\*') }}}
 {{{ bash_replace_or_append('/etc/rsyslog.d/remote.conf', '^\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}

--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/sle15.sh
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_loghost/bash/sle15.sh
@@ -1,11 +1,6 @@
 # platform = multi_platform_sle
 
 {{{ bash_instantiate_variables("rsyslog_remote_loghost_address") }}}
-RSYSLOG_CONF_FILES=$(ls /etc/rsyslog.d/*.conf)
-RSYSLOG_CONF_FILES+=("/etc/rsyslog.conf")
-for f in "${RSYSLOG_CONF_FILES[@]}"; do
-    if grep -q -m 1 -i -e '^\*\.\*' "$f"; then
-        sed -i --follow-symlinks "s/^\*\.\*.*/#&/g"
-    fi
-done
+{{{ bash_comment_config_line("/etc/rsyslog.conf", '^*.*') }}}
+{{{ bash_comment_config_line("/etc/rsyslog.d/*.conf", '^*.*') }}}
 {{{ bash_replace_or_append('/etc/rsyslog.d/remote.conf', '^\*\.\*', "@@$rsyslog_remote_loghost_address", '%s %s') }}}

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1601,10 +1601,10 @@ fi
 
 {{%- macro bash_comment_config_line(config_file, key) -%}}
 # If the key exists, comment it. Otherwise do nothing
-# We search for the key string followed by a word boundary (matched by \>),
+# We search for the key string followed by a blank space,
 # so if we search for 'setting', 'setting2' won't match.
-if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
-    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/#&/gi" "{{{ config_file }}}"
+if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}[[:blank:]]" "{{{ config_file }}}"; then
+    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}[[:blank:]].*/#&/gi" "{{{ config_file }}}"
 fi
 {{%- endmacro -%}}
 

--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1598,6 +1598,18 @@ fi
 :type format: str
 
 #}}
+
+{{%- macro bash_comment_config_line(config_file, key) -%}}
+# If the key exists, comment it. Otherwise do nothing
+# We search for the key string followed by a word boundary (matched by \>),
+# so if we search for 'setting', 'setting2' won't match.
+if LC_ALL=C grep -q -m 1 -i -e "{{{ key }}}\\>" "{{{ config_file }}}"; then
+    LC_ALL=C sed -i --follow-symlinks "s/{{{ key }}}\\>.*/#&/gi" "{{{ config_file }}}"
+fi
+{{%- endmacro -%}}
+
+
+
 {{%- macro bash_replace_or_append(config_file, key, value, format='%s = %s') -%}}
 # Strip any search characters in the key arg so that the key can be replaced without
 # adding any search characters to the config file.

--- a/tests/unit/bash/test_bash_comment_config_line.bats.jinja
+++ b/tests/unit/bash/test_bash_comment_config_line.bats.jinja
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -pu
+
+function call_comment_config_line {
+    {{{ bash_comment_config_line("$1", "$2") | indent(4) }}}
+}
+
+is_old_bats=0
+
+setup() {
+    if [[ -z "${BATS_TEST_TMPDIR:-}" ]] || [[ ! -d "${BATS_TEST_TMPDIR}" ]]; then
+        BATS_TEST_TMPDIR="$(mktemp -d)"  # 1.4.0
+        # shellcheck disable=SC2034
+        BATS_TEARDOWN_STARTED=  # 1.3.0
+        is_old_bats=1
+    else
+        is_old_bats=0
+    fi
+    pushd "${BATS_TEST_TMPDIR}" || exit 1
+    mkdir -p comment_cfg_test
+}
+
+teardown() {
+    if (( is_old_bats )); then
+        if [[ -z "${BATS_TEST_TMPDIR:-}" ]] || [[ ! -d "${BATS_TEST_TMPDIR}" ]]; then
+            >&2 echo "INTERNAL ERROR"
+            exit 3
+        fi
+        local tmppath xpwd
+        tmppath="$(readlink -f -- "${BATS_TEST_TMPDIR}")"
+        if [[ ! "${tmppath}" =~ ^/tmp/ ]] || [[ ! -d "${tmppath}" ]]; then
+            >&2 echo "INTERNAL ERROR"
+            exit 3
+        fi
+        xpwd="$(readlink -f -- .)"
+        if [[ "${tmppath}" != "${xpwd}" ]]; then
+            >&2 echo "INTERNAL ERROR"
+            exit 3
+        fi
+        popd || exit 1
+        rm -rf -- "${tmppath}"
+        BATS_TEST_TMPDIR=""
+    fi
+}
+
+@test "bash_comment_config_line - Basic line comment" {
+    printf "\nSomeSetting = true\n" > comment_cfg_test/test.conf
+    expected_output="\n#SomeSetting = true\n"
+
+    call_comment_config_line "comment_cfg_test/test.conf" "^SomeSetting"
+
+    run diff "comment_cfg_test/test.conf" <(printf "$expected_output")
+    [ "$status" -eq 0 ]
+}
+
+@test "bash_comment_config_line - Comment line with wildcards" {
+    printf "\n*.* 1.2.3.4\n" > comment_cfg_test/test.conf
+    expected_output="\n#*.* 1.2.3.4\n"
+
+    call_comment_config_line "comment_cfg_test/test.conf" "^\*\.\*"
+
+    run diff "comment_cfg_test/test.conf" <(printf "$expected_output")
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
#### Description:

- Add rsyslog_remote_loghost droping remediations

#### Rationale:

- Implement Bash and Ansible remediations that rely on drop-in configuration files