### PR TITLE
Generate CIS OpenShift 1.4.0 Section 1

### DIFF
--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -1,0 +1,353 @@
+controls:
+- id: '1'
+  title: Control Plane Components
+  status: pending
+  rules: []
+  controls:
+  - id: '1.1'
+    title: Master Node Configuration Files
+    status: pending
+    rules: []
+    controls:
+    - id: 1.1.1
+      title: Ensure that the API server pod specification file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.2
+      title: Ensure that the API server pod specification file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.3
+      title: Ensure that the controller manager pod specification file permissions
+        are set to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.4
+      title: Ensure that the controller manager pod specification file ownership is
+        set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.5
+      title: Ensure that the scheduler pod specification file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.6
+      title: Ensure that the scheduler pod specification file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.7
+      title: Ensure that the etcd pod specification file permissions are set to 600
+        or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.8
+      title: Ensure that the etcd pod specification file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.9
+      title: Ensure that the Container Network Interface file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.10
+      title: Ensure that the Container Network Interface file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.11
+      title: Ensure that the etcd data directory permissions are set to 700 or more
+        restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.12
+      title: Ensure that the etcd data directory ownership is set to etcd:etcd
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.13
+      title: Ensure that the kubeconfig file permissions are set to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.14
+      title: Ensure that the kubeconfig file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.15
+      title: Ensure that the Scheduler kubeconfig file permissions are set to 600
+        or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.16
+      title: Ensure that the Scheduler kubeconfig file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.17
+      title: Ensure that the Controller Manager kubeconfig file permissions are set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.18
+      title: Ensure that the Controller Manager kubeconfig file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.19
+      title: Ensure that the OpenShift PKI directory and file ownership is set to
+        root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.20
+      title: Ensure that the OpenShift PKI certificate file permissions are set to
+        600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.1.21
+      title: Ensure that the OpenShift PKI key file permissions are set to 600
+      status: pending
+      rules: []
+      level: level_1
+  - id: '1.2'
+    title: API Server
+    status: pending
+    rules: []
+    controls:
+    - id: 1.2.1
+      title: Ensure that anonymous requests are authorized
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.2
+      title: Ensure that the --basic-auth-file argument is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.3
+      title: Ensure that the --token-auth-file parameter is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.4
+      title: Use https for kubelet connections
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.5
+      title: Ensure that the kubelet uses certificates to authenticate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.6
+      title: Verify that the kubelet certificate authority is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.7
+      title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.8
+      title: Verify that RBAC is enabled
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.9
+      title: Ensure that the APIPriorityAndFairness feature gate is enabled
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.10
+      title: Ensure that the admission control plugin AlwaysAdmit is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.11
+      title: Ensure that the admission control plugin AlwaysPullImages is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.12
+      title: Ensure that the admission control plugin ServiceAccount is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.13
+      title: Ensure that the admission control plugin NamespaceLifecycle is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.14
+      title: Ensure that the admission control plugin SecurityContextConstraint is
+        set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.15
+      title: Ensure that the admission control plugin NodeRestriction is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.16
+      title: Ensure that the --insecure-bind-address argument is not set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.17
+      title: Ensure that the --insecure-port argument is set to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.18
+      title: Ensure that the --secure-port argument is not set to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.19
+      title: Ensure that the healthz endpoint is protected by RBAC
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.20
+      title: Ensure that the --audit-log-path argument is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.21
+      title: Ensure that the audit logs are forwarded off the cluster for retention
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.22
+      title: Ensure that the maximumRetainedFiles argument is set to 10 or as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.23
+      title: Ensure that the maximumFileSizeMegabytes argument is set to 100
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.24
+      title: Ensure that the --request-timeout argument is set
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.25
+      title: Ensure that the --service-account-lookup argument is set to true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.26
+      title: Ensure that the --service-account-key-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.27
+      title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set
+        as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.28
+      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
+        are set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.29
+      title: Ensure that the --client-ca-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.30
+      title: Ensure that the --etcd-cafile argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.31
+      title: Ensure that encryption providers are appropriately configured
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.32
+      title: Ensure that the API Server only makes use of Strong Cryptographic Ciphers
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.2.33
+      title: Ensure unsupported configuration overrides are not used
+      status: pending
+      rules: []
+      level: level_1
+  - id: '1.3'
+    title: Controller Manager
+    status: pending
+    rules: []
+    controls:
+    - id: 1.3.1
+      title: Ensure that controller manager healthz endpoints are protected by RBAC
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.2
+      title: Ensure that the --use-service-account-credentials argument is set to
+        true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.3
+      title: Ensure that the --service-account-private-key-file argument is set as
+        appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.4
+      title: Ensure that the --root-ca-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.3.5
+      title: Ensure that the --bind-address argument is set to 127.0.0.1
+      status: pending
+      rules: []
+      level: level_1
+  - id: '1.4'
+    title: Scheduler
+    status: pending
+    rules: []
+    controls:
+    - id: 1.4.1
+      title: Ensure that the healthz endpoints for the scheduler are protected by
+        RBAC
+      status: pending
+      rules: []
+      level: level_1
+    - id: 1.4.2
+      title: Verify that the scheduler API service is protected by RBAC
+      status: pending
+      rules: []
+      level: level_1
+


### PR DESCRIPTION
CIS is about to release OpenShift version 1.4.0. This patch generates
the controls from the draft spread sheet so we can get started on
implementing the profile.
