### PR TITLE
Fix in ansible part of the rule audit_rules_kernel_module_loading

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_kernel_module_loading/audit_rules_kernel_module_loading/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv
+# platform = multi_platform_rhel,multi_platform_fedora,multi_platform_ol,multi_platform_rhv,multi_platform_sle
 # reboot = true
 # strategy = restrict
 # complexity = low


### PR DESCRIPTION
#### Description:

- _Correction in ansible part to support SLE 12/15_

#### Rationale:

- In the current version the ansible part of the rule does not include multi_platform_sle
