### PR TITLE
Add platform package variables for firewalld and iptables

### DIFF
--- a/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld-backend/rule.yml
@@ -13,6 +13,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 identifiers:
     cce@rhel8: CCE-86506-3
     cce@rhel9: CCE-86507-1

--- a/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_activation/service_firewalld_enabled/rule.yml
@@ -14,6 +14,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 identifiers:
     cce@rhcos4: CCE-82554-7
     cce@rhel7: CCE-80998-8

--- a/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/firewalld_deactivation/service_firewalld_disabled/rule.yml
@@ -18,6 +18,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 identifiers:
     cce@sle15: CCE-92472-0
 

--- a/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/ruleset_modifications/set_firewalld_default_zone/rule.yml
@@ -20,6 +20,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 identifiers:
     cce@rhel7: CCE-27349-0
     cce@rhel8: CCE-80890-7

--- a/linux_os/guide/system/network/network-firewalld/set_firewalld_appropriate_zone/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/set_firewalld_appropriate_zone/rule.yml
@@ -15,6 +15,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 identifiers:
     cce@rhel7: CCE-86109-6
     cce@rhel8: CCE-86111-2

--- a/linux_os/guide/system/network/network-firewalld/unnecessary_firewalld_services_ports_disabled/rule.yml
+++ b/linux_os/guide/system/network/network-firewalld/unnecessary_firewalld_services_ports_disabled/rule.yml
@@ -21,6 +21,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 identifiers:
     cce@sle15: CCE-92552-9
 

--- a/linux_os/guide/system/network/network_implement_access_control/rule.yml
+++ b/linux_os/guide/system/network/network_implement_access_control/rule.yml
@@ -60,6 +60,8 @@ rationale: |-
 
 severity: medium
 
+platform: package[firewalld]
+
 references:
     disa: CCI-000366
     nist: CM-6 b,CM-6.1(iv)

--- a/shared/applicability/package.yml
+++ b/shared/applicability/package.yml
@@ -12,12 +12,16 @@ args:
     {{% endif %}}
   chrony:
     pkgname: chrony
+  firewalld:
+    pkgname: firewalld
   gdm:
     {{% if pkg_system == "rpm" %}}
     pkgname: gdm
     {{% else %}}
     pkgname: gdm3
     {{% endif %}}
+  iptables:
+    pkgname: iptables
   libuser:
     pkgname: libuser
   net-snmp:


### PR DESCRIPTION
#### Description:

-  Limit conflicting services  for firewall functionality with platform package rule's clauses

#### Rationale:

- Add platform package definitions for firewalld and iptables
- Add platform package clause for firewalld related rules
- Add platform package clause for iptables related rules
