### PR TITLE
create_srg_export: Enable reading check and fix from controls even if they have rules listed

### DIFF
--- a/.github/workflows/srg-mapping-table.yaml
+++ b/.github/workflows/srg-mapping-table.yaml
@@ -32,11 +32,11 @@ jobs:
       - name: Create data directory
         run: mkdir -p $PAGES_DIR
       - name: Generate XLSX for OCP4
-        run: python3 utils/create_srg_export.py -c controls/srg_ctr.yml -p ocp4 -m shared/references/disa-ctr-srg-v1r3.xml --out-format xlsx --output $PAGES_DIR/srg-mapping-ocp4.xlsx
+        run: python3 utils/create_srg_export.py -c controls/srg_ctr.yml -p ocp4 -m shared/references/disa-ctr-srg-v1r3.xml --out-format xlsx --output $PAGES_DIR/srg-mapping-ocp4.xlsx --prefer-controls
         env:
           PYTHONPATH: ${{ github.workspace }}
       - name: Generate HTML for OCP4
-        run: python3 utils/create_srg_export.py -c controls/srg_ctr.yml -p ocp4 -m shared/references/disa-ctr-srg-v1r3.xml --out-format html --output $PAGES_DIR/srg-mapping-ocp4.html
+        run: python3 utils/create_srg_export.py -c controls/srg_ctr.yml -p ocp4 -m shared/references/disa-ctr-srg-v1r3.xml --out-format html --output $PAGES_DIR/srg-mapping-ocp4.html --prefer-controls
         env:
           PYTHONPATH: ${{ github.workspace }}
       - name: Generate XLSX for RHEL9

--- a/controls/srg_ctr/SRG-APP-000026-CTR-000070.yml
+++ b/controls/srg_ctr/SRG-APP-000026-CTR-000070.yml
@@ -7,4 +7,62 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify  Red Hat Enterprise Linux CoreOS (RHCOS) generates audit records for all account creations, modifications, disabling, and termination events that affect "/etc/shadow".
 
+    Logging on as administrator, check the auditing rules in "/etc/audit/audit.rules" by executing the following:
+
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME: "; grep /etc/shadow /etc/audit/audit.rules /etc/audit/rules.d/*'; done
+
+    (Example output:
+    -w /etc/shadow -p wa -k identity)
+
+    If the command does not return a line, or the line is commented out, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000027-CTR-000075.yml
+++ b/controls/srg_ctr/SRG-APP-000027-CTR-000075.yml
@@ -7,4 +7,57 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify for each of the files that contain account information the system is configured to emit an audit event in case of a write, by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; for f in /etc/passwd /etc/group /etc/gshadow /etc/security/opasswd /etc/shadow /etc/sudoers /etc/sudoers.d/; do grep -q "\-w $f \-p wa \-k" /etc/audit/audit.rules || echo "rule for $f not found"; done' 2>/dev/null; done
+
+    If for any of the files a line saying "rule for $filename not found" is printed, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000028-CTR-000080.yml
+++ b/controls/srg_ctr/SRG-APP-000028-CTR-000080.yml
@@ -2,7 +2,7 @@ controls:
 - id: SRG-APP-000028-CTR-000080
   levels:
   - medium
-  title: {{{ full_name }}} must automatically audit account-disabling actions.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -11,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000291-CTR-000675.yml
+++ b/controls/srg_ctr/SRG-APP-000291-CTR-000675.yml
@@ -2,8 +2,7 @@ controls:
 - id: SRG-APP-000291-CTR-000675
   levels:
   - medium
-  title: {{{ full_name }}} must notify system administrators and ISSO when accounts
-    are created.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -12,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000292-CTR-000680.yml
+++ b/controls/srg_ctr/SRG-APP-000292-CTR-000680.yml
@@ -2,8 +2,7 @@ controls:
 - id: SRG-APP-000292-CTR-000680
   levels:
   - medium
-  title: {{{ full_name }}} must notify system administrators and ISSO when accounts
-    are modified.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -12,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000293-CTR-000685.yml
+++ b/controls/srg_ctr/SRG-APP-000293-CTR-000685.yml
@@ -2,8 +2,7 @@ controls:
 - id: SRG-APP-000293-CTR-000685
   levels:
   - medium
-  title: {{{ full_name }}} must notify system administrators and ISSO for account
-    disabling actions.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -12,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000294-CTR-000690.yml
+++ b/controls/srg_ctr/SRG-APP-000294-CTR-000690.yml
@@ -2,8 +2,7 @@ controls:
 - id: SRG-APP-000294-CTR-000690
   levels:
   - medium
