### PR TITLE
Generate CIS OpenShift 1.4.0 Section 2

### DIFF
--- a/controls/cis_ocp_1_4_0/section-2.yml
+++ b/controls/cis_ocp_1_4_0/section-2.yml
@@ -1,0 +1,43 @@
+controls:
+- id: '2'
+  title: etcd
+  status: pending
+  rules: []
+  controls:
+  - id: '2.1'
+    title: Ensure that the --cert-file and --key-file arguments are set as appropriate
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.2'
+    title: Ensure that the --client-cert-auth argument is set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.3'
+    title: Ensure that the --auto-tls argument is not set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.4'
+    title: Ensure that the --peer-cert-file and --peer-key-file arguments are set
+      as appropriate
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.5'
+    title: Ensure that the --peer-client-cert-auth argument is set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.6'
+    title: Ensure that the --peer-auto-tls argument is not set to true
+    status: pending
+    rules: []
+    level: level_1
+  - id: '2.7'
+    title: Ensure that a unique Certificate Authority is used for etcd
+    status: pending
+    rules: []
+    level: level_2
+


### PR DESCRIPTION
CIS is about to release OpenShift version 1.4.0. This patch generates
the controls from the draft spread sheet so we can get started on
implementing the profile.
