### PR TITLE
OCP: fix etcd_unique_ca rule e2e failures

### DIFF
--- a/applications/openshift/etcd/etcd_unique_ca/rule.yml
+++ b/applications/openshift/etcd/etcd_unique_ca/rule.yml
@@ -26,7 +26,7 @@ references:
   srg: SRG-APP-000516-CTR-001325
 
 platforms:
-  - ocp4-master-node and not ocp4-on-hypershift-hosted
+  - ocp4-master-node
 
 warnings:
   - dependency: |-


### PR DESCRIPTION
This fixes an e2e issue, the logical operator in the rule's platform can cause the rule filter in the platform profile to fail. 

ex. Moderate platform profile use filter
```
'"ocp4-node" not in platforms and "ocp4-master-node" not in platforms and "ocp4-node-on-sdn" not in platforms and "ocp4-node-on-ovn" not in platforms'
```
however, since we modified the platform in the rule to `ocp4-master-node and not ocp4-on-hypershift-hosted`, the previous filter will not work anymore


Because this is a node rule, and HyperShift does not have a master rule, we can remove condition `not ocp4-on-hypershift-hosted` from this rule.

