### PR TITLE
Removal of package_libreswan_installed from SLE 12/15 profiles

### DIFF
--- a/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/rule.yml
+++ b/linux_os/guide/system/network/network-ipsec/package_libreswan_installed/rule.yml
@@ -5,9 +5,10 @@ prodtype: alinux2,alinux3,anolis8,fedora,ol7,ol8,ol9,rhcos4,rhel7,rhel8,rhel9,rh
 title: 'Install libreswan Package'
 
 description: |-
-    The Libreswan package provides an implementation of IPsec
+    The libreswan package provides an implementation of IPsec
     and IKE, which permits the creation of secure tunnels over
     untrusted networks. {{{ describe_package_install(package="libreswan") }}}
+    
 
 rationale: |-
     Providing the ability for remote users or systems
@@ -45,8 +46,8 @@ fixtext: '{{{ fixtext_package_installed("libreswan") }}}'
 
 srg_requirement: '{{{ srg_requirement_package_installed("libreswan") }}}'
 
+
 template:
     name: package_installed
     vars:
         pkgname: libreswan
-

--- a/products/sle12/profiles/pci-dss-4.profile
+++ b/products/sle12/profiles/pci-dss-4.profile
@@ -64,6 +64,7 @@ selections:
     -  package_openldap-servers_removed
     -  package_rsh_removed
     -  package_samba_removed
+    -  '!package_libreswan_installed'
     -  package_talk_removed
     -  package_telnet_removed
     -  package_xinetd_removed

--- a/products/sle12/profiles/pci-dss.profile
+++ b/products/sle12/profiles/pci-dss.profile
@@ -25,3 +25,4 @@ selections:
     - '!service_ntp_enabled'
     - '!service_ntpd_enabled'
     - '!service_timesyncd_enabled'
+    - '!package_libreswan_installed'

--- a/products/sle15/profiles/pci-dss-4.profile
+++ b/products/sle15/profiles/pci-dss-4.profile
@@ -25,3 +25,4 @@ selections:
     - '!service_ntp_enabled'
     - '!service_ntpd_enabled'
     - '!service_timesyncd_enabled'
+    - '!package_libreswan_installed'

--- a/products/sle15/profiles/pci-dss.profile
+++ b/products/sle15/profiles/pci-dss.profile
@@ -25,3 +25,4 @@ selections:
     - '!service_ntp_enabled'
     - '!service_ntpd_enabled'
     - '!service_timesyncd_enabled'
+    - '!package_libreswan_installed'


### PR DESCRIPTION
#### Description:

- _The package package_libreswan_installed was removed from PCI DSS profiles for SLE 12/15 _

#### Rationale:

- SLE 12/15 uses strongswan package 