### PR TITLE
Implement rules for CIS OCP Section 1.1

### DIFF
--- a/applications/openshift/master/file_permissions_cni_conf/rule.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/rule.yml
@@ -7,7 +7,7 @@ platform: ocp4-node
 title: 'Verify Permissions on the OpenShift Container Network Interface Files'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/cni/net.d/*", perms="0600") }}}
 
 rationale: |-
     CNI (Container Network Interface) files consist of a specification and libraries for
@@ -26,14 +26,14 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/cni/net.d/*", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/cni/net.d/*", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/cni/net.d/*", perms="-rw-------") }}}
 
 template:
     name: file_permissions
     vars:
         filepath: ^/etc/cni/net.d/.*$
-        filemode: '0644'
+        filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_cni_conf/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_cni_conf/tests/ocp4/e2e.yml
@@ -1,2 +1,3 @@
 ---
-default_result: PASS
+# This will fail until OpenShift 4.14 is released and used by CI.
+default_result: FAIL

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the OpenShift Controller Manager Kubeconfig File'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0644") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="0600") }}}
 
 rationale: |-
   The Controller Manager's kubeconfig contains information about how the
@@ -25,10 +25,10 @@ references:
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-------") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/configmaps/controller-manager-kubeconfig/kubeconfig", perms="-rw-------") }}}
 
 platforms:
   - ocp4-master-node
@@ -43,5 +43,5 @@ template:
   name: file_permissions
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/configmaps/controller-manager-kubeconfig/kubeconfig$
-    filemode: '0644'
+    filemode: '0600'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_controller_manager_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,5 @@
 ---
+# This will fail until OpenShift 4.14 is released and used by CI.
 default_result:
-  master: PASS
+  master: FAIL
   worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_etcd_member/rule.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Etcd Member Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="0600") }}}
 
 rationale: |-
     The etcd pod specification file controls various parameters that
@@ -26,10 +26,10 @@ references:
     nist: CM-6,CM-6(1)
     srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/etcd-pod-*/etcd-pod.yaml", perms="-rw-------") }}}
 
 platforms:
     - ocp4-master-node
@@ -44,5 +44,5 @@ template:
     name: file_permissions
     vars:
         filepath: ^/etc/kubernetes/static-pod-resources/etcd-pod-.*/etcd-pod.yaml$
-        filemode: '0644'
+        filemode: '0600'
         filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_etcd_member/tests/ocp4/e2e.yml
@@ -1,4 +1,5 @@
 ---
+# This will fail until OpenShift 4.14 is released and used by CI.
 default_result:
-  master: PASS
+  master: FAIL
   worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kubernetes API Server Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="0600") }}}
 
 rationale: |-
     If the Kubernetes specification file is writable by a group-owner or the
@@ -27,7 +27,7 @@ references:
 ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-apiserver-pod-*/kube-apiserver-pod.yaml", perms="-rw-------") }}}
 
 platforms:
   - ocp4-master-node
@@ -43,4 +43,4 @@ template:
   vars:
     filepath: "^/etc/kubernetes/static-pod-resources/kube-apiserver-pod-.*/kube-apiserver-pod.yaml$"
     filepath_is_regex: "true"
-    filemode: '0644'
+    filemode: '0600'

--- a/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_apiserver/tests/ocp4/e2e.yml
@@ -1,4 +1,5 @@
 ---
+# This will fail until OpenShift 4.14 is released and used by CI.
 default_result:
-  master: PASS
+  master: FAIL
   worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kubernetes Controller Manager Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-*/kube-controller-manager-pod.yaml", perms="0600") }}}
 
 rationale: |-
     If the Kubernetes specification file is writable by a group-owner or the
@@ -43,4 +43,4 @@ template:
     vars:
         filepath: '^/etc/kubernetes/static-pod-resources/kube-controller-manager-pod-.*/kube-controller-manager-pod.yaml$'
         filepath_is_regex: 'true'
-        filemode: '0644'
+        filemode: '0600'

--- a/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_kube_controller_manager/tests/ocp4/e2e.yml
@@ -1,4 +1,5 @@
 ---