-  title: {{{ full_name }}} must notify system administrators and ISSO for account
-    removal actions.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -12,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000319-CTR-000745.yml
+++ b/controls/srg_ctr/SRG-APP-000319-CTR-000745.yml
@@ -2,7 +2,7 @@ controls:
 - id: SRG-APP-000319-CTR-000745
   levels:
   - medium
-  title: {{{ full_name }}} must automatically audit account-enabling actions.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -11,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000320-CTR-000750.yml
+++ b/controls/srg_ctr/SRG-APP-000320-CTR-000750.yml
@@ -2,8 +2,7 @@ controls:
 - id: SRG-APP-000320-CTR-000750
   levels:
   - medium
-  title: {{{ full_name }}} must notify system administrator and ISSO of account
-    enabling actions.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - idp_is_configured
   - ocp_idp_no_htpasswd
@@ -12,4 +11,64 @@ controls:
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done

--- a/controls/srg_ctr/SRG-APP-000509-CTR-001305.yml
+++ b/controls/srg_ctr/SRG-APP-000509-CTR-001305.yml
@@ -2,12 +2,71 @@ controls:
 - id: SRG-APP-000509-CTR-001305
   levels:
   - medium
-  title: {{{ full_name }}} must generate audit records for all account creations,
-    modifications, disabling, and termination events.
+  title: {{{ full_name }}} must generate audit rules to capture account creation, modification, disabling, removal and enabling actions.
   related_rules:
   - audit_profile_set
   rules:
   - audit_rules_sysadmin_actions
   - audit_rules_usergroup_modification
   status: automated
+  check: |-
+    Verify the audit rules capture account creation, modification, disabling, removal and enabling actions by executing the following:
 
+    for node in $(oc get node -oname); do oc debug $node -- chroot /host /bin/bash -c 'echo -n "$HOSTNAME "; grep -e user-modify -e group-modify -e audit_rules_usergroup_modification /etc/audit/rules.d/* /etc/audit/audit.rules' 2>/dev/null; done
+
+    Confirm the following rules exist on each node:
+    -w /etc/group -p wa -k audit_rules_usergroup_modification
+    -w /etc/gshadow -p wa -k audit_rules_usergroup_modification
+    -w /etc/security/opasswd -p wa -k audit_rules_usergroup_modification
+    -w /etc/passwd -p wa -k audit_rules_usergroup_modification
+    -w /etc/shadow -p wa -k audit_rules_usergroup_modification
+
+    If the above rules are not listed on each node, this is a finding.
+  fixtext: |-
+    Apply the machine config using the following command:
+
+    for mcpool in $(oc get mcp -oname | sed "s:.*/::" ); do
+    echo "apiVersion: machineconfiguration.openshift.io/v1
+    kind: MachineConfig
+    metadata:
+      name: 75-account-modifications-rules-$mcpool
+      labels:
+        machineconfiguration.openshift.io/role: $mcpool
+    spec:
+      config:
+        ignition:
+          version: 3.1.0
+        storage:
+          files:
+          - contents:
+              source: data:,-w%20/etc/sudoers.d/%20-p%20wa%20-k%20actions%0A-w%20/etc/sudoers%20-p%20wa%20-k%20actions%0A
+            mode: 0644
+            path: /etc/audit/rules.d/75-audit-sysadmin-actions.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/group%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_group_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/gshadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_gshadow_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/security/opasswd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_security_opasswd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/passwd%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_passwd_usergroup_modification.rules
+            overwrite: true
+          - contents:
+              source: data:,-w%20/etc/shadow%20-p%20wa%20-k%20audit_rules_usergroup_modification%0A
+            mode: 0644
+            path: /etc/audit/rules.d/30-etc_shadow_usergroup_modification.rules
+            overwrite: true
+    " | oc apply -f -
+    done


### PR DESCRIPTION
#### Description:

The OCP4 STIG if a bit of an weird case. First, it mixes OCP4 and RHCOS
controls into a single stig and second, because of how the MachineConfig
remediations are not exactly user-friendly, we often lumped several
MachineConfigs from several rules into a single SRG row in the STIG
spreadsheet.

The current script presumes that every rule would emit a single row in
the sheet and that every rule's policy would be used exactly ones. The
most straightforward way of solving this is to just put the checks and
the fixes in the controls and then let the script optionally, with a new
command line flag that this patch adds, prefer those over policy files.

That way, we can have a single row even if the control specifies several
rules.

Additionally, because the current script presumes that rows whose check
and fix are read from the control files are either NA or IM and should
be separate in the resulting sheet, the script implements a rudimentary
deduplication of duplicate rows.

This behaviour is opt-in and would only be used by the OCP4 STIG for
the time being.

The other patches actually add check and fix to several control files and 
enable the new flag for SRG export in GH actions for the OCP4 product.

#### Rationale:

- OCP4 STIG

#### Review Hints:

- Check out the sheet
- Review the code
