### PR TITLE
Ol8 update anssi profiles

### DIFF
--- a/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_drop_gratuitous_arp/rule.yml
+++ b/linux_os/guide/system/network/network-kernel/network_host_and_router_parameters/sysctl_net_ipv4_conf_all_drop_gratuitous_arp/rule.yml
@@ -1,6 +1,6 @@
 documentation_complete: true
 
-prodtype: fedora,rhel8,rhel9
+prodtype: fedora,ol8,ol9,rhel8,rhel9
 
 title: 'Drop Gratuitious ARP frames on All IPv4 Interfaces'
 

--- a/products/ol8/profiles/anssi_bp28_enhanced.profile
+++ b/products/ol8/profiles/anssi_bp28_enhanced.profile
@@ -13,4 +13,3 @@ description: |-
 
 selections:
     - anssi:all:enhanced
-    - '!selinux_state'


### PR DESCRIPTION
#### Description:

- Add rules `selinux_state` & `sysctl_net_ipv4_conf_all_drop_gratuitous_arp` to applicable anssi profiles

#### Rationale:

-  `selinux_state` was being removed with no documented reason, so added it, tested it and since it works, kept it
- `sysctl_net_ipv4_conf_all_drop_gratuitous_arp` didn't have the ol8 and ol9 products in prodtype, while the configuration is actually available in those OS's and is part of ANSSI requirements 

#### Review Hints:

- This only affects OL8/OL9 rule selections, no functional change