+# This will fail until OpenShift 4.14 is released and used by CI.
 default_result:
-  master: PASS
+  master: FAIL
   worker: NOT-APPLICABLE

--- a/applications/openshift/master/file_permissions_kube_scheduler/rule.yml
+++ b/applications/openshift/master/file_permissions_kube_scheduler/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kube Scheduler Pod Specification File'
 
 description: |-
-    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="0644") }}}
+    {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="0600") }}}
 
 rationale: |-
     If the Kube specification file is writable by a group-owner or the
@@ -21,13 +21,13 @@ severity: medium
 references:
     cis@ocp4: 1.1.5
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="-rw-------") }}}'
 
 ocil: |-
-    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="-rw-r--r--") }}}
+    {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml", perms="-rw-------") }}}
 
 #template:
 #    name: file_permissions
 #    vars:
 #        filepath: /etc/kubernetes/static-pod-resources/kube-scheduler-pod.yaml
-#        filemode: '0644'
+#        filemode: '0600'

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/rule.yml
@@ -5,7 +5,7 @@ prodtype: ocp4
 title: 'Verify Permissions on the Kubernetes Scheduler Kubeconfig File'
 
 description: |-
-  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="0644") }}}
+  {{{ describe_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="0600") }}}
 
 rationale: |-
   The kubeconfig for the Scheduler contains parameters for the scheduler
@@ -25,10 +25,10 @@ references:
   nist: CM-6,CM-6(1)
   srg: SRG-APP-000516-CTR-001325
 
-ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}'
+ocil_clause: '{{{ ocil_clause_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-------") }}}'
 
 ocil: |-
-  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-r--r--") }}}
+  {{{ ocil_file_permissions(file="/etc/kubernetes/static-pod-resources/kube-scheduler-pod-*/configmaps/scheduler-kubeconfig/kubeconfig", perms="-rw-------") }}}
 
 platforms:
   - ocp4-master-node
@@ -43,5 +43,5 @@ template:
   name: file_permissions
   vars:
     filepath: ^/etc/kubernetes/static-pod-resources/kube-scheduler-pod-.*/configmaps/scheduler-kubeconfig/kubeconfig$
-    filemode: '0644'
+    filemode: '0600'
     filepath_is_regex: "true"

--- a/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
+++ b/applications/openshift/master/file_permissions_scheduler_kubeconfig/tests/ocp4/e2e.yml
@@ -1,4 +1,5 @@
 ---
+# This will fail until OpenShift 4.14 is released and used by CI.
 default_result:
-  master: PASS
+  master: FAIL
   worker: NOT-APPLICABLE

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -6,113 +6,185 @@ controls:
   controls:
   - id: '1.1'
     title: Master Node Configuration Files
-    status: pending
+    status: automated
     rules: []
     controls:
     - id: 1.1.1
       title: Ensure that the API server pod specification file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_kube_apiserver
       levels: level_1
     - id: 1.1.2
       title: Ensure that the API server pod specification file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_kube_apiserver
+        - file_groupowner_kube_apiserver
       levels: level_1
     - id: 1.1.3
       title: Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_kube_apiserver
       levels: level_1
     - id: 1.1.4
       title: Ensure that the controller manager pod specification file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_kube_controller_manager
+        - file_groupowner_kube_controller_manager
       levels: level_1
     - id: 1.1.5
       title: Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_kube_scheduler
       levels: level_1
     - id: 1.1.6
       title: Ensure that the scheduler pod specification file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_kube_scheduler
+        - file_groupowner_kube_scheduler
       levels: level_1
     - id: 1.1.7
       title: Ensure that the etcd pod specification file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_etcd_member
       levels: level_1
     - id: 1.1.8
       title: Ensure that the etcd pod specification file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_groupowner_etcd_member
+        - file_owner_etcd_member
       levels: level_1
     - id: 1.1.9
       title: Ensure that the Container Network Interface file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_cni_conf
