### PR TITLE
Make sure sssd.conf files have 0600 permissions mode

### DIFF
--- a/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/ansible/shared.yml
@@ -11,6 +11,7 @@
       section: sssd
       option: certificate_verification
       state: absent
+      mode: 0600
 
 - name: 'Ensure that "certificate_verification" is not set in  /etc/sssd/conf.d/*.conf'
   ini_file:
@@ -18,6 +19,7 @@
       section: sssd
       option: certificate_verification
       state: absent
+      mode: 0600
 
 - name: Ensure that "certificate_verification" is set
   ini_file:
@@ -26,3 +28,4 @@
       option: certificate_verification
       value: "ocsp_dgst = {{ var_sssd_certificate_verification_digest_function }}"
       state: present
+      mode: 0600

--- a/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_certificate_verification/bash/shared.sh
@@ -6,11 +6,13 @@
 
 {{{ bash_instantiate_variables("var_sssd_certificate_verification_digest_function") }}}
 
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 MAIN_CONF="/etc/sssd/conf.d/certificate_verification.conf"
 
 {{{ bash_ensure_ini_config("$MAIN_CONF /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "sssd", "certificate_verification", "ocsp_dgst = $var_sssd_certificate_verification_digest_function") }}}
 
-if [ -e "$MAIN_CONF" ]; then
-    chown root:root "$MAIN_CONF"
-	chmod 600 "$MAIN_CONF"
-fi
+umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_pam_services/bash/shared.sh
@@ -1,5 +1,12 @@
 # platform = Red Hat Virtualization 4,multi_platform_rhel,multi_platform_ol
 
+
+
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 SSSD_CONF="/etc/sssd/sssd.conf"
 SSSD_CONF_DIR="/etc/sssd/conf.d/*.conf"
 
@@ -40,3 +47,5 @@ EOF
         break
     done
 fi
+
+umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_enable_smartcards/bash/shared.sh
@@ -4,7 +4,14 @@
 # complexity = low
 # disruption = medium
 
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 {{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "pam", "pam_cert_auth", "True") }}}
+
+umask $OLD_UMASK
 
 {{% if product in ["fedora", "ol8", "ol9", "rhel8", "rhel9"] %}}
 if [ -f /usr/bin/authselect ]; then

--- a/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_memcache_timeout/bash/shared.sh
@@ -2,4 +2,11 @@
 
 {{{ bash_instantiate_variables("var_sssd_memcache_timeout") }}}
 
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 {{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "nss", "memcache_timeout", "$var_sssd_memcache_timeout") }}}
+
+umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_offline_cred_expiration/bash/shared.sh
@@ -4,4 +4,11 @@
 # complexity = low
 # disruption = medium
 
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 {{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "pam", "offline_credentials_expiration", "1") }}}
+
+umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_run_as_sssd_user/bash/shared.sh
@@ -2,9 +2,11 @@
 
 MAIN_CONF="/etc/sssd/conf.d/ospp.conf"
 
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 {{{ bash_ensure_ini_config("$MAIN_CONF /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf", "sssd", "user", "sssd") }}}
 
-if [ -e "$MAIN_CONF" ]; then
-    chown root:root "$MAIN_CONF"
-	chmod 600 "$MAIN_CONF"
-fi
+umask $OLD_UMASK

--- a/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
+++ b/linux_os/guide/services/sssd/sssd_ssh_known_hosts_timeout/bash/shared.sh
@@ -2,4 +2,11 @@
 
 {{{ bash_instantiate_variables("var_sssd_ssh_known_hosts_timeout") }}}
 
+# sssd configuration files must be created with 600 permissions if they don't exist
+# otherwise the sssd module fails to start
+OLD_UMASK=$(umask)
+umask u=rw,go=
+
 {{{ bash_ensure_ini_config("/etc/sssd/sssd.conf", "ssh", "ssh_known_hosts_timeout", "$var_sssd_ssh_known_hosts_timeout") }}}
+
+umask $OLD_UMASK

--- a/shared/macros/10-ansible.jinja
+++ b/shared/macros/10-ansible.jinja
@@ -697,6 +697,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     section: "{{ item.section }}"
     option: "{{ item.option }}"
     value: "{{ item.value }}"
+    mode: 0600
   with_items:
     - { section: sssd, option: domains, value: default}
     - { section: domain/default, option: {{{ parameter }}}, value: "{{{ value }}}"}
@@ -712,6 +713,7 @@ The following macro remediates Audit syscall rule in :code:`/etc/audit/audit.rul
     section: "{{ test_grep_domain.stdout | regex_replace('\\[(.*)\\]','\\1') }}"
     option: {{{ parameter }}}
     value: "{{{ value }}}"
+    mode: 0600
   when:
     - test_grep_domain.stdout is defined
     - test_grep_domain.stdout | length > 0


### PR DESCRIPTION
#### Description:

- Make sure sssd.conf files have 0600 permissions mode.
#### Rationale:

- Create sssd.conf file with expected permissions
- An attempt to fix: https://bugzilla.redhat.com/show_bug.cgi?id=2211511
  - In the bugzilla, they use `oscap xccdf generate fix` and then execute the script, this doesn't take into account the applicability of SSSD rules and some remediation gets executed even if they wouldn't be applicable for example. That might be what's is causing to create a file that doesn't exist with wrong permissions, because if the file would be created by the sssd related package, then this problem would not occur.