### PR TITLE
Generate CIS OpenShift 1.4.0 Section 4

### DIFF
--- a/controls/cis_ocp_1_4_0/section-4.yml
+++ b/controls/cis_ocp_1_4_0/section-4.yml
@@ -1,0 +1,136 @@
+controls:
+- id: '4'
+  title: Worker Nodes
+  status: pending
+  rules: []
+  controls:
+  - id: '4.1'
+    title: Worker Node Configuration Files
+    status: pending
+    rules: []
+    controls:
+    - id: 4.1.1
+      title: Ensure that the kubelet service file permissions are set to 644 or more
+        restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.2
+      title: Ensure that the kubelet service file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.3
+      title: If proxy kube proxy configuration file exists ensure permissions are
+        set to 644 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.4
+      title: If proxy kubeconfig file exists ensure ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.5
+      title: Ensure that the --kubeconfig kubelet.conf file permissions are set to
+        644 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.6
+      title: Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.7
+      title: Ensure that the certificate authorities file permissions are set to 644
+        or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.8
+      title: Ensure that the client certificate authorities file ownership is set
+        to root:root
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.9
+      title: Ensure that the kubelet --config configuration file has permissions set
+        to 600 or more restrictive
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.1.10
+      title: Ensure that the kubelet configuration file ownership is set to root:root
+      status: pending
+      rules: []
+      level: level_1
+  - id: '4.2'
+    title: Kubelet
+    status: pending
+    rules: []
+    controls:
+    - id: 4.2.1
+      title: Activate Garbage collection in OpenShift Container Platform 4, as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.2
+      title: Ensure that the --anonymous-auth argument is set to false
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.3
+      title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.4
+      title: Ensure that the --client-ca-file argument is set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.5
+      title: Verify that the read only port is not used or is set to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.6
+      title: Ensure that the --streaming-connection-idle-timeout argument is not set
+        to 0
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.7
+      title: Ensure that the --make-iptables-util-chains argument is set to true
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.8
+      title: Ensure that the kubeAPIQPS [--event-qps] argument is set to 0 or a level
+        which ensures appropriate event capture
+      status: pending
+      rules: []
+      level: level_2
+    - id: 4.2.9
+      title: Ensure that the --tls-cert-file and --tls-private-key-file arguments
+        are set as appropriate
+      status: pending
+      rules: []
+      level: level_1
+    - id: 4.2.10
+      title: Ensure that the --rotate-certificates argument is not set to false
+      status: pending
+      rules: []
+      level: level_2
+    - id: 4.2.11
+      title: Verify that the RotateKubeletServerCertificate argument is set to true
+      status: pending
+      rules: []
+      level: level_2
+    - id: 4.2.12
+      title: Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers
+      status: pending
+      rules: []
+      level: level_1
+


### PR DESCRIPTION
CIS is about to release OpenShift version 1.4.0. This patch generates
the controls from the draft spread sheet so we can get started on
implementing the profile.
