### PR TITLE
Changes in SLE 12/15 profiles related to time_sync services

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -1315,6 +1315,7 @@ controls:
     rules:
     # Based on DAT-NT-012 R3
     - package_chrony_installed
+    - service_chronyd_or_ntpd_enabled
     - chronyd_specify_remote_server
     - chronyd_configure_pool_and_server
 

--- a/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_configure_pool_and_server/rule.yml
@@ -27,7 +27,7 @@ identifiers:
     cce@sle15: CCE-92526-3 
 
 references:
-    anssi: BP28(R43)
+    anssi: BP28(R71)
     cis@sle12: 2.2.1.3
     cis@sle15: 2.2.1.3
     disa:  CCI-000160,CCI-001891

--- a/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
+++ b/linux_os/guide/services/ntp/chronyd_specify_remote_server/rule.yml
@@ -29,7 +29,7 @@ identifiers:
     cce@sle15: CCE-85833-2
 
 references:
-    anssi: BP28(R43)
+    anssi: BP28(R71)
     cis@alinux2: 2.1.1.3
     cis@alinux3: 2.2.1.2
     cis@rhel7: 2.2.1.2

--- a/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
+++ b/linux_os/guide/services/ntp/package_chrony_installed/rule.yml
@@ -25,7 +25,7 @@ identifiers:
     cce@sle15: CCE-91229-5
 
 references:
-    anssi: BP28(R43)
+    anssi: BP28(R71)
     cis@alinux3: 2.2.1.1
     cis@rhel7: 2.2.1.1
     cis@rhel8: 2.1.1

--- a/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_chronyd_or_ntpd_enabled/rule.yml
@@ -47,6 +47,7 @@ identifiers:
     cce@sle15: CCE-85835-7
 
 references:
+    anssi: BP28(R71)
     cis-csc: 1,14,15,16,3,5,6
     cis@rhel8: 2.2.1.1
     cobit5: APO11.04,BAI03.05,DSS05.04,DSS05.07,MEA02.01

--- a/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
+++ b/linux_os/guide/services/ntp/service_ntp_enabled/rule.yml
@@ -38,7 +38,7 @@ references:
     nist: CM-6(a),AU-8(1)(a)
     nist-csf: PR.PT-1
     pcidss: Req-10.4
-    pcidss4: "10.6.1"
+    pcidss4: 10.6.1
 
 ocil: |-
     {{{ ocil_service_enabled(service="ntp") }}}

--- a/products/sle12/profiles/cis.profile
+++ b/products/sle12/profiles/cis.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle12:all:l2_server
+    # Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+    # rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'
+    - '!service_timesyncd_enabled'

--- a/products/sle12/profiles/cis_server_l1.profile
+++ b/products/sle12/profiles/cis_server_l1.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle12:all:l1_server
+    # Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+    # rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'
+    - '!service_timesyncd_enabled'

--- a/products/sle12/profiles/cis_workstation_l1.profile
+++ b/products/sle12/profiles/cis_workstation_l1.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle12:all:l1_workstation
+    # Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+    # rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled' 
+    - '!service_timesyncd_enabled'

--- a/products/sle12/profiles/cis_workstation_l2.profile
+++ b/products/sle12/profiles/cis_workstation_l2.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle12:all:l2_workstation
+    # Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+    # rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'
+    - '!service_timesyncd_enabled'

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -52,11 +52,14 @@ selections:
     -  group_unique_id
     -  group_unique_name
     -  no_files_unowned_by_user
+    -  '!ntpd_specify_multiple_servers'
+    -  '!ntpd_specify_remote_server'
     -  package_bind_removed
     -  package_dhcp_removed
     -  package_httpd_removed
     -  package_net-snmp_removed
     -  package_nfs-utils_removed
+    -  '!package_ntp_installed'
     -  package_openldap-servers_removed
     -  package_rsh_removed
     -  package_samba_removed
@@ -67,8 +70,11 @@ selections:
     -  service_avahi-daemon_disabled
     -  service_cron_enabled
     -  service_cups_disabled
+    -  '!service_ntp_enabled'
+    -  '!service_ntpd_enabled'
     -  service_rpcbind_disabled
     -  service_rsyncd_disabled
+    -  '!service_timesyncd_enabled'
     -  sshd_disable_rhosts
     -  sshd_disable_tcp_forwarding
     -  sshd_disable_x11_forwarding

--- a/products/sle12/profiles/pci-dss.profile
+++ b/products/sle12/profiles/pci-dss.profile
@@ -17,3 +17,11 @@ selections:
     - sshd_approved_ciphers=cis_sle12
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse 
+# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_specify_multiple_servers'
+    - '!ntpd_specify_remote_server'
+    - '!package_ntp_installed'
+    - '!service_ntp_enabled'
+    - '!service_ntpd_enabled'
+    - '!service_timesyncd_enabled'

--- a/products/sle15/profiles/cis.profile
+++ b/products/sle15/profiles/cis.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle15:all:l2_server
+# Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'    
+    - '!service_timesyncd_enabled'

--- a/products/sle15/profiles/cis_server_l1.profile
+++ b/products/sle15/profiles/cis_server_l1.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle15:all:l1_server
+# Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'    
+    - '!service_timesyncd_enabled'

--- a/products/sle15/profiles/cis_workstation_l1.profile
+++ b/products/sle15/profiles/cis_workstation_l1.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle15:all:l1_workstation
+# Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'    
+    - '!service_timesyncd_enabled'

--- a/products/sle15/profiles/cis_workstation_l2.profile
+++ b/products/sle15/profiles/cis_workstation_l2.profile
@@ -21,3 +21,10 @@ description: |-
 
 selections:
     - cis_sle15:all:l2_workstation
+# Exclude from CIS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_configure_restrictions'
+    - '!ntpd_run_as_ntp_user'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntpd_enabled'    
+    - '!service_timesyncd_enabled'

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -18,6 +18,10 @@ selections:
     -  sshd_approved_ciphers=cis_sle15 
     -  var_multiple_time_servers=suse
     -  var_multiple_time_pools=suse      
-    -  '!service_ntp_enabled'
-    -  '!service_ntpd_enabled'
-    -  '!service_timesyncd_enabled'
+# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_specify_multiple_servers'
+    - '!ntpd_specify_remote_server'
+    - '!service_ntp_enabled'
+    - '!service_ntpd_enabled'
+    - '!service_timesyncd_enabled'

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -17,3 +17,11 @@ selections:
     - sshd_approved_ciphers=cis_sle15
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse    
+# Exclude from PCI DISS profile all rules related to ntp and timesyncd and keep only 
+# rules related to chrony
+    - '!ntpd_specify_multiple_servers'
+    - '!ntpd_specify_remote_server'
+    - '!package_ntp_installed'
+    - '!service_ntp_enabled'
+    - '!service_ntpd_enabled'
+    - '!service_timesyncd_enabled'


### PR DESCRIPTION
#### Description:

- _Changes are related to all SLE 12/15 profiles which use time sync services_

#### Rationale:

- In the current realization some of profiles use rules related to ntp and chrony. With this fix only rules based on chrony remain, because according to best practices we have to set on our OS system only one type of time sync service. 

