### PR TITLE
Implement rules for CIS OCP Section 1.2

### DIFF
--- a/applications/openshift/api-server/api_server_admission_control_plugin_alwaysadmit/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_alwaysadmit/rule.yml
@@ -28,7 +28,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.11
+    cis@ocp4: 1.2.10
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_admission_control_plugin_alwayspullimages/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_alwayspullimages/rule.yml
@@ -44,7 +44,7 @@ rationale: |-
 severity: high
 
 references:
-    cis@ocp4: 1.2.12
+    cis@ocp4: 1.2.11
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_admission_control_plugin_namespacelifecycle/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_namespacelifecycle/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.15
+    cis@ocp4: 1.2.13
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_admission_control_plugin_noderestriction/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_noderestriction/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.17
+    cis@ocp4: 1.2.15
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_admission_control_plugin_scc/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_scc/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.16
+    cis@ocp4: 1.2.14
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_admission_control_plugin_service_account/rule.yml
+++ b/applications/openshift/api-server/api_server_admission_control_plugin_service_account/rule.yml
@@ -32,7 +32,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.14
+    cis@ocp4: 1.2.12
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
+++ b/applications/openshift/api-server/api_server_api_priority_gate_enabled/rule.yml
@@ -35,7 +35,7 @@ platforms:
 severity: medium
 
 references:
-  cis@ocp4: 1.2.10
+  cis@ocp4: 1.2.9
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxbackup/rule.yml
@@ -38,7 +38,7 @@ identifiers:
 severity: low
 
 references:
-    cis@ocp4: 1.2.24
+    cis@ocp4: 1.2.22
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_maxsize/rule.yml
@@ -38,7 +38,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.25
+    cis@ocp4: 1.2.23
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_audit_log_path/rule.yml
+++ b/applications/openshift/api-server/api_server_audit_log_path/rule.yml
@@ -37,7 +37,7 @@ identifiers:
 severity: high
 
 references:
-    cis@ocp4: 1.2.22
+    cis@ocp4: 1.2.20
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
+++ b/applications/openshift/api-server/api_server_auth_mode_rbac/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.9
+    cis@ocp4: 1.2.8
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_bind_address/rule.yml
@@ -27,7 +27,7 @@ identifiers:
 severity: low
 
 references:
