### PR TITLE
OCP4: Fix group ownerships checks

### DIFF
--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_not_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
-        filegid: '801'
+        filegid: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_lock_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_lock_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/.conf.db.~lock~
-        filegid: '800'
+        filegid: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_not_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/conf.db
-        filegid: '801'
+        filegid: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_conf_db_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_conf_db_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/conf.db
-        filegid: '800'
+        filegid: openvswitch

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_not_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/system-id.conf
-        filegid: '801'
+        filegid: 'hugetlbfs'

--- a/applications/openshift/master/file_groupowner_ovs_sys_id_conf_s390x/rule.yml
+++ b/applications/openshift/master/file_groupowner_ovs_sys_id_conf_s390x/rule.yml
@@ -35,4 +35,4 @@ template:
     name: file_groupowner
     vars:
         filepath: /etc/openvswitch/system-id.conf
-        filegid: '800'
+        filegid: 'hugetlbfs'

--- a/shared/templates/file_groupowner/oval.template
+++ b/shared/templates/file_groupowner/oval.template
@@ -52,11 +52,11 @@
 
   {{%- if FILEGID != '0' %}}
   <ind:textfilecontent54_object id="obj_dedicated_groupowner{{{ FILEID }}}_uid_{{{ FILEGID }}}" version="1" comment="gid of the dedicated {{{ FILEGID }}} group">
-  {{%- if product != 'rhcos4' -%}}
-    <ind:filepath>/etc/group</ind:filepath>
-  {{%- else %}}
+  {{%- if product in ["rhcos4","ocp4"] %}}
     {{# CoreOS doesn't list all groups in /etc/group - that's probably related to the FS immutability #}}
     <ind:filepath>/usr/lib/group</ind:filepath>
+  {{%- else %}}
+    <ind:filepath>/etc/group</ind:filepath>
   {{%- endif %}}
     <ind:pattern operation="pattern match">^{{{ FILEGID }}}:\w+:(\w+):.*</ind:pattern>
     <ind:instance datatype="int" operation="equals">1</ind:instance>


### PR DESCRIPTION

#### Description:

Commit
https://github.com/ComplianceAsCode/content/pull/10622/files#diff-e470af0c0d17a583faf9a1633cebb168a90bb3cc63264e5444c981c6614cb6feR59
changed the way the file_groupowner template works, but there was an
issue with the platform selection logic - the condition that looks at
/usr/lib/group instead of /etc/groups must be matched for ocp4 as well
as rhcos4.

In addition, this PR changes the checks for different OVN files to match
on group name, not GID.

#### Rationale:

- Fixes several OCP checks

#### Review Hints:

- Making sure that all the different ocp4-xxx-node profiles pass should be enough
