### PR TITLE
Fixes in 1.3.1 GC rules with updated doc links and completing control response

### DIFF
--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available_master/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available_master/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available_worker/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_imagefs_available_worker/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available/rule.yml
@@ -33,7 +33,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available_master/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available_master/rule.yml
@@ -3,7 +3,7 @@ documentation_complete: true
 prodtype: ocp4
 
 
-title: 'Ensure Eviction threshold Settings Are Set - evictionHard: imagefs.inodesFree'
+title: 'Ensure Eviction threshold Settings Are Set - evictionHard: memory.available'
 
 description: |-
   <p>Two types of garbage collection are performed on an OpenShift Container Platform node:</p>
@@ -33,12 +33,12 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 
   <p>
-  This rule pertains to the <tt>imagefs.inodesFree</tt> setting of the <tt>evictionHard</tt>
+  This rule pertains to the <tt>memory.available</tt> setting of the <tt>evictionHard</tt>
   section.
   </p>
 
@@ -58,7 +58,7 @@ references:
   srg: SRG-APP-000516-CTR-001325
 
 
-ocil_clause: '<tt>imagefs.inodesFree</tt> is not set in <tt>evictionHard</tt> section'
+ocil_clause: '<tt>memory.available</tt> is not set in <tt>evictionHard</tt> section'
 
 ocil: |-
   Run the following command on the kubelet node(s):
@@ -76,4 +76,3 @@ template:
     values:
     - value: "^.+$"
       operation: "pattern match"
-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available_worker/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_memory_available_worker/rule.yml
@@ -33,7 +33,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 
@@ -76,4 +76,3 @@ template:
     values:
     - value: "^.+$"
       operation: "pattern match"
-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.6/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available_master/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available_master/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.6/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available_worker/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_available_worker/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.6/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 
@@ -75,5 +75,3 @@ template:
     values:
     - value: "^.+$"
       operation: "pattern match"
-
-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree_master/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree_master/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 
@@ -74,5 +74,3 @@ template:
     values:
     - value: "^.+$"
       operation: "pattern match"
-
-

--- a/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree_worker/rule.yml
+++ b/applications/openshift/kubelet/kubelet_eviction_thresholds_set_hard_nodefs_inodesfree_worker/rule.yml
@@ -32,7 +32,7 @@ description: |-
 
   <p>
   To configure, follow the directions in
-  {{{ weblink(link="https://docs.openshift.com/container-platform/4.5/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
+  {{{ weblink(link="https://docs.openshift.com/container-platform/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring",
               text="the documentation") }}}
   </p>
 
@@ -74,4 +74,3 @@ template:
     values:
     - value: "^.+$"
       operation: "pattern match"
-

--- a/controls/cis_ocp_1_3_0/section-1.yml
+++ b/controls/cis_ocp_1_3_0/section-1.yml
@@ -329,8 +329,12 @@ controls:
     controls:
     - id: 1.3.1
       title: Ensure that garbage collection is configured as appropriate
-      status: partial
-      rules: [] 
+      status: Completed
+      rules:
+        - kubelet_eviction_thresholds_set_hard_memory_available
+        - kubelet_eviction_thresholds_set_hard_nodefs_available
+        - kubelet_eviction_thresholds_set_hard_nodefs_inodesfree
+        - kubelet_eviction_thresholds_set_hard_imagefs_available 
       tickets:
         - https://issues.redhat.com/browse/CMP-1977
       notes:  |-

--- a/controls/cis_ocp_1_3_0/section-1.yml
+++ b/controls/cis_ocp_1_3_0/section-1.yml
@@ -329,7 +329,7 @@ controls:
     controls:
     - id: 1.3.1
       title: Ensure that garbage collection is configured as appropriate
-      status: Pending
+      status: pending
       rules:
         - kubelet_eviction_thresholds_set_hard_memory_available
         - kubelet_eviction_thresholds_set_hard_nodefs_available

--- a/controls/cis_ocp_1_3_0/section-1.yml
+++ b/controls/cis_ocp_1_3_0/section-1.yml
@@ -329,7 +329,7 @@ controls:
     controls:
     - id: 1.3.1
       title: Ensure that garbage collection is configured as appropriate
-      status: Completed
+      status: Pending
       rules:
         - kubelet_eviction_thresholds_set_hard_memory_available
         - kubelet_eviction_thresholds_set_hard_nodefs_available
@@ -337,8 +337,10 @@ controls:
         - kubelet_eviction_thresholds_set_hard_imagefs_available 
       tickets:
         - https://issues.redhat.com/browse/CMP-1977
+        - https://workbench.cisecurity.org/benchmarks/11804/tickets/18854
       notes:  |-
         Ticket 1977 explains why terminated_pod_gc_threshhold isn’t supported in OCP4, hence removing the same.
+        Ticket 18854 tracks the movement of this rule to control section 4 as rule id 4.2.1
       level: level_1
     - id: 1.3.2
       title: Ensure that controller manager healthz endpoints are protected by RBAC


### PR DESCRIPTION
#### Description:
- Fixing `eviction_thresholds_set_hard_memory_available_master/rule.yml` to reflect correct ocil_clause
- Updating doc links to reflect the latest OCP pages
- Also adding the control response in control file cis_ocp_1_3_0 to reflect on status of the GC rules that should exist

#### Rationale:

- OCP4 CIS 1.3 cleanup and rule fixes

#### Review Hints:

- Please validate changes in `eviction_thresholds_set_hard_memory_available_master/rule.yml` and the control response file