### PR TITLE
POC: allow overriding parts of rule.yml based on compiled product

### DIFF
--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -447,6 +447,8 @@ However, the number of attributes which can be overridden in this way is limited
 
 - ocil_clause
 
+- warnings
+
 Attributes mentioned in the overriding file will replace attributes in rule.yml
 for the given product.
 

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -420,6 +420,36 @@ that begin with underscores are not meant to be used in descriptions.
 You can also check documentation for all macros in the `Jinja Macros Reference`
 section accessible from the table of contents.
 
+#### Defining rule parts for specific products
+
+There might be cases when an author desires that a specific rule attribute (see
+below for a list) is very different from the generic one in rule.yml.
+It is possible to use macros.
+However, if the attribute such as description is very different from the generic
+one, it could make the main rule.yml file long and confusing.
+Therefore there is an option which allows to extract those overrides into small files in their own folder.
+The feature can be used by creating a new folder called `rule_overrides` within
+the rule main directory, e.g. in the directory where the rule.yml file is
+placed.
+In the folder, create a file called `<product>.yml`.
+Replace `<product>` with the actual product short name, e.g. for the `rhel9`
+product the file would be called `rhel9.yml`.
+The file format is the same as for rule.yml files.
+However, the number of attributes which can be overridden in this way is limited to the following list:
+
+- title
+
+- description
+
+- rationale
+
+- ocil
+
+- ocil_clause
+
+Attributes mentioned in the overriding file will replace attributes in rule.yml
+for the given product.
+
 #### Product-specific variables
 
 To parametrize rules and remediations as well as Jinja macros,

--- a/docs/manual/developer/06_contributing_with_content.md
+++ b/docs/manual/developer/06_contributing_with_content.md
@@ -390,6 +390,8 @@ A rule may contain those reference-type attributes:
     for an example of reference-type attributes as there are others that
     are not referenced above.
 
+#### Macros
+
 Some of existing rule definitions contain attributes that use macros.
 There are two implementations of macros:
 
@@ -418,6 +420,8 @@ that begin with underscores are not meant to be used in descriptions.
 You can also check documentation for all macros in the `Jinja Macros Reference`
 section accessible from the table of contents.
 
+#### Product-specific variables
+
 To parametrize rules and remediations as well as Jinja macros,
 use product-specific variables defined either
 in `product.yml` in product root directory,
@@ -427,9 +431,13 @@ so you can use only product properties in the content.
 In other words, use this functionality to avoid referencing product versions in macros used in checks or remediations.
 Instead, use properties that directly relate to configurations being checked or set, and that help to reveal the intention of the check or remediation code.
 
+#### Product stability tests
+
 As Jinja2 conditionals are prone to errors, products can be protected by product stability tests.
 If a product sample is present in `tests/data/product_stability/`, it is compared to the actual compiled product,
 and if there is a difference that is not only cosmetic, a product stability test will fail.
+
+#### Handling of rules during build time
 
 Rules are unselected by default - even if the scanner reads rule
 definitions, they are effectively ignored during the scan or

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -697,6 +697,7 @@ class Rule(XCCDFEntity, Templatable):
         "rationale",
         "ocil",
         "ocil_clause",
+        "warnings",
     }
 
     GENERIC_FILENAME = "rule.yml"

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -692,10 +692,11 @@ class Rule(XCCDFEntity, Templatable):
     }
 
     OVERRIDABLE_KEYS = {
-        "documentation_complete",
         "title",
         "description",
         "rationale",
+        "ocil",
+        "ocil_clause",
     }
 
     GENERIC_FILENAME = "rule.yml"

--- a/tests/unit/ssg-module/data/overrides/rule.yml
+++ b/tests/unit/ssg-module/data/overrides/rule.yml
@@ -1,0 +1,21 @@
+documentation_complete: true
+
+prodtype: rhel7,rhel8,rhel9
+
+title: "original title"
+
+description: "original description"
+
+rationale: "original rationale"
+
+references:
+    disa: "123456"
+
+
+
+severity: undefined
+
+ocil: "original ocil"
+
+ocil_clause: "original ocil clause"
+

