### PR TITLE
Updated fix_rules to use product class

### DIFF
--- a/utils/fix_rules.py
+++ b/utils/fix_rules.py
@@ -801,7 +801,10 @@ def __main__():
 
     subst_dict = dict()
     if args.product:
-        subst_dict = products.load_product_yaml(args.product)
+        subst_dict = dict()
+        product = products.load_product_yaml(args.product)
+        product.read_properties_from_directory(os.path.join(project_root, "product_properties"))
+        subst_dict.update(product)
 
     args.func(args, subst_dict)
 


### PR DESCRIPTION
Fix fallout from https://github.com/ComplianceAsCode/content/pull/10529

#### Description:

While subst_dict is a dictionary used by Jinja, product got refactored to a class, and that particular usage was not updated.

#### Rationale:

Before this, e.g. CCE assignment doesn't work, afterwards, e.g. https://complianceascode.readthedocs.io/en/latest/manual/developer/05_tools_and_utilities.html#how-to-automatically-assign-cces-with-the-add-cce-sub-command works.