### PR TITLE
Introduce a JSON build manifest

### DIFF
--- a/build-scripts/generate_manifest.py
+++ b/build-scripts/generate_manifest.py
@@ -9,10 +9,11 @@ from ssg.entities import profile
 from ssg import build_yaml
 
 
-RULE_CONTENT_FILES = dict(
-    ansible="fixes/ansible/{id}.yml",
-    bash="fixes/bash/{id}.sh",
-    oval="checks/oval/{id}.xml",
+RULE_CONTENT_FILES = (
+    ("ansible", "fixes/ansible/{id}.yml"),
+    ("bash", "fixes/bash/{id}.sh"),
+    ("oval", "checks/oval/{id}.xml"),
+    ("oval", "checks_from_templates/oval/{id}.xml"),
 )
 
 RULE_ATTRIBUTES = dict(
@@ -42,7 +43,7 @@ def add_rule_attributes(main_dir, output_dict, rule_id):
 
 def add_rule_associated_content(main_dir, output_dict, rule_id):
     contents = set()
-    for content_id, expected_filename_template in RULE_CONTENT_FILES.items():
+    for content_id, expected_filename_template in RULE_CONTENT_FILES:
         expected_filename = os.path.join(main_dir, expected_filename_template.format(id=rule_id))
         if os.path.exists(expected_filename):
             contents.add(content_id)

--- a/build-scripts/generate_manifest.py
+++ b/build-scripts/generate_manifest.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+
+import os
+import json
+import argparse
+from glob import glob
+
+from ssg.entities import profile
+
+
+RULE_CONTENT_FILES = dict(
+    ansible="fixes/ansible/{id}.yml",
+    bash="fixes/bash/{id}.sh",
+    oval="checks/oval/{id}.xml",
+)
+
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--build-root", required=True,
+        help="The root of the built product"
+    )
+    parser.add_argument(
+        "--output", required=True,
+        help="Where to save the manifest"
+    )
+    return parser
+
+
+def add_rule_data(output_dict, main_dir):
+    rules_glob = os.path.join(main_dir, "rules", "*.yml")
+    filenames = glob(rules_glob)
+    for path in sorted(filenames):
+        rid = os.path.splitext(os.path.basename(path))[0]
+        output_dict[rid] = dict()
+        contents = set()
+        for content_id, expected_filename_template in RULE_CONTENT_FILES.items():
+            expected_filename = os.path.join(main_dir, expected_filename_template.format(id=rid))
+            if os.path.exists(expected_filename):
+                contents.add(content_id)
+        output_dict[rid]["content"] = list(contents)
+
+
+def add_profile_data(output_dict, main_dir):
+    profiles_glob = os.path.join(main_dir, "profiles", "*.profile")
+    filenames = glob(profiles_glob)
+    for path in sorted(filenames):
+        p = profile.Profile.from_yaml(path)
+        output_dict[p.id_] = dict()
+        output_dict[p.id_]["rules"] = sorted(p.selected)
+
+
+def main():
+    parser = create_parser()
+    args = parser.parse_args()
+
+    main_dir = args.build_root
+    product_name = os.path.basename(main_dir.rstrip("/"))
+    output_dict = dict(product_name=product_name)
+
+    rules_dict = dict()
+    add_rule_data(rules_dict, main_dir)
+    output_dict["rules"] = rules_dict
+
+    profiles_dict = dict()
+    add_profile_data(profiles_dict, main_dir)
+    output_dict["profiles"] = profiles_dict
+
+    with open(args.output, "w") as f:
+        json.dump(output_dict, f)
+
+
+if __name__ == "__main__":
+    main()

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -303,6 +303,21 @@ macro(ssg_build_cpe_oval_unlinked PRODUCT)
     )
 endmacro()
 
+macro(ssg_build_manifest PRODUCT)
+    add_custom_command(
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/manifest.json"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_manifest.py" --output "${CMAKE_CURRENT_BINARY_DIR}/manifest.json" --build-root "${CMAKE_CURRENT_BINARY_DIR}"
+        # The manifest requires compiled artifacts and OVAL, and the latter is the blocker.
+        # Individual OVAL files are produced during the build of "unlinked OVAL".
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
+        COMMENT "[${PRODUCT}-content] generating JSON manifest"
+    )
+    add_custom_target(
+        generate-ssg-${PRODUCT}-manifest.json
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/manifest.json"
+    )
+endmacro()
+
 # Builds SCE content into the build system. This occurs prior to XCCDF
 # generation so that the XCCDF builder can correctly place SCE content
 # (without needing a separate XML or XSLT linking step) and also place
@@ -736,6 +751,7 @@ macro(ssg_build_product PRODUCT)
     endif()
     ssg_build_oval_unlinked(${PRODUCT})
     ssg_build_cpe_oval_unlinked(${PRODUCT})
+    ssg_build_manifest(${PRODUCT})
     ssg_build_cpe_dictionary(${PRODUCT})
     ssg_build_xccdf_final(${PRODUCT})
     ssg_build_oval_final(${PRODUCT})
@@ -750,6 +766,7 @@ macro(ssg_build_product PRODUCT)
         generate-ssg-${PRODUCT}-xccdf.xml
         generate-ssg-${PRODUCT}-oval.xml
         generate-ssg-${PRODUCT}-ocil.xml
+        generate-ssg-${PRODUCT}-manifest.json
         generate-ssg-${PRODUCT}-cpe-dictionary.xml
         generate-ssg-${PRODUCT}-ds.xml
         generate-ssg-tables-${PRODUCT}-all

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -305,16 +305,16 @@ endmacro()
 
 macro(ssg_build_manifest PRODUCT)
     add_custom_command(
-        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/manifest.json"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_manifest.py" --output "${CMAKE_CURRENT_BINARY_DIR}/manifest.json" --build-root "${CMAKE_CURRENT_BINARY_DIR}"
-        # The manifest requires compiled artifacts and OVAL, and the latter is the blocker.
-        # Individual OVAL files are produced during the build of "unlinked OVAL".
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/oval-unlinked.xml"
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/manifest-${PRODUCT}.json"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/generate_manifest.py" --output "${CMAKE_CURRENT_BINARY_DIR}/manifest-${PRODUCT}.json" --build-root "${CMAKE_CURRENT_BINARY_DIR}"
+        # The manifest requires compiled artifacts on right places and also per-rule OVAL.
+        # It is not clear when those things assume their places, so manifest is compiled late
+        DEPENDS generate-ssg-${PRODUCT}-ds.xml "${CMAKE_BINARY_DIR}/ssg-${PRODUCT}-ds.xml"
         COMMENT "[${PRODUCT}-content] generating JSON manifest"
     )
     add_custom_target(
         generate-ssg-${PRODUCT}-manifest.json
-        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/manifest.json"
+        DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/manifest-${PRODUCT}.json"
     )
 endmacro()
 


### PR DESCRIPTION
#### Description:

Summarize product's built content in a JSON file.
The format isn't definitive, but the PR illustrates that it is easy to provide certain key information about content from compiled artifacts.

#### Rationale:

Although right now, a datastream can be used as a single source of truth, it is difficult to parse it. The JSON format is much better in this regard, and it allows e.g. machine-readable high-level comparison of two different content releases.
An accompanying tool able to compare contents of two versions of ComplianceAsCode will be added to this PR later.

#### Review Hints:

Build a product, and examine the `manifest.json` in the build directory.