--- a/tests/unit/ssg-module/data/overrides/rule_overrides/rhel7.yml
+++ b/tests/unit/ssg-module/data/overrides/rule_overrides/rhel7.yml
@@ -1,0 +1,3 @@
+description: "rhel7 description"
+
+ocil: "some ocil"

--- a/tests/unit/ssg-module/data/overrides/rule_overrides/rhel7.yml
+++ b/tests/unit/ssg-module/data/overrides/rule_overrides/rhel7.yml
@@ -1,3 +1,5 @@
 description: "rhel7 description"
 
-ocil: "some ocil"
+references:
+    some_reference: 123
+

--- a/tests/unit/ssg-module/data/overrides/rule_overrides/rhel8.yml
+++ b/tests/unit/ssg-module/data/overrides/rule_overrides/rhel8.yml
@@ -1,0 +1,1 @@
+title: "rhel8 title"

--- a/tests/unit/ssg-module/data/overrides/rule_overrides/rhel9.yml
+++ b/tests/unit/ssg-module/data/overrides/rule_overrides/rhel9.yml
@@ -1,0 +1,3 @@
+title: "rhel9 title"
+
+description: "rhel9 description"

--- a/tests/unit/ssg-module/test_build_yaml.py
+++ b/tests/unit/ssg-module/test_build_yaml.py
@@ -555,3 +555,27 @@ def profile_with_version(profile_ospp):
 def test_profile_with_version(profile_with_version):
     profile_el = profile_with_version.to_xml_element()
     assert profile_el.find("{%s}version" % XCCDF12_NS).text == "3.2.1"
+
+
+def test_aply_override_files():
+    test_rule_path = os.path.join(DATADIR, "overrides", "rule.yml")
+    test_rule = ssg.build_yaml.Rule.from_yaml(test_rule_path)
+    assert test_rule.title == "original title"
+    assert test_rule.description == "original description"
+    env_yaml = {"product": "rhel9"}
+    test_rule.apply_override_files(test_rule_path, env_yaml)
+    assert test_rule.title == "rhel9 title"
+    assert test_rule.description == "rhel9 description"
+    assert test_rule.ocil == "original ocil"
+    env_yaml = {"product": "rhel8"}
+    test_rule.apply_override_files(test_rule_path, env_yaml)
+    assert test_rule.title == "rhel8 title"
+    assert test_rule.description == "rhel9 description"
+    assert test_rule.ocil == "original ocil"
+
+def test_apply_prohibited_override():
+    test_rule_path = os.path.join(DATADIR, "overrides", "rule.yml")
+    test_rule = ssg.build_yaml.Rule.from_yaml(test_rule_path)
+    env_yaml = {"product": "rhel7"}
+    with pytest.raises(ValueError) as e:
+        test_rule.apply_override_files(test_rule_path, env_yaml)


### PR DESCRIPTION
This is just POC and work in progress.

#### Description:

If you place a file into <some_rule_folder>/rule_overrides and call it like <prodtype>.yaml, where prodtype is an existing prodtype, it will override some keys of the rule.yaml file.
Currently, the set of overridable keys is limited to documentation_complete, title, description, severity, ocil and ocil_clause.

#### Rationale:

It can make easier to produce different rule verbiage for different products. The PR #10550 might make use of this feature I believe.

#### Review Hints:

- add a new folder rule_overrides into some rule (e.g. linux_os/guide/services/ssh/file_groupownership_ssh_private_keys.
- create a file called rhel9.yml in the folder
- insert 
```
description: "blahblah"
```
into the file.
- Build rhel8 and rhel9 product.
- Examine compiled rules for both products and you should see the difference. E.g.
```
diff -u build/rhel8/rules/file_groupownership_ssh_private_keys.yml build/rhel9/rules/file_groupownership_ssh_private_keys.yml
```

#### Needs to be done

- [x] tests
- [ ] documentation