### PR TITLE
Fix grub2 remediation instructions

### DIFF
--- a/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
+++ b/linux_os/guide/system/bootloader-grub2/non-uefi/grub2_admin_username/rule.yml
@@ -15,7 +15,7 @@ description: |-
     admin, or administrator for the grub2 superuser account.
     <br /><br />
     Change the superuser to a different username (The default is 'root').
-    <pre>$ sed -i 's/\(set superuser=\).*/\1"&lt;unique user ID&gt;"/g' /etc/grub.d/01_users</pre>
+    <pre>$ sed -i 's/\(set superusers=\).*/\1"&lt;unique user ID&gt;"/g' /etc/grub.d/01_users</pre>
     <br /><br />
     Once the superuser account has been added,
     update the


### PR DESCRIPTION
#### Description:

The remediation instructions for xccdf_org.ssgproject.content_rule_grub2_admin_username are subtly wrong

#### Rationale:

The string it should look for is "superuser**s**=", not "superuser=". All the other content looks for the correct string, other than the instructions provided.

#### Review Hints:

Double check against [the tests](https://github.com/ComplianceAsCode/content/blob/master/tests/shared/grub2.sh#L32) or the [grub2 docs](https://www.gnu.org/software/grub/manual/grub/grub.html#Authentication-and-authorisation).