### PR TITLE
Remove outdated comment from OCP4 CIS profile

### DIFF
--- a/products/ocp4/profiles/cis.profile
+++ b/products/ocp4/profiles/cis.profile
@@ -93,9 +93,6 @@ selections:
     - api_server_audit_log_maxsize
     - ocp_api_server_audit_log_maxsize
   # 1.2.26 Ensure that the --request-timeout argument is set as appropriate
-    # (jhrozek) Temporarily disabling the rule because the benchmark
-    #           specifies one value (60) for the request-timeout parameter, while we
-    #           use 3600 in OCP. It is unclear if this value is appropriate...
     - api_server_request_timeout
   # 1.2.27 Ensure that the --service-account-lookup argument is set to true
     - api_server_service_account_lookup


### PR DESCRIPTION
This comment was addressed in the latest OpenShift CIS benchmark version
1.4.0. Additionally, the rule that the comment was saying is disabled
was re-enabled, but the comment was never removed.

  https://github.com/ComplianceAsCode/content/commit/57c3a7e38c1709e4d07e87c573c86d42a05aa947
