### PR TITLE
Fix traceback in release helper

### DIFF
--- a/utils/release_helper.py
+++ b/utils/release_helper.py
@@ -633,9 +633,10 @@ def stats(repo, args):
 
 def cleanup(repo, args) -> None:
     if args.branch:
-        branch_to_remove = get_old_stabilization_branch(repo)
-        if branch_to_remove:
-            remove_old_stabilization_branch(branch_to_remove)
+        branches_to_remove = get_old_stabilization_branch(repo)
+        if branches_to_remove:
+            for branch in branches_to_remove:
+                remove_old_stabilization_branch(repo, branch)
         else:
             print('Great! There is no branch to be removed.')
 


### PR DESCRIPTION
The get_old_stabilization_branch returns a list. The function remove_old_stabilization_branch needs 2 arguments.

Addressing:
```
[jcerny@fedora utils{stabilization-v0.1.68}]$ ./release_helper.py -c ~/secret.ini -r ComplianceAsCode/content cleanup --branch Traceback (most recent call last):
  File "/home/jcerny/work/git/scap-security-guide/utils/./release_helper.py", line 780, in <module>
    main()
  File "/home/jcerny/work/git/scap-security-guide/utils/./release_helper.py", line 776, in main
    subcmds[args.subcmd](repo, args)
  File "/home/jcerny/work/git/scap-security-guide/utils/./release_helper.py", line 638, in cleanup
    remove_old_stabilization_branch(branch_to_remove)
TypeError: remove_old_stabilization_branch() missing 1 required positional argument: 'branch'
```