### PR TITLE
macros: bash: Avoid matching comments in fstab macros

### DIFF
--- a/shared/macros/10-bash.jinja
+++ b/shared/macros/10-bash.jinja
@@ -1701,7 +1701,7 @@ Ensures that given mount point is in :code:`/etc/fstab`.
 
 #}}
 {{% macro bash_ensure_mount_option_in_fstab(mount_point, mount_opt, fs_spec, type) -%}}
-mount_point_match_regexp="$(printf "[[:space:]]%s[[:space:]]" {{{ mount_point }}})"
+mount_point_match_regexp="$(printf "[^#].*[[:space:]]%s[[:space:]]" {{{ mount_point }}})"
 
 # If the mount point is not in /etc/fstab, get previous mount options from /etc/mtab
 if ! grep "$mount_point_match_regexp" /etc/fstab; then
@@ -1729,7 +1729,7 @@ fi
 
 #}}
 {{% macro bash_assert_mount_point_in_fstab(mount_point) -%}}
-mount_point_match_regexp="$(printf "[[:space:]]%s[[:space:]]" "{{{ mount_point }}}")"
+mount_point_match_regexp="$(printf "[^#].*[[:space:]]%s[[:space:]]" "{{{ mount_point }}}")"
 {{#
     This macro gets expanded to code that will return 1 if MOUNTPOINT is not in /etc/fstab;
     This is consistent with the behavior prior to converting this function to a jinja macro


### PR DESCRIPTION
#### Description:

- Fixes #10426

#### Rationale:

- This probably affects other vendors as well and we already added a fix for the oval back in commit ee5352b6 but missing the same in bash