+        - file_permissions_multus_conf
+        - file_permissions_ip_allocations
+        - file_perms_openshift_sdn_cniserver_config
+        - file_permissions_ovs_pid
+        - file_permissions_ovs_conf_db
+        - file_permissions_ovs_sys_id_conf
+        - file_permissions_ovs_conf_db_lock
+        - file_permissions_ovs_vswitchd_pid
+        - file_permissions_ovsdb_server_pid
+        - file_permissions_ovn_cni_server_sock
+        - file_permissions_ovn_db_files
       levels: level_1
     - id: 1.1.10
       title: Ensure that the Container Network Interface file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_cni_conf
+        - file_groupowner_cni_conf
+        - file_owner_multus_conf
+        - file_groupowner_multus_conf
+        - file_owner_ip_allocations
+        - file_groupowner_ip_allocations
+        - file_owner_openshift_sdn_cniserver_config
+        - file_groupowner_openshift_sdn_cniserver_config
+        - file_owner_ovs_pid
+        - file_groupowner_ovs_pid
+        - file_owner_ovs_conf_db
+        - file_groupowner_ovs_conf_db
+        - file_owner_ovs_sys_id_conf
+        - file_groupowner_ovs_sys_id_conf
+        - file_owner_ovs_conf_db_lock
+        - file_groupowner_ovs_conf_db_lock
+        - file_owner_ovs_vswitchd_pid
+        - file_groupowner_ovs_vswitchd_pid
+        - file_owner_ovsdb_server_pid
+        - file_groupowner_ovsdb_server_pid
+        - file_groupowner_ovn_cni_server_sock
+        - file_owner_ovn_cni_server_sock
+        - file_owner_ovn_db_files
+        - file_groupowner_ovn_db_files
       levels: level_1
     - id: 1.1.11
       title: Ensure that the etcd data directory permissions are set to 700 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_etcd_data_dir
+        - file_permissions_etcd_data_files
       levels: level_1
     - id: 1.1.12
       title: Ensure that the etcd data directory ownership is set to etcd:etcd
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_etcd_data_dir
+        - file_groupowner_etcd_data_dir
+        - file_owner_etcd_data_files
+        - file_groupowner_etcd_data_files
       levels: level_1
     - id: 1.1.13
       title: Ensure that the kubeconfig file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_master_admin_kubeconfigs
       levels: level_1
     - id: 1.1.14
       title: Ensure that the kubeconfig file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_master_admin_kubeconfigs
+        - file_groupowner_master_admin_kubeconfigs
       levels: level_1
     - id: 1.1.15
       title: Ensure that the Scheduler kubeconfig file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_scheduler_kubeconfig
       levels: level_1
     - id: 1.1.16
       title: Ensure that the Scheduler kubeconfig file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_scheduler_kubeconfig
+        - file_groupowner_scheduler_kubeconfig
       levels: level_1
     - id: 1.1.17
       title: Ensure that the Controller Manager kubeconfig file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_controller_manager_kubeconfig
       levels: level_1
     - id: 1.1.18
       title: Ensure that the Controller Manager kubeconfig file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_controller_manager_kubeconfig
+        - file_groupowner_controller_manager_kubeconfig
       levels: level_1
     - id: 1.1.19
       title: Ensure that the OpenShift PKI directory and file ownership is set to root:root
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_owner_openshift_pki_key_files
+        - file_groupowner_openshift_pki_key_files
+        - file_owner_openshift_pki_cert_files
+        - file_groupowner_openshift_pki_cert_files
+        - file_owner_etcd_pki_cert_files
+        - file_groupowner_etcd_pki_cert_files
       levels: level_1
     - id: 1.1.20
       title: Ensure that the OpenShift PKI certificate file permissions are set to 600 or more restrictive
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_openshift_pki_cert_files
+        - file_permissions_etcd_pki_cert_files
       levels: level_1
     - id: 1.1.21
       title: Ensure that the OpenShift PKI key file permissions are set to 600
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - file_permissions_openshift_pki_key_files
       levels: level_1
   - id: '1.2'
     title: API Server


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start
wiring up the existing rules.

This commit reuses a bunch of the existing rules we have from older
versions of the OpenShift CIS benchmark. The latest version of the
benchmark (v1.4.0) includes hardening permissions from 644 to 600 and
this change takes that into account, too.
