### PR TITLE
Fix attribute for args root

### DIFF
--- a/utils/build_stig_control.py
+++ b/utils/build_stig_control.py
@@ -86,7 +86,7 @@ def get_implemented_stigs(args):
     product_dir = os.path.join(args.root, "products", args.product)
     product_yaml_path = os.path.join(product_dir, "product.yml")
     env_yaml = ssg.environment.open_environment(
-        args.build_config_yaml, product_yaml_path, os.path.join(args._root, "product_properties"))
+        args.build_config_yaml, product_yaml_path, os.path.join(args.root, "product_properties"))
 
     known_rules = dict()
     for rule in platform_rules:


### PR DESCRIPTION
#### Description:
When creating a control file from manual xccdf STIG via utils python script, an unknown attribute errors out the program.
`_root` is not a recognized attribute for args.


#### Rationale:

- Fixes #10723 
