### PR TITLE
add rules UBTU-20-010045

### DIFF
--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,Ubuntu 20.04
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/ansible/shared.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/ansible/shared.yml
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,Ubuntu 20.04
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
 # reboot = false
 # strategy = restrict
 # complexity = low

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,Ubuntu 20.04
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,multi_platform_ubuntu
 
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,\
 diffie-hellman-group-exchange-sha256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/bash/shared.sh
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/bash/shared.sh
@@ -1,4 +1,4 @@
-# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle
+# platform = Red Hat Enterprise Linux 7,Oracle Linux 7,multi_platform_sle,Ubuntu 20.04
 
 KEX_ALGOS="ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,\
 diffie-hellman-group-exchange-sha256"

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/shared.xml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/oval/shared.xml
@@ -6,7 +6,7 @@
              "diffie-hellman-group14-sha256","diffie-hellman-group16-sha512",
              "diffie-hellman-group18-sha512"] %}}
 {{% set sufix_conf="(\s.*)?'" %}}
-{{% elif product in ['ol7','rhel7','sle12','sle15'] %}}
+{{% elif product in ['ol7','rhel7','sle12','sle15','ubuntu2004'] %}}
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set prefix_conf="^\s*KexAlgorithms\s*" %}}
 {{% set kex_algos=["ecdh-sha2-nistp256","ecdh-sha2-nistp384","ecdh-sha2-nistp521",

--- a/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
+++ b/linux_os/guide/services/ssh/ssh_server/sshd_use_approved_kex_ordered_stig/rule.yml
@@ -8,7 +8,7 @@
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set conf="KexAlgorithms ecdh-sha1-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" ~
              ",diffie-hellman-group-exchange-sha256"  %}}
-{{% elif product in ['sle12','sle15'] %}}
+{{% elif product in ['sle12','sle15','ubuntu2004'] %}}
 {{% set path='/etc/ssh/sshd_config' %}}
 {{% set conf="KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521" ~
              ",diffie-hellman-group-exchange-sha256"  %}}
@@ -16,7 +16,7 @@
 
 documentation_complete: true
 
-prodtype: ol7,ol8,rhel7,rhel8,sle12,sle15
+prodtype: ol7,ol8,rhel7,rhel8,sle12,sle15,ubuntu2004
 
 title: 'Use Only FIPS 140-2 Validated Key Exchange Algorithms'
 
@@ -52,6 +52,7 @@ references:
     stigid@rhel8: RHEL-08-040342
     stigid@sle12: SLES-12-030270
     stigid@sle15: SLES-15-040450
+    stigid@ubuntu2004: UBTU-20-010045
 
 ocil_clause: 'KexAlgorithms option is commented out, contains non-approved algorithms, or the FIPS-approved algorithms are not in the exact order'
 

--- a/products/ubuntu2004/profiles/stig.profile
+++ b/products/ubuntu2004/profiles/stig.profile
@@ -86,6 +86,9 @@ selections:
     # UBTU-20-010044 The Ubuntu operating system must configure the SSH daemon to use FIPS 140-2 approved ciphers to prevent the unauthorized disclosure of information and/or detect changes to information during transmission.
     - sshd_use_approved_ciphers_ordered_stig
 
+    # UBTU-20-010045 The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms.
+    - sshd_use_approved_kex_ordered_stig
+
     # UBTU-20-010047 The Ubuntu operating system must not allow unattended or automatic login via SSH.
     - sshd_disable_empty_passwords
     - sshd_do_not_permit_user_env


### PR DESCRIPTION
#### Description:

- Update `sshd_use_approved_kex_ordered_stig` to include ubuntu 20.04

#### Rationale:

- According to DISA Canonical Ubuntu 20.04 LTS Security Guide, Version 1, and Revision 8 contains a new rule which specifies: "The Ubuntu operating system SSH server must be configured to use only FIPS-validated key exchange algorithms."
