### PR TITLE
Update of anssi profile for SLE 12/15

### DIFF
--- a/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-pam/set_password_hashing_algorithm/set_password_hashing_min_rounds_logindefs/rule.yml
@@ -31,6 +31,7 @@ identifiers:
     cce@sle15: CCE-85567-6
 
 references:
+    anssi: BP28(R68)
     disa: CCI-000196,CCI-000803
     nist@sle12: IA-5(1)(c),IA-5(1).1(v),IA-7,IA-7.1
     srg: SRG-OS-000073-GPOS-00041,SRG-OS-000120-GPOS-00061

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_password_auth/rule.yml
@@ -37,7 +37,7 @@ identifiers:
     cce@sle15: CCE-91173-5
 
 references:
-    anssi: BP28(R32)
+    anssi: BP28(R68)
     disa: CCI-000196
     srg: SRG-OS-000073-GPOS-00041
 

--- a/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
+++ b/linux_os/guide/system/accounts/accounts-restrictions/password_storage/accounts_password_pam_unix_rounds_system_auth/rule.yml
@@ -31,7 +31,7 @@ identifiers:
     cce@sle15: CCE-91172-7
 
 references:
-  anssi: BP28(R32)
+  anssi: BP28(R68)
   disa: CCI-000196
   srg: SRG-OS-000073-GPOS-00041
 

--- a/products/sle12/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle12/profiles/anssi_bp28_enhanced.profile
@@ -26,3 +26,6 @@ selections:
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
     - var_sudo_dedicated_group=default
+    - '!accounts_password_pam_unix_rounds_system_auth'
+    - '!accounts_password_pam_unix_rounds_password_auth'
+    -  set_password_hashing_min_rounds_logindefs

--- a/products/sle12/profiles/anssi_bp28_high.profile
+++ b/products/sle12/profiles/anssi_bp28_high.profile
@@ -26,3 +26,6 @@ selections:
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
     - var_sudo_dedicated_group=default
+    - '!accounts_password_pam_unix_rounds_system_auth'
+    - '!accounts_password_pam_unix_rounds_password_auth'
+    -  set_password_hashing_min_rounds_logindefs

--- a/products/sle12/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle12/profiles/anssi_bp28_intermediary.profile
@@ -26,3 +26,6 @@ selections:
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
   - var_sudo_dedicated_group=default
+  - '!accounts_password_pam_unix_rounds_system_auth'
+  - '!accounts_password_pam_unix_rounds_password_auth'
+  -  set_password_hashing_min_rounds_logindefs

--- a/products/sle12/profiles/anssi_bp28_minimal.profile
+++ b/products/sle12/profiles/anssi_bp28_minimal.profile
@@ -26,3 +26,6 @@ selections:
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
   - var_sudo_dedicated_group=default
+  - '!accounts_password_pam_unix_rounds_system_auth'
+  - '!accounts_password_pam_unix_rounds_password_auth'
+  -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_enhanced.profile
+++ b/products/sle15/profiles/anssi_bp28_enhanced.profile
@@ -26,3 +26,6 @@ selections:
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
     - var_sudo_dedicated_group=default
+    - '!accounts_password_pam_unix_rounds_system_auth'
+    - '!accounts_password_pam_unix_rounds_password_auth'
+    -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_high.profile
+++ b/products/sle15/profiles/anssi_bp28_high.profile
@@ -26,3 +26,6 @@ selections:
     - var_multiple_time_servers=suse
     - var_multiple_time_pools=suse
     - var_sudo_dedicated_group=default
+    - '!accounts_password_pam_unix_rounds_system_auth'
+    - '!accounts_password_pam_unix_rounds_password_auth'
+    -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_intermediary.profile
+++ b/products/sle15/profiles/anssi_bp28_intermediary.profile
@@ -26,3 +26,6 @@ selections:
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
   - var_sudo_dedicated_group=default
+  - '!accounts_password_pam_unix_rounds_system_auth'
+  - '!accounts_password_pam_unix_rounds_password_auth'
+  -  set_password_hashing_min_rounds_logindefs

--- a/products/sle15/profiles/anssi_bp28_minimal.profile
+++ b/products/sle15/profiles/anssi_bp28_minimal.profile
@@ -26,3 +26,6 @@ selections:
   - var_multiple_time_servers=suse
   - var_multiple_time_pools=suse
   - var_sudo_dedicated_group=default
+  - '!accounts_password_pam_unix_rounds_system_auth'
+  - '!accounts_password_pam_unix_rounds_password_auth'
+  -  set_password_hashing_min_rounds_logindefs


### PR DESCRIPTION
#### Description:

- _Include in anssi profile for SLE 12/15 the rule set_password_hashing_min_rounds_logindefs and exclude accounts_password_pam_unix_rounds_system_auth and  accounts_password_pam_unix_rounds_password_auth_

#### Rationale:

- The included rule is supported by SLE 12/15, excluded not
