### PR TITLE
Fix platform comparison in content_diff 

### DIFF
--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -99,9 +99,9 @@ class StandardContentDiffer(object):
             for cpe_p in cpe_platforms:
                 ET.dump(cpe_p)
         for cpe_platform in cpe_platforms:
-            fact_refs = cpe_platform.find_all_fact_ref_elements()
-            for fact_ref in fact_refs:
-                cpe_list.append(fact_ref.get("id-ref"))
+            check_fact_refs = cpe_platform.find_all_check_fact_ref_elements()
+            for check_fact_ref in check_fact_refs:
+                cpe_list.append(check_fact_ref.get("id-ref"))
         return cpe_list
 
     def compare_platforms(self, old_rule, new_rule, old_benchmark, new_benchmark, identifier):

--- a/ssg/content_diff.py
+++ b/ssg/content_diff.py
@@ -101,7 +101,7 @@ class StandardContentDiffer(object):
         for cpe_platform in cpe_platforms:
             fact_refs = cpe_platform.find_all_fact_ref_elements()
             for fact_ref in fact_refs:
-                cpe_list.append(fact_ref.get("name"))
+                cpe_list.append(fact_ref.get("id-ref"))
         return cpe_list
 
     def compare_platforms(self, old_rule, new_rule, old_benchmark, new_benchmark, identifier):

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -444,5 +444,5 @@ class XMLCPEPlatform(XMLElement):
     def __init__(self, root):
         super(XMLCPEPlatform, self).__init__(root)
 
-    def find_all_fact_ref_elements(self):
+    def find_all_check_fact_ref_elements(self):
         return self.root.findall(".//cpe-lang:check-fact-ref", self.ns)

--- a/ssg/xml.py
+++ b/ssg/xml.py
@@ -445,4 +445,4 @@ class XMLCPEPlatform(XMLElement):
         super(XMLCPEPlatform, self).__init__(root)
 
     def find_all_fact_ref_elements(self):
-        return self.root.findall(".//cpe-lang:fact-ref", self.ns)
+        return self.root.findall(".//cpe-lang:check-fact-ref", self.ns)

--- a/utils/compare_ds.py
+++ b/utils/compare_ds.py
@@ -24,8 +24,7 @@ def parse_args():
     )
     parser.add_argument(
         "--no-diffs", action="store_true",
-        help="Do not perform detailed comparison of checks and "
-        "remediations contents."
+        help="Do not perform detailed comparison of checks and remediations contents."
     )
     parser.add_argument(
         "--only-rules", action="store_true",


### PR DESCRIPTION
#### Description:

The `compare_platform` method from `StandardContentDiffer` class in `content_diff` was not working due to some invalid strings used to search elements and get attributes from Data Stream.

This PR fix these issues and ensure the platform comparison works as expected.

#### Rationale:

Fix issues when comparing platform changes.

#### Review Hints:

You can build the DataStream for a product, then change the platform in any rule included in this DataStream to finally build a new DataStream. Once you have these two DataStream, you can compare the changes using a command like this:
```
utils/compare_ds.py /tmp/ssg-rhel8-old-ds.xml build/ssg-rhel8-ds.xml
```