### PR TITLE
Add warning to rsyslog_remote_tls_cacert

### DIFF
--- a/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
+++ b/linux_os/guide/system/logging/rsyslog_sending_messages/rsyslog_remote_tls_cacert/rule.yml
@@ -41,3 +41,7 @@ ocil: |-
     The output should include record similar to
     <pre>global(DefaultNetstreamDriverCAFile="/etc/pki/tls/cert.pem")</pre>
     where the path to the CA file (<tt>/etc/pki/tls/cert.pem</tt> in case above) must point to the correct CA certificate.
+
+warnings:
+    - general: |-
+        Automatic remediation is not available as each organization has unique requirements.


### PR DESCRIPTION


#### Description:

As this rule does not have a remediation.

#### Rationale:
Backport of #10676