### PR TITLE
Add a Playbook name to Ansible Playbooks

### DIFF
--- a/ssg/ansible.py
+++ b/ssg/ansible.py
@@ -40,6 +40,13 @@ def add_minimum_version(ansible_src):
     return ansible_src.replace(" - hosts: all", pre_task, 1)
 
 
+def add_play_name(ansible_src, profile):
+    old_play_start = r"^( *)- hosts: all"
+    new_play_start = (
+        r"\1- name: Ansible Playbook for %s\n\1  hosts: all" % (profile))
+    return re.sub(old_play_start, new_play_start, ansible_src, flags=re.M)
+
+
 def remove_too_many_blank_lines(ansible_src):
     """
     Condenses three or more empty lines as two.

--- a/ssg/build_profile_remediations.py
+++ b/ssg/build_profile_remediations.py
@@ -7,6 +7,7 @@ from collections import namedtuple
 
 from .ansible import (
     add_minimum_version,
+    add_play_name,
     remove_too_many_blank_lines,
     remove_trailing_whitespace,
     strip_eof,
@@ -138,6 +139,7 @@ def builder(queue):
             if extension == "yml" and \
                template == "urn:xccdf:fix:script:ansible":
                 src = add_minimum_version(src)
+                src = add_play_name(src, profile_id)
                 src = remove_too_many_blank_lines(src)
                 src = remove_trailing_whitespace(src)
                 src = strip_eof(src)


### PR DESCRIPTION

Description:

In the stabilization GitHub Action CI runs all the tests ansible-playbook-per-profile-ansible-lint-check-.* fail due to a missing name. This can be easily fixed by assigning a name to all the playbooks.

Addressing:
name[play]: All plays should be named.
Rationale:

docs/release_process.md says:

    There is a GitHub Action hooked up with stabilization-vX.Y.Z branch that will run a set of
    tests on every push.
    Make sure that all these tests are passing before moving on with the release process.

Review Hints:

review the results of ansible-playbook-per-profile-ansible-lint-check CTest tests

This PR has been backported to the `stabilization-v0.1.68` by https://github.com/ComplianceAsCode/content/pull/10712.
