### PR TITLE
Change of anssi recommendation for the rule mount_option_home_nosuid

### DIFF
--- a/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
+++ b/linux_os/guide/system/permissions/partitions/mount_option_home_nosuid/rule.yml
@@ -24,7 +24,7 @@ identifiers:
     cce@sle15: CCE-85633-6
 
 references:
-    anssi: BP28(R12)
+    anssi: BP28(R28)
     cis-csc: 11,13,14,3,8,9
     cis@alinux3: 1.1.7.3
     cis@rhel8: 1.1.7.3


### PR DESCRIPTION
#### Description:

- _Change related to ANSSI recommendation_

#### Rationale:

- This is a general problem. ANSSI profile was created to cover new ANSSI v2.0, but the rules.yml files of some of the rules were not updated. Now there are rules which uses ANSSI 1.0 recommendation code instead of ANSSI v2.0.    
