### PR TITLE
Remove irrelevant selections from compiled controls

### DIFF
--- a/build-scripts/compile_all.py
+++ b/build-scripts/compile_all.py
@@ -134,6 +134,7 @@ def main():
 
     controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)
     controls_manager.load()
+    controls_manager.remove_selections_not_known(loader.all_rules)
 
     profiles_by_id = get_all_resolved_profiles_by_id(
         env_yaml, product_yaml, loader, product_cpes, controls_manager, args.controls_dir)

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -209,6 +209,13 @@ class Policy(ssg.entities.common.XCCDFEntity):
             result = [self.levels[0].id]
         return result
 
+    def remove_selections_not_known(self, known_rules):
+        for c in self.controls:
+            selections = set(c.selected).intersection(known_rules)
+            c.selected = list(selections)
+            unselections = set(c.unselected).intersection(known_rules)
+            c.unselected = list(unselections)
+
     def _create_control_from_subtree(self, subtree):
         try:
             control = Control.from_control_dict(
@@ -343,6 +350,11 @@ class ControlsManager():
             policy.load()
             self.policies[policy.id] = policy
         self.resolve_controls()
+
+    def remove_selections_not_known(self, known_rules):
+        known_rules = set(known_rules)
+        for p in self.policies.values():
+            p.remove_selections_not_known(known_rules)
 
     def resolve_controls(self):
         for pid, policy in self.policies.items():

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -412,6 +412,30 @@ def test_policy_parse_from_nested(minimal_empty_controls, one_simple_subcontrol)
     assert control.selections == ["a", "b"]
 
 
+def test_manager_removes_rules():
+    control_dict = dict(id="top", rules=["one", "two", "three", "!four", "!five"])
+
+    policy = ssg.controls.Policy("")
+    policy.save_controls_tree([control_dict])
+    policy.id = "P"
+
+    controls_manager = ssg.controls.ControlsManager("", dict())
+    controls_manager.policies[policy.id] = policy
+
+    control = controls_manager.get_control("P", "top")
+    assert len(control.selections) == 5
+
+    controls_manager.remove_selections_not_known(["one", "four"])
+    control = controls_manager.get_control("P", "top")
+    assert len(control.selections) == 2
+    assert "one" in control.selections
+    assert "!four" in control.selections
+
+    controls_manager.remove_selections_not_known([])
+    control = controls_manager.get_control("P", "top")
+    assert len(control.selections) == 0
+
+
 def test_policy_parse_from_nested():
     top_control_dict = dict(id="top", controls=["nested-1"])
     first_nested_dict = dict(id="nested-1", controls=["nested-2"], rules="Y")


### PR DESCRIPTION
Controls are designed to be largely product-agnostic, and products are effective when translating it into profiles.

However, we already know rules at control compilation time, so compiled controls can be filtered, and this is what the PR does - it strips ineffective selection from them.

#### Review Hints:

Generate content for e.g. example product and some other product, and diff some controls. e.g. `enable_authselect` has limited applicability, so it doesn't show up in the example.