### PR TITLE
Typo correction in CIS profile for SLE 12

### DIFF
--- a/controls/cis_sle12.yml
+++ b/controls/cis_sle12.yml
@@ -1191,7 +1191,7 @@ controls:
     - l2_workstation
     status: automated
     rules:
-    - audit_rules_login_events_faillock
+    - audit_rules_login_events_faillog
     - audit_rules_login_events_lastlog
     - audit_rules_login_events_tallylog
 


### PR DESCRIPTION
#### Description:

- _Correction of CIS profile for SLE 12_

#### Rationale:

- The CIS profile for SLE 12 uses a wrong rule name
