### PR TITLE
Refactoring: Remove 'prodtype'

### DIFF
--- a/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
+++ b/linux_os/guide/system/auditing/auditd_configure_rules/audit_privileged_commands/audit_rules_privileged_commands_unix2_chkpwd/rule.yml
@@ -63,4 +63,4 @@ ocil: |-
 template:
     name: audit_rules_privileged_commands
     vars:
-        path@sle15: /sbin/unix2_chkpwd
+        path: /sbin/unix2_chkpwd

--- a/ssg/entities/profile_base.py
+++ b/ssg/entities/profile_base.py
@@ -37,6 +37,7 @@ class Profile(XCCDFEntity, SelectionHandler):
     KEYS = dict(
         description=lambda: "",
         extends=lambda: "",
+        hidden=lambda: "",
         metadata=lambda: None,
         reference=lambda: None,
         selections=lambda: list(),
@@ -90,6 +91,9 @@ class Profile(XCCDFEntity, SelectionHandler):
             element.append(select)
 
     def to_xml_element(self):
+        if self.hidden:
+            return ET.Comment('Default Profile')
+
         element = ET.Element('{%s}Profile' % XCCDF12_NS)
         element.set("id", OSCAP_PROFILE + self.id_)
         if self.extends:
@@ -247,6 +251,7 @@ class Profile(XCCDFEntity, SelectionHandler):
         profile.extends = self.extends
         profile.platforms = self.platforms
         profile.platform = self.platform
+        profile.hidden = self.hidden
         profile.selected = list(set(self.selected) - set(other.selected))
         profile.selected.sort()
         profile.unselected = list(set(self.unselected) - set(other.unselected))


### PR DESCRIPTION
#### Description:

This is a PR that will eventually get rid of `prodtype` concept.

Plan:

- [X] Ignore `prodtype` when composing Benchmark
- [X] Don't include rules that are not part of any profile
- [X] Add a way to include a rule without sticking it to a particular real profile by introducing special hidden profiles
- [ ] ...
- [ ] Optional: Ged rid of `!` exclude syntax from profiles definition as rules now won't be included implicitly
- [ ] Optional: Ged rid of `filter_rules` crutch as rules now won't be included implicitly
- [ ] Optional/Controversial: Add the ability to include whole groups of rules to make profile definitions less verbose (the exclusion syntax would still make sense in this case)

#### Rationale:

The `prodtype`-based relationship of Rules and Groups with the Benchmark is hard-to-maintain, non-flexible and enigmatic.

It is better to replace it with a set of weaker, more-fitting kinds of links based on existing and yet-to-create mechanics of the build system and content hierarchy organization.

#### Review Hints:

Very **WIP**!

Implementation might suck ATM, this is really a PoC.