-    cis@ocp4: 1.2.20
+    cis@ocp4: 1.2.18
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_client_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_client_ca/rule.yml
@@ -39,7 +39,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis@ocp4: 1.2.31
+    cis@ocp4: 1.2.29
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
+++ b/applications/openshift/api-server/api_server_encryption_provider_cipher/rule.yml
@@ -58,7 +58,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.33,1.2.34,2.8
+    cis@ocp4: 1.2.31,2.8
     nerc-cip: CIP-003-8 R4.2
     nist: SC-28,SC-28(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_etcd_ca/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_ca/rule.yml
@@ -42,7 +42,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.32
+    cis@ocp4: 1.2.30
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_etcd_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_cert/rule.yml
@@ -40,7 +40,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.29
+    cis@ocp4: 1.2.27
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_etcd_key/rule.yml
+++ b/applications/openshift/api-server/api_server_etcd_key/rule.yml
@@ -40,7 +40,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.29
+    cis@ocp4: 1.2.27
     nerc-cip: CIP-003-8 R4.2,CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R5.1,CIP-007-3 R6.1
     nist: CM-6,CM-6(1),SC-8,SC-8(1)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_bind_address/rule.yml
@@ -37,7 +37,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.18
+    cis@ocp4: 1.2.16
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_insecure_port/rule.yml
+++ b/applications/openshift/api-server/api_server_insecure_port/rule.yml
@@ -44,7 +44,7 @@ platforms:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.19
+    cis@ocp4: 1.2.17
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2,Req-2.3

--- a/applications/openshift/api-server/api_server_request_timeout/rule.yml
+++ b/applications/openshift/api-server/api_server_request_timeout/rule.yml
@@ -38,7 +38,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis@ocp4: 1.2.26
+    cis@ocp4: 1.2.24
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_lookup/rule.yml
@@ -29,7 +29,7 @@ identifiers:
 severity: medium
 
 references:
-  cis@ocp4: 1.2.27
+  cis@ocp4: 1.2.25
   nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
   nist: CM-6,CM-6(1)
   pcidss: Req-2.2
@@ -49,7 +49,7 @@ ocil: |-
 warnings:
 - general: |-
     {{{ openshift_filtered_cluster_setting({custom_api_path: dump_path}) | indent(4) }}}
-      
+
 template:
   name: yamlfile_value
   vars:

--- a/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
+++ b/applications/openshift/api-server/api_server_service_account_public_key/rule.yml
@@ -40,7 +40,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.28
+    cis@ocp4: 1.2.26
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_tls_cert/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cert/rule.yml
@@ -40,7 +40,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.30
+    cis@ocp4: 1.2.28
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_cipher_suites/rule.yml
@@ -39,7 +39,7 @@ rationale: |-
 severity: medium
 
 references:
-    cis@ocp4: 1.2.35
+    cis@ocp4: 1.2.32
     nist: CM-6
     pcidss: Req-2.2,Req-2.2.3,Req-2.3
     srg: SRG-APP-000516-CTR-001325

--- a/applications/openshift/api-server/api_server_tls_private_key/rule.yml
+++ b/applications/openshift/api-server/api_server_tls_private_key/rule.yml
@@ -40,7 +40,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.30
+    cis@ocp4: 1.2.28
     nerc-cip: CIP-003-8 R4.2,CIP-007-3 R5.1
     nist: SC-8,SC-8(1),SC-8(2)
     pcidss: Req-2.2,Req-2.2.3,Req-2.3

--- a/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_enabled/rule.yml
@@ -21,7 +21,7 @@ identifiers:
   cce@ocp4: CCE-84076-9
 
 references:
-  cis@ocp4: 1.2.23
+  cis@ocp4: 1.2.21
   nerc-cip: CIP-003-8 R5.2,CIP-004-6 R2.2.2,CIP-004-6 R2.2.3,CIP-004-6 R3.3,CIP-007-3 R.1.3,CIP-007-3 R5,CIP-007-3 R5.1.1,CIP-007-3 R5.2,CIP-007-3 R5.3.1,CIP-007-3 R5.3.2,CIP-007-3 R5.3.3,CIP-007-3 R6.5
   nist: AC-2(12),AU-3(2),AU-5(1),AU-6,AU-6(1),AU-6(3),AU-9(2),SI-4(16),AU-4(1),AU-11,AU-7,AU-7(1),SI-4(20)
   pcidss: Req-2.2,Req-10.5.3,Req-10.5.4

--- a/applications/openshift/api-server/audit_log_forwarding_webhook/rule.yml
+++ b/applications/openshift/api-server/audit_log_forwarding_webhook/rule.yml
@@ -25,7 +25,7 @@ identifiers:
   cce@ocp4: CCE-86103-9
 
 references:
-  cis@ocp4: 1.2.23
+  cis@ocp4: 1.2.21
   pcidss: Req-2.2,Req-10.5.3,Req-10.5.4
 
 platform: ocp4-on-hypershift

--- a/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxbackup/rule.yml
+++ b/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxbackup/rule.yml
@@ -38,7 +38,7 @@ identifiers:
 severity: low
 
 references:
-    cis@ocp4: 1.2.24
+    cis@ocp4: 1.2.22
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxsize/rule.yml
+++ b/applications/openshift/openshift-api-server/ocp_api_server_audit_log_maxsize/rule.yml
@@ -38,7 +38,7 @@ identifiers:
 severity: medium
 
 references:
-    cis@ocp4: 1.2.25
+    cis@ocp4: 1.2.23
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
+++ b/applications/openshift/openshift-api-server/openshift_api_server_audit_log_path/rule.yml
@@ -37,7 +37,7 @@ identifiers:
 severity: high
 
 references:
-    cis@ocp4: 1.2.22
+    cis@ocp4: 1.2.20
     nerc-cip: CIP-003-8 R6,CIP-004-6 R3,CIP-007-3 R6.1
     nist: CM-6,CM-6(1)
     pcidss: Req-2.2

--- a/controls/cis_ocp_1_4_0/section-1.yml
+++ b/controls/cis_ocp_1_4_0/section-1.yml
@@ -121,93 +121,116 @@ controls:
     controls:
     - id: 1.2.1
       title: Ensure that anonymous requests are authorized
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_anonymous_auth
       levels: level_1
     - id: 1.2.2
       title: Ensure that the --basic-auth-file argument is not set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_basic_auth
       levels: level_1
     - id: 1.2.3
       title: Ensure that the --token-auth-file parameter is not set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_token_auth
       levels: level_1
     - id: 1.2.4
       title: Use https for kubelet connections
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_https_for_kubelet_conn
+        - api_server_openshift_https_serving_cert
+        - api_server_oauth_https_serving_cert
       levels: level_1
     - id: 1.2.5
       title: Ensure that the kubelet uses certificates to authenticate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_kubelet_client_cert
+        - api_server_kubelet_client_cert_pre_4_9
+        - api_server_kubelet_client_key
+        - api_server_kubelet_client_key_pre_4_9
       levels: level_1
     - id: 1.2.6
       title: Verify that the kubelet certificate authority is set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_kubelet_certificate_authority
       levels: level_1
     - id: 1.2.7
       title: Ensure that the --authorization-mode argument is not set to AlwaysAllow
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_auth_mode_no_aa
       levels: level_1
     - id: 1.2.8
       title: Verify that RBAC is enabled
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_auth_mode_rbac
       levels: level_1
     - id: 1.2.9
       title: Ensure that the APIPriorityAndFairness feature gate is enabled
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_api_priority_gate_enabled
       levels: level_1
     - id: 1.2.10
       title: Ensure that the admission control plugin AlwaysAdmit is not set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_admission_control_plugin_alwaysadmit
       levels: level_1
     - id: 1.2.11
       title: Ensure that the admission control plugin AlwaysPullImages is not set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_admission_control_plugin_alwayspullimages
       levels: level_1
     - id: 1.2.12
       title: Ensure that the admission control plugin ServiceAccount is set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_admission_control_plugin_service_account
       levels: level_1
     - id: 1.2.13
       title: Ensure that the admission control plugin NamespaceLifecycle is set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_admission_control_plugin_namespacelifecycle
       levels: level_1
     - id: 1.2.14
       title: Ensure that the admission control plugin SecurityContextConstraint is set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_admission_control_plugin_scc
       levels: level_1
     - id: 1.2.15
       title: Ensure that the admission control plugin NodeRestriction is set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_admission_control_plugin_noderestriction
       levels: level_1
     - id: 1.2.16
       title: Ensure that the --insecure-bind-address argument is not set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_insecure_bind_address
       levels: level_1
     - id: 1.2.17
       title: Ensure that the --insecure-port argument is set to 0
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_insecure_port
       levels: level_1
     - id: 1.2.18
       title: Ensure that the --secure-port argument is not set to 0
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_bind_address
       levels: level_1
     - id: 1.2.19
       title: Ensure that the healthz endpoint is protected by RBAC
@@ -216,68 +239,87 @@ controls:
       levels: level_1
     - id: 1.2.20
       title: Ensure that the --audit-log-path argument is set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_audit_log_path
+        - openshift_api_server_audit_log_path
       levels: level_1
     - id: 1.2.21
       title: Ensure that the audit logs are forwarded off the cluster for retention
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - audit_log_forwarding_enabled
+        - audit_log_forwarding_webhook
       levels: level_1
     - id: 1.2.22
       title: Ensure that the maximumRetainedFiles argument is set to 10 or as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_audit_log_maxbackup
+        - ocp_api_server_audit_log_maxbackup
       levels: level_1
     - id: 1.2.23
       title: Ensure that the maximumFileSizeMegabytes argument is set to 100
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_audit_log_maxsize
+        - ocp_api_server_audit_log_maxsize
       levels: level_1
     - id: 1.2.24
       title: Ensure that the --request-timeout argument is set
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_request_timeout
       levels: level_1
     - id: 1.2.25
       title: Ensure that the --service-account-lookup argument is set to true
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_service_account_lookup
       levels: level_1
     - id: 1.2.26
       title: Ensure that the --service-account-key-file argument is set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_service_account_public_key
       levels: level_1
     - id: 1.2.27
       title: Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_etcd_cert
+        - api_server_etcd_key
       levels: level_1
     - id: 1.2.28
       title: Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_tls_cert
+        - api_server_tls_private_key
       levels: level_1
     - id: 1.2.29
       title: Ensure that the --client-ca-file argument is set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_client_ca
       levels: level_1
     - id: 1.2.30
       title: Ensure that the --etcd-cafile argument is set as appropriate
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_etcd_ca
       levels: level_1
     - id: 1.2.31
       title: Ensure that encryption providers are appropriately configured
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_encryption_provider_cipher
       levels: level_1
     - id: 1.2.32
       title: Ensure that the API Server only makes use of Strong Cryptographic Ciphers
-      status: pending
-      rules: []
+      status: automated
+      rules:
+        - api_server_tls_cipher_suites
       levels: level_1
     - id: 1.2.33
       title: Ensure unsupported configuration overrides are not used


### PR DESCRIPTION
Now that we have a profile and control files for CIS 1.4.0, we can start wiring up the existing rules.

This commit ports all the existing rules we were using for the CIS OpenShift profile into the CIS 1.4.0 version.