### PR TITLE
Add components_root to example stability

### DIFF
--- a/tests/data/product_stability/example.yml
+++ b/tests/data/product_stability/example.yml
@@ -6,6 +6,7 @@ basic_properties_derived: true
 benchmark_id: EXAMPLE
 benchmark_root: ../../linux_os/guide
 chrony_conf_path: /etc/chrony.conf
+components_root: ../../components
 cpes:
 - example:
     check_id: installed_OS_is_part_of_Unix_family


### PR DESCRIPTION
#### Description:
Add components_root to example stability
#### Rationale:
Fix master when building with all products

#### Reviewer Hints:
1.  `./build_product -j4 example`
2.  `cd build`
3. `ctest --output-on-failure -R stable-products`