### PR TITLE
OCP4: Remove obsolete rule scheduler_no_bind_address

### DIFF
--- a/controls/nist_ocp4.yml
+++ b/controls/nist_ocp4.yml
@@ -4854,7 +4854,6 @@ controls:
   - api_server_admission_control_plugin_noderestriction
   - kubelet_configure_client_ca
   - file_owner_ovs_sys_id_conf
-  - scheduler_no_bind_address
   - file_permissions_cni_conf
   - file_groupowner_worker_service
   - file_owner_etcd_data_dir
@@ -5084,7 +5083,6 @@ controls:
   - api_server_admission_control_plugin_noderestriction
   - kubelet_configure_client_ca
   - file_owner_ovs_sys_id_conf
-  - scheduler_no_bind_address
   - file_permissions_cni_conf
   - file_groupowner_worker_service
   - file_owner_etcd_data_dir
@@ -13889,7 +13887,6 @@ controls:
   - etcd_peer_client_cert_auth
   - controller_secure_port
   - etcd_peer_cert_file
-  - scheduler_no_bind_address
   - controller_rotate_kubelet_server_certs
   - api_server_openshift_https_serving_cert
   - api_server_etcd_key
@@ -13946,7 +13943,6 @@ controls:
   - etcd_peer_client_cert_auth
   - controller_secure_port
   - etcd_peer_cert_file
-  - scheduler_no_bind_address
   - controller_rotate_kubelet_server_certs
   - api_server_openshift_https_serving_cert
   - api_server_etcd_key

--- a/controls/srg_ctr/SRG-APP-000516-CTR-001325.yml
+++ b/controls/srg_ctr/SRG-APP-000516-CTR-001325.yml
@@ -172,7 +172,6 @@ controls:
   - scc_limit_privileged_containers
   - scc_limit_process_id_namespace
   - scc_limit_root_containers
-  - scheduler_no_bind_address
   - secrets_consider_external_storage
   - secrets_no_environment_variables
   - file_groupowner_kubelet_conf

--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -140,7 +140,7 @@ selections:
   # 1.4.1 Ensure that the --profiling argument is set to false  (info only)
   # Handled by rbac_debug_role_protects_pprof
   # 1.4.2 Ensure that the --bind-address argument is set to 127.0.0.1
-    - scheduler_no_bind_address
+  # In the latest draft, there is a manual procedure that checks for RBAC
 
   ### 2 etcd
   # 2.1 Ensure that the --cert-file and --key-file arguments are set as appropriate


### PR DESCRIPTION
#### Description:

This rule was problematic because it applied at the same time to both
versioned platforms but also not hypershift. This resulted in having two
`<platforms>` elements in the resulting DS which means that once either
of them passed (and the not hypershift would pass on a regular install)
the rule would be evaluated even though it shouldn't be.

Because this rule only ever applies to obsolete releases (4.8 and 4.9),
let's just remove it.


#### Rationale:

- Fixes e2e tests

#### Review Hints:

- Run e2e tests
